### PR TITLE
Bind containers and lists: Card, Chips, NavigationBar, NavigationRail

### DIFF
--- a/src/ComposeNet.Compose/ComposableLambdas.cs
+++ b/src/ComposeNet.Compose/ComposableLambdas.cs
@@ -58,20 +58,59 @@ internal sealed class ComposableLambda2 : Java.Lang.Object, IFunction2
 
 // Function3<Scope, Composer, Integer, Unit> — Column/Row/Box/Button content.
 // p0 = scope (RowScope/ColumnScope), p1 = composer, p2 = $changed.
-// The scope receiver is ignored here; users can't access it from the
-// tree-style API anyway (modifiers like .weight live on Modifier
-// extensions, which are a Tier 2 problem).
+//
+// Two ctors:
+// * <c>Action&lt;IComposer&gt;</c> (the original): scope is discarded —
+//   used everywhere children don't need to know it (Column, Box, Button).
+// * <c>Action&lt;IntPtr, IComposer&gt;</c>: receives the raw scope handle,
+//   used by container composables whose children are extension-receiver
+//   composables (<c>RowScope.NavigationBarItem</c>). The scope is
+//   published via <see cref="RenderContext"/> so the child <c>Render</c>
+//   can read it.
 [Register("composenet/compose/ComposableLambda3")]
 internal sealed class ComposableLambda3 : Java.Lang.Object, IFunction3
 {
-    readonly System.Action<IComposer> _body;
-    public ComposableLambda3(System.Action<IComposer> body) => _body = body;
+    readonly System.Action<IntPtr, IComposer> _body;
+
+    public ComposableLambda3(System.Action<IComposer> body)
+        : this((_, c) => body(c)) { }
+
+    public ComposableLambda3(System.Action<IntPtr, IComposer> body) => _body = body;
 
     public Java.Lang.Object? Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1, Java.Lang.Object? p2)
     {
         System.ArgumentNullException.ThrowIfNull(p1);
         var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p1);
-        _body(composer);
+        _body(p0?.Handle ?? IntPtr.Zero, composer);
         return null;
+    }
+}
+
+// Thread-static stash of the current Compose receiver scope (RowScope /
+// ColumnScope) handle. Set by container composables that consume a
+// scope-receiver Function3 content lambda; read by *Item composables
+// whose underlying Kotlin static method takes the scope as its first
+// argument. Composition runs synchronously on a single thread, so a
+// [ThreadStatic] is sufficient — and a struct-disposable scope guard
+// keeps push/pop balanced even when child Render throws.
+internal static class RenderContext
+{
+    [System.ThreadStatic]
+    static IntPtr s_scope;
+
+    public static IntPtr CurrentScope => s_scope;
+
+    public static ScopeFrame PushScope(IntPtr scope)
+    {
+        var prev = s_scope;
+        s_scope = scope;
+        return new ScopeFrame(prev);
+    }
+
+    internal readonly struct ScopeFrame : System.IDisposable
+    {
+        readonly IntPtr _previous;
+        public ScopeFrame(IntPtr previous) => _previous = previous;
+        public void Dispose() => s_scope = _previous;
     }
 }

--- a/src/ComposeNet.Compose/Composables.cs
+++ b/src/ComposeNet.Compose/Composables.cs
@@ -283,3 +283,329 @@ public sealed class AlertDialog : ComposableNode
             composer:         composer);
     }
 }
