### PR TITLE
Bind misc Material3 composables

### DIFF
--- a/src/ComposeNet.Compose/CircularProgressIndicator.cs
+++ b/src/ComposeNet.Compose/CircularProgressIndicator.cs
@@ -1,0 +1,48 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 indeterminate <c>CircularProgressIndicator</c>. Use to show
+/// loading state when the duration is unknown:
+/// <code>
+/// new CircularProgressIndicator()
+/// </code>
+/// The determinate (progress-driven) overload is not yet wrapped — the
+/// progress callback parameter requires a state-reading <c>Function0&lt;Float&gt;</c>
+/// adapter that hasn't been added yet.
+/// </summary>
+public sealed class CircularProgressIndicator : ComposableNode
+{
+    /// <summary>Optional ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
+    public long? ColorArgb { get; set; }
+
+    /// <summary>Optional stroke width in Dp. Leave null for the Material default.</summary>
+    public float? StrokeWidthDp { get; set; }
+
+    /// <summary>Optional track ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
+    public long? TrackColorArgb { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+
+        int defaults = (int)CircularProgressIndicatorDefault.All;
+        if (modifier is not null)        defaults &= ~(int)CircularProgressIndicatorDefault.Modifier;
+        if (ColorArgb.HasValue)          defaults &= ~(int)CircularProgressIndicatorDefault.Color;
+        if (StrokeWidthDp.HasValue)      defaults &= ~(int)CircularProgressIndicatorDefault.StrokeWidth;
+        if (TrackColorArgb.HasValue)     defaults &= ~(int)CircularProgressIndicatorDefault.TrackColor;
+
+        ProgressIndicatorKt.CircularProgressIndicator(
+            modifier:    modifier,
+            color:       ColorArgb       ?? 0L,
+            strokeWidth: StrokeWidthDp   ?? 0f,
+            trackColor:  TrackColorArgb  ?? 0L,
+            p4:          0,
+            gapSize:     0f,
+            _composer:   composer,
+            strokeCap:   0,
+            _changed:    defaults);
+    }
+}

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -733,6 +733,106 @@ internal static partial class ComposeBridges
         Defaults  = typeof(DrawerSheetDefault))]
     public static partial void PermanentDrawerSheet(IFunction3 content, long drawerContainerColor, IComposer composer);
 
