### PR TITLE
Sample: format DatePicker selection as yyyy-MM-dd

### DIFF
--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -249,7 +249,9 @@ public class MainActivity : ComposeActivity
                                 {
                                     ConfirmButton = new Button(onClick: () =>
                                     {
-                                        pickedDate.Value = dateState.SelectedDateMillis is long ms ? ms.ToString() : "(none)";
+                                        pickedDate.Value = dateState.SelectedDateMillis is long ms
+                                            ? System.DateTimeOffset.FromUnixTimeMilliseconds(ms).UtcDateTime.ToString("yyyy-MM-dd")
+                                            : "(none)";
                                         showDate.Value = false;
                                     })
                                     { new Text("OK") },


### PR DESCRIPTION
The Pickers tab was rendering the picked date as raw Unix epoch milliseconds (e.g. `1748908800000`), which made it look like the label wasn't updating at all when you hit OK. The DatePicker itself was working correctly; only the sample's display formatting was wrong.

Run the millis through `DateTimeOffset.FromUnixTimeMilliseconds(...).UtcDateTime.ToString("yyyy-MM-dd")` in the confirm-button handler. UTC matches Material3's `selectedDateMillis` semantics (the Kotlin docs specify the value is at UTC midnight of the selected day), so we avoid an off-by-one when the device timezone is west of UTC.

No facade / generator / bridge changes — sample-only.