### PR TITLE
Bind M3 app structure: TopAppBar, TabRow, Tab, Snackbar, Badge, ListItem

### DIFF
--- a/src/ComposeNet.Compose/Badge.cs
+++ b/src/ComposeNet.Compose/Badge.cs
@@ -1,0 +1,25 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>Badge</c>. A small colored marker, typically dropped
+/// inside a <see cref="BadgedBox.Badge"/> slot. Children are the badge
+/// content (usually a count), laid out in a <c>RowScope</c>:
+/// <code>
+/// new Badge { new Text("3") }
+/// </code>
+/// Pass no children for a plain dot.
+/// </summary>
+public sealed class Badge : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3((scope, c) =>
+        {
+            using var _ = RenderContext.PushScope(scope);
+            RenderChildren(c);
+        });
+        ComposeBridges.Badge(BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/BadgedBox.cs
+++ b/src/ComposeNet.Compose/BadgedBox.cs
@@ -1,0 +1,36 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>BadgedBox</c>. Wraps a <see cref="Content"/> node
+/// (typically an <see cref="Icon"/>) and overlays a <see cref="Badge"/>
+/// on its top-end corner:
+/// <code>
+/// new BadgedBox
+/// {
+///     Badge   = new Badge { new Text("3") },
+///     Content = new Icon(Resource.Drawable.ic_inbox, "Inbox"),
+/// }
+/// </code>
+/// </summary>
+public sealed class BadgedBox : ComposableNode
+{
+    /// <summary>Required: the badge to overlay on the content.</summary>
+    public ComposableNode? Badge { get; set; }
+
+    /// <summary>Required: the underlying content the badge attaches to.</summary>
+    public ComposableNode? Content { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Badge is null || Content is null)
+            throw new System.InvalidOperationException(
+                "BadgedBox requires both Badge and Content.");
+
+        var badge   = new ComposableLambda3(c => Badge.Render(c));
+        var content = new ComposableLambda3(c => Content.Render(c));
+
+        ComposeBridges.BadgedBox(badge, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/CenterAlignedTopAppBar.cs
+++ b/src/ComposeNet.Compose/CenterAlignedTopAppBar.cs
@@ -1,0 +1,41 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>CenterAlignedTopAppBar</c> — same shape as
+/// <see cref="TopAppBar"/> but centers the <see cref="Title"/>
+/// horizontally between the navigation icon and actions.
+/// </summary>
+public sealed class CenterAlignedTopAppBar : ComposableNode
+{
+    /// <summary>Required: the bar's title slot, rendered centered.</summary>
+    public ComposableNode? Title { get; set; }
+
+    /// <summary>Optional: leading slot.</summary>
+    public ComposableNode? NavigationIcon { get; set; }
+
+    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
+    public ComposableNode? Actions { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Title is null)
+            throw new System.InvalidOperationException(
+                "CenterAlignedTopAppBar.Title is required (the Kotlin parameter has no default).");
+
+        var title = new ComposableLambda2(c => Title.Render(c));
+        ComposableLambda2? nav = NavigationIcon is null ? null
+            : new ComposableLambda2(c => NavigationIcon.Render(c));
+        ComposableLambda3? actions = Actions is null ? null
+            : new ComposableLambda3(c => Actions.Render(c));
+
+        int defaults = (int)TopAppBarDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)TopAppBarDefault.Modifier;
+        if (nav      is not null) defaults &= ~(int)TopAppBarDefault.NavigationIcon;
+        if (actions  is not null) defaults &= ~(int)TopAppBarDefault.Actions;
+
+        ComposeBridges.CenterAlignedTopAppBar(title, modifier, nav, actions, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -833,4 +833,263 @@ internal static partial class ComposeBridges
         Signature = DrawerSheetSig,
         Defaults  = typeof(DrawerSheetDefault))]
     public static partial void PermanentDrawerSheet(IFunction3 content, long drawerContainerColor, IComposer composer);
+
+    // androidx.compose.material3.AppBarKt — TopAppBar / CenterAlignedTopAppBar
+    // share the `-GHTll3U` shape (extra `expandedHeight: Dp` vs. the older
+    // unmangled overload). 8 user params: title, modifier, navigationIcon,
+    // actions, expandedHeight, windowInsets, colors, scrollBehavior.
+    const string TopAppBarSig =
+        "(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;F" +
+        "Landroidx/compose/foundation/layout/WindowInsets;" +
+        "Landroidx/compose/material3/TopAppBarColors;" +
+        "Landroidx/compose/material3/TopAppBarScrollBehavior;" +
+        "Landroidx/compose/runtime/Composer;II)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "TopAppBar-GHTll3U",
+        Signature = TopAppBarSig,
+        Defaults  = typeof(TopAppBarDefault))]
+    public static partial void TopAppBar(
+        IFunction2  title,
+        IModifier?  modifier,
+        IFunction2? navigationIcon,
+        IFunction3? actions,
+        int         defaults,
+        IComposer   composer);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "CenterAlignedTopAppBar-GHTll3U",
+        Signature = TopAppBarSig,
+        Defaults  = typeof(TopAppBarDefault))]
+    public static partial void CenterAlignedTopAppBar(
+        IFunction2  title,
+        IModifier?  modifier,
+        IFunction2? navigationIcon,
+        IFunction3? actions,
+        int         defaults,
+        IComposer   composer);
+
+    // MediumTopAppBar / LargeTopAppBar share `-oKE7A98` (two-row variants
+    // take BOTH `collapsedHeight` and `expandedHeight` Dp). 9 user params.
+    const string TwoRowsTopAppBarSig =
+        "(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;FF" +
+        "Landroidx/compose/foundation/layout/WindowInsets;" +
+        "Landroidx/compose/material3/TopAppBarColors;" +
+        "Landroidx/compose/material3/TopAppBarScrollBehavior;" +
+        "Landroidx/compose/runtime/Composer;II)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "MediumTopAppBar-oKE7A98",
+        Signature = TwoRowsTopAppBarSig,
+        Defaults  = typeof(TwoRowsTopAppBarDefault))]
+    public static partial void MediumTopAppBar(
+        IFunction2  title,
+        IModifier?  modifier,
+        IFunction2? navigationIcon,
+        IFunction3? actions,
+        int         defaults,
+        IComposer   composer);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "LargeTopAppBar-oKE7A98",
+        Signature = TwoRowsTopAppBarSig,
+        Defaults  = typeof(TwoRowsTopAppBarDefault))]
+    public static partial void LargeTopAppBar(
+        IFunction2  title,
+        IModifier?  modifier,
+        IFunction2? navigationIcon,
+        IFunction3? actions,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.TabRowKt — TabRow / PrimaryTabRow /
+    // SecondaryTabRow all share `-pAZo6Ak`. 7 user params: selectedTabIndex,
+    // modifier, containerColor, contentColor, indicator, divider, tabs.
+    // (Primary/Secondary's indicator Function3 has a TabIndicatorScope
+    // receiver; TabRow's has List<TabPosition> — irrelevant to the
+    // descriptor since both compile to Function3.)
+    const string TabRowSig =
+        "(ILandroidx/compose/ui/Modifier;JJ" +
+        "Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;" +
+        "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabRowKt",
+        JvmName   = "TabRow-pAZo6Ak",
+        Signature = TabRowSig,
+        Defaults  = typeof(TabRowDefault))]
+    public static partial void TabRow(
+        int        selectedTabIndex,
+        IModifier? modifier,
+        IFunction2 tabs,
+        IComposer  composer);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabRowKt",
+        JvmName   = "PrimaryTabRow-pAZo6Ak",
+        Signature = TabRowSig,
+        Defaults  = typeof(TabRowDefault))]
+    public static partial void PrimaryTabRow(
+        int        selectedTabIndex,
+        IModifier? modifier,
+        IFunction2 tabs,
+        IComposer  composer);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabRowKt",
+        JvmName   = "SecondaryTabRow-pAZo6Ak",
+        Signature = TabRowSig,
+        Defaults  = typeof(TabRowDefault))]
+    public static partial void SecondaryTabRow(
+        int        selectedTabIndex,
+        IModifier? modifier,
+        IFunction2 tabs,
+        IComposer  composer);
+
+    // androidx.compose.material3.TabRowKt.ScrollableTabRow-sKfQg0A.
+    // 8 user params: same as TabRow plus a leading `edgePadding: Dp`.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabRowKt",
+        JvmName   = "ScrollableTabRow-sKfQg0A",
+        Signature = "(ILandroidx/compose/ui/Modifier;JJF" +
+                    "Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(ScrollableTabRowDefault))]
+    public static partial void ScrollableTabRow(
+        int        selectedTabIndex,
+        IModifier? modifier,
+        IFunction2 tabs,
+        IComposer  composer);
+
+    // androidx.compose.material3.TabKt.Tab-wqdebIU (text/icon overload).
+    // 9 user params: selected, onClick, modifier, enabled, text, icon,
+    // selectedContentColor, unselectedContentColor, interactionSource.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabKt",
+        JvmName   = "Tab-wqdebIU",
+        Signature = "(ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;JJ" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(TabDefault))]
+    public static partial void Tab(
+        bool        selected,
+        IFunction0  onClick,
+        IModifier?  modifier,
+        IFunction2? text,
+        IFunction2? icon,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.TabKt.LeadingIconTab-wqdebIU.
+    // 9 user params: selected, onClick, text, icon, modifier, enabled,
+    // selectedContentColor, unselectedContentColor, interactionSource.
+    // Note text and icon are REQUIRED (no Kotlin default), unlike Tab.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabKt",
+        JvmName   = "LeadingIconTab-wqdebIU",
+        Signature = "(ZLkotlin/jvm/functions/Function0;" +
+                    "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+                    "Landroidx/compose/ui/Modifier;ZJJ" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(LeadingIconTabDefault))]
+    public static partial void LeadingIconTab(
+        bool       selected,
+        IFunction0 onClick,
+        IFunction2 text,
+        IFunction2 icon,
+        IModifier? modifier,
+        IComposer  composer);
+
+    // androidx.compose.material3.SnackbarKt.Snackbar-eQBnUkQ. 10 user
+    // params: modifier, action, dismissAction, actionOnNewLine, shape,
+    // 4 colors, content. Bit 9 (content) always provided.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SnackbarKt",
+        JvmName   = "Snackbar-eQBnUkQ",
+        Signature = "(Landroidx/compose/ui/Modifier;" +
+                    "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;JJJJ" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(SnackbarDefault))]
+    public static partial void Snackbar(
+        IModifier?  modifier,
+        IFunction2? action,
+        IFunction2? dismissAction,
+        IFunction2  content,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.SnackbarHostKt.SnackbarHost — UNMANGLED
+    // (no inline-class params). 3 user params: hostState, modifier,
+    // snackbar. Bits 0 (hostState) and 2 (snackbar) always provided.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SnackbarHostKt",
+        JvmName   = "SnackbarHost",
+        Signature = "(Landroidx/compose/material3/SnackbarHostState;" +
+                    "Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(SnackbarHostDefault))]
+    public static partial void SnackbarHost(
+        IntPtr     hostState,
+        IModifier? modifier,
+        IFunction3 snackbar,
+        IComposer  composer);
+
+    // androidx.compose.material3.BadgeKt.Badge-eopBjH0. 4 user params:
+    // modifier, containerColor, contentColor, content (RowScope-receiver
+    // Function3). Bit 3 (content) always provided.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/BadgeKt",
+        JvmName   = "Badge-eopBjH0",
+        Signature = "(Landroidx/compose/ui/Modifier;JJ" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(BadgeDefault))]
+    public static partial void Badge(IModifier? modifier, IFunction3 content, IComposer composer);
+
+    // androidx.compose.material3.BadgeKt.BadgedBox — UNMANGLED. 3 user
+    // params: badge (BoxScope-receiver Function3), modifier, content
+    // (BoxScope-receiver Function3). Bits 0 (badge) and 2 (content)
+    // always provided.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/BadgeKt",
+        JvmName   = "BadgedBox",
+        Signature = "(Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(BadgedBoxDefault))]
+    public static partial void BadgedBox(
+        IFunction3 badge,
+        IModifier? modifier,
+        IFunction3 content,
+        IComposer  composer);
+
+    // androidx.compose.material3.ListItemKt.ListItem-HXNGIdc. 9 user
+    // params: headlineContent, modifier, overlineContent, supportingContent,
+    // leadingContent, trailingContent, colors, tonalElevation,
+    // shadowElevation. Bit 0 (headlineContent) always provided.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/ListItemKt",
+        JvmName   = "ListItem-HXNGIdc",
+        Signature = "(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;" +
+                    "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+                    "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+                    "Landroidx/compose/material3/ListItemColors;FF" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(ListItemDefault))]
+    public static partial void ListItem(
+        IFunction2  headlineContent,
+        IModifier?  modifier,
+        IFunction2? overlineContent,
+        IFunction2? supportingContent,
+        IFunction2? leadingContent,
+        IFunction2? trailingContent,
+        int         defaults,
+        IComposer   composer);
 }

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -105,6 +105,25 @@ internal static partial class ComposeBridges
         return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingLTRBMethod, args);
     }
 
