### PR TITLE
Add fourth ComposeBridgeGenerator shape: plain Kotlin static

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,6 +123,11 @@ generator fill it in.
    (e.g. `Modifier.background`, `Modifier.border`, `Modifier.clickable`),
    there is no `Composer` slot at all; just declare the user params
    directly with the extension receiver as the first `IntPtr` param.
+   For plain Kotlin static methods with no `Composer` and no `$default`
+   (e.g. `Modifier.padding`, `RoundedCornerShape`), declare the params
+   positionally — the generator treats the first user param as an
+   extension receiver only when both it's `IntPtr` and the first JNI
+   sigParam is an object (`L`).
 2. **If** the underlying `@Composable` has at least one defaultable
    Kotlin parameter (i.e. the JNI signature has a trailing `$default`
    `I` slot after `$changed`), set `Defaults = typeof(XxxDefault)` and
@@ -172,6 +177,19 @@ The trailing `I L<marker>` slots are the `$default` bitmask plus a
 synthetic-overload `Object` marker; the generator emits both
 automatically (the marker is always `IntPtr.Zero` / `null`).
 
+Example (plain Kotlin static — no `Composer`, no `$default`):
+```csharp
+[ComposeBridge(
+    Class     = "androidx/compose/foundation/layout/PaddingKt",
+    JvmName   = "padding-3ABfNKs",
+    Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+internal static partial IntPtr ModifierPaddingAll(IntPtr modifier, float dp);
+```
+The leading `IntPtr modifier` is auto-bound to the JNI extension
+receiver slot because the first sigParam is `L`. For a non-extension
+plain static (e.g. `RoundedCornerShape(Dp)` whose signature starts
+with `F`, not `L`), the first user param is just a regular argument.
+
 ### Conventions the generator relies on
 
 - For `@Composable` bridges, `composer` is the **last** C# parameter.
@@ -188,10 +206,15 @@ automatically (the marker is always `IntPtr.Zero` / `null`).
   slot**; do not declare `int defaults` on a no-`$default` bridge.
 - Kotlin extension receivers on `@Composable` functions: declare as
   `IntPtr` with a name ending in `Scope` (e.g. `IntPtr rowScope`).
-  Non-`@Composable` extensions: declare the receiver as the first
-  `IntPtr` user parameter (any name — the generator binds it
-  positionally to the first JNI slot). In both cases the generator
-  places it at `args[0]` and excludes it from the `$default` count.
+  Non-`@Composable` extensions with `$default`: declare the receiver
+  as the first `IntPtr` user parameter (any name — the generator binds
+  it positionally to the first JNI slot). Plain Kotlin static
+  extensions (no `Composer`, no `$default`): the first user param is
+  treated as the receiver iff it is `IntPtr` AND the first JNI
+  sigParam is an object (`L`); otherwise every user param is a regular
+  positional argument (e.g. `RoundedCornerShape(float dp)` over
+  `(F)Shape;` has no receiver). In all cases the receiver is placed at
+  `args[0]` and excluded from the `$default` count.
 - `IModifier?` is special-cased to call `ComposeBridges.ModifierHandle`
   (handles `null` → `IntPtr.Zero`). `IntPtr?` is also recognized:
   `null` → `IntPtr.Zero` for the JNI arg, and the auto-mask only
@@ -206,10 +229,13 @@ automatically (the marker is always `IntPtr.Zero` / `null`).
 
 ### What still lives hand-written
 
-`ModifierHandle` and the simpler modifier-chain helpers that have
-neither `Composer` nor `$default` (`PaddingAll`, `FillMaxWidth`,
-`RoundedCornerShape`, `ClipKt.clip`, etc.) — these don't follow any
-shape the generator currently recognises and remain plain JNI calls.
+`ModifierHandle` (a managed-side `IModifier? → IntPtr` conversion) and
+`ModifierCompanionInstance` (a static field lookup, not a method
+invocation) don't fit any of the four `[ComposeBridge]` shapes and
+remain raw JNI. Two-step bridges like `ModifierClipRoundedCorners`
+(which composes `RoundedCornerShape` + `ClipKt.clip` and manages an
+intermediate `Shape` local ref) also stay hand-written — their shape
+isn't a single Kotlin call.
 
 ### Generator diagnostics
 

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -11,11 +11,13 @@ namespace ComposeNet;
 // — the trailing $default bitmask lives on the regular method). The bodies
 // for every method tagged with [ComposeBridge] are emitted by
 // ComposeNet.SourceGenerators.ComposeBridgeGenerator from the attribute
