### PR TITLE
Replace MutableIntState with generic MutableNumberState<T>

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -354,8 +354,8 @@ src/
     ComposableLambdas.cs                      [Register]'d ACW adapters
                                                 (ComposableLambda0 / 2 / 3).
     ComposeBridges.cs                         Raw-JNI bridges to Material3 Text / Button.
-    MutableState.cs                           MutableState<T> + MutableIntState
-                                                (with implicit int + operator ++/--).
+    MutableState.cs                           MutableState<T> + MutableNumberState<T>
+                                                (with operator ++/-- via INumber&lt;T&gt;).
     ComposeActivity.cs                        ComponentActivity base providing SetContent +
                                                 Remember + safe-area padding + light status bar.
   ComposeNet.Bindings.Runtime/                Binds androidx.compose.runtime 1.9.4
@@ -440,7 +440,7 @@ The exception is real subcomposition (`SubcomposeLayout`, `MovableContent`)
 which *do* hand you a different composer — those would need an
 explicit-composer overload. Tier 2 problem.
 
-### 8. `MutableIntState` with `implicit operator int` + `operator ++/--` is the killer feature for Kotlin parity
+### 8. `MutableNumberState<T>` with `operator ++/--` is the killer feature for Kotlin parity
 
 The Kotlin idiom is:
 
@@ -451,24 +451,37 @@ Button(onClick = { count++ }) { ... }
 ```
 
 C# can't do `by` (delegated properties) or trailing lambdas, but
-**operator overloading** carries enough of the load:
+**operator overloading** plus a sensible `ToString()` carries enough
+of the load:
 
 ```csharp