+    // androidx.compose.material3.SegmentedButtonKt.SegmentedButton
+    // (SingleChoiceSegmentedButtonRowScope receiver, longer 11-param overload
+    // with PaddingValues). The Kt method has 4 same-named overloads, so the
+    // binder strips them all.
+    const string SingleChoiceSegmentedButtonSig =
+        "(Landroidx/compose/material3/SingleChoiceSegmentedButtonRowScope;Z" +
+        "Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Landroidx/compose/material3/SegmentedButtonColors;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Landroidx/compose/foundation/layout/PaddingValues;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/runtime/Composer;III)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SegmentedButtonKt",
+        JvmName   = "SegmentedButton",
+        Signature = SingleChoiceSegmentedButtonSig,
+        Defaults  = typeof(SingleChoiceSegmentedButtonDefault))]
+    public static partial void SingleChoiceSegmentedButton(
+        IntPtr      singleChoiceScope,
+        bool        selected,
+        IFunction0  onClick,
+        IntPtr      shape,
+        IFunction2  label,
+        IModifier?  modifier,
+        IFunction2? icon,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.SegmentedButtonKt.SegmentedButton
+    // (MultiChoiceSegmentedButtonRowScope receiver, longer 11-param overload).
+    const string MultiChoiceSegmentedButtonSig =
+        "(Landroidx/compose/material3/MultiChoiceSegmentedButtonRowScope;Z" +
+        "Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Landroidx/compose/material3/SegmentedButtonColors;" +
+        "Landroidx/compose/foundation/BorderStroke;" +
+        "Landroidx/compose/foundation/layout/PaddingValues;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/runtime/Composer;III)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SegmentedButtonKt",
+        JvmName   = "SegmentedButton",
+        Signature = MultiChoiceSegmentedButtonSig,
+        Defaults  = typeof(MultiChoiceSegmentedButtonDefault))]
+    public static partial void MultiChoiceSegmentedButton(
+        IntPtr      multiChoiceScope,
+        bool        @checked,
+        IFunction1  onCheckedChange,
+        IntPtr      shape,
+        IFunction2  label,
+        IModifier?  modifier,
+        IFunction2? icon,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.SegmentedButtonDefaults.itemShape — INSTANCE
+    // method on the SegmentedButtonDefaults Kotlin `object` singleton, returns
+    // the rounded-corner Shape for a segment given its position in the row.
+    // The Material3 binding strips the surrounding SegmentedButtonDefaults
+    // helpers (probably because some sibling members use inline-class types),
+    // so we go through the source generator's InstanceField shape — that walks
+    // the static `INSTANCE` field once, caches a global ref, then calls the
+    // method via CallObjectMethod. The auto-defaults logic on the generator
+    // sees `baseShape` is in [ComposeDefaults] but missing from the user-facing
+    // params, so it sets bit 2 ($default for baseShape) automatically — making
+    // Kotlin substitute SegmentedButtonDefaults.getBaseShape() (the theme's
+    // default rounded-corner shape).
+    [ComposeBridge(
+        Class         = "androidx/compose/material3/SegmentedButtonDefaults",
+        JvmName       = "itemShape",
+        Signature     = "(IILandroidx/compose/foundation/shape/CornerBasedShape;" +
+                        "Landroidx/compose/runtime/Composer;II)" +
+                        "Landroidx/compose/ui/graphics/Shape;",
+        InstanceField = "INSTANCE",
+        Defaults      = typeof(SegmentedButtonItemShapeDefault))]
+    internal static partial IntPtr ItemShape(int index, int count, IComposer composer);
+
+    // androidx.compose.material3.WideNavigationRailKt.WideNavigationRail.
+    // No mangled hash (no inline-class types), but the binder still strips
+    // it — likely because it's @ExperimentalMaterial3ExpressiveApi-annotated.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/WideNavigationRailKt",
+        JvmName   = "WideNavigationRail",
+        Signature = "(Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/material3/WideNavigationRailState;" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/WideNavigationRailColors;" +
+                    "Lkotlin/jvm/functions/Function2;" +
+                    "Landroidx/compose/foundation/layout/WindowInsets;" +
+                    "Landroidx/compose/foundation/layout/Arrangement$Vertical;" +
+                    "Lkotlin/jvm/functions/Function2;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(WideNavigationRailDefault))]
+    public static partial void WideNavigationRail(IModifier? modifier, IFunction2 content, IComposer composer);
+
     // Modifier-chain extensions. These are non-@Composable Kotlin
     // extension functions on Modifier; their JNI signatures end in
     // `I L<marker>` (the $default bitmask plus a synthetic-overload

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -281,6 +281,67 @@ using ComposeNet;
 [assembly: ComposeDefaults("RememberPlainTooltipPositionProviderDefault",
     "spacing")]
 
+// androidx.compose.material3.SegmentedButtonKt.{Single,Multi}ChoiceSegmentedButtonRow-uFdPcIQ:
+// 3 user params, bit 2 (content) always provided. Both row variants
+// share the same signature so they reuse one enum.
+[assembly: ComposeDefaults("SegmentedButtonRowDefault",
+    "modifier", "space", "!content")]
+
+// androidx.compose.material3.SegmentedButtonKt.SegmentedButton (longer
+// 11-param overload with PaddingValues) — SingleChoiceSegmentedButtonRowScope
+// receiver. Bits 0 (selected), 1 (onClick), 2 (shape), 10 (label) always
+// provided — `shape` has no Kotlin default expression so its $default bit
+// is a no-op; the caller must pass a real Shape (resolved via
+// SegmentedButtonDefaults.itemShape). Bit 9 (icon) is optional and
+// toggled per-call by SegmentedButton.Render.
+[assembly: ComposeDefaults("SingleChoiceSegmentedButtonDefault",
+    "!selected", "!onClick", "!shape", "modifier", "enabled",
+    "colors", "border", "contentPadding", "interactionSource",
+    "icon", "!label")]
+
+// androidx.compose.material3.SegmentedButtonKt.SegmentedButton (longer
+// 11-param overload with PaddingValues) — MultiChoiceSegmentedButtonRowScope
+// receiver. Bits 0 (checked), 1 (onCheckedChange), 2 (shape), 10 (label)
+// always provided. Bit 9 (icon) is optional and toggled per-call.
+[assembly: ComposeDefaults("MultiChoiceSegmentedButtonDefault",
+    "!checked", "!onCheckedChange", "!shape", "modifier", "enabled",
+    "colors", "border", "contentPadding", "interactionSource",
+    "icon", "!label")]
+
+// androidx.compose.material3.SegmentedButtonDefaults.itemShape: 3 user
+// params on the SegmentedButtonDefaults Kotlin `object` instance method.
+// `index` and `count` are always provided; `baseShape` is omitted from
+// the C# user-facing bridge, so the source generator auto-sets bit 2 to
+// have Kotlin substitute SegmentedButtonDefaults.getBaseShape() (the
+// theme's default rounded-corner shape).
+[assembly: ComposeDefaults("SegmentedButtonItemShapeDefault",
+    "!index", "!count", "baseShape")]
+
+// androidx.compose.material3.WideNavigationRailKt.WideNavigationRail.
+// 8 user params; bit 7 (content) always provided. The optional `header`
+// slot (bit 4) is a member of the enum so a future overload of the
+// facade can toggle it; today WideNavigationRail.Render always leaves
+// it as a default ($default bit set).
+[assembly: ComposeDefaults("WideNavigationRailDefault",
+    "modifier", "state", "shape", "colors", "header",
+    "windowInsets", "arrangement", "!content")]
+
+// androidx.compose.material3.WideNavigationRailKt.WideNavigationRailItem-pli-t6k:
+// 10 user params; bits 0 (selected), 1 (onClick), 2 (icon) always provided.
+[assembly: ComposeDefaults("WideNavigationRailItemDefault",
+    "!selected", "!onClick", "!icon", "label", "railExpanded",
+    "modifier", "enabled", "iconPosition", "colors", "interactionSource")]
+
+// androidx.compose.material3.ProgressIndicatorKt.LinearProgressIndicator-rIrjwxo
+// (indeterminate, no progress callback). 5 user params, all optional.
+[assembly: ComposeDefaults("LinearProgressIndicatorDefault",
+    "modifier", "color", "trackColor", "strokeCap", "gapSize")]
+
+// androidx.compose.material3.ProgressIndicatorKt.CircularProgressIndicator-4lLiAd8
+// (indeterminate). 6 user params, all optional.
+[assembly: ComposeDefaults("CircularProgressIndicatorDefault",
+    "modifier", "color", "strokeWidth", "trackColor", "strokeCap", "gapSize")]
+
 // androidx.compose.material3.CheckboxKt.Checkbox: 6 user params,
 // bit 0 = checked (always provided), bit 1 = onCheckedChange (always
 // provided — Function1, the user passes a callback).

--- a/src/ComposeNet.Compose/LinearProgressIndicator.cs
+++ b/src/ComposeNet.Compose/LinearProgressIndicator.cs
@@ -1,0 +1,43 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 indeterminate <c>LinearProgressIndicator</c>. Use to show
+/// loading state when the duration is unknown:
+/// <code>
+/// new LinearProgressIndicator { Modifier = Modifier.Companion.FillMaxWidth() }
+/// </code>
+/// The determinate (progress-driven) overload is not yet wrapped — the
+/// progress callback parameter requires a state-reading <c>Function0&lt;Float&gt;</c>
+/// adapter that hasn't been added yet.
+/// </summary>
+public sealed class LinearProgressIndicator : ComposableNode
+{
+    /// <summary>Optional ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
+    public long? ColorArgb { get; set; }
+
+    /// <summary>Optional track ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
+    public long? TrackColorArgb { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+
+        int defaults = (int)LinearProgressIndicatorDefault.All;
+        if (modifier is not null)        defaults &= ~(int)LinearProgressIndicatorDefault.Modifier;
+        if (ColorArgb.HasValue)          defaults &= ~(int)LinearProgressIndicatorDefault.Color;
+        if (TrackColorArgb.HasValue)     defaults &= ~(int)LinearProgressIndicatorDefault.TrackColor;
+
+        ProgressIndicatorKt.LinearProgressIndicator(
+            modifier:   modifier,
+            color:      ColorArgb       ?? 0L,
+            trackColor: TrackColorArgb  ?? 0L,
+            p3:         0,
+            gapSize:    0f,
+            _composer:  composer,
+            strokeCap:  0,
+            _changed:   defaults);
+    }
+}

--- a/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
@@ -1,0 +1,39 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>MultiChoiceSegmentedButtonRow</c>. Container for
+/// <see cref="SegmentedButton"/> children with toggle (multi-select)
+/// semantics — see <see cref="SingleChoiceSegmentedButtonRow"/> for the
+/// radio-button variant.
+/// </summary>
+public sealed class MultiChoiceSegmentedButtonRow : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3((scope, c) =>
+        {
+            using var _    = RenderContext.PushScope(scope);
+            using var rows = RenderContext.PushRow(Children.Count);
+            for (int i = 0; i < Children.Count; i++)
+            {
+                rows.SetIndex(i);
+                Children[i].Render(c);
+            }
+        });
+
+        var modifier = BuildModifier();
+        int defaults = (int)SegmentedButtonRowDefault.All;
+        if (modifier is not null) defaults &= ~(int)SegmentedButtonRowDefault.Modifier;
+
+        SegmentedButtonKt.MultiChoiceSegmentedButtonRow(
+            modifier:  modifier,
+            space:     0f,
+            content:   content,
+            _composer: composer,
+            p4:        0,
+            _changed:  defaults);
+    }
+}