-// metadata + the matching [ComposeDefaults] enum names.
+// metadata + (for $default-bearing signatures) the matching [ComposeDefaults]
+// enum names. Plain Kotlin static helpers — no Composer, no $default — don't
+// need a [ComposeDefaults] declaration.
 //
-// A few helpers stay hand-written: the Modifier-chain helpers (no $default,
-// they wrap plain Kotlin static functions, not @Composable), and the
-// Modifier.Companion.$$INSTANCE field lookup used by Modifier.Build().
+// A few helpers stay hand-written: ModifierHandle (a managed-side conversion
+// from the IModifier wrapper to a raw handle) and ModifierCompanionInstance
+// (a static field lookup, not a method invocation).
 internal static partial class ComposeBridges
 {
     // Convert a managed Modifier wrapper (from `Modifier.Build()`) to a
@@ -48,134 +50,69 @@ internal static partial class ComposeBridges
 
     // androidx.compose.foundation.layout.PaddingKt — the Dp-taking
     // overloads have hashed JVM names from the inline-class compiler
-    // mangling (`@JvmInline value class Dp(val value: Float)`).
-    // The signatures below are stable across Compose UI 1.x.
-    const string ModifierDpSig =
-        "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;";
-    const string ModifierDp2Sig =
-        "(Landroidx/compose/ui/Modifier;FF)Landroidx/compose/ui/Modifier;";
-    const string ModifierDp4Sig =
-        "(Landroidx/compose/ui/Modifier;FFFF)Landroidx/compose/ui/Modifier;";
+    // mangling (`@JvmInline value class Dp(val value: Float)`). Bodies
+    // are emitted by the source generator's plain-static shape.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/PaddingKt",
+        JvmName   = "padding-3ABfNKs",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierPaddingAll(IntPtr modifier, float dp);
 
-    static IntPtr s_paddingKtClass;
-    static IntPtr s_paddingAllMethod;
-    static IntPtr s_paddingHVMethod;
-    static IntPtr s_paddingLTRBMethod;
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/PaddingKt",
+        JvmName   = "padding-VpY3zN4",
+        Signature = "(Landroidx/compose/ui/Modifier;FF)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierPaddingHV(IntPtr modifier, float horizontal, float vertical);
 
-    internal static unsafe IntPtr ModifierPaddingAll(IntPtr modifier, float dp)
-    {
-        if (s_paddingKtClass == IntPtr.Zero)
-            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
-        if (s_paddingAllMethod == IntPtr.Zero)
-            s_paddingAllMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding-3ABfNKs", ModifierDpSig);
-
-        JValue* args = stackalloc JValue[2];
-        args[0] = new JValue(modifier);
-        args[1] = new JValue(dp);
-        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingAllMethod, args);
-    }
-
-    internal static unsafe IntPtr ModifierPaddingHV(IntPtr modifier, float horizontal, float vertical)
-    {
-        if (s_paddingKtClass == IntPtr.Zero)
-            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
-        if (s_paddingHVMethod == IntPtr.Zero)
-            s_paddingHVMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding-VpY3zN4", ModifierDp2Sig);
-
-        JValue* args = stackalloc JValue[3];
-        args[0] = new JValue(modifier);
-        args[1] = new JValue(horizontal);
-        args[2] = new JValue(vertical);
-        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingHVMethod, args);
-    }
-
-    internal static unsafe IntPtr ModifierPaddingLTRB(IntPtr modifier, float start, float top, float end, float bottom)
-    {
-        if (s_paddingKtClass == IntPtr.Zero)
-            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
-        if (s_paddingLTRBMethod == IntPtr.Zero)
-            s_paddingLTRBMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding-qDBjuR0", ModifierDp4Sig);
-
-        JValue* args = stackalloc JValue[5];
-        args[0] = new JValue(modifier);
-        args[1] = new JValue(start);
-        args[2] = new JValue(top);
-        args[3] = new JValue(end);
-        args[4] = new JValue(bottom);
-        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingLTRBMethod, args);
-    }
-
-    static IntPtr s_paddingValuesMethod;
-    const string ModifierPaddingValuesSig =
-        "(Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;)Landroidx/compose/ui/Modifier;";
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/PaddingKt",
+        JvmName   = "padding-qDBjuR0",
+        Signature = "(Landroidx/compose/ui/Modifier;FFFF)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierPaddingLTRB(IntPtr modifier, float start, float top, float end, float bottom);
 
     // PaddingKt.padding(Modifier, PaddingValues) — unmangled because
     // PaddingValues is a regular interface, not a `value class`.