-public sealed class MutableIntState : MutableState<int>
+public class MutableState<T>
 {
-    public static implicit operator int(MutableIntState s) => s.Value;
-    public static MutableIntState operator ++(MutableIntState s) { s.Value++; return s; }
-    public override string ToString() => Value.ToString();
+    public override string ToString() => Value?.ToString() ?? string.Empty;
+    // ...
+}
+
+public class MutableNumberState<T> : MutableState<T> where T : INumber<T>
+{
+    public static MutableNumberState<T> operator ++(MutableNumberState<T> s) { s.Value++; return s; }
+    public static MutableNumberState<T> operator --(MutableNumberState<T> s) { s.Value--; return s; }
 }
 ```
 
 Result:
-- `$"Count: {count}"` interpolates via implicit `int`
-- `count++` mutates via overloaded operator
-- `count.Value` is still available for explicit `set` (e.g. `count.Value = 42`)
+- `$"Count: {count}"` interpolates via the base `ToString()` override
+- `count++` mutates via the overloaded operator (works for any
+  `INumber<T>` — `int`, `long`, `float`, `double`, …)
+- `count.Value` is still available for explicit `set` (e.g.
+  `count.Value = 42`)
 
-This single class single-handedly closes the largest readability gap
-between Kotlin Compose state usage and C# Compose state usage.
+C# *cannot* express `implicit operator T` on `MutableState<T>` (CS0553
+forbids user-defined conversions involving an enclosing type's own
+type parameter), but the `ToString()` route is good enough — string
+interpolation and `Text(...)` callsites both go through it. The only
+thing you give up vs. a hand-rolled `MutableIntState` is using `count`
+directly in arithmetic without `.Value`, which is rare in idiomatic
+Compose code.
 
 ### 9. `[CallerLineNumber]` is a usable shim for `remember`
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -470,8 +470,13 @@ public class MutableNumberState<T> : MutableState<T> where T : INumber<T>
 
 Result:
 - `$"Count: {count}"` interpolates via the base `ToString()` override
-- `count++` mutates via the overloaded operator (works for any
-  `INumber<T>` — `int`, `long`, `float`, `double`, …)
+  (which renders `null` as the literal `"null"`, matching Kotlin)
+- `count++` mutates via the overloaded operator. The class is
+  constrained to `INumber<T>`, but `MutableState<T>` only boxes the
+  built-in numeric primitives
+  (`sbyte`/`byte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`);
+  `decimal`, `Half`, `BigInteger`, `nint`, and `nuint` compile but
+  throw at construction since they have no clean Java box.
 - `count.Value` is still available for explicit `set` (e.g.
   `count.Value = 42`)
 
@@ -479,7 +484,7 @@ C# *cannot* express `implicit operator T` on `MutableState<T>` (CS0553
 forbids user-defined conversions involving an enclosing type's own
 type parameter), but the `ToString()` route is good enough — string
 interpolation and `Text(...)` callsites both go through it. The only
-thing you give up vs. a hand-rolled `MutableIntState` is using `count`
+thing you give up vs. an int-only specialization is using `count`
 directly in arithmetic without `.Value`, which is rare in idiomatic
 Compose code.
 

--- a/README.md
+++ b/README.md
@@ -339,8 +339,11 @@ directly. So the Kotlin idiom `var count by remember {
 mutableStateOf(0) } ; count++` becomes
 `var count = Remember(() => new MutableNumberState<int>(0)) ; count++` —
 character-for-character equivalent after substituting Kotlin keywords
-for C# ones, and it generalizes to `long`, `float`, `double`, … for
-free.
+for C# ones. It works for any built-in numeric primitive
+(`sbyte`/`byte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`).
+Other `INumber<T>` implementations (`decimal`, `Half`, `BigInteger`,
+`nint`, `nuint`) compile but throw at construction since they have no
+clean Java box.
 
 ### The `$default` bitmask source generator
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ public class MainActivity : ComposeActivity
         base.OnCreate(savedInstanceState);
         SetContent(() =>
         {
-            var count = Remember(() => new MutableIntState(0));
+            var count = Remember(() => new MutableNumberState<int>(0));
             return new MaterialTheme
             {
                 new Column
@@ -311,9 +311,9 @@ That's the *entire* [`MainActivity.cs`](src/ComposeNet.Sample/MainActivity.cs).
 | `Column { … }`                         | `new Column { … }` (collection-initializer)         |
 | `Button(onClick = { x++ }) { … }`      | `new Button(onClick: () => x++) { … }`              |
 | `MaterialTheme { … }`                  | `new MaterialTheme { … }`                           |
-| `var count by remember { mutableStateOf(0) }` | `var count = Remember(() => new MutableIntState(0))` |
-| `count++`                              | `count++` (operator on `MutableIntState`)           |
-| `"Count: $count"`                      | `$"Count: {count}"` (implicit `int` conversion)     |
+| `var count by remember { mutableStateOf(0) }` | `var count = Remember(() => new MutableNumberState<int>(0))` |
+| `count++`                              | `count++` (operator on `MutableNumberState<T>`)     |
+| `"Count: $count"`                      | `$"Count: {count}"` (via `MutableState<T>.ToString`)|
 
 ### How the facade works
 
@@ -331,14 +331,16 @@ Inside each container's `Render`, the existing raw-JNI bridges (`Text`,
 `Button`, `Column`, `MaterialTheme`) call the Kotlin-mangled Compose
 functions with their `$default` bitmasks. The user never sees that.
 
-`MutableIntState` is the killer feature for Kotlin parity — `implicit
-operator int` lets `$"Count: {count}"` interpolate without `.Value`,
-and `operator ++/--` lets `count++` mutate the underlying
-`IMutableState` directly. So the Kotlin idiom `var count by remember {
+`MutableNumberState<T>` is the killer feature for Kotlin parity —
+`MutableState<T>.ToString()` lets `$"Count: {count}"` interpolate
+without `.Value`, and `operator ++/--` (constrained to
+`INumber<T>`) lets `count++` mutate the underlying `IMutableState`
+directly. So the Kotlin idiom `var count by remember {
 mutableStateOf(0) } ; count++` becomes
-`var count = Remember(() => new MutableIntState(0)) ; count++` —
+`var count = Remember(() => new MutableNumberState<int>(0)) ; count++` —
 character-for-character equivalent after substituting Kotlin keywords
-for C# ones.
+for C# ones, and it generalizes to `long`, `float`, `double`, … for
+free.
 
 ### The `$default` bitmask source generator
 

--- a/src/ComposeNet.Compose/ComposeActivity.cs
+++ b/src/ComposeNet.Compose/ComposeActivity.cs
@@ -19,7 +19,7 @@ namespace ComposeNet;
 /// {
 ///     base.OnCreate(state);
 ///     SetContent(() => {
-///         var count = Remember(() => new MutableIntState(0));
+///         var count = Remember(() => new MutableNumberState&lt;int&gt;(0));
 ///         return new MaterialTheme {
 ///             new Column {
 ///                 new Text($"Count: {count}"),
@@ -48,7 +48,7 @@ public abstract class ComposeActivity : ComponentActivity
     /// Returns the value of <paramref name="factory"/> the first time
     /// this call-site is reached, then the cached value on subsequent
     /// recompositions. Use to create <see cref="MutableState{T}"/> /
-    /// <see cref="MutableIntState"/> instances at the top of a
+    /// <see cref="MutableNumberState{T}"/> instances at the top of a
     /// <see cref="SetContent"/> lambda.
     /// </summary>
     protected T Remember<T>(System.Func<T> factory, [CallerLineNumber] int key = 0)

--- a/src/ComposeNet.Compose/MutableState.cs
+++ b/src/ComposeNet.Compose/MutableState.cs
@@ -27,35 +27,50 @@ public class MutableState<T>
 
     /// <summary>
     /// Returns the underlying value's string representation so
-    /// <c>$"...{state}..."</c> interpolation reads as Kotlin would.
+    /// <c>$"...{state}..."</c> interpolation reads as Kotlin would
+    /// (a null value renders as <c>"null"</c>).
     /// </summary>
-    public override string ToString() => Value?.ToString() ?? string.Empty;
+    public override string ToString() => Value?.ToString() ?? "null";
 
     static Java.Lang.Object? ToJava(T value) => value switch
     {
         null                  => null,
         Java.Lang.Object o    => o,
         string s              => new Java.Lang.String(s),
-        int i                 => Java.Lang.Integer.ValueOf(i),
-        long l                => Java.Lang.Long.ValueOf(l),
         bool b                => Java.Lang.Boolean.ValueOf(b),
-        double d              => Java.Lang.Double.ValueOf(d),
+        char c                => Java.Lang.Character.ValueOf(c),
+        sbyte sb              => Java.Lang.Byte.ValueOf(sb),
+        byte by               => Java.Lang.Short.ValueOf((short)by),                  // widen 8u -> 16s
+        short sh              => Java.Lang.Short.ValueOf(sh),
+        ushort us             => Java.Lang.Integer.ValueOf(us),                       // widen 16u -> 32s
+        int i                 => Java.Lang.Integer.ValueOf(i),
+        uint ui               => Java.Lang.Long.ValueOf(ui),                          // widen 32u -> 64s
+        long l                => Java.Lang.Long.ValueOf(l),
+        ulong ul              => Java.Lang.Long.ValueOf(unchecked((long)ul)),         // bit-exact round-trip
         float f               => Java.Lang.Float.ValueOf(f),
+        double d              => Java.Lang.Double.ValueOf(d),
         _                     => throw new System.NotSupportedException(
-                                    $"MutableState<{typeof(T).Name}>: provide a Java.Lang.Object-derived T or use a primitive overload.")
+                                    $"MutableState<{typeof(T).Name}>: T must be a Java.Lang.Object subclass, string, bool, char, or a built-in numeric primitive (sbyte/byte/short/ushort/int/uint/long/ulong/float/double). Types like decimal, Half, BigInteger, and IntPtr have no clean Java box and are not supported.")
     };
 
     static T FromJava(Java.Lang.Object? value)
     {
         if (value is null) return default!;
         if (value is T t) return t;
-        // common boxed-primitive unwraps
-        if (typeof(T) == typeof(int))    return (T)(object)((Java.Lang.Integer)value).IntValue();
-        if (typeof(T) == typeof(long))   return (T)(object)((Java.Lang.Long)value).LongValue();
-        if (typeof(T) == typeof(bool))   return (T)(object)((Java.Lang.Boolean)value).BooleanValue();
-        if (typeof(T) == typeof(double)) return (T)(object)((Java.Lang.Double)value).DoubleValue();
-        if (typeof(T) == typeof(float))  return (T)(object)((Java.Lang.Float)value).FloatValue();
-        if (typeof(T) == typeof(string)) return (T)(object)value.ToString()!;
+        var type = typeof(T);
+        if (type == typeof(string))  return (T)(object)value.ToString()!;
+        if (type == typeof(bool))    return (T)(object)((Java.Lang.Boolean)value).BooleanValue();
+        if (type == typeof(char))    return (T)(object)((Java.Lang.Character)value).CharValue();
+        if (type == typeof(sbyte))   return (T)(object)((Java.Lang.Byte)value).ByteValue();
+        if (type == typeof(byte))    return (T)(object)(byte)((Java.Lang.Short)value).ShortValue();
+        if (type == typeof(short))   return (T)(object)((Java.Lang.Short)value).ShortValue();
+        if (type == typeof(ushort))  return (T)(object)(ushort)((Java.Lang.Integer)value).IntValue();
+        if (type == typeof(int))     return (T)(object)((Java.Lang.Integer)value).IntValue();
+        if (type == typeof(uint))    return (T)(object)(uint)((Java.Lang.Long)value).LongValue();
+        if (type == typeof(long))    return (T)(object)((Java.Lang.Long)value).LongValue();
+        if (type == typeof(ulong))   return (T)(object)unchecked((ulong)((Java.Lang.Long)value).LongValue());
+        if (type == typeof(float))   return (T)(object)((Java.Lang.Float)value).FloatValue();
+        if (type == typeof(double))  return (T)(object)((Java.Lang.Double)value).DoubleValue();
         throw new System.NotSupportedException(
             $"MutableState<{typeof(T).Name}>: don't know how to unwrap {value.GetType().Name}");
     }