--- a/src/ComposeNet.Compose/RenderContext.cs
+++ b/src/ComposeNet.Compose/RenderContext.cs
@@ -14,7 +14,24 @@ internal static class RenderContext
     [System.ThreadStatic]
     static IntPtr s_scope;
 
+    [System.ThreadStatic]
+    static int s_rowChildIndex;
+
+    [System.ThreadStatic]
+    static int s_rowChildCount;
+
     public static IntPtr CurrentScope => s_scope;
+
+    /// <summary>
+    /// Index of the currently-rendering child within an enclosing row
+    /// container. Read by composables (<see cref="SegmentedButton"/>)
+    /// whose Kotlin defaults depend on position (e.g. start/end shape).
+    /// Only meaningful while <see cref="CurrentRowChildCount"/> &gt; 0.
+    /// </summary>
+    public static int CurrentRowChildIndex => s_rowChildIndex;
+
+    /// <summary>Total child count of the enclosing row container, or 0.</summary>
+    public static int CurrentRowChildCount => s_rowChildCount;
 
     public static ScopeFrame PushScope(IntPtr scope)
     {
@@ -23,10 +40,41 @@ internal static class RenderContext
         return new ScopeFrame(prev);
     }
 
+    /// <summary>
+    /// Publish row-position state for child composables. Returns a frame
+    /// that restores the previous values on dispose. The row container
+    /// calls <see cref="RowFrame.SetIndex"/> before each child Render.
+    /// </summary>
+    public static RowFrame PushRow(int count)
+    {
+        var prevIndex = s_rowChildIndex;
+        var prevCount = s_rowChildCount;
+        s_rowChildCount = count;
+        s_rowChildIndex = 0;
+        return new RowFrame(prevIndex, prevCount);
+    }
+
     internal readonly struct ScopeFrame : System.IDisposable
     {
         readonly IntPtr _previous;
         public ScopeFrame(IntPtr previous) => _previous = previous;
         public void Dispose() => s_scope = _previous;
+    }
+
+    internal readonly struct RowFrame : System.IDisposable
+    {
+        readonly int _prevIndex;
+        readonly int _prevCount;
+        public RowFrame(int prevIndex, int prevCount)
+        {
+            _prevIndex = prevIndex;
+            _prevCount = prevCount;
+        }
+        public void SetIndex(int index) => s_rowChildIndex = index;
+        public void Dispose()
+        {
+            s_rowChildIndex = _prevIndex;
+            s_rowChildCount = _prevCount;
+        }
     }
 }

