### PR TITLE
Add Modifier support (Phase 1: Padding + FillMax*)

### DIFF
--- a/src/ComposeNet.Compose/AlertDialog.cs
+++ b/src/ComposeNet.Compose/AlertDialog.cs
@@ -66,6 +66,8 @@ public sealed class AlertDialog : ComposableNode
         // Start from "default everything" and clear the bit for each
         // optional slot the user actually supplied.
         int defaults = (int)AlertDialogDefault.All;
+        var modifier = BuildModifier();
+        if (modifier   is not null) defaults &= ~(int)AlertDialogDefault.Modifier;
         if (dismissBtn is not null) defaults &= ~(int)AlertDialogDefault.DismissButton;
         if (icon       is not null) defaults &= ~(int)AlertDialogDefault.Icon;
         if (title      is not null) defaults &= ~(int)AlertDialogDefault.Title;
@@ -74,6 +76,7 @@ public sealed class AlertDialog : ComposableNode
         ComposeBridges.AlertDialog(
             onDismissRequest: onDismiss,
             confirmButton:    confirm,
+            modifier:         modifier,
             dismissButton:    dismissBtn,
             icon:             icon,
             title:            title,

--- a/src/ComposeNet.Compose/AssistChip.cs
+++ b/src/ComposeNet.Compose/AssistChip.cs
@@ -36,9 +36,11 @@ public sealed class AssistChip : ComposableNode
         ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
 
         int defaults = (int)AssistChipDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)AssistChipDefault.Modifier;
         if (leading  is not null) defaults &= ~(int)AssistChipDefault.LeadingIcon;
         if (trailing is not null) defaults &= ~(int)AssistChipDefault.TrailingIcon;
 
-        ComposeBridges.AssistChip(click, label, leading, trailing, defaults, composer);
+        ComposeBridges.AssistChip(click, label, modifier, leading, trailing, defaults, composer);
     }
 }

--- a/src/ComposeNet.Compose/BottomSheetScaffold.cs
+++ b/src/ComposeNet.Compose/BottomSheetScaffold.cs
@@ -46,11 +46,14 @@ public sealed class BottomSheetScaffold : ComposableContainer
             : new ComposableLambda2(c => TopBar.Render(c));
 
         int defaults = (int)BottomSheetScaffoldDefault.All;
+        var modifier = BuildModifier();
+        if (modifier   is not null) defaults &= ~(int)BottomSheetScaffoldDefault.Modifier;
         if (dragHandle is not null) defaults &= ~(int)BottomSheetScaffoldDefault.SheetDragHandle;
         if (topBar     is not null) defaults &= ~(int)BottomSheetScaffoldDefault.TopBar;
 
         ComposeBridges.BottomSheetScaffold(
             sheetContent:    sheet,
+            modifier:        modifier,
             scaffoldState:   ((Java.Lang.Object)scaffoldState).Handle,
             sheetDragHandle: dragHandle,
             topBar:          topBar,

--- a/src/ComposeNet.Compose/Button.cs
+++ b/src/ComposeNet.Compose/Button.cs
@@ -16,6 +16,6 @@ public sealed class Button : ComposableContainer
     {
         var click   = new ComposableLambda0(_onClick);
         var content = new ComposableLambda3(c => RenderChildren(c));
-        ComposeBridges.Button(click, content, composer);
+        ComposeBridges.Button(click, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/Card.cs
+++ b/src/ComposeNet.Compose/Card.cs
@@ -15,6 +15,6 @@ public sealed class Card : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var content = new ComposableLambda3(c => RenderChildren(c));
-        ComposeBridges.Card(content, composer);
+        ComposeBridges.Card(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/Column.cs
+++ b/src/ComposeNet.Compose/Column.cs
@@ -8,14 +8,17 @@ public sealed class Column : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
+        var modifier = BuildModifier();
         var content = new ComposableLambda3(c => RenderChildren(c));
+        int defaults = (int)ColumnDefault.All;
+        if (modifier is not null) defaults &= ~(int)ColumnDefault.Modifier;
         ColumnKt.Column(
-            modifier:            null,
+            modifier:            modifier,
             verticalArrangement: null,
             horizontalAlignment: null,
             content:             content,
             _composer:           composer,
             p5:                  0,
-            _changed:            (int)ColumnDefault.All);
+            _changed:            defaults);
     }
 }

--- a/src/ComposeNet.Compose/ComposableContainer.cs
+++ b/src/ComposeNet.Compose/ComposableContainer.cs
@@ -20,6 +20,16 @@ public abstract class ComposableContainer : ComposableNode, IEnumerable
         if (child is not null)
             _children.Add(child);
     }
+
+    /// <summary>
+    /// Collection-initializer overload that lets callers set
+    /// <see cref="ComposableNode.Modifier"/> inline alongside children:
+    /// <code>new Column { Modifier.Companion.Padding(16), new Text("Hi") }</code>
+    /// (C# disallows mixing object-initializer assignments with
+    /// collection-initializer items in the same braces, so the modifier
+    /// is set via <c>Add</c> instead.)
+    /// </summary>
+    public void Add(Modifier modifier) => Modifier = modifier;
     IEnumerator IEnumerable.GetEnumerator() => _children.GetEnumerator();
 
     /// <summary>Internal accessor for <see cref="Render"/> impls.</summary>

--- a/src/ComposeNet.Compose/ComposableNode.cs
+++ b/src/ComposeNet.Compose/ComposableNode.cs
@@ -1,4 +1,5 @@
 using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI;
 
 namespace ComposeNet;
 
@@ -17,5 +18,26 @@ namespace ComposeNet;
 /// </summary>
 public abstract class ComposableNode
 {
+    /// <summary>
+    /// Optional <see cref="ComposeNet.Modifier"/> chain applied to this
+    /// composable. For leaf composables, set via object-initializer:
+    /// <code>new Text("Hi") { Modifier = Modifier.Companion.Padding(8) }</code>
+    /// For container composables (which use collection-initializer syntax),
+    /// add the modifier inline alongside the children:
+    /// <code>new Column { Modifier.Companion.Padding(16), new Text("Hi") }</code>
+    /// Composables without a Kotlin <c>modifier</c> parameter
+    /// (e.g. <see cref="MaterialTheme"/>) ignore this property.
+    /// </summary>
+    public Modifier? Modifier { get; set; }
+
+    /// <summary>
+    /// Materialize <see cref="Modifier"/> for the JNI call. Returns
+    /// <c>null</c> when the user did not supply a modifier OR supplied
+    /// the empty <see cref="ComposeNet.Modifier.Companion"/> — in both
+    /// cases callers should leave the Kotlin <c>$default</c> bit set so
+    /// Compose substitutes its real default.
+    /// </summary>
+    internal IModifier? BuildModifier() => Modifier?.Build();
+
     internal abstract void Render(IComposer composer);
 }

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1,5 +1,6 @@
 using Android.Runtime;
 using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI;
 using Java.Interop;
 using Kotlin.Jvm.Functions;
 
