### PR TITLE
ComposeBridgeGenerator: support non-@Composable extension functions with $default

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,9 +116,13 @@ generator fill it in.
 ### Adding a bridge
 
 1. Add `[ComposeBridge(...)]` + a `public static partial` method
-   declaration to `ComposeBridges.cs`. `composer` **must** be the last
-   C# parameter — the generator detects the composer slot by
-   inspecting the trailing param.
+   declaration to `ComposeBridges.cs`. For `@Composable` bridges,
+   `composer` **must** be the last C# parameter — the generator detects
+   the composer slot by inspecting the trailing param. For
+   non-`@Composable` Kotlin extension functions with `$default`
+   (e.g. `Modifier.background`, `Modifier.border`, `Modifier.clickable`),
+   there is no `Composer` slot at all; just declare the user params
+   directly with the extension receiver as the first `IntPtr` param.
 2. **If** the underlying `@Composable` has at least one defaultable
    Kotlin parameter (i.e. the JNI signature has a trailing `$default`
    `I` slot after `$changed`), set `Defaults = typeof(XxxDefault)` and
@@ -128,7 +132,8 @@ generator fill it in.
    always provides). **If** every Kotlin parameter is required (no
    `$default` slot in the bytecode), omit `Defaults` entirely — the
    generator infers `$default` presence from the signature itself and
-   emits CN2005 if attribute and signature disagree.
+   emits CN2005 if attribute and signature disagree. Non-`@Composable`
+   extensions with `$default` always require `Defaults`.
 3. The generator parses the JNI signature, walks the C# parameters,
    and emits everything else.
 