+    static IntPtr s_paddingValuesMethod;
+    const string ModifierPaddingValuesSig =
+        "(Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;)Landroidx/compose/ui/Modifier;";
+
+    // PaddingKt.padding(Modifier, PaddingValues) — unmangled because
+    // PaddingValues is a regular interface, not a `value class`.
+    internal static unsafe IntPtr ModifierPaddingValues(IntPtr modifier, IntPtr paddingValues)
+    {
+        if (s_paddingKtClass == IntPtr.Zero)
+            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
+        if (s_paddingValuesMethod == IntPtr.Zero)
+            s_paddingValuesMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding", ModifierPaddingValuesSig);
+
+        JValue* args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(paddingValues);
+        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingValuesMethod, args);
+    }
+
     // androidx.compose.foundation.layout.SizeKt — fillMax* take a plain
     // Float fraction, not Dp, so the JVM names are NOT mangled.
     static IntPtr s_sizeKtClass;

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -260,3 +260,75 @@ using ComposeNet;
 // 1 user param (`spacing`), defaulted by the wrapper.
 [assembly: ComposeDefaults("RememberPlainTooltipPositionProviderDefault",
     "spacing")]
+
+// androidx.compose.material3.AppBarKt.{TopAppBar,CenterAlignedTopAppBar}-GHTll3U:
+// 8 user params; bit 0 (title) always provided. Optional slot bits 2
+// (NavigationIcon) and 3 (Actions) are toggled per-call by the facades.
+[assembly: ComposeDefaults("TopAppBarDefault",
+    "!title", "modifier", "navigationIcon", "actions", "expandedHeight",
+    "windowInsets", "colors", "scrollBehavior")]
+
+// androidx.compose.material3.AppBarKt.{Medium,Large}TopAppBar-oKE7A98:
+// 9 user params; bit 0 (title) always provided. Two-row variants take
+// both collapsedHeight and expandedHeight as Dp.
+[assembly: ComposeDefaults("TwoRowsTopAppBarDefault",
+    "!title", "modifier", "navigationIcon", "actions", "collapsedHeight",
+    "expandedHeight", "windowInsets", "colors", "scrollBehavior")]
+
+// androidx.compose.material3.TabRowKt.{TabRow,PrimaryTabRow,SecondaryTabRow}-pAZo6Ak:
+// 7 user params; bits 0 (selectedTabIndex) and 6 (tabs) always provided.
+[assembly: ComposeDefaults("TabRowDefault",
+    "!selectedTabIndex", "modifier", "containerColor", "contentColor",
+    "indicator", "divider", "!tabs")]
+
+// androidx.compose.material3.TabRowKt.ScrollableTabRow-sKfQg0A:
+// 8 user params; bits 0 (selectedTabIndex) and 7 (tabs) always provided.
+[assembly: ComposeDefaults("ScrollableTabRowDefault",
+    "!selectedTabIndex", "modifier", "containerColor", "contentColor",
+    "edgePadding", "indicator", "divider", "!tabs")]
+
+// androidx.compose.material3.TabKt.Tab-wqdebIU: 9 user params; bits 0
+// (selected) and 1 (onClick) always provided. text/icon are optional
+// slots toggled per-call by Tab.Render.
+[assembly: ComposeDefaults("TabDefault",
+    "!selected", "!onClick", "modifier", "enabled", "text", "icon",
+    "selectedContentColor", "unselectedContentColor", "interactionSource")]
+
+// androidx.compose.material3.TabKt.LeadingIconTab-wqdebIU: 9 user params;
+// bits 0 (selected), 1 (onClick), 2 (text), 3 (icon) all always provided
+// — Kotlin requires text and icon (no defaults).
+[assembly: ComposeDefaults("LeadingIconTabDefault",
+    "!selected", "!onClick", "!text", "!icon", "modifier", "enabled",
+    "selectedContentColor", "unselectedContentColor", "interactionSource")]
+
+// androidx.compose.material3.SnackbarKt.Snackbar-eQBnUkQ: 10 user params;
+// bit 9 (content) always provided. action/dismissAction are optional
+// slots toggled per-call by Snackbar.Render.
+[assembly: ComposeDefaults("SnackbarDefault",
+    "modifier", "action", "dismissAction", "actionOnNewLine", "shape",
+    "containerColor", "contentColor", "actionColor", "actionContentColor",
+    "!content")]
+
+// androidx.compose.material3.SnackbarHostKt.SnackbarHost: 3 user params;
+// bits 0 (hostState) and 2 (snackbar) always provided.
+[assembly: ComposeDefaults("SnackbarHostDefault",
+    "!hostState", "modifier", "!snackbar")]
+
+// androidx.compose.material3.BadgeKt.Badge-eopBjH0: 4 user params; bit
+// 3 (content) always provided.
+[assembly: ComposeDefaults("BadgeDefault",
+    "modifier", "containerColor", "contentColor", "!content")]
+
+// androidx.compose.material3.BadgeKt.BadgedBox: 3 user params; bits 0
+// (badge) and 2 (content) always provided.
+[assembly: ComposeDefaults("BadgedBoxDefault",
+    "!badge", "modifier", "!content")]
+
+// androidx.compose.material3.ListItemKt.ListItem-HXNGIdc: 9 user params;
+// bit 0 (headlineContent) always provided. The four optional slot
+// Function2 params (overline, supporting, leading, trailing) are
+// toggled per-call by ListItem.Render.
+[assembly: ComposeDefaults("ListItemDefault",
+    "!headlineContent", "modifier", "overlineContent", "supportingContent",
+    "leadingContent", "trailingContent", "colors", "tonalElevation",
+    "shadowElevation")]

