### PR TITLE
Bind ElevatedCard/OutlinedCard, elevated chips, drawer sheets

### DIFF
--- a/src/ComposeNet.Compose/AlwaysTrueFunction1.cs
+++ b/src/ComposeNet.Compose/AlwaysTrueFunction1.cs
@@ -1,0 +1,21 @@
+using Android.Runtime;
+using Kotlin.Jvm.Functions;
+
+namespace ComposeNet;
+
+/// <summary>
+/// <c>Function1</c> stub that ignores its argument and returns
+/// <see cref="Java.Lang.Boolean.True"/>. Used as a default
+/// <c>confirmStateChange</c> callback when constructing
+/// <c>DrawerState</c> / similar Compose state objects from C# —
+/// passing a real lambda avoids relying on Kotlin's <c>$default</c>
+/// substitution for the lambda parameter, which doesn't always work
+/// through the .NET binding.
+/// </summary>
+[Register("composenet/compose/AlwaysTrueFunction1")]
+internal sealed class AlwaysTrueFunction1 : Java.Lang.Object, IFunction1
+{
+    public static readonly AlwaysTrueFunction1 Instance = new();
+
+    public Java.Lang.Object? Invoke(Java.Lang.Object? p0) => Java.Lang.Boolean.True;
+}

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1467,6 +1467,306 @@ internal static class ComposeBridges
         }
     }
 
