### PR TITLE
Add PrependModifier/AppendModifier on ComposableNode

### DIFF
--- a/src/ComposeNet.Compose/ComposableNode.cs
+++ b/src/ComposeNet.Compose/ComposableNode.cs
@@ -34,12 +34,11 @@ public abstract class ComposableNode
     Modifier? _appended;
 
     /// <summary>
-    /// Inject a <see cref="ComposeNet.Modifier"/> at the START of this
-    /// node's modifier chain. The prepended ops are consumed (and
-    /// cleared) by the next call to <see cref="BuildModifier"/>, so a
-    /// parent layout typically calls this immediately before
-    /// <see cref="Render"/>. Repeated calls before consumption
-    /// accumulate via <see cref="ComposeNet.Modifier.Then"/>.
+    /// Set the <see cref="ComposeNet.Modifier"/> to prepend at the
+    /// START of this node's modifier chain on the next call to
+    /// <see cref="BuildModifier"/>. Each call REPLACES any prior
+    /// prepended modifier — use <see cref="ComposeNet.Modifier.Then"/>
+    /// at the call site to combine multiple ops into one.
     ///
     /// Intended use: a parent layout that needs to pass a runtime
     /// modifier into a child without inserting a wrapper layout node —
@@ -48,23 +47,31 @@ public abstract class ComposableNode
     /// body's own modifier chain composes naturally with the inset
     /// padding, mirroring the Kotlin idiom
     /// <c>Column(Modifier.padding(paddingValues)) { ... }</c>.
+    ///
+    /// Caveat: the injected modifier is silently dropped if the child's
+    /// <c>Render</c> never calls <see cref="BuildModifier"/> (i.e.
+    /// composables whose Kotlin counterpart has no <c>modifier</c>
+    /// parameter — <see cref="MaterialTheme"/>, the drawer sheets).
+    /// Replace-semantics keeps the stored modifier bounded to one ref
+    /// even when the child never consumes it.
     /// </summary>
     public void PrependModifier(Modifier modifier)
     {
         System.ArgumentNullException.ThrowIfNull(modifier);
-        _prepended = _prepended is null ? modifier : _prepended.Then(modifier);
+        _prepended = modifier;
     }
 
     /// <summary>
-    /// Inject a <see cref="ComposeNet.Modifier"/> at the END of this
-    /// node's modifier chain. Mirror of <see cref="PrependModifier"/>;
-    /// consumed (and cleared) by the next call to
-    /// <see cref="BuildModifier"/>.
+    /// Set the <see cref="ComposeNet.Modifier"/> to append at the END
+    /// of this node's modifier chain on the next call to
+    /// <see cref="BuildModifier"/>. Mirror of
+    /// <see cref="PrependModifier"/> — see that method for semantics,
+    /// caveats, and replace-vs-accumulate notes.
     /// </summary>
     public void AppendModifier(Modifier modifier)
     {
         System.ArgumentNullException.ThrowIfNull(modifier);
-        _appended = _appended is null ? modifier : _appended.Then(modifier);
+        _appended = modifier;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/ComposableNode.cs
+++ b/src/ComposeNet.Compose/ComposableNode.cs
@@ -30,14 +30,66 @@ public abstract class ComposableNode
     /// </summary>
     public Modifier? Modifier { get; set; }
 
+    Modifier? _prepended;
+    Modifier? _appended;
+
     /// <summary>
-    /// Materialize <see cref="Modifier"/> for the JNI call. Returns
-    /// <c>null</c> when the user did not supply a modifier OR supplied
-    /// the empty <see cref="ComposeNet.Modifier.Companion"/> — in both
-    /// cases callers should leave the Kotlin <c>$default</c> bit set so
+    /// Inject a <see cref="ComposeNet.Modifier"/> at the START of this
+    /// node's modifier chain. The prepended ops are consumed (and
+    /// cleared) by the next call to <see cref="BuildModifier"/>, so a
+    /// parent layout typically calls this immediately before
+    /// <see cref="Render"/>. Repeated calls before consumption
+    /// accumulate via <see cref="ComposeNet.Modifier.Then"/>.
+    ///
+    /// Intended use: a parent layout that needs to pass a runtime
+    /// modifier into a child without inserting a wrapper layout node —
+    /// e.g. <see cref="Scaffold"/> threading
+    /// <c>Modifier.padding(paddingValues)</c> into its body so the
+    /// body's own modifier chain composes naturally with the inset
+    /// padding, mirroring the Kotlin idiom
+    /// <c>Column(Modifier.padding(paddingValues)) { ... }</c>.
+    /// </summary>
+    public void PrependModifier(Modifier modifier)
+    {
+        System.ArgumentNullException.ThrowIfNull(modifier);
+        _prepended = _prepended is null ? modifier : _prepended.Then(modifier);
+    }
+
+    /// <summary>
+    /// Inject a <see cref="ComposeNet.Modifier"/> at the END of this
+    /// node's modifier chain. Mirror of <see cref="PrependModifier"/>;
+    /// consumed (and cleared) by the next call to
+    /// <see cref="BuildModifier"/>.
+    /// </summary>
+    public void AppendModifier(Modifier modifier)
+    {
+        System.ArgumentNullException.ThrowIfNull(modifier);
+        _appended = _appended is null ? modifier : _appended.Then(modifier);
+    }
+
+    /// <summary>
+    /// Materialize <see cref="Modifier"/> for the JNI call, folding in
+    /// any pending <see cref="PrependModifier"/> / <see cref="AppendModifier"/>
+    /// contributions and clearing them so the next composition starts
+    /// fresh. Returns <c>null</c> when the combined chain is empty —
+    /// callers should leave the Kotlin <c>$default</c> bit set so
     /// Compose substitutes its real default.
     /// </summary>
-    internal IModifier? BuildModifier() => Modifier?.Build();
+    internal IModifier? BuildModifier()
+    {
+        var prepended = _prepended;
+        var appended = _appended;
+        _prepended = null;
+        _appended = null;
+
+        Modifier? combined = prepended;
+        if (Modifier is not null)
+            combined = combined is null ? Modifier : combined.Then(Modifier);
+        if (appended is not null)
+            combined = combined is null ? appended : combined.Then(appended);
+
+        return combined?.Build();
+    }
 
     internal abstract void Render(IComposer composer);
 }

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -74,6 +74,23 @@ public sealed class Modifier
     }
 
     /// <summary>
