### PR TITLE
Add Modifier Phase 2: Background, Border, Clip, Clickable

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -114,8 +114,48 @@ internal static partial class ComposeBridges
         Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
     internal static partial IntPtr ModifierSystemBarsPadding(IntPtr modifier);
 
+    // androidx.compose.foundation.shape.RoundedCornerShapeKt.RoundedCornerShape-0680j_4(Dp).
+    // Mangled because the lone arg is @JvmInline value class Dp (Float).
+    // Plain-static shape: no receiver, no $default, no Composer.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/shape/RoundedCornerShapeKt",
+        JvmName   = "RoundedCornerShape-0680j_4",
+        Signature = "(F)Landroidx/compose/foundation/shape/RoundedCornerShape;")]
+    internal static partial IntPtr RoundedCornerShape(float dp);
+
+    // androidx.compose.ui.draw.ClipKt.clip(Modifier, Shape) — both args
+    // required, no $default and no name mangling. Plain-static shape
+    // with a Modifier extension receiver.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/draw/ClipKt",
+        JvmName   = "clip",
+        Signature = "(Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/ui/graphics/Shape;)" +
+                    "Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierClip(IntPtr modifier, IntPtr shape);
+
+    // Convenience wrapper that composes RoundedCornerShape + ModifierClip
+    // and manages the intermediate Shape local ref. Listed as out of
+    // scope in #36 — the underlying JNI calls are both generator-driven
+    // now; only the two-step orchestration stays hand-written.
+    internal static IntPtr ModifierClipRoundedCorners(IntPtr modifier, float dp)
+    {
+        IntPtr shape = RoundedCornerShape(dp);
+        try
+        {
+            return ModifierClip(modifier, shape);
+        }
+        finally
+        {
+            if (shape != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(shape);
+        }
+    }
+
     // androidx.compose.ui.res.PainterResources_androidKt.painterResource —
     // returns a NEW local Painter ref the caller is responsible for
+    // DeleteLocalRef'ing once it's been handed to the consuming
+    // Image/Icon JNI call.
     // DeleteLocalRef'ing once it's been handed to the consuming
     // Image/Icon JNI call.
     [ComposeBridge(
@@ -854,8 +894,8 @@ internal static partial class ComposeBridges
 
     // androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
     // (Modifier, Dp width, Color, Shape). Both width and color are
-    // mangled inline-class params. The C# wrapper supplies width and
-    // color and lets shape default to RectangleShape.
+    // mangled inline-class params. Shape is optional (null → Kotlin
+    // default of RectangleShape).
     [ComposeBridge(
         Class     = "androidx/compose/foundation/BorderKt",
         JvmName   = "border-xT4_qwU$default",
@@ -863,7 +903,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)" +
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierBorderDefault))]
-    internal static partial IntPtr ModifierBorder(IntPtr modifier, float width, long color);
+    internal static partial IntPtr ModifierBorder(IntPtr modifier, float width, long color, IntPtr? shape);
 
     // androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
     // (Modifier, Boolean enabled, String onClickLabel, Role role,

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -1,3 +1,4 @@
+using Android.Graphics;
 using Android.Runtime;
 using AndroidX.Compose.UI;
 using Java.Interop;
@@ -42,9 +43,10 @@ namespace ComposeNet;
 ///
 /// Phase 1 ships <see cref="Padding(int)"/>, the horizontal/vertical
 /// + per-edge overloads, and <see cref="FillMaxWidth"/> /
-/// <see cref="FillMaxHeight"/> / <see cref="FillMaxSize"/>. Background,
-/// border, clip, clickable, and gesture modifiers land in later
-/// phases (issue #21).
+/// <see cref="FillMaxHeight"/> / <see cref="FillMaxSize"/>. Phase 2
+/// adds <see cref="Background"/>, <see cref="Border"/>,
+/// <see cref="Clip"/>, and <see cref="Clickable"/>. Gesture and
+/// size-constraint modifiers land in later phases (issue #21).
 /// </summary>
 public sealed class Modifier
 {
@@ -167,6 +169,85 @@ public sealed class Modifier
     /// </summary>
     public Modifier SystemBarsPadding() =>
         Append(h => ComposeBridges.ModifierSystemBarsPadding(h));
+
+    /// <summary>
+    /// <c>Modifier.background(color)</c> — paints a flat fill behind the
+    /// composable using a <c>RectangleShape</c>. Takes an
+    /// <see cref="Android.Graphics.Color"/>; use one of the named
+    /// constants (<c>Color.Blue</c>, <c>Color.Transparent</c>, …) or
+    /// <c>Color.Argb(a, r, g, b)</c> / <c>Color.ParseColor("#…")</c>.
+    /// (Temporary: should be <c>androidx.compose.ui.graphics.Color</c>
+    /// once dotnet/android-libraries#1437 lands.)
+    /// </summary>
+    public Modifier Background(Color color)
+    {
+        long packed = PackComposeColor(color);
+        return Append(curr => ComposeBridges.ModifierBackground(curr, packed));
+    }
+
+    /// <summary>
+    /// <c>Modifier.border(width, color, shape)</c> — draws a stroke
+    /// around the composable. <paramref name="widthDp"/> is the stroke
+    /// width in density-independent pixels.
+    /// <paramref name="cornerRadiusDp"/> defaults to <c>0</c> for a
+    /// rectangular stroke; pass a positive value to match a
+    /// <see cref="Clip(int)"/> earlier in the chain so the corners
+    /// align (otherwise the rectangular stroke gets sliced by a rounded
+    /// clip and you see jagged corner stubs).
+    /// </summary>
+    public Modifier Border(int widthDp, Color color, int cornerRadiusDp = 0)
+    {
+        var width   = (float)widthDp;
+        long packed = PackComposeColor(color);
+        if (cornerRadiusDp <= 0)
+            return Append(curr => ComposeBridges.ModifierBorder(curr, width, packed, null));
+
+        var radius = (float)cornerRadiusDp;
+        return Append(curr =>
+        {
+            IntPtr shape = ComposeBridges.RoundedCornerShape(radius);
+            try
+            {
+                return ComposeBridges.ModifierBorder(curr, width, packed, shape);
+            }
+            finally
+            {
+                if (shape != IntPtr.Zero)
+                    JNIEnv.DeleteLocalRef(shape);
+            }
+        });
+    }
+
+    // Pack an Android.Graphics.Color into the 64-bit value Kotlin's
+    // @JvmInline value class Color(val value: ULong) uses: ARGB int in
+    // the upper 32 bits, sRGB color-space id (0) in the lower 32 bits.
+    static long PackComposeColor(Color color) =>
+        unchecked((long)((ulong)(uint)color.ToArgb() << 32));
+
+    /// <summary>
+    /// <c>Modifier.clip(RoundedCornerShape(<paramref name="cornerRadiusDp"/>))</c> —
+    /// rounds the four corners by the same radius and clips drawing to the
+    /// resulting shape. Pass <c>0</c> for no rounding (rectangle clip).
+    /// </summary>
+    public Modifier Clip(int cornerRadiusDp)
+    {
+        var dp = (float)cornerRadiusDp;
+        return Append(curr => ComposeBridges.ModifierClipRoundedCorners(curr, dp));
+    }
+
+    /// <summary>
+    /// <c>Modifier.clickable { onClick() }</c> — handles taps with the
+    /// default Material indication / ripple. The click handler runs on
+    /// the UI thread.
+    /// </summary>
+    public Modifier Clickable(System.Action onClick)
+    {
+        if (onClick is null)
+            throw new System.ArgumentNullException(nameof(onClick));
+
+        var lambda = new ComposableLambda0(onClick);
+        return Append(curr => ComposeBridges.ModifierClickable(curr, lambda));
+    }
 
     /// <summary>
     /// Materialize the chain into a managed <c>IModifier</c> wrapper.

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -1,3 +1,4 @@
+using Android.Graphics;
 using Android.OS;
 using AndroidX.Compose.Material3;
 using ComposeNet;
@@ -93,6 +94,17 @@ public class MainActivity : ComposeActivity
                             new Text("Hello from .NET"),
                             new OutlinedTextField(name),
                             new Text($"Hi {(string.IsNullOrEmpty(name.Value) ? "stranger" : name.Value)}"),
+                            // Phase 2 modifier demo — clickable rounded chip painted with
+                            // Background + Border + Clip; tapping it increments the counter.
+                            new Text($"Phase 2 modifiers (tap me): {count}")
+                            {
+                                Modifier = Modifier.Companion
+                                    .Clip(12)
+                                    .Background(Color.Argb(0xFF, 0x19, 0x76, 0xD2))
+                                    .Border(2, Color.Argb(0xFF, 0x0D, 0x47, 0xA1), cornerRadiusDp: 12)
+                                    .Clickable(() => count++)
+                                    .Padding(horizontalDp: 16, verticalDp: 8),
+                            },
                         },
                         1 => new Column
                         {


### PR DESCRIPTION
Implements Phase 2 of #21. Phase 1 (`Padding` + `FillMax*`) shipped via #23; this PR adds the four ops the original issue scoped to Phase 2.

## What

Four new fluent ops on `ComposeNet.Modifier`, each backed by a raw-JNI bridge in `ComposeBridges.cs`:

| C# op | Kotlin call |
|---|---|
| `Background(Color)` | `BackgroundKt.background-bw27NRU$default` |
| `Border(int widthDp, Color)` | `BorderKt.border-xT4_qwU$default` |
| `Clip(int cornerRadiusDp)` | `ClipKt.clip(Modifier, RoundedCornerShape)` |
| `Clickable(Action)` | `ClickableKt.clickable-XHw0xAI$default` |

`Background`, `Border`, and `Clickable` invoke the Kotlin `$default` synthetic so callers can omit the trailing `Shape` / `onClickLabel` / `Role` params. Decompiled each synthetic with `javap` to verify bit positions — the extension receiver `$this` is excluded from the bitmask, so the masks are `0b10` (bg shape default), `0b100` (border shape default), and `0b110` (clickable label + role default).

`Clip(int)` builds a `RoundedCornerShape` via `RoundedCornerShapeKt.RoundedCornerShape-0680j_4(F)` and threads it into `ClipKt.clip` (no `$default` needed).

## `ComposeNet.Color`

The Kotlin API takes `androidx.compose.ui.graphics.Color`, an `@JvmInline value class Color(val value: ULong)`. The dotnet-android binder strips its constructors. This PR introduces a C# `readonly struct Color` that mirrors the Kotlin type — same packing (ARGB in upper 32 bits, sRGB id `0` in lower 32 bits), same constructors (`Color(uint argb)` and `Color(byte r, byte g, byte b, byte a = 0xFF)`), and the standard companion constants (`Color.Black/White/Red/Green/Blue/Yellow/Cyan/Magenta/Gray/DarkGray/LightGray/Transparent`).

Call sites read like Kotlin:

```csharp
.Background(new Color(0xFF1976D2))   // == Color(0xFF1976D2) in Kotlin
.Border(2, Color.Blue)
.Clip(12)
.Clickable(() => count++)
```

## Sample

`MainActivity.cs` tab 0 grows a clickable rounded blue chip that combines all four new ops, validating end-to-end at compile time.

## Phase 3 (out of scope)

Gestures (`pointerInput`, drag), size constraints (`widthIn`/`heightIn`/`aspectRatio`), `Modifier.windowInsetsPadding`, `Brush`-taking `Background`, and `Shape`/`Border` overloads with explicit shapes. To follow as separate issues / PRs.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 10/10 passing.
- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet build src/ComposeNet.Sample` — clean.