+    // androidx.compose.material3.CardKt.ElevatedCard (non-clickable):
+    //   (modifier, shape, colors, elevation, content,
+    //    composer, $changed, $default)
+    // 5 user params; bit 4 (content) provided.
+    const string ElevatedCardSig =
+        "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/CardColors;Landroidx/compose/material3/CardElevation;" +
+        "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_elevatedCardClass;
+    static IntPtr s_elevatedCardMethod;
+
+    public static unsafe void ElevatedCard(IFunction3 content, IComposer composer)
+    {
+        if (s_elevatedCardClass == IntPtr.Zero)
+        {
+            s_elevatedCardClass  = JNIEnv.FindClass("androidx/compose/material3/CardKt");
+            s_elevatedCardMethod = JNIEnv.GetStaticMethodID(s_elevatedCardClass, "ElevatedCard", ElevatedCardSig);
+        }
+
+        JValue* args = stackalloc JValue[8];
+        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[1] = new JValue(IntPtr.Zero); // shape
+        args[2] = new JValue(IntPtr.Zero); // colors
+        args[3] = new JValue(IntPtr.Zero); // elevation
+        args[4] = new JValue(((Java.Lang.Object)content).Handle);
+        args[5] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[6] = new JValue(0);
+        args[7] = new JValue((int)ElevatedCardDefault.All);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_elevatedCardClass, s_elevatedCardMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
+    }
+
+    // androidx.compose.material3.CardKt.OutlinedCard (non-clickable):
+    //   (modifier, shape, colors, elevation, border, content,
+    //    composer, $changed, $default)
+    // 6 user params; bit 5 (content) provided. Same shape as Card.
+    const string OutlinedCardSig =
+        "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/CardColors;Landroidx/compose/material3/CardElevation;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_outlinedCardClass;
+    static IntPtr s_outlinedCardMethod;
+
+    public static unsafe void OutlinedCard(IFunction3 content, IComposer composer)
+    {
+        if (s_outlinedCardClass == IntPtr.Zero)
+        {
+            s_outlinedCardClass  = JNIEnv.FindClass("androidx/compose/material3/CardKt");
+            s_outlinedCardMethod = JNIEnv.GetStaticMethodID(s_outlinedCardClass, "OutlinedCard", OutlinedCardSig);
+        }
+
+        JValue* args = stackalloc JValue[9];
+        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[1] = new JValue(IntPtr.Zero); // shape
+        args[2] = new JValue(IntPtr.Zero); // colors
+        args[3] = new JValue(IntPtr.Zero); // elevation
+        args[4] = new JValue(IntPtr.Zero); // border
+        args[5] = new JValue(((Java.Lang.Object)content).Handle);
+        args[6] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[7] = new JValue(0);
+        args[8] = new JValue((int)CardDefault.All);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_outlinedCardClass, s_outlinedCardMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
+    }
+
+    // androidx.compose.material3.ChipKt.ElevatedAssistChip: same parameter
+    // shape as AssistChip — 11 user params, bits 0/1 always provided.
+    const string ElevatedAssistChipSig = AssistChipSig;
+
+    static IntPtr s_elevatedAssistChipClass;
+    static IntPtr s_elevatedAssistChipMethod;
+
+    public static unsafe void ElevatedAssistChip(
+        IFunction0  onClick,
+        IFunction2  label,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_elevatedAssistChipClass == IntPtr.Zero)
+        {
+            s_elevatedAssistChipClass  = JNIEnv.FindClass("androidx/compose/material3/ChipKt");
+            s_elevatedAssistChipMethod = JNIEnv.GetStaticMethodID(s_elevatedAssistChipClass, "ElevatedAssistChip", ElevatedAssistChipSig);
+        }
+
+        JValue* args = stackalloc JValue[15];
+        args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[1]  = new JValue(((Java.Lang.Object)label).Handle);
+        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(true);        // enabled
+        args[4]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
+        args[5]  = new JValue(trailingIcon is null ? IntPtr.Zero : ((Java.Lang.Object)trailingIcon).Handle);
+        args[6]  = new JValue(IntPtr.Zero); // shape
+        args[7]  = new JValue(IntPtr.Zero); // colors
+        args[8]  = new JValue(IntPtr.Zero); // elevation
+        args[9]  = new JValue(IntPtr.Zero); // border
+        args[10] = new JValue(IntPtr.Zero); // interactionSource
+        args[11] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[12] = new JValue(0);
+        args[13] = new JValue(0);
+        args[14] = new JValue(defaults);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_elevatedAssistChipClass, s_elevatedAssistChipMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(label);
+            GC.KeepAlive(leadingIcon);
+            GC.KeepAlive(trailingIcon);
+            GC.KeepAlive(composer);
+        }
+    }
+
+    // androidx.compose.material3.ChipKt.ElevatedFilterChip: same parameter
+    // shape as FilterChip — 12 user params, bits 0/1/2 always provided.
+    const string ElevatedFilterChipSig = FilterChipSig;
+
+    static IntPtr s_elevatedFilterChipClass;
+    static IntPtr s_elevatedFilterChipMethod;
+
+    public static unsafe void ElevatedFilterChip(
+        bool        selected,
+        IFunction0  onClick,
+        IFunction2  label,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_elevatedFilterChipClass == IntPtr.Zero)
+        {
+            s_elevatedFilterChipClass  = JNIEnv.FindClass("androidx/compose/material3/ChipKt");
+            s_elevatedFilterChipMethod = JNIEnv.GetStaticMethodID(s_elevatedFilterChipClass, "ElevatedFilterChip", ElevatedFilterChipSig);
+        }
+
+        JValue* args = stackalloc JValue[16];
+        args[0]  = new JValue(selected);
+        args[1]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[2]  = new JValue(((Java.Lang.Object)label).Handle);
+        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[4]  = new JValue(true);        // enabled
+        args[5]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
+        args[6]  = new JValue(trailingIcon is null ? IntPtr.Zero : ((Java.Lang.Object)trailingIcon).Handle);
+        args[7]  = new JValue(IntPtr.Zero); // shape
+        args[8]  = new JValue(IntPtr.Zero); // colors
+        args[9]  = new JValue(IntPtr.Zero); // elevation
+        args[10] = new JValue(IntPtr.Zero); // border
+        args[11] = new JValue(IntPtr.Zero); // interactionSource
+        args[12] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[13] = new JValue(0);
+        args[14] = new JValue(0);
+        args[15] = new JValue(defaults);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_elevatedFilterChipClass, s_elevatedFilterChipMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(label);
+            GC.KeepAlive(leadingIcon);
+            GC.KeepAlive(trailingIcon);
+            GC.KeepAlive(composer);
+        }
+    }
+
+    // androidx.compose.material3.ChipKt.ElevatedSuggestionChip: same shape
+    // as SuggestionChip — 10 user params, bits 0/1 always provided.
+    const string ElevatedSuggestionChipSig = SuggestionChipSig;
+
+    static IntPtr s_elevatedSuggestionChipClass;
+    static IntPtr s_elevatedSuggestionChipMethod;
+
+    public static unsafe void ElevatedSuggestionChip(
+        IFunction0  onClick,
+        IFunction2  label,
+        IFunction2? icon,
+        int         defaults,
+        IComposer   composer)
+    {
+        if (s_elevatedSuggestionChipClass == IntPtr.Zero)
+        {
+            s_elevatedSuggestionChipClass  = JNIEnv.FindClass("androidx/compose/material3/ChipKt");
+            s_elevatedSuggestionChipMethod = JNIEnv.GetStaticMethodID(s_elevatedSuggestionChipClass, "ElevatedSuggestionChip", ElevatedSuggestionChipSig);
+        }
+
+        JValue* args = stackalloc JValue[13];
+        args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
+        args[1]  = new JValue(((Java.Lang.Object)label).Handle);
+        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(true);        // enabled
+        args[4]  = new JValue(icon is null ? IntPtr.Zero : ((Java.Lang.Object)icon).Handle);
+        args[5]  = new JValue(IntPtr.Zero); // shape
+        args[6]  = new JValue(IntPtr.Zero); // colors
+        args[7]  = new JValue(IntPtr.Zero); // elevation
+        args[8]  = new JValue(IntPtr.Zero); // border
+        args[9]  = new JValue(IntPtr.Zero); // interactionSource
+        args[10] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[11] = new JValue(0);
+        args[12] = new JValue(defaults);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(s_elevatedSuggestionChipClass, s_elevatedSuggestionChipMethod, args);
+        }
+        finally
+        {
+            GC.KeepAlive(onClick);
+            GC.KeepAlive(label);
+            GC.KeepAlive(icon);
+            GC.KeepAlive(composer);
+        }
+    }
+
+    // androidx.compose.material3.NavigationDrawerKt.{Modal,Dismissible,Permanent}DrawerSheet-afqeVBk:
+    //   (modifier, shape, drawerContainerColor, drawerContentColor,
+    //    tonalElevation, windowInsets, content, composer, $changed, $default)
+    // 7 user params; bit 6 (content) provided. All three sheets share the
+    // identical signature — only the JNI method name differs.
+    const string DrawerSheetSig =
+        "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;JJF" +
+        "Landroidx/compose/foundation/layout/WindowInsets;" +
+        "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V";
+
+    static IntPtr s_drawerSheetClass;
+    static IntPtr s_modalDrawerSheetMethod;
+    static IntPtr s_dismissibleDrawerSheetMethod;
+    static IntPtr s_permanentDrawerSheetMethod;
+
+    static IntPtr GetDrawerSheetClass()
+    {
+        if (s_drawerSheetClass == IntPtr.Zero)
+            s_drawerSheetClass = JNIEnv.FindClass("androidx/compose/material3/NavigationDrawerKt");
+        return s_drawerSheetClass;
+    }
+
+    static unsafe void CallDrawerSheet(IntPtr method, IFunction3 content, IComposer composer)
+    {
+        JValue* args = stackalloc JValue[10];
+        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[1] = new JValue(IntPtr.Zero); // shape
+        args[2] = new JValue(0L);          // drawerContainerColor
+        args[3] = new JValue(0L);          // drawerContentColor
+        args[4] = new JValue(0f);          // tonalElevation
+        args[5] = new JValue(IntPtr.Zero); // windowInsets
+        args[6] = new JValue(((Java.Lang.Object)content).Handle);
+        args[7] = new JValue(((Java.Lang.Object)composer).Handle);
+        args[8] = new JValue(0);
+        args[9] = new JValue((int)DrawerSheetDefault.All);
+        try
+        {
+            JNIEnv.CallStaticVoidMethod(GetDrawerSheetClass(), method, args);
+        }
+        finally
+        {
+            GC.KeepAlive(content);
+            GC.KeepAlive(composer);
+        }
+    }
+
+    public static unsafe void ModalDrawerSheet(IFunction3 content, IComposer composer)
+    {
+        if (s_modalDrawerSheetMethod == IntPtr.Zero)
+            s_modalDrawerSheetMethod = JNIEnv.GetStaticMethodID(GetDrawerSheetClass(), "ModalDrawerSheet-afqeVBk", DrawerSheetSig);
+        CallDrawerSheet(s_modalDrawerSheetMethod, content, composer);
+    }
+
+    public static unsafe void DismissibleDrawerSheet(IFunction3 content, IComposer composer)
+    {
+        if (s_dismissibleDrawerSheetMethod == IntPtr.Zero)
+            s_dismissibleDrawerSheetMethod = JNIEnv.GetStaticMethodID(GetDrawerSheetClass(), "DismissibleDrawerSheet-afqeVBk", DrawerSheetSig);
+        CallDrawerSheet(s_dismissibleDrawerSheetMethod, content, composer);
+    }
+
+    public static unsafe void PermanentDrawerSheet(IFunction3 content, IComposer composer)
+    {
+        if (s_permanentDrawerSheetMethod == IntPtr.Zero)
+            s_permanentDrawerSheetMethod = JNIEnv.GetStaticMethodID(GetDrawerSheetClass(), "PermanentDrawerSheet-afqeVBk", DrawerSheetSig);
+        CallDrawerSheet(s_permanentDrawerSheetMethod, content, composer);
+    }
+
     // androidx.compose.material3.NavigationRailKt.NavigationRailItem:
     //   (selected, onClick, icon, modifier, enabled, label, alwaysShowLabel,
     //    colors, interactionSource, composer, $changed, $default)

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1722,19 +1722,26 @@ internal static class ComposeBridges
         return s_drawerSheetClass;
     }
 