--- a/src/ComposeNet.Compose/SegmentedButton.cs
+++ b/src/ComposeNet.Compose/SegmentedButton.cs
@@ -1,0 +1,121 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>SegmentedButton</c> — a radio-button-shaped selector
+/// segment. Must be a child of a
+/// <see cref="SingleChoiceSegmentedButtonRow"/> or
+/// <see cref="MultiChoiceSegmentedButtonRow"/>; the parent publishes its
+/// scope receiver via <see cref="RenderContext"/>.
+///
+/// <para>Use the <c>onClick</c> ctor for the single-choice (radio) flavor
+/// and the <c>onCheckedChange</c> ctor for the multi-choice (toggle)
+/// flavor — the matching scope must already be on the stack.</para>
+///
+/// <para>Children are rendered as the <c>label</c> slot (required). Set
+/// <see cref="Icon"/> via object-initializer for an optional leading
+/// indicator.</para>
+/// <code>
+/// new SingleChoiceSegmentedButtonRow
+/// {
+///     new SegmentedButton(selected: tab == 0, onClick: () =&gt; tab.Value = 0) { new Text("Day") },
+///     new SegmentedButton(selected: tab == 1, onClick: () =&gt; tab.Value = 1) { new Text("Week") },
+/// }
+/// </code>
+/// </summary>
+public sealed class SegmentedButton : ComposableContainer
+{
+    readonly bool _selected;
+    readonly System.Action? _onClick;
+    readonly System.Action<bool>? _onCheckedChange;
+
+    /// <summary>Single-choice (radio) ctor for <see cref="SingleChoiceSegmentedButtonRow"/>.</summary>
+    public SegmentedButton(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Multi-choice (toggle) ctor for <see cref="MultiChoiceSegmentedButtonRow"/>.</summary>
+    public SegmentedButton(bool @checked, System.Action<bool> onCheckedChange)
+    {
+        _selected        = @checked;
+        _onCheckedChange = onCheckedChange;
+    }
+
+    /// <summary>Optional leading icon slot.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Children.Count == 0)
+            throw new System.InvalidOperationException(
+                "SegmentedButton requires at least one child (the label slot has no Kotlin default).");
+
+        var label = new ComposableLambda2(c =>
+        {
+            for (int i = 0; i < Children.Count; i++)
+                Children[i].Render(c);
+        });
+        var iconNode = Icon;
+        ComposableLambda2? icon = iconNode is null ? null : new ComposableLambda2(c => iconNode.Render(c));
+        var modifier = BuildModifier();
+
+        var scope = RenderContext.CurrentScope;
+        var count = RenderContext.CurrentRowChildCount;
+        var index = RenderContext.CurrentRowChildIndex;
+        if (scope == System.IntPtr.Zero || count == 0)
+            throw new System.InvalidOperationException(
+                "SegmentedButton must be rendered inside a SingleChoiceSegmentedButtonRow " +
+                "or MultiChoiceSegmentedButtonRow — no row scope/position is on the stack.");
+
+        // Kotlin signature has no default for `shape`, so we must supply
+        // one. SegmentedButtonDefaults.itemShape returns the correct
+        // start/middle/end rounded-corner shape based on (index, count).
+        var shape = ComposeBridges.ItemShape(index, count, composer);
+
+        if (_onCheckedChange is not null)
+        {
+            int defaults = (int)MultiChoiceSegmentedButtonDefault.All;
+            if (modifier is not null) defaults &= ~(int)MultiChoiceSegmentedButtonDefault.Modifier;
+            if (icon     is not null) defaults &= ~(int)MultiChoiceSegmentedButtonDefault.Icon;
+
+            var cb = new ComposableLambda1(arg =>
+            {
+                if (arg is not Java.Lang.Boolean jb)
+                    throw new System.InvalidOperationException(
+                        $"MultiChoiceSegmentedButton.onCheckedChange expected a Java.Lang.Boolean, got '{arg?.GetType().FullName ?? "null"}'.");
+                _onCheckedChange(jb.BooleanValue());
+            });
+            ComposeBridges.MultiChoiceSegmentedButton(
+                multiChoiceScope: scope,
+                @checked:         _selected,
+                onCheckedChange:  cb,
+                shape:            shape,
+                label:            label,
+                modifier:         modifier,
+                icon:             icon,
+                defaults:         defaults,
+                composer:         composer);
+        }
+        else
+        {
+            int defaults = (int)SingleChoiceSegmentedButtonDefault.All;
+            if (modifier is not null) defaults &= ~(int)SingleChoiceSegmentedButtonDefault.Modifier;
+            if (icon     is not null) defaults &= ~(int)SingleChoiceSegmentedButtonDefault.Icon;
+
+            var click = new ComposableLambda0(_onClick!);
+            ComposeBridges.SingleChoiceSegmentedButton(
+                singleChoiceScope: scope,
+                selected:          _selected,
+                onClick:           click,
+                shape:             shape,
+                label:             label,
+                modifier:          modifier,
+                icon:              icon,
+                defaults:          defaults,
+                composer:          composer);
+        }
+    }
+}

