### PR TITLE
Migrate ComposeActivity to edge-to-edge / NoActionBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,15 @@ Confirmed on device:
 - **MaterialTheme** with Android 12+ dynamic colors (Material You) —
   the blue/teal scheme on a stock emulator, not the Compose-default
   purple.
-- A native Android **ActionBar** with the app name as the title
-  (`Theme.Material.Light`), with the status-bar icons forced dark
-  via `WindowInsetsController.SetSystemBarsAppearance(LightStatusBars, …)`
-  so the clock/battery/wifi are readable.
+- The activity is rendered **edge-to-edge** via
+  `EdgeToEdge.Enable(this)` in `ComposeActivity.OnCreate`, hosted under
+  a `Theme.Material.Light.NoActionBar` framework theme — no framework
+  `ActionBar` overlays the content, status / nav bars are transparent,
+  and Compose's `WindowInsets` plumbing handles the safe area. Inside a
+  `Scaffold` body without a `TopBar`, pad the body with
+  `Modifier.Companion.SafeDrawingPadding()` so content doesn't draw
+  under the status bar; bare-`Column` roots use the same modifier on
+  the root.
 - A `Column` containing two **Material 3 `Text`** composables
   (`"Hello from .NET"`, `"Count: N"`) and a **Material 3 `Button`**
   whose label `"Tap to increment"` correctly inherits