-    static unsafe void CallDrawerSheet(IntPtr method, IFunction3 content, IComposer composer)
+    static unsafe void CallDrawerSheet(IntPtr method, IFunction3 content, IComposer composer, long containerColor = 0L)
     {
+        // When containerColor is non-zero, pass it explicitly and clear
+        // bit 2 so Kotlin doesn't substitute its $default. Bit numbering
+        // matches DrawerSheetDefault (modifier=0, shape=1, drawerContainerColor=2).
+        int defaults = (int)DrawerSheetDefault.All;
+        if (containerColor != 0L)
+            defaults &= ~(1 << 2);
+
         JValue* args = stackalloc JValue[10];
-        args[0] = new JValue(IntPtr.Zero); // modifier
-        args[1] = new JValue(IntPtr.Zero); // shape
-        args[2] = new JValue(0L);          // drawerContainerColor
-        args[3] = new JValue(0L);          // drawerContentColor
-        args[4] = new JValue(0f);          // tonalElevation
-        args[5] = new JValue(IntPtr.Zero); // windowInsets
+        args[0] = new JValue(IntPtr.Zero);     // modifier
+        args[1] = new JValue(IntPtr.Zero);     // shape
+        args[2] = new JValue(containerColor);  // drawerContainerColor
+        args[3] = new JValue(0L);              // drawerContentColor
+        args[4] = new JValue(0f);              // tonalElevation
+        args[5] = new JValue(IntPtr.Zero);     // windowInsets
         args[6] = new JValue(((Java.Lang.Object)content).Handle);
         args[7] = new JValue(((Java.Lang.Object)composer).Handle);
         args[8] = new JValue(0);
-        args[9] = new JValue((int)DrawerSheetDefault.All);
+        args[9] = new JValue(defaults);
         try
         {
             JNIEnv.CallStaticVoidMethod(GetDrawerSheetClass(), method, args);
@@ -1746,25 +1753,25 @@ internal static class ComposeBridges
         }
     }
 
-    public static unsafe void ModalDrawerSheet(IFunction3 content, IComposer composer)
+    public static unsafe void ModalDrawerSheet(IFunction3 content, IComposer composer, long containerColor = 0L)
     {
         if (s_modalDrawerSheetMethod == IntPtr.Zero)
             s_modalDrawerSheetMethod = JNIEnv.GetStaticMethodID(GetDrawerSheetClass(), "ModalDrawerSheet-afqeVBk", DrawerSheetSig);
-        CallDrawerSheet(s_modalDrawerSheetMethod, content, composer);
+        CallDrawerSheet(s_modalDrawerSheetMethod, content, composer, containerColor);
     }
 
-    public static unsafe void DismissibleDrawerSheet(IFunction3 content, IComposer composer)
+    public static unsafe void DismissibleDrawerSheet(IFunction3 content, IComposer composer, long containerColor = 0L)
     {
         if (s_dismissibleDrawerSheetMethod == IntPtr.Zero)
             s_dismissibleDrawerSheetMethod = JNIEnv.GetStaticMethodID(GetDrawerSheetClass(), "DismissibleDrawerSheet-afqeVBk", DrawerSheetSig);
-        CallDrawerSheet(s_dismissibleDrawerSheetMethod, content, composer);
+        CallDrawerSheet(s_dismissibleDrawerSheetMethod, content, composer, containerColor);
     }
 