--- a/src/ComposeNet.Compose/LargeTopAppBar.cs
+++ b/src/ComposeNet.Compose/LargeTopAppBar.cs
@@ -1,0 +1,41 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>LargeTopAppBar</c> — a taller variant of
+/// <see cref="MediumTopAppBar"/> that gives the title a full-width row
+/// when expanded. Same slots as <see cref="TopAppBar"/>.
+/// </summary>
+public sealed class LargeTopAppBar : ComposableNode
+{
+    /// <summary>Required: the bar's title slot.</summary>
+    public ComposableNode? Title { get; set; }
+
+    /// <summary>Optional: leading slot.</summary>
+    public ComposableNode? NavigationIcon { get; set; }
+
+    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
+    public ComposableNode? Actions { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Title is null)
+            throw new System.InvalidOperationException(
+                "LargeTopAppBar.Title is required (the Kotlin parameter has no default).");
+
+        var title = new ComposableLambda2(c => Title.Render(c));
+        ComposableLambda2? nav = NavigationIcon is null ? null
+            : new ComposableLambda2(c => NavigationIcon.Render(c));
+        ComposableLambda3? actions = Actions is null ? null
+            : new ComposableLambda3(c => Actions.Render(c));
+
+        int defaults = (int)TwoRowsTopAppBarDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Modifier;
+        if (nav      is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.NavigationIcon;
+        if (actions  is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Actions;
+
+        ComposeBridges.LargeTopAppBar(title, modifier, nav, actions, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/LeadingIconTab.cs
+++ b/src/ComposeNet.Compose/LeadingIconTab.cs
@@ -1,0 +1,39 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>LeadingIconTab</c>. Like <see cref="Tab"/> but the
+/// icon and text are required and laid out side-by-side (icon first)
+/// instead of stacked vertically.
+/// </summary>
+public sealed class LeadingIconTab : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public LeadingIconTab(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Required: tab label slot.</summary>
+    public ComposableNode? Text { get; set; }
+
+    /// <summary>Required: tab icon slot, rendered before the text.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Text is null || Icon is null)
+            throw new System.InvalidOperationException(
+                "LeadingIconTab.Text and Icon are both required (the Kotlin parameters have no defaults).");
+
+        var click = new ComposableLambda0(_onClick);
+        var text  = new ComposableLambda2(c => Text.Render(c));
+        var icon  = new ComposableLambda2(c => Icon.Render(c));
+
+        ComposeBridges.LeadingIconTab(_selected, click, text, icon, BuildModifier(), composer);
+    }
+}

--- a/src/ComposeNet.Compose/ListItem.cs
+++ b/src/ComposeNet.Compose/ListItem.cs
@@ -1,0 +1,59 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ListItem</c>. A row in a list with a required
+/// <see cref="Headline"/> and four optional content slots
+/// (<see cref="Overline"/>, <see cref="Supporting"/>,
+/// <see cref="Leading"/>, <see cref="Trailing"/>):
+/// <code>
+/// new ListItem
+/// {
+///     Headline   = new Text("Inbox"),
+///     Supporting = new Text("3 unread"),
+///     Leading    = new Icon(Resource.Drawable.ic_inbox, "Inbox"),
+///     Trailing   = new Text("→"),
+/// }
+/// </code>
+/// </summary>
+public sealed class ListItem : ComposableNode
+{
+    /// <summary>Required: primary text slot.</summary>
+    public ComposableNode? Headline { get; set; }
+
+    /// <summary>Optional: text rendered above the headline.</summary>
+    public ComposableNode? Overline { get; set; }
+
+    /// <summary>Optional: secondary text rendered below the headline.</summary>
+    public ComposableNode? Supporting { get; set; }
+
+    /// <summary>Optional: leading slot, typically an icon or avatar.</summary>
+    public ComposableNode? Leading { get; set; }
+
+    /// <summary>Optional: trailing slot.</summary>
+    public ComposableNode? Trailing { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Headline is null)
+            throw new System.InvalidOperationException(
+                "ListItem.Headline is required (the Kotlin parameter has no default).");
+
+        var headline = new ComposableLambda2(c => Headline.Render(c));
+        ComposableLambda2? overline   = Overline   is null ? null : new ComposableLambda2(c => Overline.Render(c));
+        ComposableLambda2? supporting = Supporting is null ? null : new ComposableLambda2(c => Supporting.Render(c));
+        ComposableLambda2? leading    = Leading    is null ? null : new ComposableLambda2(c => Leading.Render(c));
+        ComposableLambda2? trailing   = Trailing   is null ? null : new ComposableLambda2(c => Trailing.Render(c));
+
+        int defaults = (int)ListItemDefault.All;
+        var modifier = BuildModifier();
+        if (modifier   is not null) defaults &= ~(int)ListItemDefault.Modifier;
+        if (overline   is not null) defaults &= ~(int)ListItemDefault.OverlineContent;
+        if (supporting is not null) defaults &= ~(int)ListItemDefault.SupportingContent;
+        if (leading    is not null) defaults &= ~(int)ListItemDefault.LeadingContent;
+        if (trailing   is not null) defaults &= ~(int)ListItemDefault.TrailingContent;
+
+        ComposeBridges.ListItem(headline, modifier, overline, supporting, leading, trailing, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/MediumTopAppBar.cs
+++ b/src/ComposeNet.Compose/MediumTopAppBar.cs
@@ -1,0 +1,41 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>MediumTopAppBar</c> — a two-row top app bar that
+/// collapses to a single row as the underlying scroll behavior
+/// progresses. Same slots as <see cref="TopAppBar"/>.
+/// </summary>
+public sealed class MediumTopAppBar : ComposableNode
+{
+    /// <summary>Required: the bar's title slot.</summary>
+    public ComposableNode? Title { get; set; }
+
+    /// <summary>Optional: leading slot.</summary>
+    public ComposableNode? NavigationIcon { get; set; }
+
+    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
+    public ComposableNode? Actions { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Title is null)
+            throw new System.InvalidOperationException(
+                "MediumTopAppBar.Title is required (the Kotlin parameter has no default).");
+
+        var title = new ComposableLambda2(c => Title.Render(c));
+        ComposableLambda2? nav = NavigationIcon is null ? null
+            : new ComposableLambda2(c => NavigationIcon.Render(c));
+        ComposableLambda3? actions = Actions is null ? null
+            : new ComposableLambda3(c => Actions.Render(c));
+
+        int defaults = (int)TwoRowsTopAppBarDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Modifier;
+        if (nav      is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.NavigationIcon;
+        if (actions  is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Actions;
+
+        ComposeBridges.MediumTopAppBar(title, modifier, nav, actions, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -125,6 +125,15 @@ public sealed class Modifier
         Append(h => ComposeBridges.ModifierFillMaxSize(h, fraction));
 
     /// <summary>
+    /// <c>Modifier.padding(paddingValues)</c> — pads using the
+    /// <c>PaddingValues</c> handle a layout (e.g. <see cref="Scaffold"/>)
+    /// passes to its content lambda. Internal: only Scaffold-shaped
+    /// composables that receive a runtime <c>PaddingValues</c> need it.
+    /// </summary>
+    internal Modifier Padding(IntPtr paddingValues) =>
+        Append(curr => ComposeBridges.ModifierPaddingValues(curr, paddingValues));
+
+    /// <summary>
     /// <c>Modifier.safeDrawingPadding()</c> — pads for the union of
     /// system bars, IME, and display cutouts. Use as the outer modifier
     /// on a root composable (or inside a <see cref="Scaffold"/>'s body

--- a/src/ComposeNet.Compose/PrimaryTabRow.cs
+++ b/src/ComposeNet.Compose/PrimaryTabRow.cs
@@ -1,0 +1,21 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>PrimaryTabRow</c> — the M3 variant of
+/// <see cref="TabRow"/> with the primary indicator style (rounded pill
+/// under the selected tab). Use when the tabs are the top-level
+/// destination switcher of a screen.
+/// </summary>
+public sealed class PrimaryTabRow : ComposableContainer
+{
+    readonly int _selectedTabIndex;
+    public PrimaryTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
+
+    internal override void Render(IComposer composer)
+    {
+        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        ComposeBridges.PrimaryTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
+    }
+}

--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -47,7 +47,20 @@ public sealed class Scaffold : ComposableNode
             throw new System.InvalidOperationException(
                 "Scaffold.Body is required (the Kotlin parameter has no default).");
 
-        var content = new ComposableLambda3(c => Body.Render(c));
+        // Material 3's Scaffold passes PaddingValues as the first arg of
+        // its content lambda — body must apply it to avoid rendering
+        // behind the top/bottom bars. We can't prepend a Modifier onto
+        // Body's existing chain from out here (see #37), so we wrap it
+        // in a Box that owns the runtime `Modifier.padding(values)`.
+        // When #37 lands, drop the Box and inject the padding directly.
+        var content = new ComposableLambda3((paddingHandle, c) =>
+        {
+            new Box
+            {
+                Modifier.Companion.Padding(paddingHandle),
+                Body,
+            }.Render(c);
+        });
 
         ComposableLambda2? topBar = TopBar is null ? null
             : new ComposableLambda2(c => TopBar.Render(c));

--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -62,22 +62,25 @@ public sealed class Scaffold : ComposableNode
             }.Render(c);
         });
 
-        ComposableLambda2? topBar = TopBar is null ? null
-            : new ComposableLambda2(c => TopBar.Render(c));
-        ComposableLambda2? bottomBar = BottomBar is null ? null
-            : new ComposableLambda2(c => BottomBar.Render(c));
-        ComposableLambda2? snackbarHost = SnackbarHost is null ? null
-            : new ComposableLambda2(c => SnackbarHost.Render(c));
-        ComposableLambda2? fab = FloatingActionButton is null ? null
-            : new ComposableLambda2(c => FloatingActionButton.Render(c));
+        // Always pass non-null slot lambdas. Toggling between Compose's
+        // default `{}` (a synthetic Java SAM lambda) and our IFunction2
+        // identity confuses M3's internal `rememberComposableLambda`,
+        // which casts the slot value to ComposableLambdaImpl on every
+        // recomposition — a flip in slot type triggers a runtime
+        // ClassCastException. Emit nothing when the user didn't supply
+        // a slot; functionally identical to M3's `{}` default.
+        var topBar = new ComposableLambda2(c => TopBar?.Render(c));
+        var bottomBar = new ComposableLambda2(c => BottomBar?.Render(c));
+        var snackbarHost = new ComposableLambda2(c => SnackbarHost?.Render(c));
+        var fab = new ComposableLambda2(c => FloatingActionButton?.Render(c));
 
         int defaults = (int)ScaffoldDefault.All;
         var modifier = BuildModifier();
-        if (modifier     is not null) defaults &= ~(int)ScaffoldDefault.Modifier;
-        if (topBar       is not null) defaults &= ~(int)ScaffoldDefault.TopBar;
-        if (bottomBar    is not null) defaults &= ~(int)ScaffoldDefault.BottomBar;
-        if (snackbarHost is not null) defaults &= ~(int)ScaffoldDefault.SnackbarHost;
-        if (fab          is not null) defaults &= ~(int)ScaffoldDefault.FloatingActionButton;
+        if (modifier is not null) defaults &= ~(int)ScaffoldDefault.Modifier;
+        defaults &= ~(int)ScaffoldDefault.TopBar;
+        defaults &= ~(int)ScaffoldDefault.BottomBar;
+        defaults &= ~(int)ScaffoldDefault.SnackbarHost;
+        defaults &= ~(int)ScaffoldDefault.FloatingActionButton;
 
         ComposeBridges.Scaffold(
             modifier:             modifier,

--- a/src/ComposeNet.Compose/ScrollableTabRow.cs
+++ b/src/ComposeNet.Compose/ScrollableTabRow.cs
@@ -1,0 +1,21 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ScrollableTabRow</c>. Like <see cref="TabRow"/> but the
+/// tabs are laid out at their natural width and the row scrolls
+/// horizontally — useful when there are too many tabs to fit on one
+/// screen.
+/// </summary>
+public sealed class ScrollableTabRow : ComposableContainer
+{
+    readonly int _selectedTabIndex;
+    public ScrollableTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
+
+    internal override void Render(IComposer composer)
+    {
+        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        ComposeBridges.ScrollableTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
+    }
+}

--- a/src/ComposeNet.Compose/SecondaryTabRow.cs
+++ b/src/ComposeNet.Compose/SecondaryTabRow.cs
@@ -1,0 +1,20 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>SecondaryTabRow</c> — the M3 variant of
+/// <see cref="TabRow"/> with the secondary indicator style (full-width
+/// underline). Use for tab groups nested inside a screen.
+/// </summary>
+public sealed class SecondaryTabRow : ComposableContainer
+{
+    readonly int _selectedTabIndex;
+    public SecondaryTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
+
+    internal override void Render(IComposer composer)
+    {
+        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        ComposeBridges.SecondaryTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
+    }
+}

--- a/src/ComposeNet.Compose/Snackbar.cs
+++ b/src/ComposeNet.Compose/Snackbar.cs
@@ -1,0 +1,47 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>Snackbar</c>. A transient message bar typically
+/// rendered in <see cref="Scaffold.SnackbarHost"/>:
+/// <code>
+/// new Snackbar
+/// {
+///     Action = new Button(onClick: ...) { new Text("Undo") },
+///     Body   = new Text("Item deleted"),
+/// }
+/// </code>
+/// </summary>
+public sealed class Snackbar : ComposableNode
+{
+    /// <summary>Required: the message body slot.</summary>
+    public ComposableNode? Body { get; set; }
+
+    /// <summary>Optional: trailing action button (e.g. "Undo").</summary>
+    public ComposableNode? Action { get; set; }
+
+    /// <summary>Optional: dismiss action (e.g. close icon button).</summary>
+    public ComposableNode? DismissAction { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Body is null)
+            throw new System.InvalidOperationException(
+                "Snackbar.Body is required (the Kotlin content lambda has no default).");
+
+        var content = new ComposableLambda2(c => Body.Render(c));
+        ComposableLambda2? action = Action is null ? null
+            : new ComposableLambda2(c => Action.Render(c));
+        ComposableLambda2? dismiss = DismissAction is null ? null
+            : new ComposableLambda2(c => DismissAction.Render(c));
+
+        int defaults = (int)SnackbarDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)SnackbarDefault.Modifier;
+        if (action   is not null) defaults &= ~(int)SnackbarDefault.Action;
+        if (dismiss  is not null) defaults &= ~(int)SnackbarDefault.DismissAction;
+
+        ComposeBridges.Snackbar(modifier, action, dismiss, content, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/SnackbarHost.cs
+++ b/src/ComposeNet.Compose/SnackbarHost.cs
@@ -1,0 +1,51 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>SnackbarHost</c>. Anchors a <see cref="Snackbar"/>
+/// driven by a <see cref="ComposeNet.SnackbarHostState"/>. Typically
+/// dropped into <see cref="Scaffold.SnackbarHost"/>:
+/// <code>
+/// var hostState = Remember(() =&gt; new SnackbarHostState());
+///
+/// new Scaffold
+/// {
+///     SnackbarHost = new SnackbarHost(hostState),
+///     Body         = ...,
+/// }
+/// </code>
+/// </summary>
+/// <remarks>
+/// Triggering snackbars via <see cref="ComposeNet.SnackbarHostState"/>
+/// requires Kotlin coroutines and isn't yet wired up in this binding.
+/// For most cases, render a <see cref="Snackbar"/> directly into the
+/// <see cref="Scaffold.SnackbarHost"/> slot, gated by a
+/// <see cref="MutableState{T}"/>.
+/// </remarks>
+public sealed class SnackbarHost : ComposableNode
+{
+    readonly SnackbarHostState _hostState;
+
+    public SnackbarHost(SnackbarHostState hostState) => _hostState = hostState;
+
+    internal override void Render(IComposer composer)
+    {
+        // SnackbarHost's Function3 receives the current SnackbarData as p0.
+        // We forward to the default Snackbar renderer by calling the
+        // default-shaped Snackbar(snackbarData) Kotlin overload — but
+        // since that's a stripped variant we just emit a plain Snackbar
+        // with no message when invoked directly. In practice the host
+        // is rarely visited because the suspending trigger isn't bridged.
+        var snackbar = new ComposableLambda3((_, c) =>
+        {
+            new Snackbar { Body = new Text(string.Empty) }.Render(c);
+        });
+
+        ComposeBridges.SnackbarHost(
+            hostState: ((Java.Lang.Object)_hostState.Jvm).Handle,
+            modifier:  BuildModifier(),
+            snackbar:  snackbar,
+            composer:  composer);
+    }
+}

--- a/src/ComposeNet.Compose/SnackbarHost.cs
+++ b/src/ComposeNet.Compose/SnackbarHost.cs
@@ -32,15 +32,12 @@ public sealed class SnackbarHost : ComposableNode
     internal override void Render(IComposer composer)
     {
         // SnackbarHost's Function3 receives the current SnackbarData as p0.
-        // We forward to the default Snackbar renderer by calling the
-        // default-shaped Snackbar(snackbarData) Kotlin overload — but
-        // since that's a stripped variant we just emit a plain Snackbar
-        // with no message when invoked directly. In practice the host
-        // is rarely visited because the suspending trigger isn't bridged.
-        var snackbar = new ComposableLambda3((_, c) =>
-        {
-            new Snackbar { Body = new Text(string.Empty) }.Render(c);
-        });
+        // The suspending `showSnackbar` trigger on SnackbarHostState isn't
+        // bridged yet, so this lambda would only fire if a Java/Kotlin
+        // caller enqueued data. Render nothing rather than a blank Snackbar
+        // surface — once the `Snackbar(snackbarData)` overload is bridged
+        // we can forward to it here.
+        var snackbar = new ComposableLambda3((_, _) => { });
 
         ComposeBridges.SnackbarHost(
             hostState: ((Java.Lang.Object)_hostState.Jvm).Handle,

--- a/src/ComposeNet.Compose/SnackbarHostState.cs
+++ b/src/ComposeNet.Compose/SnackbarHostState.cs
@@ -1,0 +1,21 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Caller-supplied state holder for <see cref="SnackbarHost"/>. Wraps
+/// the bound <c>androidx.compose.material3.SnackbarHostState</c> — the
+/// Kotlin class has a public no-arg constructor and is plain enough
+/// for the binder to expose, so no JNI bridge is needed.
+/// </summary>
+/// <remarks>
+/// The Kotlin <c>showSnackbar</c> trigger is a suspending function
+/// (takes a <c>Continuation</c>) and isn't directly callable from C#
+/// without a coroutine bridge. For now, prefer toggling a
+/// <see cref="MutableState{T}"/> + rendering a <see cref="Snackbar"/>
+/// conditionally inside the <see cref="Scaffold.SnackbarHost"/> slot.
+/// This wrapper exists so the bound state can still be passed to a
+/// <see cref="SnackbarHost"/> when one is needed.
+/// </remarks>
+public sealed class SnackbarHostState
+{
+    internal AndroidX.Compose.Material3.SnackbarHostState Jvm { get; } = new();
+}

--- a/src/ComposeNet.Compose/Tab.cs
+++ b/src/ComposeNet.Compose/Tab.cs
@@ -1,0 +1,43 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>Tab</c>. Place inside a <see cref="TabRow"/> /
+/// <see cref="PrimaryTabRow"/> / <see cref="SecondaryTabRow"/> /
+/// <see cref="ScrollableTabRow"/>. <see cref="Text"/> and
+/// <see cref="Icon"/> are both optional but at least one should be
+/// supplied for the tab to be visible.
+/// </summary>
+public sealed class Tab : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public Tab(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Optional: tab label slot.</summary>
+    public ComposableNode? Text { get; set; }
+
+    /// <summary>Optional: tab icon slot.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var click = new ComposableLambda0(_onClick);
+        ComposableLambda2? text = Text is null ? null : new ComposableLambda2(c => Text.Render(c));
+        ComposableLambda2? icon = Icon is null ? null : new ComposableLambda2(c => Icon.Render(c));
+
+        int defaults = (int)TabDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)TabDefault.Modifier;
+        if (text     is not null) defaults &= ~(int)TabDefault.Text;
+        if (icon     is not null) defaults &= ~(int)TabDefault.Icon;
+
+        ComposeBridges.Tab(_selected, click, modifier, text, icon, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/TabRow.cs
+++ b/src/ComposeNet.Compose/TabRow.cs
@@ -1,0 +1,33 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>TabRow</c>. Container for fixed-width
+/// <see cref="Tab"/> / <see cref="LeadingIconTab"/> children that
+/// distribute across the available width:
+/// <code>
+/// new TabRow(selectedTabIndex: tab.Value)
+/// {
+///     new Tab(selected: tab.Value == 0, onClick: () =&gt; tab.Value = 0)
+///     {
+///         Text = new Text("Home"),
+///     },
+///     new Tab(selected: tab.Value == 1, onClick: () =&gt; tab.Value = 1)
+///     {
+///         Text = new Text("Settings"),
+///     },
+/// }
+/// </code>
+/// </summary>
+public sealed class TabRow : ComposableContainer
+{
+    readonly int _selectedTabIndex;
+    public TabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
+
+    internal override void Render(IComposer composer)
+    {
+        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        ComposeBridges.TabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
+    }
+}

--- a/src/ComposeNet.Compose/TopAppBar.cs
+++ b/src/ComposeNet.Compose/TopAppBar.cs
@@ -1,0 +1,49 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>TopAppBar</c>. <see cref="Title"/> is required;
+/// <see cref="NavigationIcon"/> and <see cref="Actions"/> are optional
+/// slots:
+/// <code>
+/// new TopAppBar
+/// {
+///     Title          = new Text("My App"),
+///     NavigationIcon = new IconButton(onClick: ...) { new Text("☰") },
+///     Actions        = new Row { new IconButton(...) { new Text("⋮") } },
+/// }
+/// </code>
+/// </summary>
+public sealed class TopAppBar : ComposableNode
+{
+    /// <summary>Required: the bar's title slot.</summary>
+    public ComposableNode? Title { get; set; }
+
+    /// <summary>Optional: leading slot, typically a menu / back button.</summary>
+    public ComposableNode? NavigationIcon { get; set; }
+
+    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
+    public ComposableNode? Actions { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Title is null)
+            throw new System.InvalidOperationException(
+                "TopAppBar.Title is required (the Kotlin parameter has no default).");
+
+        var title = new ComposableLambda2(c => Title.Render(c));
+        ComposableLambda2? nav = NavigationIcon is null ? null
+            : new ComposableLambda2(c => NavigationIcon.Render(c));
+        ComposableLambda3? actions = Actions is null ? null
+            : new ComposableLambda3(c => Actions.Render(c));
+
+        int defaults = (int)TopAppBarDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)TopAppBarDefault.Modifier;
+        if (nav      is not null) defaults &= ~(int)TopAppBarDefault.NavigationIcon;
+        if (actions  is not null) defaults &= ~(int)TopAppBarDefault.Actions;
+
+        ComposeBridges.TopAppBar(title, modifier, nav, actions, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -302,7 +302,7 @@ public class MainActivity : ComposeActivity
                         },
                         Body = new Column
                         {
-                            Modifier.Companion.SafeDrawingPadding().Padding(16),
+                            Modifier.Companion.Padding(16),
                             tabContent,
 
                             // Overlays: rendered in the body so they participate in the

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -16,8 +16,10 @@ public class MainActivity : ComposeActivity
             var name        = Remember(() => new MutableState<string>(""));
             var liked       = Remember(() => new MutableState<bool>(false));
             var tab         = Remember(() => new MutableNumberState<int>(0));
+            var sub         = Remember(() => new MutableNumberState<int>(0));
             var showAlert   = Remember(() => new MutableState<bool>(false));
             var showSheet   = Remember(() => new MutableState<bool>(false));
+            var showSnack   = Remember(() => new MutableState<bool>(false));
             var showDate    = Remember(() => new MutableState<bool>(false));
             var showTime    = Remember(() => new MutableState<bool>(false));
             var drawerKind  = Remember(() => new MutableNumberState<int>(0));
@@ -26,6 +28,8 @@ public class MainActivity : ComposeActivity
             var dateState   = Remember(() => new DatePickerState());
             var timeState   = Remember(() => new TimePickerState(initialHour: 9, initialMinute: 30));
 
+            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Pickers" };
+
             // Per-tab content. Only the current tab's column is added to
             // the screen — keeps the sample short enough to fit on one
             // phone-sized scroll area.
@@ -33,21 +37,71 @@ public class MainActivity : ComposeActivity
             {
                 0 => new Column
                 {
-                    new Text("Hello from .NET"),
-                    new Text($"Count: {count}"),
-                    new Row
+                    new TabRow(selectedTabIndex: sub.Value)
                     {
-                        new Image(Resource.Drawable.ic_star, "Star icon"),
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
-                        new Column
+                        new Tab(selected: sub.Value == 0, onClick: () => sub.Value = 0)
                         {
-                            new Button(onClick: () => count++) { new Text("Tap to increment") },
-                            new IconButton(onClick: () => count--) { new Text("−") },
+                            Text = new Text("Greeting"),
+                        },
+                        new Tab(selected: sub.Value == 1, onClick: () => sub.Value = 1)
+                        {
+                            Text = new Text("Counter"),
+                        },
+                        new LeadingIconTab(selected: sub.Value == 2, onClick: () => sub.Value = 2)
+                        {
+                            Text = new Text("List"),
+                            Icon = new Text("📋"),
                         },
                     },
-                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
-                    new OutlinedTextField(name),
-                    new Text($"Hi {(string.IsNullOrEmpty(name.Value) ? "stranger" : name.Value)}"),
+                    sub.Value switch
+                    {
+                        0 => (ComposableNode)new Column
+                        {
+                            new Text("Hello from .NET"),
+                            new OutlinedTextField(name),
+                            new Text($"Hi {(string.IsNullOrEmpty(name.Value) ? "stranger" : name.Value)}"),
+                        },
+                        1 => new Column
+                        {
+                            new Text($"Count: {count}"),
+                            new Row
+                            {
+                                new Image(Resource.Drawable.ic_star, "Star icon"),
+                                new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
+                                new Column
+                                {
+                                    new Button(onClick: () => count++) { new Text("Tap to increment") },
+                                    new IconButton(onClick: () => count--) { new Text("−") },
+                                },
+                            },
+                        },
+                        _ => new Column
+                        {
+                            new ListItem
+                            {
+                                Headline   = new Text("Inbox"),
+                                Supporting = new Text("12 unread messages"),
+                                Leading    = new Text("📥"),
+                                Trailing   = new Badge { new Text("12") },
+                            },
+                            new ListItem
+                            {
+                                Headline   = new Text("Sent"),
+                                Supporting = new Text("Last sent yesterday"),
+                                Leading    = new Text("📤"),
+                            },
+                            new ListItem
+                            {
+                                Headline = new Text("Drafts"),
+                                Leading  = new Text("📝"),
+                                Trailing = new BadgedBox
+                                {
+                                    Badge   = new Badge { new Text("3") },
+                                    Content = new Text("✉"),
+                                },
+                            },
+                        },
+                    },
                 },
                 1 => new Column
                 {
@@ -84,6 +138,10 @@ public class MainActivity : ComposeActivity
                     new FloatingActionButton(onClick: () => showAlert.Value = true)
                     {
                         new Text("✕"),
+                    },
+                    new Button(onClick: () => showSnack.Value = true)
+                    {
+                        new Text("Show snackbar"),
                     },
                 },
                 2 => new Column
@@ -197,6 +255,20 @@ public class MainActivity : ComposeActivity
                 {
                     new Scaffold
                     {
+                        TopBar = new CenterAlignedTopAppBar
+                        {
+                            Title = new Text(tabNames[tab.Value]),
+                        },
+                        SnackbarHost = showSnack.Value
+                            ? new Snackbar
+                            {
+                                Action = new Button(onClick: () => showSnack.Value = false)
+                                {
+                                    new Text("Hide"),
+                                },
+                                Body = new Text($"Hello from {tabNames[tab.Value]}"),
+                            }
+                            : null,
                         // Bottom navigation switches between the three tabs above —
                         // pinned to the bottom edge by Scaffold instead of flowing
                         // inline at the end of a Column.


### PR DESCRIPTION
Implements #13.

Adds bindings for the Material 3 app-structure family:

- `TopAppBar`, `CenterAlignedTopAppBar`, `MediumTopAppBar`, `LargeTopAppBar`
- `TabRow`, `PrimaryTabRow`, `SecondaryTabRow`, `ScrollableTabRow`, `Tab`, `LeadingIconTab`
- `Snackbar`, `SnackbarHost` (+ `SnackbarHostState` wrapper)
- `Badge`, `BadgedBox`
- `ListItem`

Each public composable is one C# file in `src/ComposeNet.Compose/`, going through `[ComposeBridge]` partial methods (mangled JVM overloads where the binder strips them) plus matching `[ComposeDefaults]` enums.

Sample app now wraps every tab in a `Scaffold` with a `CenterAlignedTopAppBar` showing the active tab name. The Basics tab uses `TabRow` + `Tab` + `LeadingIconTab` as a sub-tab switcher, with a `ListItem` demo (`Badge` in the trailing slot, `BadgedBox` demo). The Buttons tab gets a "Show snackbar" button that toggles a `Snackbar` in the `Scaffold.SnackbarHost` slot.

Verification:
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 19 passed
- `dotnet build src/ComposeNet.Compose` — succeeded
- `dotnet build src/ComposeNet.Sample` — succeeded