### PR TITLE
Bind Scaffold and use it in the sample

### DIFF
--- a/src/ComposeNet.Compose/ComposeActivity.cs
+++ b/src/ComposeNet.Compose/ComposeActivity.cs
@@ -83,13 +83,19 @@ public abstract class ComposeActivity : ComponentActivity
     void ApplySafeAreaPadding(Android.Views.View view)
     {
         // On API 36 / Theme.Material.Light the ActionBar is overlay-decor
-        // and draws on top of android.R.id.content. Push the ComposeView
-        // down by status + action bar height; pad the nav bar at bottom.
+        // and draws on top of android.R.id.content, so we still need to
+        // push content down by status + action bar height. We deliberately
+        // do NOT pad left / right / bottom here: a root-level Scaffold
+        // already handles those edges via its own WindowInsets (the
+        // bottom NavigationBar pads itself above the gesture bar, and
+        // the body lambda receives PaddingValues for cutouts). See
+        // issue #20 for the long-term plan to drop this shim entirely
+        // once the activity goes edge-to-edge under a Material 3 theme.
         view.SetPadding(
-            left:   Dp(16),
+            left:   0,
             top:    SystemBarHeight("status_bar_height") + ActionBarHeight() + Dp(16),
-            right:  Dp(16),
-            bottom: SystemBarHeight("navigation_bar_height") + Dp(16));
+            right:  0,
+            bottom: 0);
     }
 
     void ApplyLightStatusBar()

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -509,6 +509,70 @@ internal static class ComposeBridges
         }
     }
 
+    // androidx.compose.material3.ScaffoldKt.Scaffold-TvnljyQ(
+    //   modifier, topBar, bottomBar, snackbarHost, floatingActionButton,
+    //   floatingActionButtonPosition, containerColor, contentColor,
+    //   contentWindowInsets, content, composer, $changed, $default)
+    //
+    // 10 user params; only bit 9 (content) is always provided. The four
+    // optional Function2 slots (topBar, bottomBar, snackbarHost,
+    // floatingActionButton) are toggled per-call by Scaffold.Render.
+    const string ScaffoldSig =
+        "(Landroidx/compose/ui/Modifier;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "IJJ" +
+        "Landroidx/compose/foundation/layout/WindowInsets;" +
+        "Lkotlin/jvm/functions/Function3;" +
+        "Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_scaffoldClass;
+    static IntPtr s_scaffoldMethod;
+
+    public static unsafe void Scaffold(
+        IFunction2? topBar,
+        IFunction2? bottomBar,
+        IFunction2? snackbarHost,
+        IFunction2? floatingActionButton,
+        IFunction3  content,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_scaffoldClass == IntPtr.Zero)
+        {
+            s_scaffoldClass  = JNIEnv.FindClass("androidx/compose/material3/ScaffoldKt");
+            s_scaffoldMethod = JNIEnv.GetStaticMethodID(s_scaffoldClass, "Scaffold-TvnljyQ", ScaffoldSig);
+        }
+
+        JValue* args = stackalloc JValue[13];
+        args[0]  = new JValue(IntPtr.Zero); // modifier
+        args[1]  = new JValue(topBar               is null ? IntPtr.Zero : ((Java.Lang.Object)topBar).Handle);
+        args[2]  = new JValue(bottomBar            is null ? IntPtr.Zero : ((Java.Lang.Object)bottomBar).Handle);
+        args[3]  = new JValue(snackbarHost         is null ? IntPtr.Zero : ((Java.Lang.Object)snackbarHost).Handle);
+        args[4]  = new JValue(floatingActionButton is null ? IntPtr.Zero : ((Java.Lang.Object)floatingActionButton).Handle);
+        args[5]  = new JValue(0);           // floatingActionButtonPosition (FabPosition is an inline value class wrapping Int)
+        args[6]  = new JValue(0L);          // containerColor
+        args[7]  = new JValue(0L);          // contentColor
+        args[8]  = new JValue(IntPtr.Zero); // contentWindowInsets
+        args[9]  = new JValue(((Java.Lang.Object)content).Handle);
+        args[10] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[11] = new JValue(0);           // $changed
+        args[12] = new JValue(defaults);    // $default
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_scaffoldClass, s_scaffoldMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(topBar);
+            GC.KeepAlive(bottomBar);
+            GC.KeepAlive(snackbarHost);
+            GC.KeepAlive(floatingActionButton);
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
+    }
+
     // androidx.compose.material3.DatePickerDialog_androidKt.DatePickerDialog-GmEhDVc(
     //   onDismissRequest, confirmButton, modifier, dismissButton, shape,
     //   tonalElevation, colors, properties, content, composer, $changed, $default)

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -81,6 +81,15 @@ using ComposeNet;
     "containerColor", "contentColor", "tonalElevation", "scrimColor", "dragHandle",
     "windowInsets", "properties", "!content")]
 