@@ -154,21 +159,43 @@ Example (no `$default` — all params required):
 public static partial IntPtr PainterResource(int id, IComposer composer);
 ```
 
+Example (non-`@Composable` Kotlin extension with `$default`):
+```csharp
+[ComposeBridge(
+    Class     = "androidx/compose/foundation/BackgroundKt",
+    JvmName   = "background-bw27NRU$default",
+    Signature = "(Landroidx/compose/ui/Modifier;JLandroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+    Defaults  = typeof(ModifierBackgroundDefault))]
+public static partial IntPtr ModifierBackground(IntPtr modifier, long color, IntPtr? shape);
+```
+The trailing `I L<marker>` slots are the `$default` bitmask plus a
+synthetic-overload `Object` marker; the generator emits both
+automatically (the marker is always `IntPtr.Zero` / `null`).
+
 ### Conventions the generator relies on
 
-- `composer` is the **last** C# parameter (always).
-- Add an `int defaults` parameter immediately before `composer` only
-  when the caller controls the bitmask (state-holders, multi-slot
-  composables that toggle bits per call). Otherwise omit it and the
-  generator builds the mask automatically: one bit per nullable /
-  optional C# param the caller passed `null` for. **Only valid when
-  the bridge has a `$default` slot**; do not declare `int defaults`
-  on a no-`$default` bridge.
-- Kotlin extension receivers: declare as `IntPtr` with a name ending
-  in `Scope` (e.g. `IntPtr rowScope`); the generator places it at
-  `args[0]` and excludes it from the `$default` count.
+- For `@Composable` bridges, `composer` is the **last** C# parameter.
+  For non-`@Composable` extension bridges (no `Composer` in the JNI
+  signature) there is no `composer` parameter — the last param is
+  just a regular user param.
+- Add an `int defaults` parameter at the end of the user params (just
+  before `composer` for `@Composable` shapes, or as the very last
+  param for extension shapes) only when the caller controls the
+  bitmask (state-holders, multi-slot composables that toggle bits per
+  call). Otherwise omit it and the generator builds the mask
+  automatically: one bit per nullable / optional C# param the caller
+  passed `null` for. **Only valid when the bridge has a `$default`
+  slot**; do not declare `int defaults` on a no-`$default` bridge.
+- Kotlin extension receivers on `@Composable` functions: declare as
+  `IntPtr` with a name ending in `Scope` (e.g. `IntPtr rowScope`).
+  Non-`@Composable` extensions: declare the receiver as the first
+  `IntPtr` user parameter (any name — the generator binds it
+  positionally to the first JNI slot). In both cases the generator
+  places it at `args[0]` and excludes it from the `$default` count.
 - `IModifier?` is special-cased to call `ComposeBridges.ModifierHandle`
-  (handles `null` → `IntPtr.Zero`).
+  (handles `null` → `IntPtr.Zero`). `IntPtr?` is also recognized:
+  `null` → `IntPtr.Zero` for the JNI arg, and the auto-mask only
+  clears the corresponding `$default` bit when the value is non-null.
 - String params are hoisted into a `IntPtr __ref_<name>` and freed in
   the generated `finally`.
 - Non-void return (state holders): the generator emits
@@ -179,9 +206,10 @@ public static partial IntPtr PainterResource(int id, IComposer composer);
 
 ### What still lives hand-written
 
-`ModifierHandle` and the modifier-chain helpers (`PaddingAll`,
-`FillMaxWidth`, etc.) — these don't follow the
-`@Composable + $default` shape, so they remain plain JNI calls.
+`ModifierHandle` and the simpler modifier-chain helpers that have
+neither `Composer` nor `$default` (`PaddingAll`, `FillMaxWidth`,
+`RoundedCornerShape`, `ClipKt.clip`, etc.) — these don't follow any
+shape the generator currently recognises and remain plain JNI calls.
 
 ### Generator diagnostics
 

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -805,4 +805,52 @@ internal static partial class ComposeBridges
         Signature = DrawerSheetSig,
         Defaults  = typeof(DrawerSheetDefault))]
     public static partial void PermanentDrawerSheet(IFunction3 content, long drawerContainerColor, IComposer composer);
+
+    // Modifier-chain extensions. These are non-@Composable Kotlin
+    // extension functions on Modifier; their JNI signatures end in
+    // `I L<marker>` (the $default bitmask plus a synthetic-overload
+    // Object marker, which Kotlin always passes as null). The bridge
+    // generator emits the marker slot automatically.
+
+    // androidx.compose.foundation.BackgroundKt.background-bw27NRU$default —
+    // (Modifier, Color, Shape). Color is mangled because it's a
+    // @JvmInline value class (ULong). The C# wrapper supplies color
+    // and lets shape default to RectangleShape.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/BackgroundKt",
+        JvmName   = "background-bw27NRU$default",
+        Signature = "(Landroidx/compose/ui/Modifier;J" +
+                    "Landroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierBackgroundDefault))]
+    internal static partial IntPtr ModifierBackground(IntPtr modifier, long color);
+
+    // androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
+    // (Modifier, Dp width, Color, Shape). Both width and color are
+    // mangled inline-class params. The C# wrapper supplies width and
+    // color and lets shape default to RectangleShape.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/BorderKt",
+        JvmName   = "border-xT4_qwU$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FJ" +
+                    "Landroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierBorderDefault))]
+    internal static partial IntPtr ModifierBorder(IntPtr modifier, float width, long color);
+
+    // androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
+    // (Modifier, Boolean enabled, String onClickLabel, Role role,
+    // Function0 onClick). Returns a Modifier directly — the lambda is
+    // wrapped via composed { ... } internally so no Composer is needed.
+    // The C# wrapper supplies onClick; enabled/onClickLabel/role are
+    // left to Kotlin's defaults.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/ClickableKt",
+        JvmName   = "clickable-XHw0xAI$default",
+        Signature = "(Landroidx/compose/ui/Modifier;ZLjava/lang/String;" +
+                    "Landroidx/compose/ui/semantics/Role;" +
+                    "Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierClickableDefault))]
+    internal static partial IntPtr ModifierClickable(IntPtr modifier, IFunction0 onClick);
 }

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -226,6 +226,26 @@ using ComposeNet;
     "!selected", "!onClick", "!icon", "modifier", "enabled", "label",
     "alwaysShowLabel", "colors", "interactionSource")]
 
+// androidx.compose.foundation.BackgroundKt.background-bw27NRU$default —
+// non-@Composable Modifier extension. Mangled because Color is a
+// @JvmInline value class (ULong). Bit 0 = color (always supplied by
+// the C# wrapper), bit 1 = shape (Compose substitutes RectangleShape
+// when defaulted).
+[assembly: ComposeDefaults("ModifierBackgroundDefault", "!color", "shape")]
+
+// androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
+// non-@Composable Modifier extension. Both width (Dp) and color
+// (Color) are @JvmInline value classes, hence the mangled name.
+// Bits 0/1 = width/color (always supplied), bit 2 = shape.
+[assembly: ComposeDefaults("ModifierBorderDefault", "!width", "!color", "shape")]
+
+// androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
+// non-@Composable Modifier extension. Bit 3 (onClick) is always
+// supplied by the C# wrapper; bits 0/1/2 (enabled/onClickLabel/role)
+// are left to Kotlin's defaults.
+[assembly: ComposeDefaults("ModifierClickableDefault",
+    "enabled", "onClickLabel", "role", "!onClick")]
+
 // androidx.compose.material3.NavigationRailKt.NavigationRail-qi6gXK8:
 // 6 user params, bit 5 = content provided.
 [assembly: ComposeDefaults("NavigationRailDefault",

--- a/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -509,4 +509,187 @@ public class BridgeGeneratorTests
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
     }
+
+    [Fact]
+    public void ExtensionWithDefault_BackgroundShape_OneReceiverPrimitiveAndNullableRef()
+    {
+        // Mirrors androidx.compose.foundation.BackgroundKt.background-bw27NRU$default —
+        // a non-@Composable Modifier extension. Tail is `I L<marker>`,
+        // no Composer. The marker is always passed null.
+        var code = """
+            using ComposeNet;
+
+            [assembly: ComposeDefaults("ModifierBackgroundDefault", "!color", "shape")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/BackgroundKt",
+                        JvmName = "background-bw27NRU$default",
+                        Signature = "(Landroidx/compose/ui/Modifier;JLandroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+                        Defaults = typeof(ModifierBackgroundDefault))]
+                    public static partial System.IntPtr ModifierBackground(System.IntPtr modifier, long color, System.IntPtr? shape);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("FindClass(\"androidx/compose/foundation/BackgroundKt\")", emitted);
+        Assert.Contains("\"background-bw27NRU$default\"", emitted);
+
+        // Receiver at args[0], color at args[1], shape at args[2], $default at args[3], marker at args[4].
+        Assert.Contains("global::Android.Runtime.JValue[5]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(modifier)", emitted);
+        Assert.Contains("args[1] = new global::Android.Runtime.JValue(color)", emitted);
+        Assert.Contains("args[3] = new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.Contains("args[4] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+        Assert.DoesNotContain("args[5]", emitted);
+
+        // No Composer arg, no $changed, no GC.KeepAlive(composer).
+        Assert.DoesNotContain("Composer", emitted);
+        Assert.DoesNotContain("KeepAlive(composer)", emitted);
+
+        // Auto-mask still emitted: shape is a nullable bit.
+        Assert.Contains("(int)global::ComposeNet.ModifierBackgroundDefault.All", emitted);
+        Assert.Contains("ModifierBackgroundDefault.Shape", emitted);
+
+        // Non-void return.
+        Assert.Contains("return global::Android.Runtime.JNIEnv.CallStaticObjectMethod(", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ExtensionWithDefault_BorderShape_TwoPrimitivesAndNullableRef()
+    {
+        // Mirrors androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
+        // Modifier extension with width (F), color (J), shape (Shape).
+        var code = """
+            using ComposeNet;
+
+            [assembly: ComposeDefaults("ModifierBorderDefault", "!width", "!color", "shape")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/BorderKt",
+                        JvmName = "border-xT4_qwU$default",
+                        Signature = "(Landroidx/compose/ui/Modifier;FJLandroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+                        Defaults = typeof(ModifierBorderDefault))]
+                    public static partial System.IntPtr ModifierBorder(System.IntPtr modifier, float width, long color, System.IntPtr? shape);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Receiver, width, color, shape, $default, marker = 6 slots.
+        Assert.Contains("global::Android.Runtime.JValue[6]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(modifier)", emitted);
+        Assert.Contains("args[1] = new global::Android.Runtime.JValue(width)", emitted);
+        Assert.Contains("args[2] = new global::Android.Runtime.JValue(color)", emitted);
+        Assert.Contains("args[4] = new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.Contains("args[5] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ExtensionWithDefault_ClickableShape_PrimitiveStringRefAndRequiredFunction()
+    {
+        // Mirrors androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
+        // Modifier extension: enabled (Z), onClickLabel (String, nullable),
+        // role (Role, nullable), onClick (Function0, required).
+        var code = """
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("ModifierClickableDefault",
+                "enabled", "onClickLabel", "role", "!onClick")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/ClickableKt",
+                        JvmName = "clickable-XHw0xAI$default",
+                        Signature = "(Landroidx/compose/ui/Modifier;ZLjava/lang/String;Landroidx/compose/ui/semantics/Role;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+                        Defaults = typeof(ModifierClickableDefault))]
+                    public static partial System.IntPtr ModifierClickable(
+                        System.IntPtr modifier, bool enabled, string? onClickLabel,
+                        System.IntPtr? role, IFunction0 onClick);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Receiver, enabled, onClickLabel, role, onClick, $default, marker = 7.
+        Assert.Contains("global::Android.Runtime.JValue[7]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(modifier)", emitted);
+        Assert.Contains("args[1] = new global::Android.Runtime.JValue(enabled)", emitted);
+        Assert.Contains("args[5] = new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.Contains("args[6] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+
+        // String parameter hoisted into NewString/__ref.
+        Assert.Contains("NewString(onClickLabel)", emitted);
+        Assert.Contains("__ref_onClickLabel", emitted);
+        Assert.Contains("DeleteLocalRef(__ref_onClickLabel)", emitted);
+
+        // onClick (required Function0) gets KeepAlive; composer not present.
+        Assert.Contains("global::System.GC.KeepAlive(onClick);", emitted);
+        Assert.DoesNotContain("KeepAlive(composer)", emitted);
+
+        // No Composer in emitted output at all.
+        Assert.DoesNotContain("Composer", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ExtensionWithDefault_CallerProvidesDefaults_SuppressesAutoMask()
+    {
+        // Same Background shape but the C# stub takes `int defaults` so
+        // the auto-mask logic is suppressed.
+        var code = """
+            using ComposeNet;
+
+            [assembly: ComposeDefaults("ModifierBackgroundDefault", "!color", "shape")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/BackgroundKt",
+                        JvmName = "background-bw27NRU$default",
+                        Signature = "(Landroidx/compose/ui/Modifier;JLandroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+                        Defaults = typeof(ModifierBackgroundDefault))]
+                    public static partial System.IntPtr ModifierBackground(
+                        System.IntPtr modifier, long color, System.IntPtr shape, int defaults);
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.DoesNotContain("(int)global::ComposeNet.ModifierBackgroundDefault.All", emitted);
+        Assert.Contains("args[3] = new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.Contains("args[4] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+    }
 }

--- a/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
@@ -90,30 +90,76 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             });
         }
 
-        // Infer whether the bytecode signature has a trailing $default slot.
-        // Kotlin's @Composable codegen emits ceil(userParams/10) (min 1)
-        // $changed groups, and one $default slot iff at least one parameter
-        // has a default value. So:
-        //   trailingI =  $changedGroups + ($default ? 1 : 0)
-        // Anything beyond the expected $changed count is the $default slot.
-        int trailingInts = 0;
-        for (int i = sigParams.Count - 1; i >= 0 && sigParams[i].Code == 'I' && sigParams[i].ArrayDepth == 0; i--)
-            trailingInts++;
-        int sigUserParamCount = sigParams.Count - 1 /*composer*/ - trailingInts;
-        int expectedChangedSlots = Math.Max(1, (sigUserParamCount + 9) / 10);
-        bool signatureHasDefault = trailingInts > expectedChangedSlots;
+        // Detect the JNI signature "shape". Three supported today:
+        //   1. ComposableWithDefault — ...Composer;I+ trailing (multiple Is).
+        //   2. ComposableNoDefault   — ...Composer;I  trailing (single I).
+        //   3. ExtensionWithDefault  — non-@Composable Kotlin extension
+        //      function with default values; tail is `I L<marker>`,
+        //      no Composer. The marker is always Ljava/lang/Object; and
+        //      is passed `null` (IntPtr.Zero).
+        int composerSigIdx = -1;
+        for (int i = 0; i < sigParams.Count; i++)
+        {
+            if (sigParams[i].Code == 'L' && sigParams[i].ClassName == "androidx/compose/runtime/Composer")
+            {
+                composerSigIdx = i;
+                break;
+            }
+        }
+        bool hasComposerSlot = composerSigIdx >= 0;
+
+        bool extensionWithDefault = false;
+        bool signatureHasDefault;
+        if (hasComposerSlot)
+        {
+            // Kotlin's @Composable codegen emits ceil(userParams/10) (min 1)
+            // $changed groups, and one $default slot iff at least one
+            // parameter has a default value:
+            //   trailingI = $changedGroups + ($default ? 1 : 0)
+            int trailingInts = 0;
+            for (int i = sigParams.Count - 1; i >= 0 && sigParams[i].Code == 'I' && sigParams[i].ArrayDepth == 0; i--)
+                trailingInts++;
+            int sigUserParamCount = sigParams.Count - 1 /*composer*/ - trailingInts;
+            int expectedChangedSlots = Math.Max(1, (sigUserParamCount + 9) / 10);
+            signatureHasDefault = trailingInts > expectedChangedSlots;
+        }
+        else if (sigParams.Count >= 2 &&
+                 sigParams[sigParams.Count - 1].Code == 'L' &&
+                 sigParams[sigParams.Count - 1].ClassName == "java/lang/Object" &&
+                 sigParams[sigParams.Count - 1].ArrayDepth == 0 &&
+                 sigParams[sigParams.Count - 2].Code == 'I' &&
+                 sigParams[sigParams.Count - 2].ArrayDepth == 0)
+        {
+            // Non-@Composable extension function with $default + synthetic
+            // marker. Kotlin's bytecode passes the marker as null at every
+            // call site; we always emit IntPtr.Zero for that slot.
+            extensionWithDefault = true;
+            signatureHasDefault = true;
+        }
+        else
+        {
+            // Non-@Composable, no $default — e.g. RoundedCornerShape or
+            // ClipKt.clip. Not supported by this generator yet (issue #30
+            // explicitly leaves these hand-written).
+            return new GenerationResult(null, null, new[] {
+                Diagnostic.Create(Diagnostics.BridgeMalformedSignature, loc, method.Name,
+                    "signature has neither a Composer slot nor an `I L<marker>` $default tail; this shape is not yet supported")
+            });
+        }
+
+        bool hasDefaultSlot = signatureHasDefault;
 
         // Cross-validate signature against attribute metadata: a mismatch
         // would silently produce a broken bridge (wrong $default slot
         // packing, missing bitmask, etc.) so we fail fast.
-        if (signatureHasDefault && defaultsType is null)
+        if (hasDefaultSlot && defaultsType is null)
         {
             return new GenerationResult(null, null, new[] {
                 Diagnostic.Create(Diagnostics.BridgeDefaultsMismatch, loc, method.Name,
                     "JNI signature has a $default slot but [ComposeBridge] omits 'Defaults'")
             });
         }
-        if (!signatureHasDefault && defaultsType is not null)
+        if (!hasDefaultSlot && defaultsType is not null)
         {
             return new GenerationResult(null, null, new[] {
                 Diagnostic.Create(Diagnostics.BridgeDefaultsMismatch, loc, method.Name,
@@ -127,7 +173,6 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         // slots (no $default bitmask) — every parameter is required.
         IReadOnlyList<string> kotlinNames;
         string? defaultsEnumName = defaultsType?.Name;
-        bool hasDefaultSlot = signatureHasDefault;
         if (defaultsType is not null && declarativeAttr is not null)
         {
             var match = compilation.Assembly.GetAttributes()
@@ -158,20 +203,35 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             kotlinNames = Array.Empty<string>();
         }
 
-        // C# parameter walk. composer is required and must be last.
+        // C# parameter walk. For composable shapes the last param must be
+        // an IComposer; for extension shapes there is no Composer slot and
+        // the last param is just the trailing user parameter.
         var csParams = method.Parameters;
-        if (csParams.Length == 0 || !ComposeDefaultsGenerator.IsComposer(csParams[csParams.Length - 1].Type))
+        IParameterSymbol? composerParam;
+        int csTail; // exclusive upper bound of "user-controlled" params before composer
+        if (hasComposerSlot)
         {
-            return new GenerationResult(null, null, new[] {
-                Diagnostic.Create(Diagnostics.MalformedAttribute, loc, method.Name)
-            });
+            if (csParams.Length == 0 || !ComposeDefaultsGenerator.IsComposer(csParams[csParams.Length - 1].Type))
+            {
+                return new GenerationResult(null, null, new[] {
+                    Diagnostic.Create(Diagnostics.MalformedAttribute, loc, method.Name)
+                });
+            }
+            composerParam = csParams[csParams.Length - 1];
+            csTail = csParams.Length - 1;
         }
-        var composerParam = csParams[csParams.Length - 1];
+        else
+        {
+            composerParam = null;
+            csTail = csParams.Length;
+        }
 
-        // Detect optional `int defaults` immediately before composer.
+        // Detect optional `int defaults` immediately before composer (or
+        // at the very end for extension shapes). Caller-controlled bitmask
+        // is only meaningful when the function actually has a $default slot.
         bool callerProvidesDefaults = false;
-        int userTail = csParams.Length - 1;
-        if (userTail > 0 &&
+        int userTail = csTail;
+        if (hasDefaultSlot && userTail > 0 &&
             csParams[userTail - 1].Type.SpecialType == SpecialType.System_Int32 &&
             csParams[userTail - 1].Name == "defaults")
         {
@@ -180,11 +240,27 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         }
         var userParams = csParams.Take(userTail).ToArray();
 
-        // Detect leading IntPtr <name>Scope receiver.
+        // Detect leading extension receiver. For composable shapes the
+        // convention is `IntPtr <name>Scope` (e.g. `IntPtr rowScope`); for
+        // extension shapes the receiver is whatever the first sigParam is
+        // (e.g. Modifier) and we bind it positionally to the first IntPtr
+        // C# parameter regardless of name.
         IParameterSymbol? receiverParam = null;
-        if (userParams.Length > 0 &&
-            userParams[0].Type.SpecialType == SpecialType.System_IntPtr &&
-            userParams[0].Name.EndsWith("Scope", StringComparison.Ordinal))
+        if (extensionWithDefault)
+        {
+            if (userParams.Length == 0 ||
+                userParams[0].Type.SpecialType != SpecialType.System_IntPtr)
+            {
+                return new GenerationResult(null, null, new[] {
+                    Diagnostic.Create(Diagnostics.MalformedAttribute, loc, method.Name)
+                });
+            }
+            receiverParam = userParams[0];
+            userParams = userParams.Skip(1).ToArray();
+        }
+        else if (userParams.Length > 0 &&
+                 userParams[0].Type.SpecialType == SpecialType.System_IntPtr &&
+                 userParams[0].Name.EndsWith("Scope", StringComparison.Ordinal))
         {
             receiverParam = userParams[0];
             userParams = userParams.Skip(1).ToArray();
@@ -227,10 +303,12 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         if (diags.Count > 0)
             return new GenerationResult(null, null, diags.ToArray());
 
-        var changedSlots = ChangedSlotCount(sigParams, hasDefaultSlot);
+        var changedSlots = ChangedSlotCount(sigParams, hasDefaultSlot, hasComposerSlot);
         int defaultSlotCount = hasDefaultSlot ? 1 : 0;
         int receiverSlotCount = receiverParam is null ? 0 : 1;
-        int actualUserSlots = sigParams.Count - receiverSlotCount - 1 /*composer*/ - changedSlots - defaultSlotCount;
+        int composerSlotCount = hasComposerSlot ? 1 : 0;
+        int markerSlotCount = extensionWithDefault ? 1 : 0;
+        int actualUserSlots = sigParams.Count - receiverSlotCount - composerSlotCount - changedSlots - defaultSlotCount - markerSlotCount;
         int expectedUserSlots = hasDefaultSlot ? kotlinNames.Count : userParams.Length;
         if (actualUserSlots != expectedUserSlots)
         {
@@ -240,22 +318,24 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         }
 
         var source = Emit(method, attr, className, jvmName, signature, defaultsEnumName, sigParams,
-            kotlinNames, userParams, userBitOf, receiverParam, callerProvidesDefaults, hasDefaultSlot, instanceField);
+            kotlinNames, userParams, userBitOf, receiverParam, callerProvidesDefaults, hasDefaultSlot,
+            hasComposerSlot, extensionWithDefault, instanceField);
         var hint = $"ComposeNet.{method.ContainingType.Name}.{method.Name}.g.cs";
         return new GenerationResult(source, hint, Array.Empty<Diagnostic>());
     }
 
     /// <summary>
     /// Number of trailing <c>I</c> params that represent <c>$changed</c>
-    /// slots. With <paramref name="hasDefaultSlot"/>=<c>true</c> the very
-    /// last <c>I</c> is the <c>$default</c> bitmask, so this returns
+    /// slots. <c>$changed</c> only exists in @Composable signatures, so
+    /// when <paramref name="hasComposer"/> is <c>false</c> this returns
+    /// <c>0</c>. With <paramref name="hasDefaultSlot"/>=<c>true</c> the
+    /// very last <c>I</c> is the <c>$default</c> bitmask, so this returns
     /// <c>trailing-1</c>; otherwise every trailing <c>I</c> is part of
     /// the <c>$changed</c> group(s).
     /// </summary>
-    static int ChangedSlotCount(IReadOnlyList<JniType> sigParams, bool hasDefaultSlot)
+    static int ChangedSlotCount(IReadOnlyList<JniType> sigParams, bool hasDefaultSlot, bool hasComposer)
     {
-        // Find composer position from the right: composer is the L Composer; before the trailing Is.
-        // Walk back over all trailing I's; with $default the count of them minus one is changedSlots.
+        if (!hasComposer) return 0;
         int trailingInts = 0;
         for (int i = sigParams.Count - 1; i >= 0 && sigParams[i].Code == 'I' && sigParams[i].ArrayDepth == 0; i--)
             trailingInts++;
@@ -272,6 +352,8 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         IParameterSymbol? receiverParam,
         bool callerProvidesDefaults,
         bool hasDefaultSlot,
+        bool hasComposerSlot,
+        bool extensionWithDefault,
         string? instanceField)
     {
         var sb = new StringBuilder();
@@ -395,13 +477,16 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             sb.AppendLine(");");
         }
 
-        // Composer.
-        var composer = method.Parameters[method.Parameters.Length - 1];
-        sb.Append("                args[").Append(idx).Append("] = new global::Android.Runtime.JValue(((global::Java.Lang.Object)").Append(composer.Name).AppendLine(").Handle);");
-        idx++;
+        // Composer (only present in @Composable shapes).
+        IParameterSymbol? composer = hasComposerSlot ? method.Parameters[method.Parameters.Length - 1] : null;
+        if (composer is not null)
+        {
+            sb.Append("                args[").Append(idx).Append("] = new global::Android.Runtime.JValue(((global::Java.Lang.Object)").Append(composer.Name).AppendLine(").Handle);");
+            idx++;
+        }
 
         // $changed slots.
-        int changedCount = ChangedSlotCount(sigParams, hasDefaultSlot);
+        int changedCount = ChangedSlotCount(sigParams, hasDefaultSlot, hasComposerSlot);
         for (int c = 0; c < changedCount; c++, idx++)
             sb.Append("                args[").Append(idx).AppendLine("] = new global::Android.Runtime.JValue(0);");
 
@@ -409,6 +494,15 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         if (hasDefaultSlot)
         {
             sb.Append("                args[").Append(idx).AppendLine("] = new global::Android.Runtime.JValue(defaults);");
+            idx++;
+        }
+
+        // Synthetic-overload marker for non-@Composable extension functions
+        // with $default. Kotlin always passes null here.
+        if (extensionWithDefault)
+        {
+            sb.Append("                args[").Append(idx).AppendLine("] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero);");
+            idx++;
         }
 
         // Call.
@@ -436,7 +530,8 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             if (NeedsKeepAlive(p))
                 sb.Append("            global::System.GC.KeepAlive(").Append(p.Name).AppendLine(");");
         }
-        sb.Append("            global::System.GC.KeepAlive(").Append(composer.Name).AppendLine(");");
+        if (composer is not null)
+            sb.Append("            global::System.GC.KeepAlive(").Append(composer.Name).AppendLine(");");
         sb.AppendLine("        }");
 
         sb.AppendLine("    }");
@@ -477,6 +572,15 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             sb.Append(p.Name);
             return;
         }
+        if (IsNullableIntPtr(p.Type))
+        {
+            // `IntPtr? x` → null means "let the Kotlin default kick in";
+            // pass IntPtr.Zero in that slot. The auto-mask logic still
+            // clears the corresponding $default bit only when the user
+            // supplied a value.
+            sb.Append('(').Append(p.Name).Append(" ?? global::System.IntPtr.Zero)");
+            return;
+        }
         if (p.Type.SpecialType is SpecialType.System_Boolean
             or SpecialType.System_Int32
             or SpecialType.System_Int64
@@ -514,8 +618,15 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             or SpecialType.System_IntPtr
             or SpecialType.System_String)
             return false;
+        if (IsNullableIntPtr(p.Type)) return false;
         return true;
     }
+
+    static bool IsNullableIntPtr(ITypeSymbol t) =>
+        t is INamedTypeSymbol n &&
+        n.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
+        n.TypeArguments.Length == 1 &&
+        n.TypeArguments[0].SpecialType == SpecialType.System_IntPtr;
 
     static bool IsModifierType(ITypeSymbol t)
     {


### PR DESCRIPTION
Closes #30 (generator + tests). Sibling to #29.

`ComposeBridgeGenerator` now recognises three JNI signature shapes:

| Shape                  | Tail                       | Composer? | `$default`? |
|------------------------|----------------------------|-----------|-------------|
| ComposableWithDefault  | `…Composer;I+`             | yes       | yes         |
| ComposableNoDefault    | `…Composer;I`              | yes       | no          |
| **ExtensionWithDefault** (new) | `…I L<marker>;)…` (no `Composer`) | **no**    | yes         |

The third shape covers non-`@Composable` Kotlin extension functions with default values — the canonical examples being `Modifier.background`, `Modifier.border`, and `Modifier.clickable`. Kotlin always passes the synthetic-overload `Object` marker as `null`, so the generator emits `IntPtr.Zero` there.

### What changed

- Shape detection runs up front from the JNI signature; `signatureHasDefault` now reflects either trailing-I heuristic (composable) or the `I L<marker>` tail (extension).
- `IComposer composer` is **optional** in the C# stub — only required when the signature has a Composer slot. Extension stubs end in a regular user param.
- Receiver binding loosened: for extension shapes the first sigParam is the receiver and binds positionally to the first `IntPtr` C# param, no name suffix required. The existing `IntPtr <name>Scope` convention is unchanged for `@Composable` extension receivers.
- `$changed` slot emission and `GC.KeepAlive(composer)` skipped when no Composer.
- After the `$default` bitmask, the marker slot is filled with `IntPtr.Zero`.
- `IntPtr?` is now recognised: `null → IntPtr.Zero` in the JNI arg, and the auto-mask only clears the bit when non-null. This matches what nullable references already did.

### Tests

Four new `BridgeGeneratorTests` mirror the AC:

- `ExtensionWithDefault_BackgroundShape_OneReceiverPrimitiveAndNullableRef`
- `ExtensionWithDefault_BorderShape_TwoPrimitivesAndNullableRef`
- `ExtensionWithDefault_ClickableShape_PrimitiveStringRefAndRequiredFunction`
- `ExtensionWithDefault_CallerProvidesDefaults_SuppressesAutoMask`

All 26 generator tests pass. Facade still builds clean.

### Out of scope

The issue's migration step (`ComposeBridges.ModifierBackground` / `ModifierBorder` / `ModifierClickable` → `[ComposeBridge]`) is not in this PR — those hand-written bridges live on **#26 (Modifier Phase 2)**, which hasn't merged yet. Once #26 lands, swapping them over is a small follow-up and exercises the new generator path end-to-end.

Documentation in `.github/copilot-instructions.md` is updated to describe the new shape, the new `IntPtr?` handling, and that `composer` is only required for `@Composable` shapes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>