+
+// ---- Card ----
+
+/// <summary>
+/// Material 3 non-clickable <c>Card</c> — a tonal surface with rounded
+/// corners that lays its children out as a Column. Children are added
+/// via collection-initializer syntax:
+/// <code>
+/// new Card { new Text("Title"), new Text("Subtitle") }
+/// </code>
+/// </summary>
+public sealed class Card : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3(c => RenderChildren(c));
+        ComposeBridges.Card(content, composer);
+    }
+}
+
+// ---- Chip family ----
+
+/// <summary>
+/// Material 3 <c>AssistChip</c>. <see cref="Label"/> is required;
+/// <see cref="LeadingIcon"/> and <see cref="TrailingIcon"/> are optional
+/// slots:
+/// <code>
+/// new AssistChip(onClick: ...) { Label = new Text("Filter") }
+/// </code>
+/// </summary>
+public sealed class AssistChip : ComposableNode
+{
+    readonly System.Action _onClick;
+    public AssistChip(System.Action onClick) => _onClick = onClick;
+
+    /// <summary>Required: chip text.</summary>
+    public ComposableNode? Label { get; set; }
+
+    /// <summary>Optional: leading slot (e.g. icon).</summary>
+    public ComposableNode? LeadingIcon { get; set; }
+
+    /// <summary>Optional: trailing slot.</summary>
+    public ComposableNode? TrailingIcon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Label is null)
+            throw new System.InvalidOperationException(
+                "AssistChip.Label is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var label = new ComposableLambda2(c => Label.Render(c));
+        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
+        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+
+        int defaults = (int)AssistChipDefault.All;
+        if (leading  is not null) defaults &= ~(int)AssistChipDefault.LeadingIcon;
+        if (trailing is not null) defaults &= ~(int)AssistChipDefault.TrailingIcon;
+
+        ComposeBridges.AssistChip(click, label, leading, trailing, defaults, composer);
+    }
+}
+
+/// <summary>
+/// Material 3 <c>FilterChip</c>. Renders as either selected or unselected;
+/// the <c>onClick</c> handler typically toggles the bound boolean state.
+/// </summary>
+public sealed class FilterChip : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public FilterChip(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Required: chip text.</summary>
+    public ComposableNode? Label { get; set; }
+
+    /// <summary>Optional: leading slot (typically the check / unselected icon).</summary>
+    public ComposableNode? LeadingIcon { get; set; }
+
+    /// <summary>Optional: trailing slot.</summary>
+    public ComposableNode? TrailingIcon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Label is null)
+            throw new System.InvalidOperationException(
+                "FilterChip.Label is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var label = new ComposableLambda2(c => Label.Render(c));
+        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
+        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+
+        int defaults = (int)FilterChipDefault.All;
+        if (leading  is not null) defaults &= ~(int)FilterChipDefault.LeadingIcon;
+        if (trailing is not null) defaults &= ~(int)FilterChipDefault.TrailingIcon;
+
+        ComposeBridges.FilterChip(_selected, click, label, leading, trailing, defaults, composer);
+    }
+}
+
+/// <summary>
+/// Material 3 <c>InputChip</c>. Adds an <see cref="Avatar"/> slot in
+/// addition to the leading/trailing slots common to the chip family.
+/// </summary>
+public sealed class InputChip : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public InputChip(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Required: chip text.</summary>
+    public ComposableNode? Label { get; set; }
+
+    public ComposableNode? LeadingIcon  { get; set; }
+    public ComposableNode? Avatar       { get; set; }
+    public ComposableNode? TrailingIcon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Label is null)
+            throw new System.InvalidOperationException(
+                "InputChip.Label is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var label = new ComposableLambda2(c => Label.Render(c));
+        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
+        ComposableLambda2? avatar   = Avatar       is null ? null : new ComposableLambda2(c => Avatar.Render(c));
+        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+
+        int defaults = (int)InputChipDefault.All;
+        if (leading  is not null) defaults &= ~(int)InputChipDefault.LeadingIcon;
+        if (avatar   is not null) defaults &= ~(int)InputChipDefault.Avatar;
+        if (trailing is not null) defaults &= ~(int)InputChipDefault.TrailingIcon;
+
+        ComposeBridges.InputChip(_selected, click, label, leading, avatar, trailing, defaults, composer);
+    }
+}
+
+/// <summary>
+/// Material 3 <c>SuggestionChip</c>. Single-icon variant — only an
+/// <see cref="Icon"/> slot is exposed (vs. AssistChip's leading + trailing).
+/// </summary>
+public sealed class SuggestionChip : ComposableNode
+{
+    readonly System.Action _onClick;
+    public SuggestionChip(System.Action onClick) => _onClick = onClick;
+
+    /// <summary>Required: chip text.</summary>
+    public ComposableNode? Label { get; set; }
+
+    /// <summary>Optional: leading slot.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Label is null)
+            throw new System.InvalidOperationException(
+                "SuggestionChip.Label is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var label = new ComposableLambda2(c => Label.Render(c));
+        ComposableLambda2? icon = Icon is null ? null : new ComposableLambda2(c => Icon.Render(c));
+
+        int defaults = (int)SuggestionChipDefault.All;
+        if (icon is not null) defaults &= ~(int)SuggestionChipDefault.Icon;
+
+        ComposeBridges.SuggestionChip(click, label, icon, defaults, composer);
+    }
+}
+
+// ---- NavigationBar / NavigationBarItem ----
+
+/// <summary>
+/// Material 3 <c>NavigationBar</c>. Container for
+/// <see cref="NavigationBarItem"/> children laid out horizontally:
+/// <code>
+/// new NavigationBar
+/// {
+///     new NavigationBarItem(selected: tab == 0, onClick: () =&gt; tab.Value = 0)
+///     {
+///         Icon = new Text("🏠"), Label = new Text("Home"),
+///     },
+///     new NavigationBarItem(selected: tab == 1, onClick: () =&gt; tab.Value = 1)
+///     {
+///         Icon = new Text("⚙"), Label = new Text("Settings"),
+///     },
+/// }
+/// </code>
+/// </summary>
+public sealed class NavigationBar : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        // Capture the RowScope receiver (p0 of the Function3) and publish
+        // it so child NavigationBarItems can pass it to their underlying
+        // RowScope-extension static.
+        var content = new ComposableLambda3((scope, c) =>
+        {
+            using var _ = RenderContext.PushScope(scope);
+            RenderChildren(c);
+        });
+        ComposeBridges.NavigationBar(content, composer);
+    }
+}
+
+/// <summary>
+/// Material 3 <c>NavigationBarItem</c>. Must be a child of
+/// <see cref="NavigationBar"/> — the Kotlin static method takes a
+/// <c>RowScope</c> extension receiver, which the parent
+/// <see cref="NavigationBar"/> publishes via <c>RenderContext</c>.
+/// <see cref="Icon"/> is required; <see cref="Label"/> is optional.
+/// </summary>
+public sealed class NavigationBarItem : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public NavigationBarItem(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Required: item icon.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    /// <summary>Optional: item label.</summary>
+    public ComposableNode? Label { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Icon is null)
+            throw new System.InvalidOperationException(
+                "NavigationBarItem.Icon is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var icon  = new ComposableLambda2(c => Icon.Render(c));
+        ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
+
+        int defaults = (int)NavigationBarItemDefault.All;
+        if (label is not null) defaults &= ~(int)NavigationBarItemDefault.Label;
+
+        ComposeBridges.NavigationBarItem(
+            rowScope: RenderContext.CurrentScope,
+            selected: _selected,
+            onClick:  click,
+            icon:     icon,
+            label:    label,
+            defaults: defaults,
+            composer: composer);
+    }
+}
+
+// ---- NavigationRail / NavigationRailItem ----
+
+/// <summary>
+/// Material 3 <c>NavigationRail</c>. Vertical analog of
+/// <see cref="NavigationBar"/>. Children are <see cref="NavigationRailItem"/>s:
+/// <code>
+/// new NavigationRail
+/// {
+///     new NavigationRailItem(selected: tab == 0, onClick: ...) { Icon = ..., Label = ... },
+///     new NavigationRailItem(selected: tab == 1, onClick: ...) { Icon = ..., Label = ... },
+/// }
+/// </code>
+/// </summary>
+public sealed class NavigationRail : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        // NavigationRailItem (unlike NavigationBarItem) is a top-level
+        // static, not a ColumnScope extension — so we don't need to
+        // publish the scope. Children can render directly.
+        var content = new ComposableLambda3(c => RenderChildren(c));
+        ComposeBridges.NavigationRail(content, composer);
+    }
+}
+
+/// <summary>
+/// Material 3 <c>NavigationRailItem</c>. Used inside
+/// <see cref="NavigationRail"/>.
+/// </summary>
+public sealed class NavigationRailItem : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public NavigationRailItem(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Required: item icon.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    /// <summary>Optional: item label.</summary>
+    public ComposableNode? Label { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Icon is null)
+            throw new System.InvalidOperationException(
+                "NavigationRailItem.Icon is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var icon  = new ComposableLambda2(c => Icon.Render(c));
+        ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
+
+        int defaults = (int)NavigationRailItemDefault.All;
+        if (label is not null) defaults &= ~(int)NavigationRailItemDefault.Label;
+
+        ComposeBridges.NavigationRailItem(_selected, click, icon, label, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -365,4 +365,414 @@ internal static class ComposeBridges
             JNIEnv.DeleteLocalRef(valueRef);
         }
     }
+
+    // androidx.compose.material3.CardKt.Card (non-clickable):
+    //   (modifier, shape, colors, elevation, border, content,
+    //    composer, $changed, $default)
+    // 6 user params, only bit 5 (content) provided.
+    const string CardSig =
+        "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/CardColors;Landroidx/compose/material3/CardElevation;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_cardClass;
+    static IntPtr s_cardMethod;
+
+    public static unsafe void Card(IFunction3 content, IComposer composer)
+    {
+        if (s_cardClass == IntPtr.Zero)
+        {
+            s_cardClass  = JNIEnv.FindClass("androidx/compose/material3/CardKt");
+            s_cardMethod = JNIEnv.GetStaticMethodID(s_cardClass, "Card", CardSig);
+        }
+
+        JValue* args = stackalloc JValue[9];
+        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[1] = new JValue(IntPtr.Zero); // shape
+        args[2] = new JValue(IntPtr.Zero); // colors
+        args[3] = new JValue(IntPtr.Zero); // elevation
+        args[4] = new JValue(IntPtr.Zero); // border
+        args[5] = new JValue(((Java.Lang.Object)content).Handle);
+        args[6] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[7] = new JValue(0);
+        args[8] = new JValue((int)CardDefault.All);
+        JNIEnv.CallStaticVoidMethod(s_cardClass, s_cardMethod, args);
+    }
+
+    // androidx.compose.material3.ChipKt.AssistChip:
+    //   (onClick, label, modifier, enabled, leadingIcon, trailingIcon,
+    //    shape, colors, elevation, border, interactionSource,
+    //    composer, $changed, $changed1, $default)
+    // 11 user params; bit 0 (onClick), bit 1 (label) always provided.
+    // bits 4 (leadingIcon) + 5 (trailingIcon) toggled per-call.
+    const string AssistChipSig =
+        "(Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/ChipColors;Landroidx/compose/material3/ChipElevation;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Landroidx/compose/runtime/Composer;III)V";
+
+    static IntPtr s_assistChipClass;
+    static IntPtr s_assistChipMethod;
+
+    public static unsafe void AssistChip(
+        IFunction0  onClick,
+        IFunction2  label,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_assistChipClass == IntPtr.Zero)
+        {
+            s_assistChipClass  = JNIEnv.FindClass("androidx/compose/material3/ChipKt");
+            s_assistChipMethod = JNIEnv.GetStaticMethodID(s_assistChipClass, "AssistChip", AssistChipSig);
+        }
+
+        JValue* args = stackalloc JValue[15];
+        args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[1]  = new JValue(((Java.Lang.Object)label).Handle);
+        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(true);        // enabled
+        args[4]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
+        args[5]  = new JValue(trailingIcon is null ? IntPtr.Zero : ((Java.Lang.Object)trailingIcon).Handle);
+        args[6]  = new JValue(IntPtr.Zero); // shape
+        args[7]  = new JValue(IntPtr.Zero); // colors
+        args[8]  = new JValue(IntPtr.Zero); // elevation
+        args[9]  = new JValue(IntPtr.Zero); // border
+        args[10] = new JValue(IntPtr.Zero); // interactionSource
+        args[11] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[12] = new JValue(0);           // $changed
+        args[13] = new JValue(0);           // $changed1
+        args[14] = new JValue(defaults);    // $default
+        JNIEnv.CallStaticVoidMethod(s_assistChipClass, s_assistChipMethod, args);
+    }
+
+    // androidx.compose.material3.ChipKt.FilterChip:
+    //   (selected, onClick, label, modifier, enabled, leadingIcon, trailingIcon,
+    //    shape, colors, elevation, border, interactionSource,
+    //    composer, $changed, $changed1, $default)
+    // 12 user params; bits 0 (selected), 1 (onClick), 2 (label) always provided.
+    const string FilterChipSig =
+        "(ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/SelectableChipColors;" +
+        "Landroidx/compose/material3/SelectableChipElevation;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Landroidx/compose/runtime/Composer;III)V";
+
+    static IntPtr s_filterChipClass;
+    static IntPtr s_filterChipMethod;
+
+    public static unsafe void FilterChip(
+        bool        selected,
+        IFunction0  onClick,
+        IFunction2  label,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_filterChipClass == IntPtr.Zero)
+        {
+            s_filterChipClass  = JNIEnv.FindClass("androidx/compose/material3/ChipKt");
+            s_filterChipMethod = JNIEnv.GetStaticMethodID(s_filterChipClass, "FilterChip", FilterChipSig);
+        }
+
+        JValue* args = stackalloc JValue[16];
+        args[0]  = new JValue(selected);
+        args[1]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[2]  = new JValue(((Java.Lang.Object)label).Handle);
+        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[4]  = new JValue(true);        // enabled
+        args[5]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
+        args[6]  = new JValue(trailingIcon is null ? IntPtr.Zero : ((Java.Lang.Object)trailingIcon).Handle);
+        args[7]  = new JValue(IntPtr.Zero); // shape
+        args[8]  = new JValue(IntPtr.Zero); // colors
+        args[9]  = new JValue(IntPtr.Zero); // elevation
+        args[10] = new JValue(IntPtr.Zero); // border
+        args[11] = new JValue(IntPtr.Zero); // interactionSource
+        args[12] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[13] = new JValue(0);
+        args[14] = new JValue(0);
+        args[15] = new JValue(defaults);
+        JNIEnv.CallStaticVoidMethod(s_filterChipClass, s_filterChipMethod, args);
+    }
+
+    // androidx.compose.material3.ChipKt.InputChip:
+    //   (selected, onClick, label, modifier, enabled, leadingIcon, avatar,
+    //    trailingIcon, shape, colors, elevation, border, interactionSource,
+    //    composer, $changed, $changed1, $default)
+    // 13 user params; bits 0/1/2 always provided.
+    const string InputChipSig =
+        "(ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/SelectableChipColors;" +
+        "Landroidx/compose/material3/SelectableChipElevation;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Landroidx/compose/runtime/Composer;III)V";
+
+    static IntPtr s_inputChipClass;
+    static IntPtr s_inputChipMethod;
+
+    public static unsafe void InputChip(
+        bool        selected,
+        IFunction0  onClick,
+        IFunction2  label,
+        IFunction2? leadingIcon,
+        IFunction2? avatar,
+        IFunction2? trailingIcon,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_inputChipClass == IntPtr.Zero)
+        {
+            s_inputChipClass  = JNIEnv.FindClass("androidx/compose/material3/ChipKt");
+            s_inputChipMethod = JNIEnv.GetStaticMethodID(s_inputChipClass, "InputChip", InputChipSig);
+        }
+
+        JValue* args = stackalloc JValue[17];
+        args[0]  = new JValue(selected);
+        args[1]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[2]  = new JValue(((Java.Lang.Object)label).Handle);
+        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[4]  = new JValue(true);        // enabled
+        args[5]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
+        args[6]  = new JValue(avatar       is null ? IntPtr.Zero : ((Java.Lang.Object)avatar).Handle);
+        args[7]  = new JValue(trailingIcon is null ? IntPtr.Zero : ((Java.Lang.Object)trailingIcon).Handle);
+        args[8]  = new JValue(IntPtr.Zero); // shape
+        args[9]  = new JValue(IntPtr.Zero); // colors
+        args[10] = new JValue(IntPtr.Zero); // elevation
+        args[11] = new JValue(IntPtr.Zero); // border
+        args[12] = new JValue(IntPtr.Zero); // interactionSource
+        args[13] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[14] = new JValue(0);
+        args[15] = new JValue(0);
+        args[16] = new JValue(defaults);
+        JNIEnv.CallStaticVoidMethod(s_inputChipClass, s_inputChipMethod, args);
+    }
+
+    // androidx.compose.material3.ChipKt.SuggestionChip:
+    //   (onClick, label, modifier, enabled, icon, shape, colors, elevation,
+    //    border, interactionSource, composer, $changed, $default)
+    // 10 user params; bits 0 (onClick), 1 (label) always provided.
+    const string SuggestionChipSig =
+        "(Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/ChipColors;Landroidx/compose/material3/ChipElevation;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_suggestionChipClass;
+    static IntPtr s_suggestionChipMethod;
+
+    public static unsafe void SuggestionChip(
+        IFunction0  onClick,
+        IFunction2  label,
+        IFunction2? icon,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_suggestionChipClass == IntPtr.Zero)
+        {
+            s_suggestionChipClass  = JNIEnv.FindClass("androidx/compose/material3/ChipKt");
+            s_suggestionChipMethod = JNIEnv.GetStaticMethodID(s_suggestionChipClass, "SuggestionChip", SuggestionChipSig);
+        }
+
+        JValue* args = stackalloc JValue[13];
+        args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[1]  = new JValue(((Java.Lang.Object)label).Handle);
+        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(true);        // enabled
+        args[4]  = new JValue(icon is null ? IntPtr.Zero : ((Java.Lang.Object)icon).Handle);
+        args[5]  = new JValue(IntPtr.Zero); // shape
+        args[6]  = new JValue(IntPtr.Zero); // colors
+        args[7]  = new JValue(IntPtr.Zero); // elevation
+        args[8]  = new JValue(IntPtr.Zero); // border
+        args[9]  = new JValue(IntPtr.Zero); // interactionSource
+        args[10] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[11] = new JValue(0);
+        args[12] = new JValue(defaults);
+        JNIEnv.CallStaticVoidMethod(s_suggestionChipClass, s_suggestionChipMethod, args);
+    }
+
+    // androidx.compose.material3.NavigationBarKt.NavigationBar-HsRjFd4:
+    //   (modifier, containerColor, contentColor, tonalElevation, windowInsets,
+    //    content, composer, $changed, $default)
+    // 6 user params; only bit 5 (content) provided.
+    const string NavigationBarSig =
+        "(Landroidx/compose/ui/Modifier;JJF" +
+        "Landroidx/compose/foundation/layout/WindowInsets;" +
+        "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_navBarClass;
+    static IntPtr s_navBarMethod;
+
+    public static unsafe void NavigationBar(IFunction3 content, IComposer composer)
+    {
+        if (s_navBarClass == IntPtr.Zero)
+        {
+            s_navBarClass  = JNIEnv.FindClass("androidx/compose/material3/NavigationBarKt");
+            s_navBarMethod = JNIEnv.GetStaticMethodID(s_navBarClass, "NavigationBar-HsRjFd4", NavigationBarSig);
+        }
+
+        JValue* args = stackalloc JValue[9];
+        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[1] = new JValue(0L);          // containerColor
+        args[2] = new JValue(0L);          // contentColor
+        args[3] = new JValue(0f);          // tonalElevation
+        args[4] = new JValue(IntPtr.Zero); // windowInsets
+        args[5] = new JValue(((Java.Lang.Object)content).Handle);
+        args[6] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[7] = new JValue(0);
+        args[8] = new JValue((int)NavigationBarDefault.All);
+        JNIEnv.CallStaticVoidMethod(s_navBarClass, s_navBarMethod, args);
+    }
+
+    // androidx.compose.material3.NavigationBarKt.NavigationBarItem:
+    //   (RowScope, selected, onClick, icon, modifier, enabled, label,
+    //    alwaysShowLabel, colors, interactionSource, composer, $changed, $default)
+    // RowScope is the Kotlin extension receiver (first param). 9 user params
+    // (after the receiver); bits 0 (selected), 1 (onClick), 2 (icon) provided.
+    const string NavigationBarItemSig =
+        "(Landroidx/compose/foundation/layout/RowScope;Z" +
+        "Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Lkotlin/jvm/functions/Function2;Z" +
+        "Landroidx/compose/material3/NavigationBarItemColors;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_navBarItemClass;
+    static IntPtr s_navBarItemMethod;
+
+    public static unsafe void NavigationBarItem(
+        IntPtr      rowScope,
+        bool        selected,
+        IFunction0  onClick,
+        IFunction2  icon,
+        IFunction2? label,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_navBarItemClass == IntPtr.Zero)
+        {
+            s_navBarItemClass  = JNIEnv.FindClass("androidx/compose/material3/NavigationBarKt");
+            s_navBarItemMethod = JNIEnv.GetStaticMethodID(s_navBarItemClass, "NavigationBarItem", NavigationBarItemSig);
+        }
+
+        if (rowScope == IntPtr.Zero)
+            throw new System.InvalidOperationException(
+                "NavigationBarItem must be a child of NavigationBar (no RowScope receiver in scope).");
+
+        JValue* args = stackalloc JValue[13];
+        args[0]  = new JValue(rowScope);
+        args[1]  = new JValue(selected);
+        args[2]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[3]  = new JValue(((Java.Lang.Object)icon).Handle);
+        args[4]  = new JValue(IntPtr.Zero); // modifier
+        args[5]  = new JValue(true);        // enabled
+        args[6]  = new JValue(label is null ? IntPtr.Zero : ((Java.Lang.Object)label).Handle);
+        args[7]  = new JValue(true);        // alwaysShowLabel
+        args[8]  = new JValue(IntPtr.Zero); // colors
+        args[9]  = new JValue(IntPtr.Zero); // interactionSource
+        args[10] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[11] = new JValue(0);
+        args[12] = new JValue(defaults);
+        JNIEnv.CallStaticVoidMethod(s_navBarItemClass, s_navBarItemMethod, args);
+    }
+
+    // androidx.compose.material3.NavigationRailKt.NavigationRail-qi6gXK8:
+    //   (modifier, containerColor, contentColor, header, windowInsets,
+    //    content, composer, $changed, $default)
+    // 6 user params; only bit 5 (content) provided. (`header` is a slot we
+    // don't surface — defaulted via bit 3.)
+    const string NavigationRailSig =
+        "(Landroidx/compose/ui/Modifier;JJ" +
+        "Lkotlin/jvm/functions/Function3;" +
+        "Landroidx/compose/foundation/layout/WindowInsets;" +
+        "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_navRailClass;
+    static IntPtr s_navRailMethod;
+
+    public static unsafe void NavigationRail(IFunction3 content, IComposer composer)
+    {
+        if (s_navRailClass == IntPtr.Zero)
+        {
+            s_navRailClass  = JNIEnv.FindClass("androidx/compose/material3/NavigationRailKt");
+            s_navRailMethod = JNIEnv.GetStaticMethodID(s_navRailClass, "NavigationRail-qi6gXK8", NavigationRailSig);
+        }
+
+        JValue* args = stackalloc JValue[9];
+        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[1] = new JValue(0L);          // containerColor
+        args[2] = new JValue(0L);          // contentColor
+        args[3] = new JValue(IntPtr.Zero); // header
+        args[4] = new JValue(IntPtr.Zero); // windowInsets
+        args[5] = new JValue(((Java.Lang.Object)content).Handle);
+        args[6] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[7] = new JValue(0);
+        args[8] = new JValue((int)NavigationRailDefault.All);
+        JNIEnv.CallStaticVoidMethod(s_navRailClass, s_navRailMethod, args);
+    }
+
+    // androidx.compose.material3.NavigationRailKt.NavigationRailItem:
+    //   (selected, onClick, icon, modifier, enabled, label, alwaysShowLabel,
+    //    colors, interactionSource, composer, $changed, $default)
+    // 9 user params (no scope receiver despite parent NavigationRail
+    // exposing a ColumnScope content lambda — NavigationRailItem is a
+    // top-level static, not a ColumnScope extension).
+    const string NavigationRailItemSig =
+        "(ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Lkotlin/jvm/functions/Function2;Z" +
+        "Landroidx/compose/material3/NavigationRailItemColors;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_navRailItemClass;
+    static IntPtr s_navRailItemMethod;
+
+    public static unsafe void NavigationRailItem(
+        bool        selected,
+        IFunction0  onClick,
+        IFunction2  icon,
+        IFunction2? label,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_navRailItemClass == IntPtr.Zero)
+        {
+            s_navRailItemClass  = JNIEnv.FindClass("androidx/compose/material3/NavigationRailKt");
+            s_navRailItemMethod = JNIEnv.GetStaticMethodID(s_navRailItemClass, "NavigationRailItem", NavigationRailItemSig);
+        }
+
+        JValue* args = stackalloc JValue[12];
+        args[0]  = new JValue(selected);
+        args[1]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[2]  = new JValue(((Java.Lang.Object)icon).Handle);
+        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[4]  = new JValue(true);        // enabled
+        args[5]  = new JValue(label is null ? IntPtr.Zero : ((Java.Lang.Object)label).Handle);
+        args[6]  = new JValue(true);        // alwaysShowLabel
+        args[7]  = new JValue(IntPtr.Zero); // colors
+        args[8]  = new JValue(IntPtr.Zero); // interactionSource
+        args[9]  = new JValue(((Java.Lang.Object)composer).Handle);
+        args[10] = new JValue(0);
+        args[11] = new JValue(defaults);
+        JNIEnv.CallStaticVoidMethod(s_navRailItemClass, s_navRailItemMethod, args);
+    }
 }

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -9,15 +9,17 @@
 // attribute below — the binder exposes those Kt classes, so the
 // generator can read parameter names off the longest overload.
 //