+// androidx.compose.material3.ScaffoldKt.Scaffold-TvnljyQ:
+// 10 user params; bit 9 (content) always provided. Optional slot bits
+// 1 (topBar), 2 (bottomBar), 3 (snackbarHost), 4 (floatingActionButton)
+// are toggled per-call by Scaffold.Render.
+[assembly: ComposeDefaults("ScaffoldDefault",
+    "modifier", "topBar", "bottomBar", "snackbarHost", "floatingActionButton",
+    "floatingActionButtonPosition", "containerColor", "contentColor",
+    "contentWindowInsets", "!content")]
+
 // androidx.compose.material3.BottomSheetScaffoldKt.BottomSheetScaffold-sdMYb0k:
 // 17 user params; bits 0 (sheetContent), 2 (scaffoldState), 16 (content) always provided.
 [assembly: ComposeDefaults("BottomSheetScaffoldDefault",

--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -1,0 +1,76 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>Scaffold</c>. Hosts a primary <see cref="Body"/> with
+/// optional Material chrome — top app bar, bottom bar, snackbar host,
+/// and floating action button — pinned to their conventional edges of
+/// the screen.
+///
+/// The Kotlin overload is stripped from the binding because
+/// <c>floatingActionButtonPosition</c> (<c>FabPosition</c>),
+/// <c>containerColor</c> and <c>contentColor</c> (<c>Color</c>) are
+/// <c>@JvmInline value class</c> parameters; we call it through a JNI
+/// bridge in <see cref="ComposeBridges"/> against the mangled name
+/// <c>Scaffold-TvnljyQ</c>.
+///
+/// <code>
+/// new Scaffold
+/// {
+///     TopBar    = new Text("My App"),
+///     BottomBar = new NavigationBar { ... },
+///     Body      = tabContent,
+/// }
+/// </code>
+/// </summary>
+public sealed class Scaffold : ComposableNode
+{
+    /// <summary>Optional: persistent top app bar slot.</summary>
+    public ComposableNode? TopBar { get; set; }
+
+    /// <summary>Optional: persistent bottom bar slot (e.g. <see cref="NavigationBar"/>).</summary>
+    public ComposableNode? BottomBar { get; set; }
+
+    /// <summary>Optional: snackbar host slot, typically anchored above <see cref="BottomBar"/>.</summary>
+    public ComposableNode? SnackbarHost { get; set; }
+
+    /// <summary>Optional: floating action button slot.</summary>
+    public ComposableNode? FloatingActionButton { get; set; }
+
+    /// <summary>Required: the main body, laid out under the top bar and above the bottom bar.</summary>
+    public ComposableNode? Body { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Body is null)
+            throw new System.InvalidOperationException(
+                "Scaffold.Body is required (the Kotlin parameter has no default).");
+
+        var content = new ComposableLambda3(c => Body.Render(c));
+
+        ComposableLambda2? topBar = TopBar is null ? null
+            : new ComposableLambda2(c => TopBar.Render(c));
+        ComposableLambda2? bottomBar = BottomBar is null ? null
+            : new ComposableLambda2(c => BottomBar.Render(c));
+        ComposableLambda2? snackbarHost = SnackbarHost is null ? null
+            : new ComposableLambda2(c => SnackbarHost.Render(c));
+        ComposableLambda2? fab = FloatingActionButton is null ? null
+            : new ComposableLambda2(c => FloatingActionButton.Render(c));
+
+        int defaults = (int)ScaffoldDefault.All;
+        if (topBar       is not null) defaults &= ~(int)ScaffoldDefault.TopBar;
+        if (bottomBar    is not null) defaults &= ~(int)ScaffoldDefault.BottomBar;
+        if (snackbarHost is not null) defaults &= ~(int)ScaffoldDefault.SnackbarHost;
+        if (fab          is not null) defaults &= ~(int)ScaffoldDefault.FloatingActionButton;
+
+        ComposeBridges.Scaffold(
+            topBar:               topBar,
+            bottomBar:            bottomBar,
+            snackbarHost:         snackbarHost,
+            floatingActionButton: fab,
+            content:              content,
+            defaults:             defaults,
+            composer:             composer);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -84,12 +84,12 @@ public class MainActivity : ComposeActivity
             {
                 new Surface
                 {
-                    new Column
+                    new Scaffold
                     {
-                        tabContent,
-
-                        // Bottom navigation switches between the three tabs above.
-                        new NavigationBar
+                        // Bottom navigation switches between the three tabs above —
+                        // pinned to the bottom edge by Scaffold instead of flowing
+                        // inline at the end of a Column.
+                        BottomBar = new NavigationBar
                         {
                             new NavigationBarItem(selected: tab.Value == 0, onClick: () => tab.Value = 0)
                             {
@@ -107,67 +107,72 @@ public class MainActivity : ComposeActivity
                                 Label = new Text("Pickers"),
                             },
                         },
+                        Body = new Column
+                        {
+                            tabContent,
 
-                        // --- Overlays: rendered at the root regardless of tab,
-                        // so a dialog opened on Tab 1 still works after switching. ---
-                        showAlert.Value
-                            ? new AlertDialog(onDismissRequest: () => showAlert.Value = false)
-                            {
-                                Title         = new Text("Reset counter?"),
-                                Text          = new Text("This will set the counter back to zero."),
-                                ConfirmButton = new Button(onClick: () => { count.Value = 0; showAlert.Value = false; })
+                            // Overlays: rendered in the body so they participate in the
+                            // same composition as the tab content. A dialog opened on
+                            // Tab 1 still works after switching tabs.
+                            showAlert.Value
+                                ? new AlertDialog(onDismissRequest: () => showAlert.Value = false)
                                 {
-                                    new Text("Reset"),
-                                },
-                                DismissButton = new Button(onClick: () => showAlert.Value = false)
-                                {
-                                    new Text("Cancel"),
-                                },
-                            }
-                            : null,
+                                    Title         = new Text("Reset counter?"),
+                                    Text          = new Text("This will set the counter back to zero."),
+                                    ConfirmButton = new Button(onClick: () => { count.Value = 0; showAlert.Value = false; })
+                                    {
+                                        new Text("Reset"),
+                                    },
+                                    DismissButton = new Button(onClick: () => showAlert.Value = false)
+                                    {
+                                        new Text("Cancel"),
+                                    },
+                                }
+                                : null,
 
-                        // ModalBottomSheet — SheetState comes from the bound C#
-                        // RememberModalBottomSheetState (NOT stripped, no JNI).
-                        showSheet.Value
-                            ? new ModalBottomSheet(onDismissRequest: () => showSheet.Value = false)
-                              {
-                                  new Column
+                            // ModalBottomSheet — SheetState comes from the bound C#
+                            // RememberModalBottomSheetState (NOT stripped, no JNI).
+                            showSheet.Value
+                                ? new ModalBottomSheet(onDismissRequest: () => showSheet.Value = false)
                                   {
-                                      new Text("Modal bottom sheet"),
-                                      new Text("Drag down or tap outside to dismiss."),
-                                      new Button(onClick: () => showSheet.Value = false) { new Text("Hide") },
-                                  },
-                              }
-                            : null,
+                                      new Column
+                                      {
+                                          new Text("Modal bottom sheet"),
+                                          new Text("Drag down or tap outside to dismiss."),
+                                          new Button(onClick: () => showSheet.Value = false) { new Text("Hide") },
+                                      },
+                                  }
+                                : null,
 
-                        showDate.Value
-                            ? new DatePickerDialog(onDismissRequest: () => showDate.Value = false)
-                            {
-                                ConfirmButton = new Button(onClick: () =>
+                            showDate.Value
+                                ? new DatePickerDialog(onDismissRequest: () => showDate.Value = false)
                                 {
-                                    pickedDate.Value = dateState.SelectedDateMillis is long ms ? ms.ToString() : "(none)";
-                                    showDate.Value = false;
-                                })
-                                { new Text("OK") },
-                                DismissButton = new Button(onClick: () => showDate.Value = false) { new Text("Cancel") },
-                                Body          = new DatePicker(dateState),
-                            }
-                            : null,
+                                    ConfirmButton = new Button(onClick: () =>
+                                    {
+                                        pickedDate.Value = dateState.SelectedDateMillis is long ms ? ms.ToString() : "(none)";
+                                        showDate.Value = false;
+                                    })
+                                    { new Text("OK") },
+                                    DismissButton = new Button(onClick: () => showDate.Value = false) { new Text("Cancel") },
+                                    Body          = new DatePicker(dateState),
+                                }
+                                : null,
 
-                        showTime.Value
-                            ? new TimePickerDialog(onDismissRequest: () => showTime.Value = false)
-                            {
-                                Title         = new Text("Pick a time"),
-                                ConfirmButton = new Button(onClick: () =>
+                            showTime.Value
+                                ? new TimePickerDialog(onDismissRequest: () => showTime.Value = false)
                                 {
-                                    pickedTime.Value = $"{timeState.Hour:D2}:{timeState.Minute:D2}";
-                                    showTime.Value = false;
-                                })
-                                { new Text("OK") },
-                                DismissButton = new Button(onClick: () => showTime.Value = false) { new Text("Cancel") },
-                                Body          = new TimePicker(timeState),
-                            }
-                            : null,
+                                    Title         = new Text("Pick a time"),
+                                    ConfirmButton = new Button(onClick: () =>
+                                    {
+                                        pickedTime.Value = $"{timeState.Hour:D2}:{timeState.Minute:D2}";
+                                        showTime.Value = false;
+                                    })
+                                    { new Text("OK") },
+                                    DismissButton = new Button(onClick: () => showTime.Value = false) { new Text("Cancel") },
+                                    Body          = new TimePicker(timeState),
+                                }
+                                : null,
+                        },
                     },
                 },
             };