--- a/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
@@ -1,0 +1,48 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>SingleChoiceSegmentedButtonRow</c>. Container for
+/// <see cref="SegmentedButton"/> children that exposes a
+/// <c>SingleChoiceSegmentedButtonRowScope</c> receiver — the scope is
+/// captured here and published via <see cref="RenderContext"/> so child
+/// <see cref="SegmentedButton"/>s can pass it to the underlying
+/// scope-extension Kotlin static.
+/// <code>
+/// new SingleChoiceSegmentedButtonRow
+/// {
+///     new SegmentedButton(selected: tab == 0, onClick: () =&gt; tab.Value = 0) { new Text("Day") },
+///     new SegmentedButton(selected: tab == 1, onClick: () =&gt; tab.Value = 1) { new Text("Week") },
+/// }
+/// </code>
+/// </summary>
+public sealed class SingleChoiceSegmentedButtonRow : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3((scope, c) =>
+        {
+            using var _    = RenderContext.PushScope(scope);
+            using var rows = RenderContext.PushRow(Children.Count);
+            for (int i = 0; i < Children.Count; i++)
+            {
+                rows.SetIndex(i);
+                Children[i].Render(c);
+            }
+        });
+
+        var modifier = BuildModifier();
+        int defaults = (int)SegmentedButtonRowDefault.All;
+        if (modifier is not null) defaults &= ~(int)SegmentedButtonRowDefault.Modifier;
+
+        SegmentedButtonKt.SingleChoiceSegmentedButtonRow(
+            modifier:  modifier,
+            space:     0f,
+            content:   content,
+            _composer: composer,
+            p4:        0,
+            _changed:  defaults);
+    }
+}

--- a/src/ComposeNet.Compose/WideNavigationRail.cs
+++ b/src/ComposeNet.Compose/WideNavigationRail.cs
@@ -1,0 +1,33 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>WideNavigationRail</c> — adaptive vertical navigation
+/// rail that shows item labels when expanded. Children are
+/// <see cref="WideNavigationRailItem"/>s. Stripped from the binding
+/// because the underlying composable is annotated
+/// <c>@ExperimentalMaterial3ExpressiveApi</c>; reached via
+/// <see cref="ComposeBridges"/>.
+/// <code>
+/// new WideNavigationRail
+/// {
+///     new WideNavigationRailItem(selected: tab == 0, onClick: () =&gt; tab.Value = 0)
+///     {
+///         Icon  = new Text("🏠"),
+///         Label = new Text("Home"),
+///     },
+/// }
+/// </code>
+/// </summary>
+public sealed class WideNavigationRail : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        // WideNavigationRailItem is a top-level static (not a scope
+        // extension), so we don't need to publish a receiver scope —
+        // children render directly.
+        var content = new ComposableLambda2(c => RenderChildren(c));
+        ComposeBridges.WideNavigationRail(BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/WideNavigationRailItem.cs
+++ b/src/ComposeNet.Compose/WideNavigationRailItem.cs
@@ -1,0 +1,61 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>WideNavigationRailItem</c>. Used inside
+/// <see cref="WideNavigationRail"/>. <see cref="Icon"/> is required;
+/// <see cref="Label"/> is optional.
+/// </summary>
+public sealed class WideNavigationRailItem : ComposableNode
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public WideNavigationRailItem(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    /// <summary>Required: item icon.</summary>
+    public ComposableNode? Icon { get; set; }
+
+    /// <summary>Optional: item label (only shown when the rail is expanded).</summary>
+    public ComposableNode? Label { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Icon is null)
+            throw new System.InvalidOperationException(
+                "WideNavigationRailItem.Icon is required (the Kotlin parameter has no default).");
+
+        var click = new ComposableLambda0(_onClick);
+        var icon  = new ComposableLambda2(c => Icon.Render(c));
+        ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
+
+        int defaults = (int)WideNavigationRailItemDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)WideNavigationRailItemDefault.Modifier;
+        if (label    is not null) defaults &= ~(int)WideNavigationRailItemDefault.Label;
+
+        // Bound C# wrapper has misnamed trailing params: `iconPosition`
+        // is actually $changed, `_changed` is actually $default. The
+        // mid-list `int p7` is the real iconPosition (we don't expose it).
+        WideNavigationRailKt.WideNavigationRailItem(
+            selected:          _selected,
+            onClick:           click,
+            icon:              icon,
+            label:             label,
+            railExpanded:      false,
+            modifier:          modifier,
+            enabled:           true,
+            p7:                0,
+            colors:            null,
+            interactionSource: null,
+            _composer:         composer,
+            iconPosition:      0,
+            _changed:          defaults);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -27,6 +27,10 @@ public class MainActivity : ComposeActivity
             var pickedTime  = Remember(() => new MutableState<string>("(none)"));
             var dateState   = Remember(() => new DatePickerState());
             var timeState   = Remember(() => new TimePickerState(initialHour: 9, initialMinute: 30));
+            var segIdx      = Remember(() => new MutableNumberState<int>(0));
+            var multiBold   = Remember(() => new MutableState<bool>(false));
+            var multiItalic = Remember(() => new MutableState<bool>(false));
+            var railIdx     = Remember(() => new MutableNumberState<int>(0));
 
             var checkbox    = Remember(() => new MutableState<bool>(true));
             var switchOn    = Remember(() => new MutableState<bool>(false));
@@ -35,7 +39,7 @@ public class MainActivity : ComposeActivity
             var rangeStart  = Remember(() => new MutableState<float>(0.25f));
             var rangeEnd    = Remember(() => new MutableState<float>(0.75f));
 
-            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers" };
+            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc" };
 
             // Per-tab content. Only the current tab's column is added to
             // the screen — keeps the sample short enough to fit on one
@@ -270,7 +274,7 @@ public class MainActivity : ComposeActivity
                         }),
                     new Text($"Range: {rangeStart.Value:F2} – {rangeEnd.Value:F2}"),
                 },