-    internal static unsafe IntPtr ModifierPaddingValues(IntPtr modifier, IntPtr paddingValues)
-    {
-        if (s_paddingKtClass == IntPtr.Zero)
-            s_paddingKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/PaddingKt");
-        if (s_paddingValuesMethod == IntPtr.Zero)
-            s_paddingValuesMethod = JNIEnv.GetStaticMethodID(s_paddingKtClass, "padding", ModifierPaddingValuesSig);
-
-        JValue* args = stackalloc JValue[2];
-        args[0] = new JValue(modifier);
-        args[1] = new JValue(paddingValues);
-        return JNIEnv.CallStaticObjectMethod(s_paddingKtClass, s_paddingValuesMethod, args);
-    }
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/PaddingKt",
+        JvmName   = "padding",
+        Signature = "(Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierPaddingValues(IntPtr modifier, IntPtr paddingValues);
 
     // androidx.compose.foundation.layout.SizeKt — fillMax* take a plain
     // Float fraction, not Dp, so the JVM names are NOT mangled.
-    static IntPtr s_sizeKtClass;
-    static IntPtr s_fillMaxWidthMethod;
-    static IntPtr s_fillMaxHeightMethod;
-    static IntPtr s_fillMaxSizeMethod;
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "fillMaxWidth",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierFillMaxWidth(IntPtr modifier, float fraction);
 
-    internal static unsafe IntPtr ModifierFillMaxWidth(IntPtr modifier, float fraction)
-    {
-        if (s_sizeKtClass == IntPtr.Zero)
-            s_sizeKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/SizeKt");
-        if (s_fillMaxWidthMethod == IntPtr.Zero)
-            s_fillMaxWidthMethod = JNIEnv.GetStaticMethodID(s_sizeKtClass, "fillMaxWidth", ModifierDpSig);
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "fillMaxHeight",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierFillMaxHeight(IntPtr modifier, float fraction);
 
-        JValue* args = stackalloc JValue[2];
-        args[0] = new JValue(modifier);
-        args[1] = new JValue(fraction);
-        return JNIEnv.CallStaticObjectMethod(s_sizeKtClass, s_fillMaxWidthMethod, args);
-    }
-
-    internal static unsafe IntPtr ModifierFillMaxHeight(IntPtr modifier, float fraction)
-    {
-        if (s_sizeKtClass == IntPtr.Zero)
-            s_sizeKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/SizeKt");
-        if (s_fillMaxHeightMethod == IntPtr.Zero)
-            s_fillMaxHeightMethod = JNIEnv.GetStaticMethodID(s_sizeKtClass, "fillMaxHeight", ModifierDpSig);
-
-        JValue* args = stackalloc JValue[2];
-        args[0] = new JValue(modifier);
-        args[1] = new JValue(fraction);
-        return JNIEnv.CallStaticObjectMethod(s_sizeKtClass, s_fillMaxHeightMethod, args);
-    }
-
-    internal static unsafe IntPtr ModifierFillMaxSize(IntPtr modifier, float fraction)
-    {
-        if (s_sizeKtClass == IntPtr.Zero)
-            s_sizeKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/SizeKt");
-        if (s_fillMaxSizeMethod == IntPtr.Zero)
-            s_fillMaxSizeMethod = JNIEnv.GetStaticMethodID(s_sizeKtClass, "fillMaxSize", ModifierDpSig);
-
-        JValue* args = stackalloc JValue[2];
-        args[0] = new JValue(modifier);
-        args[1] = new JValue(fraction);
-        return JNIEnv.CallStaticObjectMethod(s_sizeKtClass, s_fillMaxSizeMethod, args);
-    }
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "fillMaxSize",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierFillMaxSize(IntPtr modifier, float fraction);
 
     // androidx.compose.foundation.layout.WindowInsetsPadding_androidKt —
     // Modifier extensions that read WindowInsets from CompositionLocals
     // and apply them as padding. Take only Modifier (no Dp), so JVM
     // names are unmangled.