-// The other seven (Button, Text, IconButton, FloatingActionButton,
-// Surface, AlertDialog, TextField/OutlinedTextField) are *also*
-// generated, but from the declarative `[ComposeDefaults]` overload.
-// Their Kotlin overloads with the trailing $default param are stripped
-// from the binding (mangled JVM names like `Text--4IGK_g` from inline
-// classes such as `Color`/`TextUnit`/`Dp`), so there is no IMethodSymbol
-// for the generator to introspect — we hand it the Kotlin parameter
-// names instead. Names prefixed with `!` consume a bit position but
-// don't emit an enum member (e.g. params the caller always provides).
+// The other enums are *also* generated, but from the declarative
+// `[ComposeDefaults]` overload. Their Kotlin overloads with the trailing
+// $default param are stripped from the binding (mangled JVM names like
+// `Text--4IGK_g` from inline classes such as `Color`/`TextUnit`/`Dp`),
+// so there is no IMethodSymbol for the generator to introspect — we
+// hand it the Kotlin parameter names instead. Names prefixed with `!`
+// consume a bit position but don't emit an enum member (e.g. params
+// the caller always provides). For extension-receiver functions
+// (NavigationBarItem takes a RowScope receiver), the receiver is NOT
+// part of the $default bitmask — start the name list at the first
+// user-facing parameter.
 //
 // When dotnet/java-interop#1440 lands and exposes the inline-class
 // overloads, the declarative attributes can be replaced with