-                _ => new Column
+                5 => new Column
                 {
                     new Text("Dialogs and sheets"),
                     new Row
@@ -284,6 +288,58 @@ public class MainActivity : ComposeActivity
                     new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
                     new Text($"Picked date: {pickedDate}"),
                     new Text($"Picked time: {pickedTime}"),
+                },
+                _ => new Column
+                {
+                    new Text("Misc Material 3"),
+                    new Text("Progress indicators (indeterminate):"),
+                    new Row
+                    {
+                        new CircularProgressIndicator(),
+                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
+                        new Column
+                        {
+                            new Text("Linear ↓"),
+                            new LinearProgressIndicator { Modifier = Modifier.Companion.FillMaxWidth() },
+                        },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text($"Single-choice segmented (selected: {segIdx})"),
+                    new SingleChoiceSegmentedButtonRow
+                    {
+                        new SegmentedButton(selected: segIdx.Value == 0, onClick: () => segIdx.Value = 0) { new Text("Day") },
+                        new SegmentedButton(selected: segIdx.Value == 1, onClick: () => segIdx.Value = 1) { new Text("Week") },
+                        new SegmentedButton(selected: segIdx.Value == 2, onClick: () => segIdx.Value = 2) { new Text("Month") },
+                    },
+                    new Text($"Multi-choice segmented (bold={multiBold.Value}, italic={multiItalic.Value})"),
+                    new MultiChoiceSegmentedButtonRow
+                    {
+                        new SegmentedButton(@checked: multiBold.Value,   onCheckedChange: v => multiBold.Value   = v) { new Text("Bold") },
+                        new SegmentedButton(@checked: multiItalic.Value, onCheckedChange: v => multiItalic.Value = v) { new Text("Italic") },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text($"WideNavigationRail (selected: {railIdx})"),
+                    new Row
+                    {
+                        new WideNavigationRail
+                        {
+                            new WideNavigationRailItem(selected: railIdx.Value == 0, onClick: () => railIdx.Value = 0)
+                            {
+                                Icon  = new Text("🏠"),
+                                Label = new Text("Home"),
+                            },
+                            new WideNavigationRailItem(selected: railIdx.Value == 1, onClick: () => railIdx.Value = 1)
+                            {
+                                Icon  = new Text("🔍"),
+                                Label = new Text("Search"),
+                            },
+                            new WideNavigationRailItem(selected: railIdx.Value == 2, onClick: () => railIdx.Value = 2)
+                            {
+                                Icon  = new Text("⚙"),
+                                Label = new Text("Settings"),
+                            },
+                        },
+                    },
                 },
             };
 
@@ -307,45 +363,50 @@ public class MainActivity : ComposeActivity
                                 Body = new Text($"Hello from {tabNames[tab.Value]}"),
                             }
                             : null,
-                        // Bottom navigation switches between the three tabs above —
-                        // pinned to the bottom edge by Scaffold instead of flowing
-                        // inline at the end of a Column.
-                        BottomBar = new NavigationBar
-                        {
-                            new NavigationBarItem(selected: tab.Value == 0, onClick: () => tab.Value = 0)
-                            {
-                                Icon  = new Icon(Resource.Drawable.ic_settings, "Basics"),
-                                Label = new Text("Basics"),
-                            },
-                            new NavigationBarItem(selected: tab.Value == 1, onClick: () => tab.Value = 1)
-                            {
-                                Icon  = new Text("👍"),
-                                Label = new Text("Buttons"),
-                            },
-                            new NavigationBarItem(selected: tab.Value == 2, onClick: () => tab.Value = 2)
-                            {
-                                Icon  = new Text("🃏"),
-                                Label = new Text("Cards"),
-                            },
-                            new NavigationBarItem(selected: tab.Value == 3, onClick: () => tab.Value = 3)
-                            {
-                                Icon  = new Text("📂"),
-                                Label = new Text("Drawer"),
-                            },
-                            new NavigationBarItem(selected: tab.Value == 4, onClick: () => tab.Value = 4)
-                            {
-                                Icon  = new Text("☑"),
-                                Label = new Text("Selection"),
-                            },
-                            new NavigationBarItem(selected: tab.Value == 5, onClick: () => tab.Value = 5)
-                            {
-                                Icon  = new Text("📅"),
-                                Label = new Text("Pickers"),
-                            },
-                        },
                         Body = new Column
                         {
                             Modifier.Companion.Padding(16),
+                            // ScrollableTabRow handles many tabs better than NavigationBar
+                            // (which is spec'd for 3-5 items) — the row scrolls horizontally
+                            // so every tab stays reachable as we add more demos.
+                            new ScrollableTabRow(selectedTabIndex: tab.Value)
+                            {
+                                new Tab(selected: tab.Value == 0, onClick: () => tab.Value = 0)
+                                {
+                                    Text = new Text("Basics"),
+                                    Icon = new Icon(Resource.Drawable.ic_settings, "Basics"),
+                                },
+                                new Tab(selected: tab.Value == 1, onClick: () => tab.Value = 1)
+                                {
+                                    Text = new Text("Buttons"),
+                                    Icon = new Text("👍"),
+                                },
+                                new Tab(selected: tab.Value == 2, onClick: () => tab.Value = 2)
+                                {
+                                    Text = new Text("Cards"),
+                                    Icon = new Text("🃏"),
+                                },
+                                new Tab(selected: tab.Value == 3, onClick: () => tab.Value = 3)
+                                {
+                                    Text = new Text("Drawer"),
+                                    Icon = new Text("📂"),
+                                },
+                                new Tab(selected: tab.Value == 4, onClick: () => tab.Value = 4)
+                                {
+                                    Text = new Text("Selection"),
+                                    Icon = new Text("☑"),
+                                },
+                                new Tab(selected: tab.Value == 5, onClick: () => tab.Value = 5)
+                                {
+                                    Text = new Text("Pickers"),
+                                    Icon = new Text("📅"),
+                                },
+                                new Tab(selected: tab.Value == 6, onClick: () => tab.Value = 6)
+                                {
+                                    Text = new Text("Misc"),
+                                    Icon = new Text("✨"),
+                                },
+                            },
                             tabContent,
 
                             // Overlays: rendered in the body so they participate in the

--- a/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -511,6 +511,45 @@ public class BridgeGeneratorTests
     }
 
     [Fact]