+    /// Concatenate <paramref name="other"/> onto this chain, returning
+    /// a new <see cref="Modifier"/>. Mirrors Kotlin's
+    /// <c>Modifier.then(other)</c> — the receiver's ops apply first,
+    /// then <paramref name="other"/>'s ops.
+    /// </summary>
+    public Modifier Then(Modifier other)
+    {
+        System.ArgumentNullException.ThrowIfNull(other);
+        if (other._ops.Length == 0) return this;
+        if (_ops.Length == 0) return other;
+        var arr = new System.Func<IntPtr, IntPtr>[_ops.Length + other._ops.Length];
+        System.Array.Copy(_ops, arr, _ops.Length);
+        System.Array.Copy(other._ops, 0, arr, _ops.Length, other._ops.Length);
+        return new Modifier(arr);
+    }
+
+    /// <summary>
     /// <c>Modifier.padding(all: Dp)</c> — applies <paramref name="allDp"/>
     /// of padding to every edge.
     /// </summary>

--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -49,17 +49,16 @@ public sealed class Scaffold : ComposableNode
 
         // Material 3's Scaffold passes PaddingValues as the first arg of
         // its content lambda — body must apply it to avoid rendering
-        // behind the top/bottom bars. We can't prepend a Modifier onto
-        // Body's existing chain from out here (see #37), so we wrap it
-        // in a Box that owns the runtime `Modifier.padding(values)`.
-        // When #37 lands, drop the Box and inject the padding directly.
+        // behind the top/bottom bars. Prepend a runtime
+        // `Modifier.padding(values)` onto Body's existing chain so the
+        // padding and Body's own modifiers compose on the same layout
+        // node, mirroring Kotlin's
+        // `Column(Modifier.padding(paddingValues)) { ... }`.
+        var body = Body;
         var content = new ComposableLambda3((paddingHandle, c) =>
         {
-            new Box
-            {
-                Modifier.Companion.Padding(paddingHandle),
-                Body,
-            }.Render(c);
+            body.PrependModifier(Modifier.Companion.Padding(paddingHandle));
+            body.Render(c);
         });
 
         // Always pass non-null slot lambdas. Toggling between Compose's


### PR DESCRIPTION
Fixes #37.

## What

Expose `ComposableNode.PrependModifier(Modifier)` and `AppendModifier(Modifier)` so a parent layout can inject a runtime `Modifier` into a child's chain without inserting an extra layout node. Both are folded into the child's existing `Modifier` by `BuildModifier()` and cleared on consumption, so each recomposition starts fresh.

## How

- `Modifier.Then(other)` — public chain-concat helper, mirrors Kotlin's `Modifier.then`. Same fast-paths as `Append` (returns the non-empty operand on either side being empty).
- `ComposableNode._prepended` / `_appended` accumulate via `Then` on repeated calls before `BuildModifier()` consumes them.
- `BuildModifier()` composes `prepended → Modifier → appended` and returns `null` only when the entire combined chain is empty (preserving the "leave the `$default` bit set" contract).

## Scaffold

Switched `Scaffold.Render` to:

```csharp
body.PrependModifier(Modifier.Companion.Padding(paddingHandle));
body.Render(c);
```

Dropping the synthetic `Box` wrapper. The user's `Body` modifier and the Scaffold-supplied inset padding now compose on the same layout node, matching Kotlin's `Column(Modifier.padding(paddingValues)) { ... }` idiom — `fillMaxSize`, alignment, and scroll modifiers on the user's root now compose with the inset padding the way Compose users expect.

The "(see #37)" / "When #37 lands…" comments in `Scaffold.cs` are gone.

## Validation

- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet test  src/ComposeNet.SourceGenerators.Tests` — 26/26 pass.
- `dotnet build src/ComposeNet.Sample` — clean (0 warnings, 0 errors).