@@ -12,6 +13,139 @@ namespace ComposeNet;
 // internal — user code never touches these directly.
 internal static class ComposeBridges
 {
+    // Convert a managed Modifier wrapper (from `Modifier.Build()`) to a
+    // raw JNI handle, or IntPtr.Zero when null. Each bridge that takes
+    // a modifier param uses this + KeepAlive's the wrapper across the
+    // JNI call so its handle stays alive.
+    internal static IntPtr ModifierHandle(IModifier? modifier) =>
+        modifier is null ? IntPtr.Zero : ((Java.Lang.Object)modifier).Handle;
+
+    // androidx.compose.ui.Modifier$Companion.$$INSTANCE — the empty
+    // Modifier that every chain builds on top of. Cached as a global
+    // ref so the chain builder doesn't pay the FindClass +
+    // GetStaticObjectField cost on every recomposition.
+    static IntPtr s_modifierCompanionInstance;
+
+    internal static unsafe IntPtr ModifierCompanionInstance()
+    {
+        if (s_modifierCompanionInstance == IntPtr.Zero)
+        {
+            IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/Modifier$Companion");
+            IntPtr fid = JNIEnv.GetStaticFieldID(cls, "$$INSTANCE", "Landroidx/compose/ui/Modifier$Companion;");
+            IntPtr local = JNIEnv.GetStaticObjectField(cls, fid);
+            s_modifierCompanionInstance = JNIEnv.NewGlobalRef(local);
+            JNIEnv.DeleteLocalRef(local);
+        }
+        // Returning a NEW local ref each call so callers can DeleteLocalRef
+        // it uniformly while walking the op chain.
+        return JNIEnv.NewLocalRef(s_modifierCompanionInstance);
+    }
+
+    // androidx.compose.foundation.layout.PaddingKt — the Dp-taking
+    // overloads have hashed JVM names from the inline-class compiler
+    // mangling (`@JvmInline value class Dp(val value: Float)`).
+    // The signatures below are stable across Compose UI 1.x.
+    const string ModifierDpSig =
+        "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;";
+    const string ModifierDp2Sig =
+        "(Landroidx/compose/ui/Modifier;FF)Landroidx/compose/ui/Modifier;";
+    const string ModifierDp4Sig =
+        "(Landroidx/compose/ui/Modifier;FFFF)Landroidx/compose/ui/Modifier;";
+
+    static IntPtr s_paddingKtClass;
+    static IntPtr s_paddingAllMethod;
+    static IntPtr s_paddingHVMethod;
+    static IntPtr s_paddingLTRBMethod;
+
+    internal static unsafe IntPtr ModifierPaddingAll(IntPtr modifier, float dp)
+    {
+        if (s_paddingKtClass == IntPtr.Zero)
+            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
+        if (s_paddingAllMethod == IntPtr.Zero)
+            s_paddingAllMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding-3ABfNKs", ModifierDpSig);
+
+        JValue* args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(dp);
+        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingAllMethod, args);
+    }
+
+    internal static unsafe IntPtr ModifierPaddingHV(IntPtr modifier, float horizontal, float vertical)
+    {
+        if (s_paddingKtClass == IntPtr.Zero)
+            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
+        if (s_paddingHVMethod == IntPtr.Zero)
+            s_paddingHVMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding-VpY3zN4", ModifierDp2Sig);
+
+        JValue* args = stackalloc JValue[3];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(horizontal);
+        args[2] = new JValue(vertical);
+        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingHVMethod, args);
+    }
+
+    internal static unsafe IntPtr ModifierPaddingLTRB(IntPtr modifier, float start, float top, float end, float bottom)
+    {
+        if (s_paddingKtClass == IntPtr.Zero)
+            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
+        if (s_paddingLTRBMethod == IntPtr.Zero)
+            s_paddingLTRBMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding-qDBjuR0", ModifierDp4Sig);
+
+        JValue* args = stackalloc JValue[5];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(start);
+        args[2] = new JValue(top);
+        args[3] = new JValue(end);
+        args[4] = new JValue(bottom);
+        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingLTRBMethod, args);
+    }
+
+    // androidx.compose.foundation.layout.SizeKt — fillMax* take a plain
+    // Float fraction, not Dp, so the JVM names are NOT mangled.
+    static IntPtr s_sizeKtClass;
+    static IntPtr s_fillMaxWidthMethod;
+    static IntPtr s_fillMaxHeightMethod;
+    static IntPtr s_fillMaxSizeMethod;
+
+    internal static unsafe IntPtr ModifierFillMaxWidth(IntPtr modifier, float fraction)
+    {
+        if (s_sizeKtClass == IntPtr.Zero)
+            s_sizeKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/SizeKt");
+        if (s_fillMaxWidthMethod == IntPtr.Zero)
+            s_fillMaxWidthMethod = JNIEnv.GetStaticMethodID(s_sizeKtClass, "fillMaxWidth", ModifierDpSig);
+
+        JValue* args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(fraction);
+        return JNIEnv.CallStaticObjectMethod(s_sizeKtClass, s_fillMaxWidthMethod, args);
+    }
+
+    internal static unsafe IntPtr ModifierFillMaxHeight(IntPtr modifier, float fraction)
+    {
+        if (s_sizeKtClass == IntPtr.Zero)
+            s_sizeKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/SizeKt");
+        if (s_fillMaxHeightMethod == IntPtr.Zero)
+            s_fillMaxHeightMethod = JNIEnv.GetStaticMethodID(s_sizeKtClass, "fillMaxHeight", ModifierDpSig);
+
+        JValue* args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(fraction);
+        return JNIEnv.CallStaticObjectMethod(s_sizeKtClass, s_fillMaxHeightMethod, args);
+    }
+
+    internal static unsafe IntPtr ModifierFillMaxSize(IntPtr modifier, float fraction)
+    {
+        if (s_sizeKtClass == IntPtr.Zero)
+            s_sizeKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/SizeKt");
+        if (s_fillMaxSizeMethod == IntPtr.Zero)
+            s_fillMaxSizeMethod = JNIEnv.GetStaticMethodID(s_sizeKtClass, "fillMaxSize", ModifierDpSig);
+
+        JValue* args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(fraction);
+        return JNIEnv.CallStaticObjectMethod(s_sizeKtClass, s_fillMaxSizeMethod, args);
+    }
+
     // androidx.compose.material3.TextKt.Text--4IGK_g(text, modifier, color,
     //   fontSize, fontStyle, fontWeight, fontFamily, letterSpacing, decoration,
     //   align, lineHeight, overflow, softWrap, maxLines, minLines, onTextLayout,
@@ -29,7 +163,7 @@ internal static class ComposeBridges
     static IntPtr s_textClass;
     static IntPtr s_textMethod;
 