@@ -287,7 +292,7 @@ the only differences are `new`, commas, `() =>`, and `$"…"`:
 
 ```csharp
 [Activity(Label = "@string/app_name", MainLauncher = true,
-          Theme = "@android:style/Theme.Material.Light")]
+          Theme = "@android:style/Theme.Material.Light.NoActionBar")]
 public class MainActivity : ComposeActivity
 {
     protected override void OnCreate(Bundle? savedInstanceState)
@@ -300,6 +305,7 @@ public class MainActivity : ComposeActivity
             {
                 new Column
                 {
+                    Modifier.Companion.SafeDrawingPadding(),
                     new Text("Hello from .NET"),
                     new Text($"Count: {count}"),
                     new Button(onClick: () => count++)

--- a/src/ComposeNet.Compose/ComposeActivity.cs
+++ b/src/ComposeNet.Compose/ComposeActivity.cs
@@ -30,6 +30,29 @@ namespace ComposeNet;
 /// }
 /// </code>
 ///
+/// The activity opts the window into edge-to-edge in
+/// <see cref="OnCreate(Bundle?)"/> via <see cref="EdgeToEdge.Enable(ComponentActivity)"/>
+/// — system bars become transparent overlays, and Compose's
+/// <c>WindowInsets</c> propagation handles inset padding. Pair this with a
+/// <c>NoActionBar</c> framework / Material theme on the activity (e.g.
+/// <c>@android:style/Theme.Material.Light.NoActionBar</c>) so no
+/// framework <c>ActionBar</c> overlays the content.
+///
+/// Inset handling at the composition level:
+/// <list type="bullet">
+///   <item><description>
+///     Inside a <see cref="Scaffold"/>, the top app bar / bottom bar slots
+///     pad themselves; pad the body root with
+///     <c>Modifier.Companion.SafeDrawingPadding()</c> when no top bar is
+///     supplied so content doesn't draw under the status bar.
+///   </description></item>
+///   <item><description>
+///     Outside a <see cref="Scaffold"/>, wrap the root composable in
+///     <c>Modifier.Companion.SafeDrawingPadding()</c> (or
+///     <c>SystemBarsPadding()</c>) so it stays inside the safe area.
+///   </description></item>
+/// </list>
+///
 /// The <c>content</c> lambda runs on every recomposition; tree allocation
 /// is the per-recomposition cost of the Tier 1.5 facade (Tier 2 codegen
 /// would skip it).
@@ -59,6 +82,19 @@ public abstract class ComposeActivity : ComponentActivity
     }
 
     /// <summary>
+    /// Opts the window into edge-to-edge. Call <c>base.OnCreate</c>
+    /// first thing in your subclass override — that runs
+    /// <see cref="EdgeToEdge.Enable(ComponentActivity)"/> before
+    /// <c>ComponentActivity.OnCreate</c>, which is the order the AndroidX
+    /// API expects.
+    /// </summary>
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        EdgeToEdge.Enable(this);
+        base.OnCreate(savedInstanceState);
+    }
+
+    /// <summary>
     /// Sets the activity's content view to a Compose composition that
     /// runs <paramref name="content"/> on each composition pass and
     /// renders the returned tree.
@@ -67,84 +103,13 @@ public abstract class ComposeActivity : ComponentActivity
     {
         var view = new ComposeView(this);
 
-        ApplySafeAreaPadding(view);
-
         view.SetContent(ComposableLambdaKt.ComposableLambdaInstance(
             key:     -1,
             tracked: false,
             block:   new ComposableLambda2(composer => content().Render(composer))));
 
         SetContentView(view);
-        ApplyLightStatusBar();
 
         Log.Debug(TAG, "ComposeActivity content set");
-    }
-
-    void ApplySafeAreaPadding(Android.Views.View view)
-    {
-        // On API 36 / Theme.Material.Light the ActionBar is overlay-decor
-        // and draws on top of android.R.id.content, so we still need to
-        // push content down by status + action bar height. We deliberately
-        // do NOT pad left / right / bottom here: a root-level Scaffold
-        // already handles those edges via its own WindowInsets (the
-        // bottom NavigationBar pads itself above the gesture bar, and
-        // the body lambda receives PaddingValues for cutouts). See
-        // issue #20 for the long-term plan to drop this shim entirely
-        // once the activity goes edge-to-edge under a Material 3 theme.
-        view.SetPadding(
-            left:   0,
-            top:    SystemBarHeight("status_bar_height") + ActionBarHeight() + Dp(16),
-            right:  0,
-            bottom: 0);
-    }
-
-    void ApplyLightStatusBar()
-    {
-        var window = Window;
-        System.Diagnostics.Debug.Assert(window != null, "Window non-null after SetContentView");
-
-        if (OperatingSystem.IsAndroidVersionAtLeast(30))
-        {
-            var insetsController = window.InsetsController;
-            if (insetsController != null)
-            {
-                insetsController.SetSystemBarsAppearance(
-                    (int)Android.Views.WindowInsetsControllerAppearance.LightStatusBars,
-                    (int)Android.Views.WindowInsetsControllerAppearance.LightStatusBars);
-            }
-        }
-        else
-        {
-            var decor = window.DecorView;
-#pragma warning disable CA1422 // Validate platform compatibility
-            decor.SystemUiFlags |= Android.Views.SystemUiFlags.LightStatusBar;
-#pragma warning restore CA1422
-        }
-    }
-
-    int ActionBarHeight()
-    {
-        var theme = Theme;
-        var resources = Resources;
-        System.Diagnostics.Debug.Assert(theme != null && resources != null);
-        var tv = new TypedValue();
-        if (theme.ResolveAttribute(Android.Resource.Attribute.ActionBarSize, tv, true))
-            return TypedValue.ComplexToDimensionPixelSize(tv.Data, resources.DisplayMetrics);
-        return 0;
-    }
-
-    int Dp(int dp)
-    {
-        var resources = Resources;
-        System.Diagnostics.Debug.Assert(resources != null);
-        return (int)(dp * resources.DisplayMetrics!.Density);
-    }
-
-    int SystemBarHeight(string resName)
-    {
-        var resources = Resources;
-        System.Diagnostics.Debug.Assert(resources != null);
-        int id = resources.GetIdentifier(resName, "dimen", "android");
-        return id > 0 ? resources.GetDimensionPixelSize(id) : 0;
     }
 }

--- a/src/ComposeNet.Compose/ComposeActivity.cs
+++ b/src/ComposeNet.Compose/ComposeActivity.cs
@@ -49,7 +49,7 @@ namespace ComposeNet;
 ///   <item><description>
 ///     Outside a <see cref="Scaffold"/>, wrap the root composable in
 ///     <c>Modifier.Companion.SafeDrawingPadding()</c> (or
-///     <c>SystemBarsPadding()</c>) so it stays inside the safe area.
+///     <c>Modifier.Companion.SystemBarsPadding()</c>) so it stays inside the safe area.
 ///   </description></item>
 /// </list>
 ///

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -146,6 +146,41 @@ internal static class ComposeBridges
         return JNIEnv.CallStaticObjectMethod(s_sizeKtClass, s_fillMaxSizeMethod, args);
     }
 
+    // androidx.compose.foundation.layout.WindowInsetsPadding_androidKt —
+    // Modifier extensions that read WindowInsets from CompositionLocals
+    // and apply them as padding. Take only Modifier (no Dp), so JVM
+    // names are unmangled.
+    const string ModifierToModifierSig =
+        "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;";
+
+    static IntPtr s_windowInsetsPaddingAndroidKtClass;
+    static IntPtr s_safeDrawingPaddingMethod;
+    static IntPtr s_systemBarsPaddingMethod;
+
+    internal static unsafe IntPtr ModifierSafeDrawingPadding(IntPtr modifier)
+    {
+        if (s_windowInsetsPaddingAndroidKtClass == IntPtr.Zero)
+            s_windowInsetsPaddingAndroidKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/WindowInsetsPadding_androidKt");
+        if (s_safeDrawingPaddingMethod == IntPtr.Zero)
+            s_safeDrawingPaddingMethod = JNIEnv.GetStaticMethodID(s_windowInsetsPaddingAndroidKtClass, "safeDrawingPadding", ModifierToModifierSig);
+
+        JValue* args = stackalloc JValue[1];
+        args[0] = new JValue(modifier);
+        return JNIEnv.CallStaticObjectMethod(s_windowInsetsPaddingAndroidKtClass, s_safeDrawingPaddingMethod, args);
+    }
+
+    internal static unsafe IntPtr ModifierSystemBarsPadding(IntPtr modifier)
+    {
+        if (s_windowInsetsPaddingAndroidKtClass == IntPtr.Zero)
+            s_windowInsetsPaddingAndroidKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/WindowInsetsPadding_androidKt");
+        if (s_systemBarsPaddingMethod == IntPtr.Zero)
+            s_systemBarsPaddingMethod = JNIEnv.GetStaticMethodID(s_windowInsetsPaddingAndroidKtClass, "systemBarsPadding", ModifierToModifierSig);
+
+        JValue* args = stackalloc JValue[1];
+        args[0] = new JValue(modifier);
+        return JNIEnv.CallStaticObjectMethod(s_windowInsetsPaddingAndroidKtClass, s_systemBarsPaddingMethod, args);
+    }
+
     // androidx.compose.material3.TextKt.Text--4IGK_g(text, modifier, color,
     //   fontSize, fontStyle, fontWeight, fontFamily, letterSpacing, decoration,
     //   align, lineHeight, overflow, softWrap, maxLines, minLines, onTextLayout,

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -125,6 +125,24 @@ public sealed class Modifier
         Append(h => ComposeBridges.ModifierFillMaxSize(h, fraction));
 
     /// <summary>
+    /// <c>Modifier.safeDrawingPadding()</c> — pads for the union of
+    /// system bars, IME, and display cutouts. Use as the outer modifier
+    /// on a root composable (or inside a <see cref="Scaffold"/>'s body
+    /// when no <see cref="Scaffold.TopBar"/> is supplied) to keep
+    /// content out of inset regions under edge-to-edge.
+    /// </summary>
+    public Modifier SafeDrawingPadding() =>
+        Append(h => ComposeBridges.ModifierSafeDrawingPadding(h));
+
+    /// <summary>
+    /// <c>Modifier.systemBarsPadding()</c> — pads for status + nav bars
+    /// only (ignoring IME and cutouts). Prefer
+    /// <see cref="SafeDrawingPadding"/> in most apps.
+    /// </summary>
+    public Modifier SystemBarsPadding() =>
+        Append(h => ComposeBridges.ModifierSystemBarsPadding(h));
+
+    /// <summary>
     /// Materialize the chain into a managed <c>IModifier</c> wrapper.
     /// Returns <c>null</c> when the chain is empty (no ops appended) so
     /// callers can keep the Kotlin <c>$default</c> bit set and let

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -4,7 +4,7 @@ using ComposeNet;
 
 namespace ComposeNet.Sample;
 
-[Activity(Label = "@string/app_name", MainLauncher = true, Theme = "@android:style/Theme.Material.Light")]
+[Activity(Label = "@string/app_name", MainLauncher = true, Theme = "@android:style/Theme.Material.Light.NoActionBar")]
 public class MainActivity : ComposeActivity
 {
     protected override void OnCreate(Bundle? savedInstanceState)
@@ -209,7 +209,7 @@ public class MainActivity : ComposeActivity
                         },
                         Body = new Column
                         {
-                            Modifier.Companion.Padding(16),
+                            Modifier.Companion.SafeDrawingPadding().Padding(16),
                             tabContent,
 
                             // Overlays: rendered in the body so they participate in the


### PR DESCRIPTION
Closes #20.

The pre-AndroidX status-bar / action-bar shim in `ComposeActivity` had outlived its purpose: `ApplySafeAreaPadding` hand-computed pixels via `Resources.GetIdentifier("status_bar_height", "dimen", "android")` and pushed them onto the root `ComposeView`, while `ApplyLightStatusBar` toggled `WindowInsetsController` flags imperatively. That worked for bare-`Column` roots, but once #19 introduced `Scaffold` it started fighting Compose's own inset handling, and the resource trick never accounted for foldables, cutouts, or gesture nav anyway.

This PR moves to the canonical Compose edge-to-edge setup:

- `ComposeActivity.OnCreate` now calls `EdgeToEdge.Enable(this)` before `base.OnCreate`, which is the order the AndroidX API expects. System bars become transparent overlays, and Compose's `WindowInsets` propagation drives padding from there.
- `ApplySafeAreaPadding`, `ApplyLightStatusBar`, and the `ActionBarHeight` / `Dp` / `SystemBarHeight` helpers (and their calls in `SetContent`) are deleted.
- The sample's `MainActivity` switches from `Theme.Material.Light` to `Theme.Material.Light.NoActionBar`, so no framework `ActionBar` overlays the content. (No new NuGet dependency: a framework `NoActionBar` theme is enough for our purposes since `MaterialTheme` does the real Material 3 theming inside the composition.)
- Two new modifiers, `Modifier.SafeDrawingPadding()` and `Modifier.SystemBarsPadding()`, bridge to `WindowInsetsPadding_androidKt` so callers can pad bare-`Column` roots, or `Scaffold` bodies that don't have a `TopBar`. The sample applies `SafeDrawingPadding()` on the `Scaffold` body for exactly that reason — the bottom `NavigationBar` continues to handle its own gesture-bar inset via the Material 3 default.

README is updated with the new sample snippet and the "Confirmed on device" bullet describing the edge-to-edge setup.

### Notes for reviewers

- Generator unit tests still pass (`dotnet test src/ComposeNet.SourceGenerators.Tests`, 10/10).
- Sample builds and deploys (`dotnet build src/ComposeNet.Sample -t:Run`); the framework "ComposeNet.Sample" title strip is gone, status bar is transparent over the body, and `NavigationBar` sits flush with the bottom edge.
- The two new modifier bridges follow the existing JNI pattern in `ComposeBridges.cs`. They could in principle call the bound `WindowInsetsPadding_androidKt.SafeDrawingPadding(IModifier)` directly, but keeping them on raw `IntPtr` matches how the rest of the modifier op-chain already works.