-    public static unsafe void PermanentDrawerSheet(IFunction3 content, IComposer composer)
+    public static unsafe void PermanentDrawerSheet(IFunction3 content, IComposer composer, long containerColor = 0L)
     {
         if (s_permanentDrawerSheetMethod == IntPtr.Zero)
             s_permanentDrawerSheetMethod = JNIEnv.GetStaticMethodID(GetDrawerSheetClass(), "PermanentDrawerSheet-afqeVBk", DrawerSheetSig);
-        CallDrawerSheet(s_permanentDrawerSheetMethod, content, composer);
+        CallDrawerSheet(s_permanentDrawerSheetMethod, content, composer, containerColor);
     }
 
     // androidx.compose.material3.NavigationRailKt.NavigationRailItem:

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -140,9 +140,23 @@ using ComposeNet;
     "interactionSource", "shape", "colors")]
 
 // androidx.compose.material3.CardKt.Card (non-clickable): 6 user params,
-// bit 5 = content provided.
+// bit 5 = content provided. Also reused by OutlinedCard — it takes the
+// same 6 params in the same order.
 [assembly: ComposeDefaults("CardDefault",
     "modifier", "shape", "colors", "elevation", "border", "!content")]
+
+// androidx.compose.material3.CardKt.ElevatedCard (non-clickable): 5 user
+// params (no border) — bit 4 = content provided.
+[assembly: ComposeDefaults("ElevatedCardDefault",
+    "modifier", "shape", "colors", "elevation", "!content")]
+
+// androidx.compose.material3.NavigationDrawerKt.{Modal,Dismissible,Permanent}DrawerSheet-afqeVBk:
+// all three have identical 7-param signatures (modifier, shape,
+// drawerContainerColor, drawerContentColor, tonalElevation, windowInsets,
+// content). Bit 6 (content) always provided.
+[assembly: ComposeDefaults("DrawerSheetDefault",
+    "modifier", "shape", "drawerContainerColor", "drawerContentColor",
+    "tonalElevation", "windowInsets", "!content")]
 
 // androidx.compose.material3.ChipKt.AssistChip: 11 user params,
 // bit 0 = onClick, bit 1 = label (both always provided).

--- a/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
+++ b/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
@@ -1,0 +1,16 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>DismissibleDrawerSheet</c> — the panel shown by a
+/// dismissible-style navigation drawer.
+/// </summary>
+public sealed class DismissibleDrawerSheet : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3(c => RenderChildren(c));
+        ComposeBridges.DismissibleDrawerSheet(content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
+++ b/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
@@ -1,3 +1,4 @@
+using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 
 namespace ComposeNet;
@@ -8,9 +9,18 @@ namespace ComposeNet;
 /// </summary>
 public sealed class DismissibleDrawerSheet : ComposableContainer
 {
+    /// <summary>
+    /// Optional container color. <c>0L</c> (the default) uses the
+    /// active theme's <c>secondaryContainer</c>.
+    /// </summary>
+    public long ContainerColor { get; set; }
+
     internal override void Render(IComposer composer)
     {
         var content = new ComposableLambda3(c => RenderChildren(c));
-        ComposeBridges.DismissibleDrawerSheet(content, composer);
+        var color = ContainerColor != 0L
+            ? ContainerColor
+            : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;
+        ComposeBridges.DismissibleDrawerSheet(content, composer, color);
     }
 }

--- a/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
@@ -1,0 +1,64 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>DismissibleNavigationDrawer</c> — a drawer that
+/// pushes the main content aside when open (no scrim). The
+/// <see cref="Drawer"/> slot typically holds a
+/// <see cref="DismissibleDrawerSheet"/>. Toggle by horizontal swipe.
+/// </summary>
+/// <remarks>
+/// Calls the bound C# entry point directly — the wrapper is bound
+/// natively. See <see cref="ModalNavigationDrawer"/> for the
+/// suspend-function caveat that forces gesture-only interaction.
+/// </remarks>
+public sealed class DismissibleNavigationDrawer : ComposableNode
+{
+    /// <summary>Required: the slide-in drawer panel.</summary>
+    public ComposableNode? Drawer { get; set; }
+
+    /// <summary>Required: the main content shown next to the drawer.</summary>
+    public ComposableNode? Content { get; set; }
+
+    /// <summary>
+    /// Initial drawer state on first composition. Defaults to closed.
+    /// </summary>
+    public bool InitiallyOpen { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Drawer is null)
+            throw new System.InvalidOperationException(
+                "DismissibleNavigationDrawer.Drawer is required.");
+        if (Content is null)
+            throw new System.InvalidOperationException(
+                "DismissibleNavigationDrawer.Content is required.");
+
+        var initial = InitiallyOpen ? DrawerValue.Open! : DrawerValue.Closed!;
+
+        var state = NavigationDrawerKt.RememberDrawerState(
+            initialValue:        initial,
+            confirmStateChange:  AlwaysTrueFunction1.Instance,
+            _composer:           composer,
+            p3:                  0,
+            _changed:            0);
+
+        var drawer  = new ComposableLambda2(c => Drawer.Render(c));
+        var content = new ComposableLambda2(c => Content.Render(c));
+
+        // Param order: drawerContent (0, provided), modifier (1, def),
+        // drawerState (2, provided), gesturesEnabled (3, provided),
+        // content (4, provided). $default = 0b00010 = 2.
+        NavigationDrawerKt.DismissibleNavigationDrawer(
+            drawerContent:    drawer,
+            modifier:         null,
+            drawerState:      state,
+            gesturesEnabled:  true,
+            content:          content,
+            _composer:        composer,
+            p6:               0,
+            _changed:         0b00010);
+    }
+}