-    const string ModifierToModifierSig =
-        "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;";
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "safeDrawingPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierSafeDrawingPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "systemBarsPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierSystemBarsPadding(IntPtr modifier);
 
     // androidx.compose.ui.res.PainterResources_androidKt.painterResource —
     // returns a NEW local Painter ref the caller is responsible for
@@ -186,35 +123,6 @@ internal static partial class ComposeBridges
         JvmName   = "painterResource",
         Signature = "(ILandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;")]
     public static partial IntPtr PainterResource(int id, IComposer composer);
-
-
-    static IntPtr s_windowInsetsPaddingAndroidKtClass;
-    static IntPtr s_safeDrawingPaddingMethod;
-    static IntPtr s_systemBarsPaddingMethod;
-
-    internal static unsafe IntPtr ModifierSafeDrawingPadding(IntPtr modifier)
-    {
-        if (s_windowInsetsPaddingAndroidKtClass == IntPtr.Zero)
-            s_windowInsetsPaddingAndroidKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/WindowInsetsPadding_androidKt");
-        if (s_safeDrawingPaddingMethod == IntPtr.Zero)
-            s_safeDrawingPaddingMethod = JNIEnv.GetStaticMethodID(s_windowInsetsPaddingAndroidKtClass, "safeDrawingPadding", ModifierToModifierSig);
-
-        JValue* args = stackalloc JValue[1];
-        args[0] = new JValue(modifier);
-        return JNIEnv.CallStaticObjectMethod(s_windowInsetsPaddingAndroidKtClass, s_safeDrawingPaddingMethod, args);
-    }
-
-    internal static unsafe IntPtr ModifierSystemBarsPadding(IntPtr modifier)
-    {
-        if (s_windowInsetsPaddingAndroidKtClass == IntPtr.Zero)
-            s_windowInsetsPaddingAndroidKtClass = JNIEnv.FindClass("androidx/compose/foundation/layout/WindowInsetsPadding_androidKt");
-        if (s_systemBarsPaddingMethod == IntPtr.Zero)
-            s_systemBarsPaddingMethod = JNIEnv.GetStaticMethodID(s_windowInsetsPaddingAndroidKtClass, "systemBarsPadding", ModifierToModifierSig);
-
-        JValue* args = stackalloc JValue[1];
-        args[0] = new JValue(modifier);
-        return JNIEnv.CallStaticObjectMethod(s_windowInsetsPaddingAndroidKtClass, s_systemBarsPaddingMethod, args);
-    }
 
     // Source-generated bridges below. Each [ComposeBridge] partial
     // declaration is paired with a matching [ComposeDefaults] in

--- a/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -696,4 +696,195 @@ public class BridgeGeneratorTests
         Assert.Contains("args[3] = new global::Android.Runtime.JValue(defaults)", emitted);
         Assert.Contains("args[4] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
     }
