### PR TITLE
Add GC.KeepAlive to ComposeBridges JNI calls

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,6 +122,33 @@ Pattern, copied throughout the file:
    `try`/`finally` that calls `DeleteLocalRef`.
 6. Pass managed objects as `((Java.Lang.Object)obj).Handle`. Use
    `IntPtr.Zero` for `null`.
+7. **Always wrap `JNIEnv.CallStatic*Method` in `try { … } finally { … }`
+   and call `GC.KeepAlive(...)` on every managed parameter whose
+   `.Handle` was read into a `JValue` (lambdas, the composer, optional
+   slot wrappers — `null` is a no-op so unconditional `KeepAlive` on
+   nullable params is fine).** This matches what
+   `dotnet/java-interop` generates for bound members. Without it, the
+   JIT considers each managed wrapper dead the instant `.Handle` is
+   read, and a GC during the JNI call can finalize the wrapper and
+   invalidate the underlying handle. Combine with the `DeleteLocalRef`
+   `finally` for string args — one `try`/`finally` doing both is the
+   normal shape.
+
+Pattern:
+```csharp
+JValue* args = stackalloc JValue[N];
+// fill args ...
+try
+{
+    JNIEnv.CallStaticVoidMethod(s_cls, s_method, args);
+}
+finally
+{
+    GC.KeepAlive(onClick);
+    GC.KeepAlive(content);
+    GC.KeepAlive(composer);
+}
+```
 
 Keep these methods `internal` — user code never touches JNI directly.
 **Do not add new JNI bridges if the binding already exposes the

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -70,6 +70,7 @@ internal static class ComposeBridges
         finally
         {
             JNIEnv.DeleteLocalRef(textRef);
+            GC.KeepAlive(composer);
         }
     }
 
@@ -112,7 +113,16 @@ internal static class ComposeBridges
         args[10] = new JValue(((Java.Lang.Object)composer).Handle);
         args[11] = new JValue(0);
         args[12] = new JValue(defaults);