-    public static unsafe void Text(string text, IComposer composer)
+    public static unsafe void Text(string text, IModifier? modifier, IComposer composer)
     {
         if (s_textClass == IntPtr.Zero)
         {
@@ -37,15 +171,16 @@ internal static class ComposeBridges
             s_textMethod = JNIEnv.GetStaticMethodID(s_textClass, "Text--4IGK_g", MaterialTextSig);
         }
 
-        // Everything but `text` is defaulted.
+        // Everything but `text` (and optionally `modifier`) is defaulted.
         int defaults = (int)TextDefault.All;
+        if (modifier is not null) defaults &= ~(int)TextDefault.Modifier;
 
         IntPtr textRef = JNIEnv.NewString(text);
         try
         {
             JValue* args = stackalloc JValue[21];
             args[0]  = new JValue(textRef);
-            args[1]  = new JValue(IntPtr.Zero); // modifier
+            args[1]  = new JValue(ModifierHandle(modifier));
             args[2]  = new JValue(0L);          // color = Unspecified
             args[3]  = new JValue(0L);          // fontSize
             args[4]  = new JValue(IntPtr.Zero); // fontStyle
@@ -70,6 +205,7 @@ internal static class ComposeBridges
         finally
         {
             JNIEnv.DeleteLocalRef(textRef);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(composer);
         }
     }
@@ -88,7 +224,7 @@ internal static class ComposeBridges
     static IntPtr s_buttonClass;
     static IntPtr s_buttonMethod;
 
-    public static unsafe void Button(IFunction0 onClick, IFunction3 content, IComposer composer)
+    public static unsafe void Button(IFunction0 onClick, IModifier? modifier, IFunction3 content, IComposer composer)
     {
         if (s_buttonClass == IntPtr.Zero)
         {
@@ -98,10 +234,11 @@ internal static class ComposeBridges
 
         // onClick (bit 0) and content (bit 9) are provided; default everything else.
         int defaults = (int)ButtonDefault.All;
+        if (modifier is not null) defaults &= ~(int)ButtonDefault.Modifier;
 
         JValue* args = stackalloc JValue[13];
         args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
-        args[1]  = new JValue(IntPtr.Zero);
+        args[1]  = new JValue(ModifierHandle(modifier));
         args[2]  = new JValue(true);
         args[3]  = new JValue(IntPtr.Zero);
         args[4]  = new JValue(IntPtr.Zero);
@@ -120,6 +257,7 @@ internal static class ComposeBridges
         finally
         {
             GC.KeepAlive(onClick);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -136,7 +274,7 @@ internal static class ComposeBridges
     static IntPtr s_iconButtonClass;
     static IntPtr s_iconButtonMethod;
 
-    public static unsafe void IconButton(IFunction0 onClick, IFunction2 content, IComposer composer)
+    public static unsafe void IconButton(IFunction0 onClick, IModifier? modifier, IFunction2 content, IComposer composer)
     {
         if (s_iconButtonClass == IntPtr.Zero)
         {
@@ -144,16 +282,19 @@ internal static class ComposeBridges
             s_iconButtonMethod = JNIEnv.GetStaticMethodID(s_iconButtonClass, "IconButton", IconButtonSig);
         }
 
+        int defaults = (int)IconButtonDefault.All;
+        if (modifier is not null) defaults &= ~(int)IconButtonDefault.Modifier;
+
         JValue* args = stackalloc JValue[9];
         args[0] = new JValue(((Java.Lang.Object)onClick).Handle);
-        args[1] = new JValue(IntPtr.Zero);
+        args[1] = new JValue(ModifierHandle(modifier));
         args[2] = new JValue(true);
         args[3] = new JValue(IntPtr.Zero);
         args[4] = new JValue(IntPtr.Zero);
         args[5] = new JValue(((Java.Lang.Object)content).Handle);
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
-        args[8] = new JValue((int)IconButtonDefault.All);
+        args[8] = new JValue(defaults);
         try
         {
             JNIEnv.CallStaticVoidMethod(s_iconButtonClass, s_iconButtonMethod, args);
@@ -161,6 +302,7 @@ internal static class ComposeBridges
         finally
         {
             GC.KeepAlive(onClick);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -179,7 +321,7 @@ internal static class ComposeBridges
     static IntPtr s_fabClass;
     static IntPtr s_fabMethod;
 
-    public static unsafe void FloatingActionButton(IFunction0 onClick, IFunction2 content, IComposer composer)
+    public static unsafe void FloatingActionButton(IFunction0 onClick, IModifier? modifier, IFunction2 content, IComposer composer)
     {
         if (s_fabClass == IntPtr.Zero)
         {
@@ -187,9 +329,12 @@ internal static class ComposeBridges
             s_fabMethod = JNIEnv.GetStaticMethodID(s_fabClass, "FloatingActionButton-X-z6DiA", FabSig);
         }
 
+        int defaults = (int)FloatingActionButtonDefault.All;
+        if (modifier is not null) defaults &= ~(int)FloatingActionButtonDefault.Modifier;
+
         JValue* args = stackalloc JValue[11];
         args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
-        args[1]  = new JValue(IntPtr.Zero); // modifier
+        args[1]  = new JValue(ModifierHandle(modifier)); // modifier
         args[2]  = new JValue(IntPtr.Zero); // shape
         args[3]  = new JValue(0L);          // containerColor
         args[4]  = new JValue(0L);          // contentColor
@@ -198,7 +343,7 @@ internal static class ComposeBridges
         args[7]  = new JValue(((Java.Lang.Object)content).Handle);
         args[8]  = new JValue(((Java.Lang.Object)composer).Handle);
         args[9]  = new JValue(0);
-        args[10] = new JValue((int)FloatingActionButtonDefault.All);
+        args[10] = new JValue(defaults);
         try
         {
             JNIEnv.CallStaticVoidMethod(s_fabClass, s_fabMethod, args);
@@ -206,6 +351,7 @@ internal static class ComposeBridges
         finally
         {
             GC.KeepAlive(onClick);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -222,7 +368,7 @@ internal static class ComposeBridges
     static IntPtr s_surfaceClass;
     static IntPtr s_surfaceMethod;
 
-    public static unsafe void Surface(IFunction2 content, IComposer composer)
+    public static unsafe void Surface(IModifier? modifier, IFunction2 content, IComposer composer)
     {
         if (s_surfaceClass == IntPtr.Zero)
         {
@@ -230,8 +376,11 @@ internal static class ComposeBridges
             s_surfaceMethod = JNIEnv.GetStaticMethodID(s_surfaceClass, "Surface-T9BRK9s", SurfaceSig);
         }
 
+        int defaults = (int)SurfaceDefault.All;
+        if (modifier is not null) defaults &= ~(int)SurfaceDefault.Modifier;
+
         JValue* args = stackalloc JValue[11];
-        args[0]  = new JValue(IntPtr.Zero); // modifier
+        args[0]  = new JValue(ModifierHandle(modifier)); // modifier
         args[1]  = new JValue(IntPtr.Zero); // shape
         args[2]  = new JValue(0L);          // color
         args[3]  = new JValue(0L);          // contentColor
@@ -241,13 +390,14 @@ internal static class ComposeBridges
         args[7]  = new JValue(((Java.Lang.Object)content).Handle);
         args[8]  = new JValue(((Java.Lang.Object)composer).Handle);
         args[9]  = new JValue(0);
-        args[10] = new JValue((int)SurfaceDefault.All);
+        args[10] = new JValue(defaults);
         try
         {
             JNIEnv.CallStaticVoidMethod(s_surfaceClass, s_surfaceMethod, args);
         }
         finally
         {
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -280,24 +430,28 @@ internal static class ComposeBridges
     static IntPtr s_outlinedTextFieldClass;
     static IntPtr s_outlinedTextFieldMethod;
 
-    public static unsafe void TextField(string value, IFunction1 onValueChange, IComposer composer)
+    public static unsafe void TextField(string value, IFunction1 onValueChange, IModifier? modifier, IComposer composer)
     {
         if (s_textFieldClass == IntPtr.Zero)
         {
             s_textFieldClass  = JNIEnv.FindClass("androidx/compose/material3/TextFieldKt");
             s_textFieldMethod = JNIEnv.GetStaticMethodID(s_textFieldClass, "TextField", TextFieldStringSig);
         }
-        InvokeTextField(s_textFieldClass, s_textFieldMethod, value, onValueChange, composer, (int)TextFieldDefault.All);
+        int defaults = (int)TextFieldDefault.All;
+        if (modifier is not null) defaults &= ~(int)TextFieldDefault.Modifier;
+        InvokeTextField(s_textFieldClass, s_textFieldMethod, value, onValueChange, modifier, composer, defaults);
     }
 
-    public static unsafe void OutlinedTextField(string value, IFunction1 onValueChange, IComposer composer)
+    public static unsafe void OutlinedTextField(string value, IFunction1 onValueChange, IModifier? modifier, IComposer composer)
     {
         if (s_outlinedTextFieldClass == IntPtr.Zero)
         {
             s_outlinedTextFieldClass  = JNIEnv.FindClass("androidx/compose/material3/OutlinedTextFieldKt");
             s_outlinedTextFieldMethod = JNIEnv.GetStaticMethodID(s_outlinedTextFieldClass, "OutlinedTextField", TextFieldStringSig);
         }
-        InvokeTextField(s_outlinedTextFieldClass, s_outlinedTextFieldMethod, value, onValueChange, composer, (int)TextFieldDefault.All);
+        int defaults = (int)TextFieldDefault.All;
+        if (modifier is not null) defaults &= ~(int)TextFieldDefault.Modifier;
+        InvokeTextField(s_outlinedTextFieldClass, s_outlinedTextFieldMethod, value, onValueChange, modifier, composer, defaults);
     }
 
     // androidx.compose.material3.AndroidAlertDialog_androidKt.AlertDialog-Oix01E0(
@@ -325,6 +479,7 @@ internal static class ComposeBridges
     public static unsafe void AlertDialog(
         IFunction0  onDismissRequest,
         IFunction2  confirmButton,
+        IModifier?  modifier,
         IFunction2? dismissButton,
         IFunction2? icon,
         IFunction2? title,
@@ -341,7 +496,7 @@ internal static class ComposeBridges
         JValue* args = stackalloc JValue[18];
         args[0]  = new JValue(((Java.Lang.Object)onDismissRequest).Handle);
         args[1]  = new JValue(((Java.Lang.Object)confirmButton).Handle);
-        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[2]  = new JValue(ModifierHandle(modifier)); // modifier
         args[3]  = new JValue(dismissButton is null ? IntPtr.Zero : ((Java.Lang.Object)dismissButton).Handle);
         args[4]  = new JValue(icon          is null ? IntPtr.Zero : ((Java.Lang.Object)icon).Handle);
         args[5]  = new JValue(title         is null ? IntPtr.Zero : ((Java.Lang.Object)title).Handle);
@@ -365,6 +520,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onDismissRequest);
             GC.KeepAlive(confirmButton);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(dismissButton);
             GC.KeepAlive(icon);
             GC.KeepAlive(title);
@@ -392,6 +548,7 @@ internal static class ComposeBridges
 
     public static unsafe void ModalBottomSheet(
         IFunction0  onDismissRequest,
+        IModifier?  modifier,
         IntPtr      sheetState,
         IFunction2? dragHandle,
         IFunction3  content,
@@ -406,7 +563,7 @@ internal static class ComposeBridges
 
         JValue* args = stackalloc JValue[17];
         args[0]  = new JValue(((Java.Lang.Object)onDismissRequest).Handle);
-        args[1]  = new JValue(IntPtr.Zero); // modifier
+        args[1]  = new JValue(ModifierHandle(modifier)); // modifier
         args[2]  = new JValue(sheetState);
         args[3]  = new JValue(0f);          // sheetMaxWidth
         args[4]  = new JValue(IntPtr.Zero); // shape
@@ -429,6 +586,7 @@ internal static class ComposeBridges
         finally
         {
             GC.KeepAlive(onDismissRequest);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(dragHandle);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
@@ -458,6 +616,7 @@ internal static class ComposeBridges
 
     public static unsafe void BottomSheetScaffold(
         IFunction3  sheetContent,
+        IModifier?  modifier,
         IntPtr      scaffoldState,
         IFunction2? sheetDragHandle,
         IFunction2? topBar,
@@ -474,7 +633,7 @@ internal static class ComposeBridges
 
         JValue* args = stackalloc JValue[21];
         args[0]  = new JValue(((Java.Lang.Object)sheetContent).Handle);
-        args[1]  = new JValue(IntPtr.Zero); // modifier
+        args[1]  = new JValue(ModifierHandle(modifier)); // modifier
         args[2]  = new JValue(scaffoldState);
         args[3]  = new JValue(0f);          // sheetPeekHeight
         args[4]  = new JValue(0f);          // sheetMaxWidth
@@ -501,6 +660,7 @@ internal static class ComposeBridges
         finally
         {
             GC.KeepAlive(sheetContent);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(sheetDragHandle);
             GC.KeepAlive(topBar);
             GC.KeepAlive(snackbarHost);
@@ -530,6 +690,7 @@ internal static class ComposeBridges
     static IntPtr s_scaffoldMethod;
 
     public static unsafe void Scaffold(
+        IModifier?  modifier,
         IFunction2? topBar,
         IFunction2? bottomBar,
         IFunction2? snackbarHost,
@@ -545,7 +706,7 @@ internal static class ComposeBridges
         }
 
         JValue* args = stackalloc JValue[13];
-        args[0]  = new JValue(IntPtr.Zero); // modifier
+        args[0]  = new JValue(ModifierHandle(modifier)); // modifier
         args[1]  = new JValue(topBar               is null ? IntPtr.Zero : ((Java.Lang.Object)topBar).Handle);
         args[2]  = new JValue(bottomBar            is null ? IntPtr.Zero : ((Java.Lang.Object)bottomBar).Handle);
         args[3]  = new JValue(snackbarHost         is null ? IntPtr.Zero : ((Java.Lang.Object)snackbarHost).Handle);
@@ -564,6 +725,7 @@ internal static class ComposeBridges
         }
         finally
         {
+            GC.KeepAlive(modifier);
             GC.KeepAlive(topBar);
             GC.KeepAlive(bottomBar);
             GC.KeepAlive(snackbarHost);
@@ -594,6 +756,7 @@ internal static class ComposeBridges
     public static unsafe void DatePickerDialog(
         IFunction0  onDismissRequest,
         IFunction2  confirmButton,
+        IModifier?  modifier,
         IFunction2? dismissButton,
         IFunction3  content,
         int         defaults,
@@ -608,7 +771,7 @@ internal static class ComposeBridges
         JValue* args = stackalloc JValue[12];
         args[0]  = new JValue(((Java.Lang.Object)onDismissRequest).Handle);
         args[1]  = new JValue(((Java.Lang.Object)confirmButton).Handle);
-        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[2]  = new JValue(ModifierHandle(modifier)); // modifier
         args[3]  = new JValue(dismissButton is null ? IntPtr.Zero : ((Java.Lang.Object)dismissButton).Handle);
         args[4]  = new JValue(IntPtr.Zero); // shape
         args[5]  = new JValue(0f);          // tonalElevation
@@ -626,6 +789,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onDismissRequest);
             GC.KeepAlive(confirmButton);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(dismissButton);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
@@ -643,7 +807,7 @@ internal static class ComposeBridges
     static IntPtr s_timePickerClass;
     static IntPtr s_timePickerMethod;
 
-    public static unsafe void TimePicker(IntPtr state, int defaults, IComposer composer)
+    public static unsafe void TimePicker(IntPtr state, IModifier? modifier, int defaults, IComposer composer)
     {
         if (s_timePickerClass == IntPtr.Zero)
         {
@@ -653,7 +817,7 @@ internal static class ComposeBridges
 
         JValue* args = stackalloc JValue[7];
         args[0] = new JValue(state);
-        args[1] = new JValue(IntPtr.Zero); // modifier
+        args[1] = new JValue(ModifierHandle(modifier)); // modifier
         args[2] = new JValue(IntPtr.Zero); // colors
         args[3] = new JValue(0);           // layoutType
         args[4] = new JValue(((Java.Lang.Object)composer).Handle);
@@ -665,6 +829,7 @@ internal static class ComposeBridges
         }
         finally
         {
+            GC.KeepAlive(modifier);
             GC.KeepAlive(composer);
         }
     }
@@ -692,6 +857,7 @@ internal static class ComposeBridges
         IFunction0  onDismissRequest,
         IFunction2  confirmButton,
         IFunction2  dismissButton,
+        IModifier?  modifier,
         IFunction2? title,
         IFunction2? modeToggleButton,
         IFunction3  content,
@@ -708,7 +874,7 @@ internal static class ComposeBridges
         args[0]  = new JValue(((Java.Lang.Object)onDismissRequest).Handle);
         args[1]  = new JValue(((Java.Lang.Object)confirmButton).Handle);
         args[2]  = new JValue(((Java.Lang.Object)dismissButton).Handle);
-        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(ModifierHandle(modifier)); // modifier
         args[4]  = new JValue(IntPtr.Zero); // properties
         args[5]  = new JValue(title            is null ? IntPtr.Zero : ((Java.Lang.Object)title).Handle);
         args[6]  = new JValue(modeToggleButton is null ? IntPtr.Zero : ((Java.Lang.Object)modeToggleButton).Handle);
@@ -727,6 +893,7 @@ internal static class ComposeBridges
             GC.KeepAlive(onDismissRequest);
             GC.KeepAlive(confirmButton);
             GC.KeepAlive(dismissButton);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(title);
             GC.KeepAlive(modeToggleButton);
             GC.KeepAlive(content);
@@ -753,6 +920,7 @@ internal static class ComposeBridges
         IntPtr     positionProvider,
         IFunction3 tooltip,
         IntPtr     state,
+        IModifier? modifier,
         IFunction2 content,
         int        defaults,
         IComposer  composer)
@@ -767,7 +935,7 @@ internal static class ComposeBridges
         args[0] = new JValue(positionProvider);
         args[1] = new JValue(((Java.Lang.Object)tooltip).Handle);
         args[2] = new JValue(state);
-        args[3] = new JValue(IntPtr.Zero); // modifier
+        args[3] = new JValue(ModifierHandle(modifier)); // modifier
         args[4] = new JValue(true);        // focusable
         args[5] = new JValue(true);        // enableUserInput
         args[6] = new JValue(((Java.Lang.Object)content).Handle);
@@ -781,6 +949,7 @@ internal static class ComposeBridges
         finally
         {
             GC.KeepAlive(tooltip);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -803,7 +972,7 @@ internal static class ComposeBridges
     static IntPtr s_datePickerClass;
     static IntPtr s_datePickerMethod;
 
-    public static unsafe void DatePicker(IntPtr state, int defaults, IComposer composer)
+    public static unsafe void DatePicker(IntPtr state, IModifier? modifier, int defaults, IComposer composer)
     {
         if (s_datePickerClass == IntPtr.Zero)
         {
@@ -813,7 +982,7 @@ internal static class ComposeBridges
 
         JValue* args = stackalloc JValue[11];
         args[0]  = new JValue(state);
-        args[1]  = new JValue(IntPtr.Zero); // modifier
+        args[1]  = new JValue(ModifierHandle(modifier)); // modifier
         args[2]  = new JValue(IntPtr.Zero); // dateFormatter
         args[3]  = new JValue(IntPtr.Zero); // colors
         args[4]  = new JValue(IntPtr.Zero); // title
@@ -829,6 +998,7 @@ internal static class ComposeBridges
         }
         finally
         {
+            GC.KeepAlive(modifier);
             GC.KeepAlive(composer);
         }
     }
@@ -982,7 +1152,7 @@ internal static class ComposeBridges
         }
     }
 
-    static unsafe void InvokeTextField(IntPtr cls, IntPtr method, string value, IFunction1 onValueChange, IComposer composer, int defaults)
+    static unsafe void InvokeTextField(IntPtr cls, IntPtr method, string value, IFunction1 onValueChange, IModifier? modifier, IComposer composer, int defaults)
     {
         IntPtr valueRef = JNIEnv.NewString(value);
         try
@@ -990,7 +1160,7 @@ internal static class ComposeBridges
             JValue* args = stackalloc JValue[28];
             args[0]  = new JValue(valueRef);
             args[1]  = new JValue(((Java.Lang.Object)onValueChange).Handle);
-            args[2]  = new JValue(IntPtr.Zero); // modifier
+            args[2]  = new JValue(ModifierHandle(modifier)); // modifier
             args[3]  = new JValue(true);        // enabled
             args[4]  = new JValue(false);       // readOnly
             args[5]  = new JValue(IntPtr.Zero); // textStyle
@@ -1022,6 +1192,7 @@ internal static class ComposeBridges
         {
             JNIEnv.DeleteLocalRef(valueRef);
             GC.KeepAlive(onValueChange);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(composer);
         }
     }
@@ -1039,7 +1210,7 @@ internal static class ComposeBridges
     static IntPtr s_cardClass;
     static IntPtr s_cardMethod;
 
-    public static unsafe void Card(IFunction3 content, IComposer composer)
+    public static unsafe void Card(IModifier? modifier, IFunction3 content, IComposer composer)
     {
         if (s_cardClass == IntPtr.Zero)
         {
@@ -1047,8 +1218,11 @@ internal static class ComposeBridges
             s_cardMethod = JNIEnv.GetStaticMethodID(s_cardClass, "Card", CardSig);
         }
 
+        int defaults = (int)CardDefault.All;
+        if (modifier is not null) defaults &= ~(int)CardDefault.Modifier;
+
         JValue* args = stackalloc JValue[9];
-        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[0] = new JValue(ModifierHandle(modifier)); // modifier
         args[1] = new JValue(IntPtr.Zero); // shape
         args[2] = new JValue(IntPtr.Zero); // colors
         args[3] = new JValue(IntPtr.Zero); // elevation
@@ -1056,13 +1230,14 @@ internal static class ComposeBridges
         args[5] = new JValue(((Java.Lang.Object)content).Handle);
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
-        args[8] = new JValue((int)CardDefault.All);
+        args[8] = new JValue(defaults);
         try
         {
             JNIEnv.CallStaticVoidMethod(s_cardClass, s_cardMethod, args);
         }
         finally
         {
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -1090,6 +1265,7 @@ internal static class ComposeBridges
     public static unsafe void AssistChip(
         IFunction0  onClick,
         IFunction2  label,
+        IModifier?  modifier,
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         int         defaults,
@@ -1104,7 +1280,7 @@ internal static class ComposeBridges
         JValue* args = stackalloc JValue[15];
         args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
         args[1]  = new JValue(((Java.Lang.Object)label).Handle);
-        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[2]  = new JValue(ModifierHandle(modifier)); // modifier
         args[3]  = new JValue(true);        // enabled
         args[4]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
         args[5]  = new JValue(trailingIcon is null ? IntPtr.Zero : ((Java.Lang.Object)trailingIcon).Handle);
@@ -1125,6 +1301,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onClick);
             GC.KeepAlive(label);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(leadingIcon);
             GC.KeepAlive(trailingIcon);
             GC.KeepAlive(composer);
@@ -1154,6 +1331,7 @@ internal static class ComposeBridges
         bool        selected,
         IFunction0  onClick,
         IFunction2  label,
+        IModifier?  modifier,
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         int         defaults,
@@ -1169,7 +1347,7 @@ internal static class ComposeBridges
         args[0]  = new JValue(selected);
         args[1]  = new JValue(((Java.Lang.Object)onClick).Handle);
         args[2]  = new JValue(((Java.Lang.Object)label).Handle);
-        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(ModifierHandle(modifier)); // modifier
         args[4]  = new JValue(true);        // enabled
         args[5]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
         args[6]  = new JValue(trailingIcon is null ? IntPtr.Zero : ((Java.Lang.Object)trailingIcon).Handle);
@@ -1190,6 +1368,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onClick);
             GC.KeepAlive(label);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(leadingIcon);
             GC.KeepAlive(trailingIcon);
             GC.KeepAlive(composer);
@@ -1219,6 +1398,7 @@ internal static class ComposeBridges
         bool        selected,
         IFunction0  onClick,
         IFunction2  label,
+        IModifier?  modifier,
         IFunction2? leadingIcon,
         IFunction2? avatar,
         IFunction2? trailingIcon,
@@ -1235,7 +1415,7 @@ internal static class ComposeBridges
         args[0]  = new JValue(selected);
         args[1]  = new JValue(((Java.Lang.Object)onClick).Handle);
         args[2]  = new JValue(((Java.Lang.Object)label).Handle);
-        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(ModifierHandle(modifier)); // modifier
         args[4]  = new JValue(true);        // enabled
         args[5]  = new JValue(leadingIcon  is null ? IntPtr.Zero : ((Java.Lang.Object)leadingIcon).Handle);
         args[6]  = new JValue(avatar       is null ? IntPtr.Zero : ((Java.Lang.Object)avatar).Handle);
@@ -1257,6 +1437,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onClick);
             GC.KeepAlive(label);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(leadingIcon);
             GC.KeepAlive(avatar);
             GC.KeepAlive(trailingIcon);
@@ -1283,6 +1464,7 @@ internal static class ComposeBridges
     public static unsafe void SuggestionChip(
         IFunction0  onClick,
         IFunction2  label,
+        IModifier?  modifier,
         IFunction2? icon,
         int         defaults,
         IComposer   composer)
@@ -1296,7 +1478,7 @@ internal static class ComposeBridges
         JValue* args = stackalloc JValue[13];
         args[0]  = new JValue(((Java.Lang.Object)onClick).Handle);
         args[1]  = new JValue(((Java.Lang.Object)label).Handle);
-        args[2]  = new JValue(IntPtr.Zero); // modifier
+        args[2]  = new JValue(ModifierHandle(modifier)); // modifier
         args[3]  = new JValue(true);        // enabled
         args[4]  = new JValue(icon is null ? IntPtr.Zero : ((Java.Lang.Object)icon).Handle);
         args[5]  = new JValue(IntPtr.Zero); // shape
@@ -1315,6 +1497,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onClick);
             GC.KeepAlive(label);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(icon);
             GC.KeepAlive(composer);
         }
@@ -1332,7 +1515,7 @@ internal static class ComposeBridges
     static IntPtr s_navBarClass;
     static IntPtr s_navBarMethod;
 
-    public static unsafe void NavigationBar(IFunction3 content, IComposer composer)
+    public static unsafe void NavigationBar(IModifier? modifier, IFunction3 content, IComposer composer)
     {
         if (s_navBarClass == IntPtr.Zero)
         {
@@ -1340,8 +1523,11 @@ internal static class ComposeBridges
             s_navBarMethod = JNIEnv.GetStaticMethodID(s_navBarClass, "NavigationBar-HsRjFd4", NavigationBarSig);
         }
 
+        int defaults = (int)NavigationBarDefault.All;
+        if (modifier is not null) defaults &= ~(int)NavigationBarDefault.Modifier;
+
         JValue* args = stackalloc JValue[9];
-        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[0] = new JValue(ModifierHandle(modifier)); // modifier
         args[1] = new JValue(0L);          // containerColor
         args[2] = new JValue(0L);          // contentColor
         args[3] = new JValue(0f);          // tonalElevation
@@ -1349,13 +1535,14 @@ internal static class ComposeBridges
         args[5] = new JValue(((Java.Lang.Object)content).Handle);
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
-        args[8] = new JValue((int)NavigationBarDefault.All);
+        args[8] = new JValue(defaults);
         try
         {
             JNIEnv.CallStaticVoidMethod(s_navBarClass, s_navBarMethod, args);
         }
         finally
         {
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -1383,6 +1570,7 @@ internal static class ComposeBridges
         bool        selected,
         IFunction0  onClick,
         IFunction2  icon,
+        IModifier?  modifier,
         IFunction2? label,
         int         defaults,
         IComposer   composer)
@@ -1402,7 +1590,7 @@ internal static class ComposeBridges
         args[1]  = new JValue(selected);
         args[2]  = new JValue(((Java.Lang.Object)onClick).Handle);
         args[3]  = new JValue(((Java.Lang.Object)icon).Handle);
-        args[4]  = new JValue(IntPtr.Zero); // modifier
+        args[4]  = new JValue(ModifierHandle(modifier)); // modifier
         args[5]  = new JValue(true);        // enabled
         args[6]  = new JValue(label is null ? IntPtr.Zero : ((Java.Lang.Object)label).Handle);
         args[7]  = new JValue(true);        // alwaysShowLabel
@@ -1419,6 +1607,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onClick);
             GC.KeepAlive(icon);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(label);
             GC.KeepAlive(composer);
         }
@@ -1438,7 +1627,7 @@ internal static class ComposeBridges
     static IntPtr s_navRailClass;
     static IntPtr s_navRailMethod;
 
-    public static unsafe void NavigationRail(IFunction3 content, IComposer composer)
+    public static unsafe void NavigationRail(IModifier? modifier, IFunction3 content, IComposer composer)
     {
         if (s_navRailClass == IntPtr.Zero)
         {
@@ -1446,8 +1635,11 @@ internal static class ComposeBridges
             s_navRailMethod = JNIEnv.GetStaticMethodID(s_navRailClass, "NavigationRail-qi6gXK8", NavigationRailSig);
         }
 
+        int defaults = (int)NavigationRailDefault.All;
+        if (modifier is not null) defaults &= ~(int)NavigationRailDefault.Modifier;
+
         JValue* args = stackalloc JValue[9];
-        args[0] = new JValue(IntPtr.Zero); // modifier
+        args[0] = new JValue(ModifierHandle(modifier)); // modifier
         args[1] = new JValue(0L);          // containerColor
         args[2] = new JValue(0L);          // contentColor
         args[3] = new JValue(IntPtr.Zero); // header
@@ -1455,13 +1647,14 @@ internal static class ComposeBridges
         args[5] = new JValue(((Java.Lang.Object)content).Handle);
         args[6] = new JValue(((Java.Lang.Object)composer).Handle);
         args[7] = new JValue(0);
-        args[8] = new JValue((int)NavigationRailDefault.All);
+        args[8] = new JValue(defaults);
         try
         {
             JNIEnv.CallStaticVoidMethod(s_navRailClass, s_navRailMethod, args);
         }
         finally
         {
+            GC.KeepAlive(modifier);
             GC.KeepAlive(content);
             GC.KeepAlive(composer);
         }
@@ -1795,6 +1988,7 @@ internal static class ComposeBridges
         bool        selected,
         IFunction0  onClick,
         IFunction2  icon,
+        IModifier?  modifier,
         IFunction2? label,
         int         defaults,
         IComposer   composer)
@@ -1809,7 +2003,7 @@ internal static class ComposeBridges
         args[0]  = new JValue(selected);
         args[1]  = new JValue(((Java.Lang.Object)onClick).Handle);
         args[2]  = new JValue(((Java.Lang.Object)icon).Handle);
-        args[3]  = new JValue(IntPtr.Zero); // modifier
+        args[3]  = new JValue(ModifierHandle(modifier)); // modifier
         args[4]  = new JValue(true);        // enabled
         args[5]  = new JValue(label is null ? IntPtr.Zero : ((Java.Lang.Object)label).Handle);
         args[6]  = new JValue(true);        // alwaysShowLabel
@@ -1826,6 +2020,7 @@ internal static class ComposeBridges
         {
             GC.KeepAlive(onClick);
             GC.KeepAlive(icon);
+            GC.KeepAlive(modifier);
             GC.KeepAlive(label);
             GC.KeepAlive(composer);
         }

--- a/src/ComposeNet.Compose/DatePicker.cs
+++ b/src/ComposeNet.Compose/DatePicker.cs
@@ -24,6 +24,9 @@ public sealed class DatePicker : ComposableNode
         var stateHandle = ComposeBridges.RememberDatePickerState(composer);
         if (_state is not null && _state.Jvm is null)
             _state.Jvm = Java.Lang.Object.GetObject<IDatePickerState>(stateHandle, JniHandleOwnership.DoNotTransfer)!;
-        ComposeBridges.DatePicker(stateHandle, (int)DatePickerDefault.All, composer);
+        var modifier = BuildModifier();
+        int defaults = (int)DatePickerDefault.All;
+        if (modifier is not null) defaults &= ~(int)DatePickerDefault.Modifier;
+        ComposeBridges.DatePicker(stateHandle, modifier, defaults, composer);
     }
 }

--- a/src/ComposeNet.Compose/DatePickerDialog.cs
+++ b/src/ComposeNet.Compose/DatePickerDialog.cs
@@ -39,11 +39,14 @@ public sealed class DatePickerDialog : ComposableNode
             : new ComposableLambda2(c => DismissButton.Render(c));
 
         int defaults = (int)DatePickerDialogDefault.All;
-        if (dismiss is not null) defaults &= ~(int)DatePickerDialogDefault.DismissButton;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)DatePickerDialogDefault.Modifier;
+        if (dismiss  is not null) defaults &= ~(int)DatePickerDialogDefault.DismissButton;
 
         ComposeBridges.DatePickerDialog(
             onDismissRequest: onDismiss,
             confirmButton:    confirm,
+            modifier:         modifier,
             dismissButton:    dismiss,
             content:          content,
             defaults:         defaults,

--- a/src/ComposeNet.Compose/FilterChip.cs
+++ b/src/ComposeNet.Compose/FilterChip.cs
@@ -38,9 +38,11 @@ public sealed class FilterChip : ComposableNode
         ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
 
         int defaults = (int)FilterChipDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)FilterChipDefault.Modifier;
         if (leading  is not null) defaults &= ~(int)FilterChipDefault.LeadingIcon;
         if (trailing is not null) defaults &= ~(int)FilterChipDefault.TrailingIcon;
 
-        ComposeBridges.FilterChip(_selected, click, label, leading, trailing, defaults, composer);
+        ComposeBridges.FilterChip(_selected, click, label, modifier, leading, trailing, defaults, composer);
     }
 }

--- a/src/ComposeNet.Compose/FloatingActionButton.cs
+++ b/src/ComposeNet.Compose/FloatingActionButton.cs
@@ -12,6 +12,6 @@ public sealed class FloatingActionButton : ComposableContainer
     {
         var click   = new ComposableLambda0(_onClick);
         var content = new ComposableLambda2(c => RenderChildren(c));
-        ComposeBridges.FloatingActionButton(click, content, composer);
+        ComposeBridges.FloatingActionButton(click, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/IconButton.cs
+++ b/src/ComposeNet.Compose/IconButton.cs
@@ -15,6 +15,6 @@ public sealed class IconButton : ComposableContainer
     {
         var click   = new ComposableLambda0(_onClick);
         var content = new ComposableLambda2(c => RenderChildren(c));
-        ComposeBridges.IconButton(click, content, composer);
+        ComposeBridges.IconButton(click, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/InputChip.cs
+++ b/src/ComposeNet.Compose/InputChip.cs
@@ -37,10 +37,12 @@ public sealed class InputChip : ComposableNode
         ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
 
         int defaults = (int)InputChipDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)InputChipDefault.Modifier;
         if (leading  is not null) defaults &= ~(int)InputChipDefault.LeadingIcon;
         if (avatar   is not null) defaults &= ~(int)InputChipDefault.Avatar;
         if (trailing is not null) defaults &= ~(int)InputChipDefault.TrailingIcon;
 
-        ComposeBridges.InputChip(_selected, click, label, leading, avatar, trailing, defaults, composer);
+        ComposeBridges.InputChip(_selected, click, label, modifier, leading, avatar, trailing, defaults, composer);
     }
 }

--- a/src/ComposeNet.Compose/ModalBottomSheet.cs
+++ b/src/ComposeNet.Compose/ModalBottomSheet.cs
@@ -51,10 +51,13 @@ public sealed class ModalBottomSheet : ComposableContainer
             : new ComposableLambda2(c => DragHandle.Render(c));
 
         int defaults = (int)ModalBottomSheetDefault.All;
+        var modifier = BuildModifier();
+        if (modifier   is not null) defaults &= ~(int)ModalBottomSheetDefault.Modifier;
         if (dragHandle is not null) defaults &= ~(int)ModalBottomSheetDefault.DragHandle;
 
         ComposeBridges.ModalBottomSheet(
             onDismissRequest: onDismiss,
+            modifier:         modifier,
             sheetState:       ((Java.Lang.Object)sheetState).Handle,
             dragHandle:       dragHandle,
             content:          content,

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -1,0 +1,142 @@
+using Android.Runtime;
+using AndroidX.Compose.UI;
+using Java.Interop;
+
+namespace ComposeNet;
+
+/// <summary>
+/// C# mirror of Kotlin's <c>androidx.compose.ui.Modifier</c> chain.
+/// Build a chain by calling fluent methods on
+/// <see cref="Companion"/> — each call returns a NEW immutable
+/// <see cref="Modifier"/> with the op appended:
+///
+/// <code>
+/// new Column
+/// {
+///     Modifier = Modifier.Companion.Padding(16).FillMaxWidth(),
+///     // ...
+/// }
+/// </code>
+///
+/// At <c>Render</c> time the chain is materialized into an
+/// <c>IModifier</c> by replaying each op against
+/// <c>androidx.compose.ui.Modifier.Companion.INSTANCE</c> via JNI
+/// (see <see cref="ComposeBridges"/>). Building cheap modifier
+/// chains every recomposition is the per-composition cost the
+/// Tier 1.5 facade pays — Tier 2 codegen would skip it.
+///
+/// Phase 1 ships <see cref="Padding(int)"/>, the horizontal/vertical
+/// + per-edge overloads, and <see cref="FillMaxWidth"/> /
+/// <see cref="FillMaxHeight"/> / <see cref="FillMaxSize"/>. Background,
+/// border, clip, clickable, and gesture modifiers land in later
+/// phases (issue #21).
+/// </summary>
+public sealed class Modifier
+{
+    static readonly System.Func<IntPtr, IntPtr>[] EmptyOps = System.Array.Empty<System.Func<IntPtr, IntPtr>>();
+    static readonly Modifier _companion = new Modifier(EmptyOps);
+
+    /// <summary>
+    /// The empty Modifier — entry point for the fluent chain.
+    /// Mirrors Kotlin's <c>Modifier.Companion</c> object, which is
+    /// also the identity element of <c>Modifier.then(...)</c>.
+    /// </summary>
+    public static Modifier Companion => _companion;
+
+    readonly System.Func<IntPtr, IntPtr>[] _ops;
+
+    Modifier(System.Func<IntPtr, IntPtr>[] ops)
+    {
+        _ops = ops;
+    }
+
+    Modifier Append(System.Func<IntPtr, IntPtr> op)
+    {
+        var arr = new System.Func<IntPtr, IntPtr>[_ops.Length + 1];
+        System.Array.Copy(_ops, arr, _ops.Length);
+        arr[_ops.Length] = op;
+        return new Modifier(arr);
+    }
+
+    /// <summary>
+    /// <c>Modifier.padding(all: Dp)</c> — applies <paramref name="allDp"/>
+    /// of padding to every edge.
+    /// </summary>
+    public Modifier Padding(int allDp)
+    {
+        var dp = (float)allDp;
+        return Append(h => ComposeBridges.ModifierPaddingAll(h, dp));
+    }
+
+    /// <summary>
+    /// <c>Modifier.padding(horizontal: Dp, vertical: Dp)</c>.
+    /// </summary>
+    public Modifier Padding(int horizontalDp, int verticalDp)
+    {
+        var h = (float)horizontalDp;
+        var v = (float)verticalDp;
+        return Append(curr => ComposeBridges.ModifierPaddingHV(curr, h, v));
+    }
+
+    /// <summary>
+    /// <c>Modifier.padding(start: Dp, top: Dp, end: Dp, bottom: Dp)</c>.
+    /// </summary>
+    public Modifier Padding(int startDp, int topDp, int endDp, int bottomDp)
+    {
+        var s = (float)startDp;
+        var t = (float)topDp;
+        var e = (float)endDp;
+        var b = (float)bottomDp;
+        return Append(curr => ComposeBridges.ModifierPaddingLTRB(curr, s, t, e, b));
+    }
+
+    /// <summary>
+    /// <c>Modifier.fillMaxWidth(fraction)</c>. Defaults to filling
+    /// the entire available width (<paramref name="fraction"/> = 1).
+    /// </summary>
+    public Modifier FillMaxWidth(float fraction = 1f) =>
+        Append(h => ComposeBridges.ModifierFillMaxWidth(h, fraction));
+
+    /// <summary>
+    /// <c>Modifier.fillMaxHeight(fraction)</c>.
+    /// </summary>
+    public Modifier FillMaxHeight(float fraction = 1f) =>
+        Append(h => ComposeBridges.ModifierFillMaxHeight(h, fraction));
+
+    /// <summary>
+    /// <c>Modifier.fillMaxSize(fraction)</c> — fills both width and height.
+    /// </summary>
+    public Modifier FillMaxSize(float fraction = 1f) =>
+        Append(h => ComposeBridges.ModifierFillMaxSize(h, fraction));
+
+    /// <summary>
+    /// Materialize the chain into a managed <c>IModifier</c> wrapper.
+    /// Returns <c>null</c> when the chain is empty (no ops appended) so
+    /// callers can keep the Kotlin <c>$default</c> bit set and let
+    /// Compose substitute the real default.
+    /// </summary>
+    internal IModifier? Build()
+    {
+        if (_ops.Length == 0)
+            return null;
+
+        IntPtr current = ComposeBridges.ModifierCompanionInstance();
+        try
+        {
+            for (int i = 0; i < _ops.Length; i++)
+            {
+                IntPtr next = _ops[i](current);
+                JNIEnv.DeleteLocalRef(current);
+                current = next;
+            }
+        }
+        catch
+        {
+            if (current != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(current);
+            throw;
+        }
+
+        return Java.Lang.Object.GetObject<IModifier>(current, JniHandleOwnership.TransferLocalRef)!;
+    }
+}

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -8,22 +8,37 @@ namespace ComposeNet;
 /// C# mirror of Kotlin's <c>androidx.compose.ui.Modifier</c> chain.
 /// Build a chain by calling fluent methods on
 /// <see cref="Companion"/> — each call returns a NEW immutable
-/// <see cref="Modifier"/> with the op appended:
+/// <see cref="Modifier"/> with the op appended.
+///
+/// On a container (anything deriving from
+/// <see cref="ComposableContainer"/>) the chain is added as a
+/// collection-initializer item — C# doesn't allow mixing object- and
+/// collection-initializers in the same braces, so
+/// <see cref="ComposableContainer.Add(Modifier)"/> sets the
+/// <see cref="ComposableNode.Modifier"/> property for you:
 ///
 /// <code>
 /// new Column
 /// {
-///     Modifier = Modifier.Companion.Padding(16).FillMaxWidth(),
-///     // ...
+///     Modifier.Companion.Padding(16).FillMaxWidth(),
+///     new Text("Hello"),
 /// }
+/// </code>
+///
+/// On a leaf composable use object-initializer syntax:
+///
+/// <code>
+/// new Text("Hello") { Modifier = Modifier.Companion.Padding(8) }
 /// </code>
 ///
 /// At <c>Render</c> time the chain is materialized into an
 /// <c>IModifier</c> by replaying each op against
-/// <c>androidx.compose.ui.Modifier.Companion.INSTANCE</c> via JNI
-/// (see <see cref="ComposeBridges"/>). Building cheap modifier
-/// chains every recomposition is the per-composition cost the
-/// Tier 1.5 facade pays — Tier 2 codegen would skip it.
+/// <c>androidx.compose.ui.Modifier.Companion</c> (resolved via the
+/// <c>$$INSTANCE</c> static field Kotlin emits for <c>object</c>
+/// declarations) via JNI — see
+/// <see cref="ComposeBridges.ModifierCompanionInstance"/>. Building
+/// cheap modifier chains every recomposition is the per-composition
+/// cost the Tier 1.5 facade pays — Tier 2 codegen would skip it.
 ///
 /// Phase 1 ships <see cref="Padding(int)"/>, the horizontal/vertical
 /// + per-edge overloads, and <see cref="FillMaxWidth"/> /

--- a/src/ComposeNet.Compose/NavigationBar.cs
+++ b/src/ComposeNet.Compose/NavigationBar.cs
@@ -31,6 +31,6 @@ public sealed class NavigationBar : ComposableContainer
             using var _ = RenderContext.PushScope(scope);
             RenderChildren(c);
         });
-        ComposeBridges.NavigationBar(content, composer);
+        ComposeBridges.NavigationBar(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/NavigationBarItem.cs
+++ b/src/ComposeNet.Compose/NavigationBarItem.cs
@@ -37,13 +37,16 @@ public sealed class NavigationBarItem : ComposableNode
         ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
 
         int defaults = (int)NavigationBarItemDefault.All;
-        if (label is not null) defaults &= ~(int)NavigationBarItemDefault.Label;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)NavigationBarItemDefault.Modifier;
+        if (label    is not null) defaults &= ~(int)NavigationBarItemDefault.Label;
 
         ComposeBridges.NavigationBarItem(
             rowScope: RenderContext.CurrentScope,
             selected: _selected,
             onClick:  click,
             icon:     icon,
+            modifier: modifier,
             label:    label,
             defaults: defaults,
             composer: composer);

--- a/src/ComposeNet.Compose/NavigationRail.cs
+++ b/src/ComposeNet.Compose/NavigationRail.cs
@@ -21,6 +21,6 @@ public sealed class NavigationRail : ComposableContainer
         // static, not a ColumnScope extension — so we don't need to
         // publish the scope. Children can render directly.
         var content = new ComposableLambda3(c => RenderChildren(c));
-        ComposeBridges.NavigationRail(content, composer);
+        ComposeBridges.NavigationRail(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/NavigationRailItem.cs
+++ b/src/ComposeNet.Compose/NavigationRailItem.cs
@@ -34,8 +34,10 @@ public sealed class NavigationRailItem : ComposableNode
         ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
 
         int defaults = (int)NavigationRailItemDefault.All;
-        if (label is not null) defaults &= ~(int)NavigationRailItemDefault.Label;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)NavigationRailItemDefault.Modifier;
+        if (label    is not null) defaults &= ~(int)NavigationRailItemDefault.Label;
 
-        ComposeBridges.NavigationRailItem(_selected, click, icon, label, defaults, composer);
+        ComposeBridges.NavigationRailItem(_selected, click, icon, modifier, label, defaults, composer);
     }
 }

--- a/src/ComposeNet.Compose/OutlinedTextField.cs
+++ b/src/ComposeNet.Compose/OutlinedTextField.cs
@@ -14,6 +14,6 @@ public sealed class OutlinedTextField : ComposableNode
     internal override void Render(IComposer composer)
     {
         var onChange = new ComposableLambda1(v => _state.Value = v?.ToString() ?? string.Empty);
-        ComposeBridges.OutlinedTextField(_state.Value ?? string.Empty, onChange, composer);
+        ComposeBridges.OutlinedTextField(_state.Value ?? string.Empty, onChange, BuildModifier(), composer);
     }
 }

--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -59,12 +59,15 @@ public sealed class Scaffold : ComposableNode
             : new ComposableLambda2(c => FloatingActionButton.Render(c));
 
         int defaults = (int)ScaffoldDefault.All;
+        var modifier = BuildModifier();
+        if (modifier     is not null) defaults &= ~(int)ScaffoldDefault.Modifier;
         if (topBar       is not null) defaults &= ~(int)ScaffoldDefault.TopBar;
         if (bottomBar    is not null) defaults &= ~(int)ScaffoldDefault.BottomBar;
         if (snackbarHost is not null) defaults &= ~(int)ScaffoldDefault.SnackbarHost;
         if (fab          is not null) defaults &= ~(int)ScaffoldDefault.FloatingActionButton;
 
         ComposeBridges.Scaffold(
+            modifier:             modifier,
             topBar:               topBar,
             bottomBar:            bottomBar,
             snackbarHost:         snackbarHost,

--- a/src/ComposeNet.Compose/SuggestionChip.cs
+++ b/src/ComposeNet.Compose/SuggestionChip.cs
@@ -28,8 +28,10 @@ public sealed class SuggestionChip : ComposableNode
         ComposableLambda2? icon = Icon is null ? null : new ComposableLambda2(c => Icon.Render(c));
 
         int defaults = (int)SuggestionChipDefault.All;
-        if (icon is not null) defaults &= ~(int)SuggestionChipDefault.Icon;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)SuggestionChipDefault.Modifier;
+        if (icon     is not null) defaults &= ~(int)SuggestionChipDefault.Icon;
 
-        ComposeBridges.SuggestionChip(click, label, icon, defaults, composer);
+        ComposeBridges.SuggestionChip(click, label, modifier, icon, defaults, composer);
     }
 }

--- a/src/ComposeNet.Compose/Surface.cs
+++ b/src/ComposeNet.Compose/Surface.cs
@@ -11,6 +11,6 @@ public sealed class Surface : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var content = new ComposableLambda2(c => RenderChildren(c));
-        ComposeBridges.Surface(content, composer);
+        ComposeBridges.Surface(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/Text.cs
+++ b/src/ComposeNet.Compose/Text.cs
@@ -8,5 +8,5 @@ public sealed class Text : ComposableNode
     readonly string _text;
     public Text(string text) => _text = text;
     internal override void Render(IComposer composer) =>
-        ComposeBridges.Text(_text, composer);
+        ComposeBridges.Text(_text, BuildModifier(), composer);
 }

--- a/src/ComposeNet.Compose/TextField.cs
+++ b/src/ComposeNet.Compose/TextField.cs
@@ -15,6 +15,6 @@ public sealed class TextField : ComposableNode
     internal override void Render(IComposer composer)
     {
         var onChange = new ComposableLambda1(v => _state.Value = v?.ToString() ?? string.Empty);
-        ComposeBridges.TextField(_state.Value ?? string.Empty, onChange, composer);
+        ComposeBridges.TextField(_state.Value ?? string.Empty, onChange, BuildModifier(), composer);
     }
 }

--- a/src/ComposeNet.Compose/TimePicker.cs
+++ b/src/ComposeNet.Compose/TimePicker.cs
@@ -21,6 +21,9 @@ public sealed class TimePicker : ComposableNode
         var stateHandle = ComposeBridges.RememberTimePickerState(_state.InitialHour, _state.InitialMinute, _state.InitialIs24Hour, composer);
         if (_state.Jvm is null)
             _state.Jvm = Java.Lang.Object.GetObject<ITimePickerState>(stateHandle, JniHandleOwnership.DoNotTransfer)!;
-        ComposeBridges.TimePicker(stateHandle, (int)TimePickerDefault.All, composer);
+        var modifier = BuildModifier();
+        int defaults = (int)TimePickerDefault.All;
+        if (modifier is not null) defaults &= ~(int)TimePickerDefault.Modifier;
+        ComposeBridges.TimePicker(stateHandle, modifier, defaults, composer);
     }
 }