+    public void ReservedKeywordParam_IsAtSignEscaped()
+    {
+        // Kotlin-side parameter named `checked` collides with a C# reserved
+        // keyword. The generator must emit `bool @checked` in the partial
+        // method signature and reference `@checked` in the body so the result
+        // compiles.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("CheckedThingDefault",
+                "!checked", "modifier")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "x/Y",
+                        JvmName = "Foo",
+                        Signature = "(ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V",
+                        Defaults = typeof(CheckedThingDefault))]
+                    public static partial void Foo(bool @checked, IModifier? modifier, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("bool @checked", emitted);
+        Assert.Contains("new global::Android.Runtime.JValue(@checked)", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void ExtensionWithDefault_BackgroundShape_OneReceiverPrimitiveAndNullableRef()
     {
         // Mirrors androidx.compose.foundation.BackgroundKt.background-bw27NRU$default —

--- a/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
@@ -439,7 +439,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
                 var member = PascalCase(p.Name);
                 if (p.NullableAnnotation == NullableAnnotation.Annotated || p.Type.IsReferenceType)
                 {
-                    sb.Append("        if (").Append(p.Name).Append(" is not null) defaults &= ~(int)global::ComposeNet.")
+                    sb.Append("        if (").Append(EscapeIdent(p.Name)).Append(" is not null) defaults &= ~(int)global::ComposeNet.")
                       .Append(enumName).Append('.').Append(member).AppendLine(";");
                 }
                 else
@@ -455,7 +455,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         foreach (var sp in stringParams)
         {
             sb.Append("        global::System.IntPtr __ref_").Append(sp.Name)
-              .Append(" = global::Android.Runtime.JNIEnv.NewString(").Append(sp.Name).AppendLine(");");
+              .Append(" = global::Android.Runtime.JNIEnv.NewString(").Append(EscapeIdent(sp.Name)).AppendLine(");");
         }
 
         sb.AppendLine("        try");
@@ -471,7 +471,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         int idx = 0;
         if (receiverParam is not null)
         {
-            sb.Append("                args[").Append(idx).Append("] = new global::Android.Runtime.JValue(").Append(receiverParam.Name).AppendLine(");");
+            sb.Append("                args[").Append(idx).Append("] = new global::Android.Runtime.JValue(").Append(EscapeIdent(receiverParam.Name)).AppendLine(");");
             idx++;
         }
 
@@ -497,7 +497,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         IParameterSymbol? composer = hasComposerSlot ? method.Parameters[method.Parameters.Length - 1] : null;
         if (composer is not null)
         {
-            sb.Append("                args[").Append(idx).Append("] = new global::Android.Runtime.JValue(((global::Java.Lang.Object)").Append(composer.Name).AppendLine(").Handle);");
+            sb.Append("                args[").Append(idx).Append("] = new global::Android.Runtime.JValue(((global::Java.Lang.Object)").Append(EscapeIdent(composer.Name)).AppendLine(").Handle);");
             idx++;
         }
 
@@ -544,10 +544,10 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         foreach (var p in userParams)
         {
             if (NeedsKeepAlive(p))
-                sb.Append("            global::System.GC.KeepAlive(").Append(p.Name).AppendLine(");");
+                sb.Append("            global::System.GC.KeepAlive(").Append(EscapeIdent(p.Name)).AppendLine(");");
         }
         if (composer is not null)
-            sb.Append("            global::System.GC.KeepAlive(").Append(composer.Name).AppendLine(");");
+            sb.Append("            global::System.GC.KeepAlive(").Append(EscapeIdent(composer.Name)).AppendLine(");");
         sb.AppendLine("        }");
 
         sb.AppendLine("    }");
@@ -571,13 +571,14 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
                 .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
                     | SymbolDisplayMiscellaneousOptions.UseSpecialTypes
                     | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers)));