+
+    [Fact]
+    public void PlainStatic_ReceiverPlusPrimitive()
+    {
+        // Mirrors androidx.compose.foundation.layout.SizeKt.fillMaxWidth —
+        // plain Kotlin static extension on Modifier, no Composer, no $default.
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/layout/SizeKt",
+                        JvmName = "fillMaxWidth",
+                        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+                    public static partial System.IntPtr ModifierFillMaxWidth(System.IntPtr modifier, float fraction);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("FindClass(\"androidx/compose/foundation/layout/SizeKt\")", emitted);
+        Assert.Contains("GetStaticMethodID(s_ModifierFillMaxWidth_class, \"fillMaxWidth\"", emitted);
+
+        // Receiver at args[0], fraction at args[1] — 2 slots total.
+        Assert.Contains("global::Android.Runtime.JValue[2]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(modifier)", emitted);
+        Assert.Contains("args[1] = new global::Android.Runtime.JValue(fraction)", emitted);
+        Assert.DoesNotContain("args[2]", emitted);
+
+        // No bitmask, no $default slot, no marker, no Composer.
+        Assert.DoesNotContain(".All;", emitted);
+        Assert.DoesNotContain("new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.DoesNotContain("new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+        Assert.DoesNotContain("Composer", emitted);
+        Assert.DoesNotContain("KeepAlive(composer)", emitted);
+
+        Assert.Contains("return global::Android.Runtime.JNIEnv.CallStaticObjectMethod(", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void PlainStatic_ReceiverOnly()
+    {
+        // Mirrors androidx.compose.foundation.layout.WindowInsetsPadding_androidKt.safeDrawingPadding —
+        // Modifier extension with no other parameters.
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+                        JvmName = "safeDrawingPadding",
+                        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+                    public static partial System.IntPtr ModifierSafeDrawingPadding(System.IntPtr modifier);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("global::Android.Runtime.JValue[1]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(modifier)", emitted);
+        Assert.DoesNotContain("args[1]", emitted);
+        Assert.DoesNotContain("Composer", emitted);
+        Assert.DoesNotContain("new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.Contains("return global::Android.Runtime.JNIEnv.CallStaticObjectMethod(", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void PlainStatic_FourPrimitives()
+    {
+        // Mirrors androidx.compose.foundation.layout.PaddingKt.padding-qDBjuR0 —
+        // Modifier extension with four Dp values.
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/layout/PaddingKt",
+                        JvmName = "padding-qDBjuR0",
+                        Signature = "(Landroidx/compose/ui/Modifier;FFFF)Landroidx/compose/ui/Modifier;")]
+                    public static partial System.IntPtr ModifierPaddingLTRB(
+                        System.IntPtr modifier, float start, float top, float end, float bottom);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("\"padding-qDBjuR0\"", emitted);
+        Assert.Contains("global::Android.Runtime.JValue[5]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(modifier)", emitted);
+        Assert.Contains("args[1] = new global::Android.Runtime.JValue(start)", emitted);
+        Assert.Contains("args[2] = new global::Android.Runtime.JValue(top)", emitted);
+        Assert.Contains("args[3] = new global::Android.Runtime.JValue(end)", emitted);
+        Assert.Contains("args[4] = new global::Android.Runtime.JValue(bottom)", emitted);
+        Assert.DoesNotContain("args[5]", emitted);
+        Assert.DoesNotContain("Composer", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void PlainStatic_NoReceiver_PrimitiveInObjectOut()
+    {
+        // Mirrors androidx.compose.foundation.shape.RoundedCornerShapeKt.RoundedCornerShape —
+        // plain static call with no leading receiver, returns an object.
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/shape/RoundedCornerShapeKt",
+                        JvmName = "RoundedCornerShape-0680j_4",
+                        Signature = "(F)Landroidx/compose/foundation/shape/RoundedCornerShape;")]
+                    public static partial System.IntPtr RoundedCornerShape(float dp);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("FindClass(\"androidx/compose/foundation/shape/RoundedCornerShapeKt\")", emitted);
+        Assert.Contains("\"RoundedCornerShape-0680j_4\"", emitted);
+
+        // No receiver — dp goes into args[0].
+        Assert.Contains("global::Android.Runtime.JValue[1]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(dp)", emitted);
+        Assert.DoesNotContain("args[1]", emitted);
+
+        // No Composer, no $default, no marker.
+        Assert.DoesNotContain("Composer", emitted);
+        Assert.DoesNotContain("new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.DoesNotContain("new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+
+        Assert.Contains("return global::Android.Runtime.JNIEnv.CallStaticObjectMethod(", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void PlainStatic_DefaultsSpecified_ReportsCN2005()
+    {
+        // Plain-static shape rejects Defaults via the existing CN2005
+        // "signature has no $default slot" check.
+        var code = """
+            using ComposeNet;
+
+            [assembly: ComposeDefaults("FooDefault", "dp")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "x/Y",
+                        JvmName = "Foo",
+                        Signature = "(F)Landroidx/compose/foundation/shape/RoundedCornerShape;",
+                        Defaults = typeof(FooDefault))]
+                    public static partial System.IntPtr Foo(float dp);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code);
+        Assert.Contains(diags, d => d.Id == "CN2005");
+    }
 }

--- a/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
@@ -90,13 +90,17 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             });
         }
 
-        // Detect the JNI signature "shape". Three supported today:
+        // Detect the JNI signature "shape". Four supported today:
         //   1. ComposableWithDefault — ...Composer;I+ trailing (multiple Is).
         //   2. ComposableNoDefault   — ...Composer;I  trailing (single I).
         //   3. ExtensionWithDefault  — non-@Composable Kotlin extension
         //      function with default values; tail is `I L<marker>`,
         //      no Composer. The marker is always Ljava/lang/Object; and
         //      is passed `null` (IntPtr.Zero).
+        //   4. PlainStatic           — plain Kotlin static method on a Kt
+        //      class with no Composer slot and no $default bitmask; just
+        //      (args…)Return. Used for Modifier-chain helpers and other
+        //      synchronous Kotlin utilities (e.g. RoundedCornerShape).
         int composerSigIdx = -1;
         for (int i = 0; i < sigParams.Count; i++)
         {
@@ -138,13 +142,12 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         }
         else
         {
-            // Non-@Composable, no $default — e.g. RoundedCornerShape or
-            // ClipKt.clip. Not supported by this generator yet (issue #30
-            // explicitly leaves these hand-written).
-            return new GenerationResult(null, null, new[] {
-                Diagnostic.Create(Diagnostics.BridgeMalformedSignature, loc, method.Name,
-                    "signature has neither a Composer slot nor an `I L<marker>` $default tail; this shape is not yet supported")
-            });
+            // Plain static call, no Composer, no $default — e.g.
+            // PaddingKt.padding(Modifier, Dp), RoundedCornerShape(Dp).
+            // Every Kotlin parameter is required; the C# stub lists them
+            // positionally (with an optional leading IntPtr receiver
+            // when the Kotlin function is an extension method).
+            signatureHasDefault = false;
         }
 
         bool hasDefaultSlot = signatureHasDefault;
@@ -242,9 +245,13 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
 
         // Detect leading extension receiver. For composable shapes the
         // convention is `IntPtr <name>Scope` (e.g. `IntPtr rowScope`); for
-        // extension shapes the receiver is whatever the first sigParam is
-        // (e.g. Modifier) and we bind it positionally to the first IntPtr
-        // C# parameter regardless of name.
+        // extension-with-default shapes the receiver is whatever the first
+        // sigParam is (e.g. Modifier) and we bind it positionally to the
+        // first IntPtr C# parameter regardless of name; for the plain-static
+        // shape we treat the first user param as the receiver iff the
+        // first sigParam is an object (`L`) AND the first C# param is
+        // `IntPtr` — that covers Modifier-chain extensions while leaving
+        // non-extension static calls (e.g. `RoundedCornerShape(Dp)`) alone.
         IParameterSymbol? receiverParam = null;
         if (extensionWithDefault)
         {
@@ -258,9 +265,18 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             receiverParam = userParams[0];
             userParams = userParams.Skip(1).ToArray();
         }
-        else if (userParams.Length > 0 &&
+        else if (hasComposerSlot &&
+                 userParams.Length > 0 &&
                  userParams[0].Type.SpecialType == SpecialType.System_IntPtr &&
                  userParams[0].Name.EndsWith("Scope", StringComparison.Ordinal))
+        {
+            receiverParam = userParams[0];
+            userParams = userParams.Skip(1).ToArray();
+        }
+        else if (!hasComposerSlot && !extensionWithDefault &&
+                 userParams.Length > 0 && sigParams.Count > 0 &&
+                 userParams[0].Type.SpecialType == SpecialType.System_IntPtr &&
+                 sigParams[0].Code == 'L' && sigParams[0].ArrayDepth == 0)
         {
             receiverParam = userParams[0];
             userParams = userParams.Skip(1).ToArray();


### PR DESCRIPTION
Closes #36.

Adds the fourth `[ComposeBridge]` signature shape — plain Kotlin static methods with no `Composer` slot and no `$default` bitmask (just `(args…)Return;`) — so the generator now covers every Modifier-chain helper that was previously hand-written.

## Generator (`ComposeBridgeGenerator.cs`)

- New shape detected when neither the composable nor the extension-with-default shape matches: `hasComposerSlot=false`, `signatureHasDefault=false`.
- Receiver detection for the new shape: if the first user param is `IntPtr` **and** the first JNI sigParam is an object (`L`), the user param is auto-bound to `args[0]` as the extension receiver; otherwise every user param is a regular positional argument. That means `ModifierPaddingAll(IntPtr modifier, float dp)` over `(Modifier;F)Modifier;` gets the modifier as the receiver, while `RoundedCornerShape(float dp)` over `(F)Shape;` does not.
- No new diagnostic needed — the existing `CN2005` ("signature has no `$default` slot but `[ComposeBridge]` specifies `Defaults`") already rejects the wrong combination.
- No `$changed`, no `$default`, no marker, no `KeepAlive(composer)` emission (`ChangedSlotCount` already returned 0 when there's no composer).

## Migrated helpers (`ComposeBridges.cs`)

Removed hand-written cache fields + signature consts and replaced nine helpers with `[ComposeBridge]` partials:

- `ModifierPaddingAll` / `HV` / `LTRB` / `Values`
- `ModifierFillMaxWidth` / `Height` / `Size`
- `ModifierSafeDrawingPadding` / `SystemBarsPadding`

Only `ModifierHandle` (managed-side `IModifier? → IntPtr` conversion) and `ModifierCompanionInstance` (a static field lookup, not a method call) remain hand-written, matching the issue's "out of scope".

## Tests (`BridgeGeneratorTests.cs`)

Added five tests covering the new shape:

- `PlainStatic_ReceiverPlusPrimitive` — `(Modifier;F)Modifier;`
- `PlainStatic_ReceiverOnly` — `(Modifier;)Modifier;`
- `PlainStatic_FourPrimitives` — `(Modifier;FFFF)Modifier;`
- `PlainStatic_NoReceiver_PrimitiveInObjectOut` — `(F)Shape;`
- `PlainStatic_DefaultsSpecified_ReportsCN2005`

Each test asserts the receiver placement, slot count, and (per rubber-duck review) the absence of `defaults`, `$default` JValue, marker `IntPtr.Zero`, Composer, and `KeepAlive(composer)`. All 31 tests pass (was 26).

## Docs

Updated `.github/copilot-instructions.md` — added a plain-static example in "Adding a bridge", extended the receiver-conventions bullet, and corrected the "What still lives hand-written" section.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` → 31 passed.
- `dotnet build src/ComposeNet.Compose` → succeeded (only pre-existing warnings).
- `dotnet build src/ComposeNet.Sample` → succeeded.