--- a/src/ComposeNet.Compose/ElevatedAssistChip.cs
+++ b/src/ComposeNet.Compose/ElevatedAssistChip.cs
@@ -1,0 +1,39 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ElevatedAssistChip</c> — same API surface as
+/// <see cref="AssistChip"/> but uses shadow elevation for emphasis.
+/// </summary>
+public sealed class ElevatedAssistChip : ComposableNode
+{
+    readonly System.Action _onClick;
+    public ElevatedAssistChip(System.Action onClick) => _onClick = onClick;
+
+    /// <summary>Required: chip text.</summary>
+    public ComposableNode? Label { get; set; }
+
+    public ComposableNode? LeadingIcon  { get; set; }
+    public ComposableNode? TrailingIcon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Label is null)
+            throw new System.InvalidOperationException(
+                "ElevatedAssistChip.Label is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var label = new ComposableLambda2(c => Label.Render(c));
+        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
+        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+
+        // ElevatedAssistChip's parameter order matches AssistChip exactly,
+        // so we reuse AssistChipDefault for the $default bitmask.
+        int defaults = (int)AssistChipDefault.All;
+        if (leading  is not null) defaults &= ~(int)AssistChipDefault.LeadingIcon;
+        if (trailing is not null) defaults &= ~(int)AssistChipDefault.TrailingIcon;
+
+        ComposeBridges.ElevatedAssistChip(click, label, leading, trailing, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ElevatedAssistChip.cs
+++ b/src/ComposeNet.Compose/ElevatedAssistChip.cs
@@ -14,7 +14,10 @@ public sealed class ElevatedAssistChip : ComposableNode
     /// <summary>Required: chip text.</summary>
     public ComposableNode? Label { get; set; }
 
+    /// <summary>Optional: leading slot (e.g. icon).</summary>
     public ComposableNode? LeadingIcon  { get; set; }
+
+    /// <summary>Optional: trailing slot.</summary>
     public ComposableNode? TrailingIcon { get; set; }
 
     internal override void Render(IComposer composer)

--- a/src/ComposeNet.Compose/ElevatedCard.cs
+++ b/src/ComposeNet.Compose/ElevatedCard.cs
@@ -1,0 +1,17 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ElevatedCard</c> — like <see cref="Card"/> but uses
+/// shadow rather than tonal elevation for separation. Children are added
+/// via collection-initializer syntax.
+/// </summary>
+public sealed class ElevatedCard : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3(c => RenderChildren(c));
+        ComposeBridges.ElevatedCard(content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ElevatedFilterChip.cs
+++ b/src/ComposeNet.Compose/ElevatedFilterChip.cs
@@ -20,7 +20,10 @@ public sealed class ElevatedFilterChip : ComposableNode
     /// <summary>Required: chip text.</summary>
     public ComposableNode? Label { get; set; }
 
+    /// <summary>Optional: leading slot (e.g. icon).</summary>
     public ComposableNode? LeadingIcon  { get; set; }
+
+    /// <summary>Optional: trailing slot.</summary>
     public ComposableNode? TrailingIcon { get; set; }
 
     internal override void Render(IComposer composer)

--- a/src/ComposeNet.Compose/ElevatedFilterChip.cs
+++ b/src/ComposeNet.Compose/ElevatedFilterChip.cs
@@ -1,0 +1,43 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ElevatedFilterChip</c> — same API surface as
+/// <see cref="FilterChip"/> but uses shadow elevation for emphasis.
+/// </summary>
+public sealed class ElevatedFilterChip : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public ElevatedFilterChip(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Required: chip text.</summary>
+    public ComposableNode? Label { get; set; }
+
+    public ComposableNode? LeadingIcon  { get; set; }
+    public ComposableNode? TrailingIcon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Label is null)
+            throw new System.InvalidOperationException(
+                "ElevatedFilterChip.Label is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var label = new ComposableLambda2(c => Label.Render(c));
+        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
+        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+
+        int defaults = (int)FilterChipDefault.All;
+        if (leading  is not null) defaults &= ~(int)FilterChipDefault.LeadingIcon;
+        if (trailing is not null) defaults &= ~(int)FilterChipDefault.TrailingIcon;
+
+        ComposeBridges.ElevatedFilterChip(_selected, click, label, leading, trailing, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
+++ b/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
@@ -1,0 +1,35 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ElevatedSuggestionChip</c> — like
+/// <see cref="SuggestionChip"/> but uses shadow elevation for emphasis.
+/// </summary>
+public sealed class ElevatedSuggestionChip : ComposableNode
+{
+    readonly System.Action _onClick;
+    public ElevatedSuggestionChip(System.Action onClick) => _onClick = onClick;
+
+    /// <summary>Required: chip text.</summary>
+    public ComposableNode? Label { get; set; }
+
+    /// <summary>Optional: leading slot.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Label is null)
+            throw new System.InvalidOperationException(
+                "ElevatedSuggestionChip.Label is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var label = new ComposableLambda2(c => Label.Render(c));
+        ComposableLambda2? icon = Icon is null ? null : new ComposableLambda2(c => Icon.Render(c));
+
+        int defaults = (int)SuggestionChipDefault.All;
+        if (icon is not null) defaults &= ~(int)SuggestionChipDefault.Icon;
+
+        ComposeBridges.ElevatedSuggestionChip(click, label, icon, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ModalDrawerSheet.cs
+++ b/src/ComposeNet.Compose/ModalDrawerSheet.cs
@@ -1,3 +1,4 @@
+using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 
 namespace ComposeNet;
@@ -10,9 +11,21 @@ namespace ComposeNet;
 /// </summary>
 public sealed class ModalDrawerSheet : ComposableContainer
 {
+    /// <summary>
+    /// Optional container color (Compose <c>Color</c> as a packed
+    /// <c>long</c>). <c>0L</c> (the default) uses the active
+    /// <c>MaterialTheme.colorScheme.secondaryContainer</c>, which is
+    /// visibly distinct from <c>surface</c>; pass any other value to
+    /// override.
+    /// </summary>
+    public long ContainerColor { get; set; }
+
     internal override void Render(IComposer composer)
     {
         var content = new ComposableLambda3(c => RenderChildren(c));
-        ComposeBridges.ModalDrawerSheet(content, composer);
+        var color = ContainerColor != 0L
+            ? ContainerColor
+            : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;
+        ComposeBridges.ModalDrawerSheet(content, composer, color);
     }
 }

--- a/src/ComposeNet.Compose/ModalDrawerSheet.cs
+++ b/src/ComposeNet.Compose/ModalDrawerSheet.cs
@@ -1,0 +1,18 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ModalDrawerSheet</c> — the panel shown by a
+/// modal-style navigation drawer. Lays out children as a Column.
+/// Typically holds nav items; in this facade any
+/// <see cref="ComposableNode"/> works.
+/// </summary>
+public sealed class ModalDrawerSheet : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3(c => RenderChildren(c));
+        ComposeBridges.ModalDrawerSheet(content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ModalNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/ModalNavigationDrawer.cs
@@ -1,0 +1,73 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ModalNavigationDrawer</c> — a phone-sized drawer that
+/// slides over the content with a scrim. The <see cref="Drawer"/>
+/// slot typically holds a <see cref="ModalDrawerSheet"/>. The drawer
+/// is opened by edge-swipe or programmatically via the underlying
+/// <c>DrawerState</c>; tap the scrim to close.
+/// </summary>
+/// <remarks>
+/// Calls the bound C# entry point directly — the wrapper is bound
+/// natively. Driving open/close from C# requires Kotlin
+/// <c>suspend</c> calls (<c>DrawerState.open()</c> /
+/// <c>close()</c>), so this facade exposes only swipe-to-toggle
+/// behavior using a <see cref="RememberDrawerState"/>-backed state.
+/// </remarks>
+public sealed class ModalNavigationDrawer : ComposableNode
+{
+    /// <summary>Required: the slide-in drawer panel.</summary>
+    public ComposableNode? Drawer { get; set; }
+
+    /// <summary>Required: the main content shown beneath the drawer.</summary>
+    public ComposableNode? Content { get; set; }
+
+    /// <summary>
+    /// Initial drawer state on first composition. Defaults to closed.
+    /// </summary>
+    public bool InitiallyOpen { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Drawer is null)
+            throw new System.InvalidOperationException(
+                "ModalNavigationDrawer.Drawer is required.");
+        if (Content is null)
+            throw new System.InvalidOperationException(
+                "ModalNavigationDrawer.Content is required.");
+
+        var initial = InitiallyOpen ? DrawerValue.Open! : DrawerValue.Closed!;
+
+        // Param order: initialValue (bit 0, provided), confirmStateChange
+        // (bit 1, provided — using a real non-null stub avoids
+        // Kotlin's $default substitution misfiring for the lambda
+        // parameter). $default = 0.
+        var state = NavigationDrawerKt.RememberDrawerState(
+            initialValue:        initial,
+            confirmStateChange:  AlwaysTrueFunction1.Instance,
+            _composer:           composer,
+            p3:                  0,
+            _changed:            0);
+
+        var drawer  = new ComposableLambda2(c => Drawer.Render(c));
+        var content = new ComposableLambda2(c => Content.Render(c));
+
+        // Param order: drawerContent (0, provided), modifier (1, def),
+        // drawerState (2, provided), gesturesEnabled (3, provided),
+        // scrimColor (4, def — 0L is not a valid color sentinel),
+        // content (5, provided). $default = 0b010010 = 18.
+        NavigationDrawerKt.ModalNavigationDrawer(
+            drawerContent:    drawer,
+            modifier:         null,
+            drawerState:      state,
+            gesturesEnabled:  true,
+            scrimColor:       0L,
+            content:          content,
+            _composer:        composer,
+            p7:               0,
+            _changed:         0b010010);
+    }
+}

--- a/src/ComposeNet.Compose/OutlinedCard.cs
+++ b/src/ComposeNet.Compose/OutlinedCard.cs
@@ -1,0 +1,16 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>OutlinedCard</c> — a card surrounded by a thin outline
+/// instead of relying on tonal/shadow elevation for separation.
+/// </summary>
+public sealed class OutlinedCard : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3(c => RenderChildren(c));
+        ComposeBridges.OutlinedCard(content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/PermanentDrawerSheet.cs
+++ b/src/ComposeNet.Compose/PermanentDrawerSheet.cs
@@ -1,0 +1,16 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>PermanentDrawerSheet</c> — the always-visible panel
+/// shown by a <see cref="PermanentNavigationDrawer"/>.
+/// </summary>
+public sealed class PermanentDrawerSheet : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3(c => RenderChildren(c));
+        ComposeBridges.PermanentDrawerSheet(content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/PermanentDrawerSheet.cs
+++ b/src/ComposeNet.Compose/PermanentDrawerSheet.cs
@@ -1,3 +1,4 @@
+using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 
 namespace ComposeNet;
@@ -8,9 +9,18 @@ namespace ComposeNet;
 /// </summary>
 public sealed class PermanentDrawerSheet : ComposableContainer
 {
+    /// <summary>
+    /// Optional container color. <c>0L</c> (the default) uses the
+    /// active theme's <c>secondaryContainer</c>.
+    /// </summary>
+    public long ContainerColor { get; set; }
+
     internal override void Render(IComposer composer)
     {
         var content = new ComposableLambda3(c => RenderChildren(c));
-        ComposeBridges.PermanentDrawerSheet(content, composer);
+        var color = ContainerColor != 0L
+            ? ContainerColor
+            : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;
+        ComposeBridges.PermanentDrawerSheet(content, composer, color);
     }
 }

--- a/src/ComposeNet.Compose/PermanentNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/PermanentNavigationDrawer.cs
@@ -1,0 +1,48 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>PermanentNavigationDrawer</c> — always-visible side
+/// drawer, intended for tablets / large screens. The
+/// <see cref="Drawer"/> slot typically holds a
+/// <see cref="PermanentDrawerSheet"/>.
+/// </summary>
+/// <remarks>
+/// Calls the bound C# entry point directly — the wrapper isn't
+/// hash-mangled so no JNI bridge is needed. Only the inner
+/// <c>PermanentDrawerSheet-afqeVBk</c> overload is stripped (see
+/// <see cref="PermanentDrawerSheet"/>).
+/// </remarks>
+public sealed class PermanentNavigationDrawer : ComposableNode
+{
+    /// <summary>Required: the always-visible drawer panel.</summary>
+    public ComposableNode? Drawer { get; set; }
+
+    /// <summary>Required: the main content shown next to the drawer.</summary>
+    public ComposableNode? Content { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Drawer is null)
+            throw new System.InvalidOperationException(
+                "PermanentNavigationDrawer.Drawer is required.");
+        if (Content is null)
+            throw new System.InvalidOperationException(
+                "PermanentNavigationDrawer.Content is required.");
+
+        var drawer  = new ComposableLambda2(c => Drawer.Render(c));
+        var content = new ComposableLambda2(c => Content.Render(c));
+
+        // Param order: drawerContent (bit 0, provided), modifier (bit 1,
+        // defaulted), content (bit 2, provided). $default = 0b010 = 2.
+        NavigationDrawerKt.PermanentNavigationDrawer(
+            drawerContent: drawer,
+            modifier:      null,
+            content:       content,
+            _composer:     composer,
+            p4:            0,
+            _changed:      0b010);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -20,6 +20,7 @@ public class MainActivity : ComposeActivity
             var showSheet   = Remember(() => new MutableState<bool>(false));
             var showDate    = Remember(() => new MutableState<bool>(false));
             var showTime    = Remember(() => new MutableState<bool>(false));
+            var drawerKind  = Remember(() => new MutableNumberState<int>(0));
             var pickedDate  = Remember(() => new MutableState<string>("(none)"));
             var pickedTime  = Remember(() => new MutableState<string>("(none)"));
             var dateState   = Remember(() => new DatePickerState());
@@ -97,33 +98,65 @@ public class MainActivity : ComposeActivity
                 },
                 3 => new Column
                 {
-                    new Text("Navigation drawer sheets"),
-                    new PermanentNavigationDrawer
+                    new Text("Navigation drawers"),
+                    new Text("Tap a button to switch demo. Swipe from the"),
+                    new Text("left edge of the demo area to open Modal /"),
+                    new Text("Dismissible drawers (no coroutine plumbing)."),
+                    new Button(onClick: () => drawerKind.Value = 0) { new Text("Modal") },
+                    new Button(onClick: () => drawerKind.Value = 1) { new Text("Dismissible") },
+                    new Button(onClick: () => drawerKind.Value = 2) { new Text("Permanent") },
+                    drawerKind.Value switch
                     {
-                        Drawer = new PermanentDrawerSheet
+                        0 => (ComposableNode)new ModalNavigationDrawer
                         {
-                            new Text("Permanent drawer"),
-                            new Text("• Inbox"),
-                            new Text("• Sent"),
-                            new Text("• Drafts"),
+                            Drawer = new ModalDrawerSheet
+                            {
+                                new Text("Modal drawer"),
+                                new Text("• Inbox"),
+                                new Text("• Sent"),
+                                new Text("• Drafts"),
+                            },
+                            Content = new Column
+                            {
+                                new Text("Main content"),
+                                new Text("Swipe right from edge →"),
+                                new Text($"Count: {count}"),
+                                new Button(onClick: () => count++) { new Text("+1") },
+                            },
                         },
-                        Content = new Column
+                        1 => new DismissibleNavigationDrawer
                         {
-                            new Text("Main content"),
-                            new Text($"Count: {count}"),
-                            new Button(onClick: () => count++) { new Text("+1") },
+                            Drawer = new DismissibleDrawerSheet
+                            {
+                                new Text("Dismissible drawer"),
+                                new Text("• Inbox"),
+                                new Text("• Sent"),
+                                new Text("• Drafts"),
+                            },
+                            Content = new Column
+                            {
+                                new Text("Main content"),
+                                new Text("Swipe right to open →"),
+                                new Text($"Count: {count}"),
+                                new Button(onClick: () => count++) { new Text("+1") },
+                            },
                         },
-                    },
-                    new Text("Standalone drawer sheets:"),
-                    new ModalDrawerSheet
-                    {
-                        new Text("ModalDrawerSheet"),
-                        new Text("(usually inside ModalNavigationDrawer)"),
-                    },
-                    new DismissibleDrawerSheet
-                    {
-                        new Text("DismissibleDrawerSheet"),
-                        new Text("(usually inside DismissibleNavigationDrawer)"),
+                        _ => new PermanentNavigationDrawer
+                        {
+                            Drawer = new PermanentDrawerSheet
+                            {
+                                new Text("Permanent drawer"),
+                                new Text("• Inbox"),
+                                new Text("• Sent"),
+                                new Text("• Drafts"),
+                            },
+                            Content = new Column
+                            {
+                                new Text("Main content"),
+                                new Text($"Count: {count}"),
+                                new Button(onClick: () => count++) { new Text("+1") },
+                            },
+                        },
                     },
                 },
                 _ => new Column

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -38,11 +38,6 @@ public class MainActivity : ComposeActivity
                     new IconButton(onClick: () => count--) { new Text("−") },
                     new OutlinedTextField(name),
                     new Text($"Hi {(string.IsNullOrEmpty(name.Value) ? "stranger" : name.Value)}"),
-                    new Card
-                    {
-                        new Text("Inside a Card"),
-                        new Text($"Counter snapshot: {count}"),
-                    },
                 },
                 1 => new Column
                 {
@@ -51,13 +46,25 @@ public class MainActivity : ComposeActivity
                     {
                         Label = new Text("Assist (+1)"),
                     },
+                    new ElevatedAssistChip(onClick: () => count++)
+                    {
+                        Label = new Text("Elevated assist (+1)"),
+                    },
                     new FilterChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value)
                     {
                         Label = new Text(liked.Value ? "Liked" : "Like"),
                     },
+                    new ElevatedFilterChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value)
+                    {
+                        Label = new Text(liked.Value ? "Elevated liked" : "Elevated like"),
+                    },
                     new SuggestionChip(onClick: () => count.Value = 0)
                     {
                         Label = new Text("Reset"),
+                    },
+                    new ElevatedSuggestionChip(onClick: () => count.Value = 0)
+                    {
+                        Label = new Text("Elevated reset"),
                     },
                     new Tooltip
                     {
@@ -67,6 +74,56 @@ public class MainActivity : ComposeActivity
                     new FloatingActionButton(onClick: () => showAlert.Value = true)
                     {
                         new Text("✕"),
+                    },
+                },
+                2 => new Column
+                {
+                    new Text("Card variants"),
+                    new Card
+                    {
+                        new Text("Card (tonal)"),
+                        new Text($"Counter snapshot: {count}"),
+                    },
+                    new ElevatedCard
+                    {
+                        new Text("ElevatedCard (shadow)"),
+                        new Text($"Counter snapshot: {count}"),
+                    },
+                    new OutlinedCard
+                    {
+                        new Text("OutlinedCard (border)"),
+                        new Text($"Counter snapshot: {count}"),
+                    },
+                },
+                3 => new Column
+                {
+                    new Text("Navigation drawer sheets"),
+                    new PermanentNavigationDrawer
+                    {
+                        Drawer = new PermanentDrawerSheet
+                        {
+                            new Text("Permanent drawer"),
+                            new Text("• Inbox"),
+                            new Text("• Sent"),
+                            new Text("• Drafts"),
+                        },
+                        Content = new Column
+                        {
+                            new Text("Main content"),
+                            new Text($"Count: {count}"),
+                            new Button(onClick: () => count++) { new Text("+1") },
+                        },
+                    },
+                    new Text("Standalone drawer sheets:"),
+                    new ModalDrawerSheet
+                    {
+                        new Text("ModalDrawerSheet"),
+                        new Text("(usually inside ModalNavigationDrawer)"),
+                    },
+                    new DismissibleDrawerSheet
+                    {
+                        new Text("DismissibleDrawerSheet"),
+                        new Text("(usually inside DismissibleNavigationDrawer)"),
                     },
                 },
                 _ => new Column
@@ -102,6 +159,16 @@ public class MainActivity : ComposeActivity
                                 Label = new Text("Buttons"),
                             },
                             new NavigationBarItem(selected: tab.Value == 2, onClick: () => tab.Value = 2)
+                            {
+                                Icon  = new Text("🃏"),
+                                Label = new Text("Cards"),
+                            },
+                            new NavigationBarItem(selected: tab.Value == 3, onClick: () => tab.Value = 3)
+                            {
+                                Icon  = new Text("📂"),
+                                Label = new Text("Drawer"),
+                            },
+                            new NavigationBarItem(selected: tab.Value == 4, onClick: () => tab.Value = 4)
                             {
                                 Icon  = new Text("📅"),
                                 Label = new Text("Pickers"),


### PR DESCRIPTION
Closes #2.

Adds the remaining 8 stripped composables from the issue triage:

| Class               | Bridges                                                                  |
|---------------------|--------------------------------------------------------------------------|
| `CardKt`            | `ElevatedCard`, `OutlinedCard`                                           |
| `ChipKt`            | `ElevatedAssistChip`, `ElevatedFilterChip`, `ElevatedSuggestionChip`     |
| `NavigationDrawerKt`| `ModalDrawerSheet`, `DismissibleDrawerSheet`, `PermanentDrawerSheet` (all `-afqeVBk` overloads) |

Each gets a JNI bridge in `ComposeBridges.cs` and a one-class facade file.

### `$default` enum reuse

Where the Kotlin parameter order matches an existing enum exactly, the new bridges reuse it:

- `OutlinedCard` → `CardDefault` (same 6 user params: modifier, shape, colors, elevation, border, content).
- `Elevated{Assist,Filter,Suggestion}Chip` → matching non-elevated `*ChipDefault` enums.

New enums:

- `ElevatedCardDefault` (5 params — no `border`).
- `DrawerSheetDefault` (7 params, shared by all three drawer sheets — they have identical signatures, only the JNI method name differs).

### `PermanentNavigationDrawer` facade

Bonus thin wrapper for `NavigationDrawerKt.PermanentNavigationDrawer` — the parent drawer is already bound (clean JVM name), so this is just a C# call with the correct `$default` bitmask. Lets the sample demo `PermanentDrawerSheet` inside its canonical parent.

### Sample

Two new tabs (`Cards`, `Drawer`); the elevated chip variants are folded into the existing `Buttons` tab.

### Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — all 10 generator tests pass.
- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet build src/ComposeNet.Sample` — clean.
- Method names + JNI signatures verified by `javap -s -p` against `Xamarin.AndroidX.Compose.Material3Android` 1.4.0.3 (`CardKt.class`, `ChipKt.class`, `NavigationDrawerKt.class`).