-        JNIEnv.CallStaticVoidMethod(s_buttonClass, s_buttonMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_buttonClass, s_buttonMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.IconButtonKt.IconButton(onClick, modifier,
@@ -144,7 +154,16 @@ internal static class ComposeBridges
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
         args[8] = new JValue((int)IconButtonDefault.All);
-        JNIEnv.CallStaticVoidMethod(s_iconButtonClass, s_iconButtonMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_iconButtonClass, s_iconButtonMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.FloatingActionButtonKt.FloatingActionButton-X-z6DiA(
@@ -180,7 +199,16 @@ internal static class ComposeBridges
         args[8]  = new JValue(((Java.Lang.Object)composer).Handle);
         args[9]  = new JValue(0);
         args[10] = new JValue((int)FloatingActionButtonDefault.All);
-        JNIEnv.CallStaticVoidMethod(s_fabClass, s_fabMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_fabClass, s_fabMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.SurfaceKt.Surface-T9BRK9s (non-interactive):
@@ -214,7 +242,15 @@ internal static class ComposeBridges
         args[8]  = new JValue(((Java.Lang.Object)composer).Handle);
         args[9]  = new JValue(0);
         args[10] = new JValue((int)SurfaceDefault.All);
-        JNIEnv.CallStaticVoidMethod(s_surfaceClass, s_surfaceMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_surfaceClass, s_surfaceMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.TextFieldKt.TextField (String overload):
@@ -321,7 +357,20 @@ internal static class ComposeBridges
         args[15] = new JValue(0);           // $changed
         args[16] = new JValue(0);           // $changed1
         args[17] = new JValue(defaults);    // $default
-        JNIEnv.CallStaticVoidMethod(s_alertDialogClass, s_alertDialogMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_alertDialogClass, s_alertDialogMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onDismissRequest);
+            GC.KeepAlive(confirmButton);
+            GC.KeepAlive(dismissButton);
+            GC.KeepAlive(icon);
+            GC.KeepAlive(title);
+            GC.KeepAlive(text);
+            GC.KeepAlive(composer);
+        }
     }
 
     static unsafe void InvokeTextField(IntPtr cls, IntPtr method, string value, IFunction1 onValueChange, IComposer composer, int defaults)
@@ -363,6 +412,8 @@ internal static class ComposeBridges
         finally
         {
             JNIEnv.DeleteLocalRef(valueRef);
+            GC.KeepAlive(onValueChange);
+            GC.KeepAlive(composer);
         }
     }
 
@@ -397,7 +448,15 @@ internal static class ComposeBridges
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
         args[8] = new JValue((int)CardDefault.All);
-        JNIEnv.CallStaticVoidMethod(s_cardClass, s_cardMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_cardClass, s_cardMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.ChipKt.AssistChip:
@@ -449,7 +508,18 @@ internal static class ComposeBridges
         args[12] = new JValue(0);           // $changed
         args[13] = new JValue(0);           // $changed1
         args[14] = new JValue(defaults);    // $default
-        JNIEnv.CallStaticVoidMethod(s_assistChipClass, s_assistChipMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_assistChipClass, s_assistChipMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(label);
+            GC.KeepAlive(leadingIcon);
+            GC.KeepAlive(trailingIcon);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.ChipKt.FilterChip:
@@ -503,7 +573,18 @@ internal static class ComposeBridges
         args[13] = new JValue(0);
         args[14] = new JValue(0);
         args[15] = new JValue(defaults);
-        JNIEnv.CallStaticVoidMethod(s_filterChipClass, s_filterChipMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_filterChipClass, s_filterChipMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(label);
+            GC.KeepAlive(leadingIcon);
+            GC.KeepAlive(trailingIcon);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.ChipKt.InputChip:
@@ -559,7 +640,19 @@ internal static class ComposeBridges
         args[14] = new JValue(0);
         args[15] = new JValue(0);
         args[16] = new JValue(defaults);
-        JNIEnv.CallStaticVoidMethod(s_inputChipClass, s_inputChipMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_inputChipClass, s_inputChipMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(label);
+            GC.KeepAlive(leadingIcon);
+            GC.KeepAlive(avatar);
+            GC.KeepAlive(trailingIcon);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.ChipKt.SuggestionChip:
@@ -605,7 +698,17 @@ internal static class ComposeBridges
         args[10] = new JValue(((Java.Lang.Object)composer).Handle);
         args[11] = new JValue(0);
         args[12] = new JValue(defaults);
-        JNIEnv.CallStaticVoidMethod(s_suggestionChipClass, s_suggestionChipMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_suggestionChipClass, s_suggestionChipMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(label);
+            GC.KeepAlive(icon);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.NavigationBarKt.NavigationBar-HsRjFd4:
@@ -638,7 +741,15 @@ internal static class ComposeBridges
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
         args[8] = new JValue((int)NavigationBarDefault.All);
-        JNIEnv.CallStaticVoidMethod(s_navBarClass, s_navBarMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_navBarClass, s_navBarMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.NavigationBarKt.NavigationBarItem:
@@ -691,7 +802,17 @@ internal static class ComposeBridges
         args[10] = new JValue(((Java.Lang.Object)composer).Handle);
         args[11] = new JValue(0);
         args[12] = new JValue(defaults);
-        JNIEnv.CallStaticVoidMethod(s_navBarItemClass, s_navBarItemMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_navBarItemClass, s_navBarItemMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(icon);
+            GC.KeepAlive(label);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.NavigationRailKt.NavigationRail-qi6gXK8:
@@ -726,7 +847,15 @@ internal static class ComposeBridges
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
         args[8] = new JValue((int)NavigationRailDefault.All);
-        JNIEnv.CallStaticVoidMethod(s_navRailClass, s_navRailMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_navRailClass, s_navRailMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
     }
 
     // androidx.compose.material3.NavigationRailKt.NavigationRailItem:
@@ -773,6 +902,16 @@ internal static class ComposeBridges
         args[9]  = new JValue(((Java.Lang.Object)composer).Handle);
         args[10] = new JValue(0);
         args[11] = new JValue(defaults);
-        JNIEnv.CallStaticVoidMethod(s_navRailItemClass, s_navRailItemMethod, args);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_navRailItemClass, s_navRailItemMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(icon);
+            GC.KeepAlive(label);
+            GC.KeepAlive(composer);
+        }
     }
 }


### PR DESCRIPTION
The raw-JNI bridges in `ComposeBridges.cs` were missing the `GC.KeepAlive` pattern that `dotnet/java-interop` emits for every bound member. Once `((Java.Lang.Object)obj).Handle` is read into a `JValue`, the JIT considers the managed wrapper dead, so a GC during the JNI call can finalize it and invalidate the underlying handle. In practice it usually doesn't crash because the lambda wrappers are referenced from `ComposableLambda*`/the call stack and Compose calls are short, but under GC pressure it's exactly the kind of bug that surfaces as a "stale local reference" JNI error.

## What changed

Every bridge (`Text`, `Button`, `IconButton`, `FloatingActionButton`, `Surface`, `TextField`/`OutlinedTextField`, `AlertDialog`, `Card`, `AssistChip`/`FilterChip`/`InputChip`/`SuggestionChip`, `NavigationBar`/`NavigationBarItem`, `NavigationRail`/`NavigationRailItem`) now wraps `JNIEnv.CallStaticVoidMethod` in a `try { ... } finally { GC.KeepAlive(...); }` block, with one `KeepAlive` per managed parameter whose `.Handle` was read into a `JValue`. The bridges that already had a `try`/`finally` to `DeleteLocalRef` a `JNIEnv.NewString` ref (`Text`, `InvokeTextField`) fold the new `KeepAlive` calls into that existing finally rather than nesting a second one.

`GC.KeepAlive(null)` is a no-op so the optional slot wrappers in `AlertDialog`, the chips, and the nav items are kept alive unconditionally without a null check.

## Instructions update

Added rule #7 under the JNI-bridges section of `.github/copilot-instructions.md` documenting the `try`/`finally` + `GC.KeepAlive` shape, the rationale (matches `dotnet/java-interop` output), and a copy-paste pattern, so future bridges get it right from the first commit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>