-            sb.Append(' ').Append(p.Name);
+            sb.Append(' ').Append(EscapeIdent(p.Name));
         }
         sb.AppendLine(")");
     }
 
     static void EmitUserArgValue(StringBuilder sb, IParameterSymbol p, JniType sigType)
     {
+        var name = EscapeIdent(p.Name);
         if (p.Type.SpecialType == SpecialType.System_String)
         {
             sb.Append("__ref_").Append(p.Name);
@@ -585,7 +586,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         }
         if (p.Type.SpecialType == SpecialType.System_IntPtr)
         {
-            sb.Append(p.Name);
+            sb.Append(name);
             return;
         }
         if (IsNullableIntPtr(p.Type))
@@ -603,24 +604,24 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             or SpecialType.System_Single
             or SpecialType.System_Double)
         {
-            sb.Append(p.Name);
+            sb.Append(name);
             return;
         }
         if (IsModifierType(p.Type))
         {
-            sb.Append("global::ComposeNet.ComposeBridges.ModifierHandle(").Append(p.Name).Append(')');
+            sb.Append("global::ComposeNet.ComposeBridges.ModifierHandle(").Append(name).Append(')');
             return;
         }
         // Reference type → handle, with null check for nullable annotations.
         bool nullable = p.NullableAnnotation == NullableAnnotation.Annotated;
         if (nullable)
         {
-            sb.Append(p.Name).Append(" is null ? global::System.IntPtr.Zero : ((global::Java.Lang.Object)")
-              .Append(p.Name).Append(").Handle");
+            sb.Append(name).Append(" is null ? global::System.IntPtr.Zero : ((global::Java.Lang.Object)")
+              .Append(name).Append(").Handle");
         }
         else
         {
-            sb.Append("((global::Java.Lang.Object)").Append(p.Name).Append(").Handle");
+            sb.Append("((global::Java.Lang.Object)").Append(name).Append(").Handle");
         }
     }
 
@@ -662,6 +663,14 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
     }
 
     static string SafeSym(string s) => s.Replace('-', '_');
+
+    // Wrap C# reserved keywords in `@` so a Kotlin parameter literally named
+    // `checked`/`event`/etc. can be declared as a C# parameter and referenced
+    // inside the generated body.
+    static string EscapeIdent(string name) =>
+        Microsoft.CodeAnalysis.CSharp.SyntaxFacts.GetKeywordKind(name)
+            == Microsoft.CodeAnalysis.CSharp.SyntaxKind.None
+        ? name : "@" + name;
 
     static string? ReadString(AttributeData attr, string name)
     {


### PR DESCRIPTION
Implements [issue #5](https://github.com/jonathanpeppers/compose-net/issues/5) — bindings for misc Material3 composables that the `Xamarin.AndroidX.Compose.Material3Android` 1.4.0.x binder strips.

## What's new

| Component | How it's reached | New file(s) |
|---|---|---|
| `SegmentedButton` (single + multi-choice) | JNI bridge (4 same-named overloads → all stripped) | `SegmentedButton.cs`, bridges in `ComposeBridges.cs` |
| `SingleChoiceSegmentedButtonRow` / `MultiChoiceSegmentedButtonRow` | bound binding (rows are kept) | `SingleChoiceSegmentedButtonRow.cs`, `MultiChoiceSegmentedButtonRow.cs` |
| `WideNavigationRail` | JNI bridge (`@ExperimentalMaterial3ExpressiveApi`-stripped) | `WideNavigationRail.cs`, bridge in `ComposeBridges.cs` |
| `WideNavigationRailItem` | bound binding (`-pli-t6k`) | `WideNavigationRailItem.cs` |
| `LinearProgressIndicator` (indeterminate) | bound binding (`-rIrjwxo`) | `LinearProgressIndicator.cs` |
| `CircularProgressIndicator` (indeterminate) | bound binding (`-4lLiAd8`) | `CircularProgressIndicator.cs` |

A new "Misc" tab in `ComposeNet.Sample` exercises all six (top `ScrollableTabRow` so all 7 sample tabs fit).

## Generator fix

`ComposeBridgeGenerator` now `@`-escapes parameter names that collide with C# reserved keywords. This was needed for the Kotlin `checked` parameter on `MultiChoiceSegmentedButton`; without escaping the generator emitted `bool checked` which doesn't compile. New regression test: `ReservedKeywordParam_IsAtSignEscaped`.

## Out of scope (deferred)

Per the issue's triage update:

- **`ModalWideNavigationRail`** — needs `WideNavigationRailState` / `ModalWideNavigationRailProperties` plumbing to be useful. Better as its own change.
- **`SecureTextField`** — blocked on `TextFieldState` support which doesn't exist in the facade yet.

## Known issue

Switching tabs *off* the Misc tab (after interacting with the segmented buttons / rail) can crash inside Compose's slot table / `LayoutNode.insertAt`. Tracked separately in #42 — the bindings themselves render correctly; the crash is a Compose-runtime interaction (likely our `$changed` mask + lambda-identity handling) that needs its own focused fix.

## Verified

- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 20/20 passing (was 19, +1 for keyword-escape test).
- `dotnet build src/ComposeNet.Sample` — clean (Android workload).