@@ -82,3 +84,63 @@ using ComposeNet;
     "keyboardOptions", "keyboardActions", "singleLine", "maxLines", "minLines",
     "interactionSource", "shape", "colors")]
 
+// androidx.compose.material3.CardKt.Card (non-clickable): 6 user params,
+// bit 5 = content provided.
+[assembly: ComposeDefaults("CardDefault",
+    "modifier", "shape", "colors", "elevation", "border", "!content")]
+
+// androidx.compose.material3.ChipKt.AssistChip: 11 user params,
+// bit 0 = onClick, bit 1 = label (both always provided).
+// Optional slot bits 4 (LeadingIcon) and 5 (TrailingIcon) are toggled
+// per-call by AssistChip.Render.
+[assembly: ComposeDefaults("AssistChipDefault",
+    "!onClick", "!label", "modifier", "enabled", "leadingIcon", "trailingIcon",
+    "shape", "colors", "elevation", "border", "interactionSource")]
+
+// androidx.compose.material3.ChipKt.FilterChip: 12 user params,
+// bits 0 = selected, 1 = onClick, 2 = label (all always provided).
+[assembly: ComposeDefaults("FilterChipDefault",
+    "!selected", "!onClick", "!label", "modifier", "enabled",
+    "leadingIcon", "trailingIcon", "shape", "colors", "elevation",
+    "border", "interactionSource")]
+
+// androidx.compose.material3.ChipKt.InputChip: 13 user params,
+// bits 0 = selected, 1 = onClick, 2 = label (all always provided).
+[assembly: ComposeDefaults("InputChipDefault",
+    "!selected", "!onClick", "!label", "modifier", "enabled",
+    "leadingIcon", "avatar", "trailingIcon", "shape", "colors",
+    "elevation", "border", "interactionSource")]
+
+// androidx.compose.material3.ChipKt.SuggestionChip: 10 user params,
+// bit 0 = onClick, bit 1 = label (both always provided).
+[assembly: ComposeDefaults("SuggestionChipDefault",
+    "!onClick", "!label", "modifier", "enabled", "icon",
+    "shape", "colors", "elevation", "border", "interactionSource")]
+
+// androidx.compose.material3.NavigationBarKt.NavigationBar-HsRjFd4:
+// 6 user params, bit 5 = content provided.
+[assembly: ComposeDefaults("NavigationBarDefault",
+    "modifier", "containerColor", "contentColor", "tonalElevation",
+    "windowInsets", "!content")]
+
+// androidx.compose.material3.NavigationBarKt.NavigationBarItem: 9 user
+// params after the RowScope receiver (the receiver is not part of the
+// $default bitmask). Bits 0 = selected, 1 = onClick, 2 = icon (all
+// always provided). The optional Label slot is toggled by
+// NavigationBarItem.Render.
+[assembly: ComposeDefaults("NavigationBarItemDefault",
+    "!selected", "!onClick", "!icon", "modifier", "enabled", "label",
+    "alwaysShowLabel", "colors", "interactionSource")]
+
+// androidx.compose.material3.NavigationRailKt.NavigationRail-qi6gXK8:
+// 6 user params, bit 5 = content provided.
+[assembly: ComposeDefaults("NavigationRailDefault",
+    "modifier", "containerColor", "contentColor", "header",
+    "windowInsets", "!content")]
+
+// androidx.compose.material3.NavigationRailKt.NavigationRailItem:
+// 9 user params; bits 0 = selected, 1 = onClick, 2 = icon
+// (all always provided).
+[assembly: ComposeDefaults("NavigationRailItemDefault",
+    "!selected", "!onClick", "!icon", "modifier", "enabled", "label",
+    "alwaysShowLabel", "colors", "interactionSource")]

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -14,6 +14,8 @@ public class MainActivity : ComposeActivity
             var count    = Remember(() => new MutableNumberState<int>(0));
             var name     = Remember(() => new MutableState<string>(""));
             var showDlg  = Remember(() => new MutableState<bool>(false));