--- a/src/ComposeNet.Compose/TimePickerDialog.cs
+++ b/src/ComposeNet.Compose/TimePickerDialog.cs
@@ -39,13 +39,16 @@ public sealed class TimePickerDialog : ComposableNode
             : new ComposableLambda2(c => ModeToggleButton.Render(c));
 
         int defaults = (int)TimePickerDialogDefault.All;
-        if (title  is not null) defaults &= ~(int)TimePickerDialogDefault.Title;
-        if (toggle is not null) defaults &= ~(int)TimePickerDialogDefault.ModeToggleButton;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)TimePickerDialogDefault.Modifier;
+        if (title    is not null) defaults &= ~(int)TimePickerDialogDefault.Title;
+        if (toggle   is not null) defaults &= ~(int)TimePickerDialogDefault.ModeToggleButton;
 
         ComposeBridges.TimePickerDialog(
             onDismissRequest: onDismiss,
             confirmButton:    confirm,
             dismissButton:    dismiss,
+            modifier:         modifier,
             title:            title,
             modeToggleButton: toggle,
             content:          content,

--- a/src/ComposeNet.Compose/Tooltip.cs
+++ b/src/ComposeNet.Compose/Tooltip.cs
@@ -35,12 +35,17 @@ public sealed class Tooltip : ComposableNode
         var tooltip = new ComposableLambda3(c => Tip.Render(c));
         var anchor  = new ComposableLambda2(c => Anchor.Render(c));
 
+        var modifier = BuildModifier();
+        int defaults = (int)TooltipBoxDefault.All;
+        if (modifier is not null) defaults &= ~(int)TooltipBoxDefault.Modifier;
+
         ComposeBridges.TooltipBox(
             positionProvider: positionProvider,
             tooltip:          tooltip,
             state:            stateHandle,
+            modifier:         modifier,
             content:          anchor,
-            defaults:         (int)TooltipBoxDefault.All,
+            defaults:         defaults,
             composer:         composer);
     }
 }

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -209,6 +209,7 @@ public class MainActivity : ComposeActivity
                         },
                         Body = new Column
                         {
+                            Modifier.Companion.Padding(16),
                             tabContent,
 
                             // Overlays: rendered in the body so they participate in the


### PR DESCRIPTION
Implements Phase 1 of #21.

## What

Introduces a C# `Modifier` builder that mirrors Kotlin's chained `Modifier.foo().bar()` API and threads through every public composable in the facade. With this PR users can finally style layout — starting with the padding/fill ops needed to fix the regression from #19 (tab content flush against the screen edges).

```csharp
new Column
{
    Modifier.Companion.Padding(16),       // <-- new in this PR
    new Text("Hello"),
}
```

## API

- New `ComposeNet.Modifier` type with `Companion`, `Padding(int)`, `Padding(int h, int v)`, `Padding(int l, int t, int r, int b)`, `FillMaxWidth(float = 1f)`, `FillMaxHeight(float = 1f)`, `FillMaxSize(float = 1f)`. Each op returns a new immutable `Modifier` so the chain is reusable.
- `internal IModifier? Build()` materializes the chain at `Render` time via JNI: `Modifier.Companion.$$INSTANCE` resolved via `JNIEnv.GetStaticFieldID`, then each op invokes the matching Kotlin static (`PaddingKt.padding-3ABfNKs/-VpY3zN4/-qDBjuR0`, `SizeKt.fillMaxWidth/Height/Size`).
- `ComposableNode.Modifier { get; set; }` — every composable accepts an optional modifier.

## Setting `Modifier` on containers vs. leaves

C# disallows mixing object-init assignments with collection-init items in the same `{ }`. Leaves (Text, Button, …) keep object-init syntax:

```csharp
new Text("Hi") { Modifier = Modifier.Companion.Padding(8) }
```

For containers that derive from `ComposableContainer` (Column, Card, Surface, Scaffold, …) I added an `Add(Modifier)` overload so the modifier is set inline alongside children — the canonical C# trick for this situation:

```csharp
new Column { Modifier.Companion.Padding(16), child1, child2 }
```

## Wiring

- `ComposeBridges.cs`: added `ModifierHandle` / `ModifierCompanionInstance` / `ModifierPadding{All,HV,LTRB}` / `ModifierFillMax{Width,Height,Size}` JNI helpers, and threaded an `IModifier? modifier` parameter through every existing bridge (Text, Button, IconButton, FAB, Surface, Card, TextField/OutlinedTextField, AlertDialog, ModalBottomSheet, BottomSheetScaffold, Scaffold, DatePicker(Dialog), TimePicker(Dialog), Tooltip, *Chip, NavigationBar(Item), NavigationRail(Item)).
- Each composable's `Render` now calls `BuildModifier()` and clears the `Modifier` bit in its `$default` mask when the user supplied one.
- `Column` uses the bound `ColumnKt.Column` directly (no JNI bridge), so it just passes the modifier through.

## Sample

`MainActivity.cs` adds `Modifier.Companion.Padding(16)` to the Scaffold body's root `Column`, restoring the horizontal gutter that was dropped in #19 while leaving the BottomBar flush against the edges.

## Phase 2+ (out of scope)

`Background`, `Border`, `Clip`, `Clickable`, gestures, size constraints, window-insets — to follow as separate issues / PRs.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 10/10 passing.
- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet build src/ComposeNet.Sample` — clean.

Closes #21 (Phase 1).