@@ -69,8 +84,14 @@ public class MutableState<T>
 /// count++;                  // mutates the underlying value
 /// Text($"Count: {count}");  // ToString() forwards to Value
 /// </code>
-/// Works for any <see cref="INumber{TSelf}"/> — <c>int</c>, <c>long</c>,
-/// <c>float</c>, <c>double</c>, etc.
+/// The class constraint is <see cref="INumber{TSelf}"/>, but <typeparamref name="T"/>
+/// must also be a built-in numeric primitive that <see cref="MutableState{T}"/>
+/// knows how to box for the JVM: <c>sbyte</c>, <c>byte</c>, <c>short</c>,
+/// <c>ushort</c>, <c>int</c>, <c>uint</c>, <c>long</c>, <c>ulong</c>,
+/// <c>float</c>, or <c>double</c>. Other <see cref="INumber{TSelf}"/>
+/// implementations (<c>decimal</c>, <c>Half</c>, <c>BigInteger</c>,
+/// <c>nint</c>, <c>nuint</c>) compile but throw at construction because
+/// they have no clean Java box.
 /// </summary>
 public class MutableNumberState<T> : MutableState<T> where T : INumber<T>
 {

--- a/src/ComposeNet.Compose/MutableState.cs
+++ b/src/ComposeNet.Compose/MutableState.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using AndroidX.Compose.Runtime;
 
 namespace ComposeNet;
@@ -23,6 +24,12 @@ public class MutableState<T>
         get => FromJava(_state.Value);
         set => _state.Value = ToJava(value);
     }