+            var liked    = Remember(() => new MutableState<bool>(false));
+            var tab      = Remember(() => new MutableNumberState<int>(0));
             return new MaterialTheme
             {
                 new Surface
@@ -32,6 +34,36 @@ public class MainActivity : ComposeActivity
                         },
                         new OutlinedTextField(name),
                         new Text($"Hi {(string.IsNullOrEmpty(name.Value) ? "stranger" : name.Value)}"),
+                        new Card
+                        {
+                            new Text("Inside a Card"),
+                            new Text($"Counter snapshot: {count}"),
+                        },
+                        new AssistChip(onClick: () => count++)
+                        {
+                            Label = new Text("Assist (+1)"),
+                        },
+                        new FilterChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value)
+                        {
+                            Label = new Text(liked.Value ? "Liked" : "Like"),
+                        },
+                        new SuggestionChip(onClick: () => count.Value = 0)
+                        {
+                            Label = new Text("Reset"),
+                        },
+                        new NavigationBar
+                        {
+                            new NavigationBarItem(selected: tab.Value == 0, onClick: () => tab.Value = 0)
+                            {
+                                Icon  = new Text("🏠"),
+                                Label = new Text("Home"),
+                            },
+                            new NavigationBarItem(selected: tab.Value == 1, onClick: () => tab.Value = 1)
+                            {
+                                Icon  = new Text("⚙"),
+                                Label = new Text("Settings"),
+                            },
+                        },
                         new FloatingActionButton(onClick: () => showDlg.Value = true)
                         {
                             new Text("✕"),


### PR DESCRIPTION
Adds JNI bridges + tree-style facade for the next batch of Material 3 composables stripped from `Xamarin.AndroidX.Compose.Material3Android` 1.4.0.3.

Closes part of #2.

## Composables landed

| Composable | JVM target | Notes |
|------------|-----------|-------|
| `Card` (non-clickable) | `CardKt.Card` (no mangle) | `ColumnScope` `Function3` content via collection-init |
| `AssistChip` | `ChipKt.AssistChip` | `Label` required; `LeadingIcon`/`TrailingIcon` optional slots |
| `FilterChip` | `ChipKt.FilterChip` | + `selected` bool ctor param |
| `InputChip`  | `ChipKt.InputChip`  | + `Avatar` slot |
| `SuggestionChip` | `ChipKt.SuggestionChip` | single `Icon` slot |
| `NavigationBar` + `NavigationBarItem` | `NavigationBarKt.NavigationBar-HsRjFd4` / `NavigationBarItem` | RowScope receiver threaded via `RenderContext` |
| `NavigationRail` + `NavigationRailItem` | `NavigationRailKt.NavigationRail-qi6gXK8` / `NavigationRailItem` | RailItem is top-level static, no scope plumbing |

## Scope-receiver plumbing

`NavigationBarItem` is a Kotlin `RowScope` extension static — the JVM signature begins with `Landroidx/compose/foundation/layout/RowScope;`. The receiver only exists inside the parent `NavigationBar`'s content `Function3` (`p0` of the lambda). To pass it down to children:

* `ComposableLambda3` grew a second ctor `Action<IntPtr scope, IComposer>` that captures `p0?.Handle` and hands it to the body. The original `Action<IComposer>` ctor is preserved (delegates to the new one, discarding scope) so existing callers (`Column`, `Box`, `Button`, `Card`) need no change.
* `RenderContext` is a `[ThreadStatic]` stash with a struct-disposable push/pop guard. `NavigationBar.Render` pushes the scope before `RenderChildren`; `NavigationBarItem.Render` reads `RenderContext.CurrentScope` and passes it as the first JNI arg.

`NavigationRailItem` does **not** take an extension receiver in the bytecode (despite `NavigationRail` exposing a `ColumnScope` content `Function3`), so it renders directly without consulting `RenderContext`.

## Defaults bookkeeping

Each new bridge gets a `*Default` `[Flags]` enum **generated** by `ComposeNet.SourceGenerators` from a declarative `[assembly: ComposeDefaults("Name", "param1", "!param2", ...)]` attribute in `ComposeDefaults.cs` (the new pattern from #8). The `!` prefix consumes a bit but emits no enum member — used for params the caller always provides (`!onClick`, `!label`, `!selected`, `!content`, `!icon`).

For optional slots (`LeadingIcon`, `TrailingIcon`, `Avatar`, `Icon`, `Label`), the bits stay as enum members — bridges start with `All` and clear them per-call when the user supplies the slot, same pattern as `AlertDialog`.

## Sample

`MainActivity.cs` exercises:

* a `Card` containing a counter snapshot,
* an `AssistChip` (+1), `FilterChip` (toggles its own label), `SuggestionChip` (resets counter),
* a `NavigationBar` with two `NavigationBarItem`s flipping a `MutableNumberState<int>` tab.

Build verified with `dotnet build src/ComposeNet.Sample`. Source-generator tests pass (10/10). Deployed to an emulator and confirmed all controls render correctly.

## Deferred to follow-ups (still part of #2)

State-bearing composables that need new infrastructure (calling `rememberDrawerState` / `rememberCarouselState` from inside `Render` and exposing the resulting `DrawerState` / `CarouselState` to user code):

* `ModalNavigationDrawer` / `DismissibleNavigationDrawer` / `PermanentNavigationDrawer` (need `DrawerState` + `rememberDrawerState`)
* `HorizontalUncontainedCarousel` / `HorizontalMultiBrowseCarousel` (need `CarouselState` + `rememberCarouselState` + a new `Function4` lambda for the `CarouselItemScope` extension content)