### PR DESCRIPTION
Closes #12.

## What

Binds `androidx.compose.material3.ScaffoldKt.Scaffold` using the slot-property facade pattern established by `AlertDialog` (#6).

The Kotlin overload is stripped from the binding because `floatingActionButtonPosition` (`FabPosition`), `containerColor`, and `contentColor` (`Color`) are `@JvmInline value class` parameters, so we call it via a JNI bridge in `ComposeBridges.cs`. Verified the mangled name against `androidx.compose.material3.material3-android` 1.4.0.3 with `javap` — it's `Scaffold-TvnljyQ` (10 user params, single `$changed`, then `$default`).

### New API

```csharp
new Scaffold
{
    TopBar    = new Text("My App"),     // optional
    BottomBar = new NavigationBar { ... }, // optional
    SnackbarHost         = ...,         // optional
    FloatingActionButton = ...,         // optional
    Body = tabContent,                  // required
}
```

## Sample fix

`MainActivity.cs` now wraps the per-tab content + overlays in a `Scaffold`, moving the `NavigationBar` from the bottom of an inline `Column` into the `BottomBar` slot so it pins to the bottom edge of the screen (above the system nav bar) instead of floating mid-screen.

## Files

- `src/ComposeNet.Compose/Scaffold.cs` — new facade.
- `src/ComposeNet.Compose/ComposeBridges.cs` — `Scaffold-TvnljyQ` JNI bridge with `GC.KeepAlive` on every managed param.
- `src/ComposeNet.Compose/ComposeDefaults.cs` — declarative `[ComposeDefaults("ScaffoldDefault", ...)]` attribute (10 bits, only `content` marked `!`).
- `src/ComposeNet.Sample/MainActivity.cs` — uses `Scaffold` instead of a tail-positioned `NavigationBar`.

## Verification

- `dotnet build src/ComposeNet.Compose` ✅ (no new warnings)
- `dotnet build src/ComposeNet.Sample` ✅
- `dotnet test src/ComposeNet.SourceGenerators.Tests` ✅ (10/10 pass — `ScaffoldDefault` is generated from the declarative attribute)