+
+    /// <summary>
+    /// Returns the underlying value's string representation so
+    /// <c>$"...{state}..."</c> interpolation reads as Kotlin would.
+    /// </summary>
+    public override string ToString() => Value?.ToString() ?? string.Empty;
 
     static Java.Lang.Object? ToJava(T value) => value switch
     {
@@ -55,22 +62,20 @@ public class MutableState<T>
 }
 
 /// <summary>
-/// Int-specialized mutable state. Adds <c>implicit operator int</c> and
-/// <c>operator ++/--</c> so user code reads almost identically to Kotlin:
+/// Numeric-specialized mutable state. Adds <c>operator ++/--</c> so user
+/// code reads almost identically to Kotlin:
 /// <code>
-/// var count = Remember(() => new MutableIntState(0));
-/// count++;                  // mutates
-/// Text($"Count: {count}");  // implicitly converts to int
+/// var count = Remember(() => new MutableNumberState&lt;int&gt;(0));
+/// count++;                  // mutates the underlying value
+/// Text($"Count: {count}");  // ToString() forwards to Value
 /// </code>
+/// Works for any <see cref="INumber{TSelf}"/> — <c>int</c>, <c>long</c>,
+/// <c>float</c>, <c>double</c>, etc.
 /// </summary>
-public sealed class MutableIntState : MutableState<int>
+public class MutableNumberState<T> : MutableState<T> where T : INumber<T>
 {
-    public MutableIntState(int initial) : base(initial) { }
+    public MutableNumberState(T initial) : base(initial) { }
 
-    public static implicit operator int(MutableIntState s) => s.Value;
-
-    public static MutableIntState operator ++(MutableIntState s) { s.Value++; return s; }
-    public static MutableIntState operator --(MutableIntState s) { s.Value--; return s; }
-
-    public override string ToString() => Value.ToString();
+    public static MutableNumberState<T> operator ++(MutableNumberState<T> s) { s.Value++; return s; }
+    public static MutableNumberState<T> operator --(MutableNumberState<T> s) { s.Value--; return s; }
 }

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -11,7 +11,7 @@ public class MainActivity : ComposeActivity
         base.OnCreate(savedInstanceState);
         SetContent(() =>
         {
-            var count    = Remember(() => new MutableIntState(0));
+            var count    = Remember(() => new MutableNumberState<int>(0));
             var name     = Remember(() => new MutableState<string>(""));
             var showDlg  = Remember(() => new MutableState<bool>(false));
             return new MaterialTheme


### PR DESCRIPTION
`MutableIntState` was a sealed `int`-only subclass that provided two ergonomics on top of `MutableState<T>`: an `implicit operator int` so `$"Count: {count}"` interpolated cleanly, and `operator ++/--` so `count++` mutated the underlying `IMutableState`. With C#'s `INumber<T>` static abstracts we can lift the operator half onto a generic class, and the implicit conversion turns out to be unnecessary as long as `MutableState<T>.ToString()` forwards to `Value`.

## Approach

- `MutableState<T>` gets a `ToString()` override returning `Value?.ToString() ?? "null"` (null renders as the literal `"null"` to match Kotlin string-interpolation semantics). String interpolation and `Text(...)` already go through `ToString()`, so the implicit `int` conversion was only ever pulling its weight in arithmetic contexts (rare in idiomatic Compose code).
- New `MutableNumberState<T> : MutableState<T> where T : INumber<T>` carries `operator ++/--`. Works for every built-in numeric primitive: `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `float`, `double`.
- `MutableState<T>.ToJava` / `FromJava` extended to box all of those plus `char`. Unsigned types widen cleanly (`byte` -> Java `Short`, `ushort` -> `Integer`, `uint` -> `Long`); `ulong` round-trips bit-exactly via `unchecked`.
- `MutableIntState` is deleted. The sample's `new MutableIntState(0)` becomes `new MutableNumberState<int>(0)`; everything else (`count++`, `count--`, `count.Value = 0`, `$"Count: {count}"`) compiles and runs unchanged.

## Why not put the operators directly on `MutableState<T>`?

The class is intentionally unconstrained so it can hold `string`, `bool`, `Java.Lang.Object` subclasses, etc. Adding `++`/`--` requires `where T : INumber<T>`, which would break those uses. A constrained subclass is the only clean option.

## Why not also lift the implicit `int` conversion?

C# CS0553 forbids a user-defined conversion between a generic type and one of its own type parameters, so `implicit operator T(MutableState<T>)` won't compile. The `ToString()` route covers every interpolation/`Text(...)` callsite in practice, and `count.Value` is still available for the rare arithmetic case.

## Known gap: `INumber<T>` is wider than the JVM boxing

The class constraint admits a few `INumber<T>` implementations that have no clean Java box: `decimal`, `Half`, `BigInteger`, `nint`, `nuint`. These compile but throw `NotSupportedException` at construction. The `MutableNumberState<T>` XML doc and the exception message both spell this out.

## Verification

- `dotnet build src/ComposeNet.Compose` clean.
- `dotnet build src/ComposeNet.Sample -t:Run` deploys and the sample runs on-device (`ComposeActivity content set` in logcat, no `AndroidRuntime` errors).
- Updated `README.md` comparison table and `NOTES.md` §8 to match the new API.