### PR TITLE
Bind remaining public M3 controls for #13

### DIFF
--- a/src/ComposeNet.Compose/BottomAppBar.cs
+++ b/src/ComposeNet.Compose/BottomAppBar.cs
@@ -1,0 +1,36 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>BottomAppBar</c>. The actions slot is laid out in a
+/// <c>RowScope</c> and filled from this bar's children;
+/// <see cref="FloatingActionButton"/> is an optional trailing slot:
+/// <code>
+/// new BottomAppBar
+/// {
+///     FloatingActionButton = new FloatingActionButton(onClick: ...) { ... },
+///
+///     new IconButton(onClick: ...) { new Icon(painter, "Search") },
+///     new IconButton(onClick: ...) { new Icon(painter, "Settings") },
+/// }
+/// </code>
+/// </summary>
+public sealed class BottomAppBar : ComposableContainer
+{
+    /// <summary>Optional: trailing slot, typically a <see cref="ComposeNet.FloatingActionButton"/>.</summary>
+    public ComposableNode? FloatingActionButton { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var actions = new ComposableLambda3((scope, c) =>
+        {
+            using var _ = RenderContext.PushScope(scope);
+            RenderChildren(c);
+        });
+        ComposableLambda2? fab = FloatingActionButton is null ? null
+            : new ComposableLambda2(c => FloatingActionButton.Render(c));
+
+        ComposeBridges.BottomAppBar(actions, BuildModifier(), fab, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1131,4 +1131,185 @@ internal static partial class ComposeBridges
         IFunction2? trailingContent,
         int         defaults,
         IComposer   composer);
+
+    // androidx.compose.material3.AppBarKt.TopAppBar-cJHQLPU (subtitle
+    // overload). 10 user params: title, subtitle, modifier, navigationIcon,
+    // actions, titleHorizontalAlignment, expandedHeight, windowInsets,
+    // colors, scrollBehavior.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "TopAppBar-cJHQLPU",
+        Signature = "(Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+                    "Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Alignment$Horizontal;F" +
+                    "Landroidx/compose/foundation/layout/WindowInsets;" +
+                    "Landroidx/compose/material3/TopAppBarColors;" +
+                    "Landroidx/compose/material3/TopAppBarScrollBehavior;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(TopAppBarSubtitleDefault))]
+    public static partial void TopAppBarWithSubtitle(
+        IFunction2  title,
+        IFunction2  subtitle,
+        IModifier?  modifier,
+        IFunction2? navigationIcon,
+        IFunction3? actions,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.AppBarKt.{Medium,Large}FlexibleTopAppBar-eXZ4JBQ
+    // share the descriptor (trailing `III` because 11 params * 3 bits per
+    // $changed slot exceeds the 31 bits in one int). 11 user params:
+    // title, modifier, subtitle, navigationIcon, actions,
+    // titleHorizontalAlignment, collapsedHeight, expandedHeight,
+    // windowInsets, colors, scrollBehavior.
+    const string FlexibleTopAppBarSig =
+        "(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Alignment$Horizontal;FF" +
+        "Landroidx/compose/foundation/layout/WindowInsets;" +
+        "Landroidx/compose/material3/TopAppBarColors;" +
+        "Landroidx/compose/material3/TopAppBarScrollBehavior;" +
+        "Landroidx/compose/runtime/Composer;III)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "MediumFlexibleTopAppBar-eXZ4JBQ",
+        Signature = FlexibleTopAppBarSig,
+        Defaults  = typeof(FlexibleTopAppBarDefault))]
+    public static partial void MediumFlexibleTopAppBar(
+        IFunction2  title,
+        IModifier?  modifier,
+        IFunction2? subtitle,
+        IFunction2? navigationIcon,
+        IFunction3? actions,
+        int         defaults,
+        IComposer   composer);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "LargeFlexibleTopAppBar-eXZ4JBQ",
+        Signature = FlexibleTopAppBarSig,
+        Defaults  = typeof(FlexibleTopAppBarDefault))]
+    public static partial void LargeFlexibleTopAppBar(
+        IFunction2  title,
+        IModifier?  modifier,
+        IFunction2? subtitle,
+        IFunction2? navigationIcon,
+        IFunction3? actions,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.AppBarKt.BottomAppBar-qhFBPw4 (actions +
+    // FAB + scrollBehavior — the most flexible of the four BottomAppBar
+    // overloads). 9 user params: actions (RowScope-receiver Function3),
+    // modifier, floatingActionButton, containerColor, contentColor,
+    // tonalElevation, contentPadding, windowInsets, scrollBehavior.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "BottomAppBar-qhFBPw4",
+        Signature = "(Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;" +
+                    "Lkotlin/jvm/functions/Function2;JJF" +
+                    "Landroidx/compose/foundation/layout/PaddingValues;" +
+                    "Landroidx/compose/foundation/layout/WindowInsets;" +
+                    "Landroidx/compose/material3/BottomAppBarScrollBehavior;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(BottomAppBarDefault))]
+    public static partial void BottomAppBar(
+        IFunction3  actions,
+        IModifier?  modifier,
+        IFunction2? floatingActionButton,
+        IComposer   composer);
+
+    // androidx.compose.material3.AppBarKt.FlexibleBottomAppBar-wBhsO_E.
+    // 9 user params: modifier, containerColor, contentColor, contentPadding,
+    // horizontalArrangement, expandedHeight, windowInsets, scrollBehavior,
+    // content (RowScope-receiver Function3). Bit 8 (content) always provided.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/AppBarKt",
+        JvmName   = "FlexibleBottomAppBar-wBhsO_E",
+        Signature = "(Landroidx/compose/ui/Modifier;JJ" +
+                    "Landroidx/compose/foundation/layout/PaddingValues;" +
+                    "Landroidx/compose/foundation/layout/Arrangement$Horizontal;F" +
+                    "Landroidx/compose/foundation/layout/WindowInsets;" +
+                    "Landroidx/compose/material3/BottomAppBarScrollBehavior;" +
+                    "Lkotlin/jvm/functions/Function3;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(FlexibleBottomAppBarDefault))]
+    public static partial void FlexibleBottomAppBar(
+        IModifier? modifier,
+        IFunction3 content,
+        IComposer  composer);
+
+    // androidx.compose.material3.TabRowKt.{Primary,Secondary}ScrollableTabRow-qhFBPw4
+    // (simpler overload of -cx2KkNY without the TabIndicatorScope-aware
+    // indicator/divider Function2 wrap — both share the descriptor).
+    // 9 user params: selectedTabIndex, modifier, scrollState (optional —
+    // null lets Kotlin allocate the default ScrollState), containerColor,
+    // contentColor, edgePadding, indicator, divider, tabs.
+    const string PrimaryScrollableTabRowSig =
+        "(ILandroidx/compose/ui/Modifier;Landroidx/compose/foundation/ScrollState;JJF" +
+        "Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;" +
+        "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabRowKt",
+        JvmName   = "PrimaryScrollableTabRow-qhFBPw4",
+        Signature = PrimaryScrollableTabRowSig,
+        Defaults  = typeof(PrimaryScrollableTabRowDefault))]
+    public static partial void PrimaryScrollableTabRow(
+        int        selectedTabIndex,
+        IModifier? modifier,
+        IntPtr?    scrollState,
+        IFunction2 tabs,
+        IComposer  composer);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabRowKt",
+        JvmName   = "SecondaryScrollableTabRow-qhFBPw4",
+        Signature = PrimaryScrollableTabRowSig,
+        Defaults  = typeof(PrimaryScrollableTabRowDefault))]
+    public static partial void SecondaryScrollableTabRow(
+        int        selectedTabIndex,
+        IModifier? modifier,
+        IntPtr?    scrollState,
+        IFunction2 tabs,
+        IComposer  composer);
+
+    // androidx.compose.material3.TabKt.Tab-bogVsAg (ColumnScope content
+    // lambda overload — alternative to Tab-wqdebIU). 8 user params:
+    // selected, onClick, modifier, enabled, selectedContentColor,
+    // unselectedContentColor, interactionSource, content.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TabKt",
+        JvmName   = "Tab-bogVsAg",
+        Signature = "(ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZJJ" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(TabContentDefault))]
+    public static partial void TabContent(
+        bool       selected,
+        IFunction0 onClick,
+        IModifier? modifier,
+        IFunction3 content,
+        IComposer  composer);
+
+    // androidx.compose.material3.SnackbarKt.Snackbar-sDKtq54 (SnackbarData
+    // overload — fed by SnackbarHost's content lambda when state has
+    // queued data). 9 user params: snackbarData, modifier, actionOnNewLine,
+    // shape, containerColor, contentColor, actionColor, actionContentColor,
+    // dismissActionContentColor. Bit 0 (snackbarData) always provided —
+    // we take the raw JNI handle so SnackbarHost can forward Function3's
+    // p0 (a Java.Lang.Object SnackbarData) directly.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SnackbarKt",
+        JvmName   = "Snackbar-sDKtq54",
+        Signature = "(Landroidx/compose/material3/SnackbarData;" +
+                    "Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;JJJJJ" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(SnackbarFromDataDefault))]
+    public static partial void SnackbarFromData(
+        IntPtr     snackbarData,
+        IModifier? modifier,
+        IComposer  composer);
 }

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -352,3 +352,60 @@ using ComposeNet;
     "!headlineContent", "modifier", "overlineContent", "supportingContent",
     "leadingContent", "trailingContent", "colors", "tonalElevation",
     "shadowElevation")]
+
+// androidx.compose.material3.AppBarKt.TopAppBar-cJHQLPU (subtitle overload):
+// 10 user params; bits 0 (title) and 1 (subtitle) always provided.
+// Optional slot bits 3 (NavigationIcon) and 4 (Actions) are toggled
+// per-call by TopAppBar.Render when Subtitle is set.
+[assembly: ComposeDefaults("TopAppBarSubtitleDefault",
+    "!title", "!subtitle", "modifier", "navigationIcon", "actions",
+    "titleHorizontalAlignment", "expandedHeight", "windowInsets",
+    "colors", "scrollBehavior")]
+
+// androidx.compose.material3.AppBarKt.{Medium,Large}FlexibleTopAppBar-eXZ4JBQ:
+// 11 user params; bit 0 (title) always provided. Optional slot bits
+// 2 (Subtitle), 3 (NavigationIcon), 4 (Actions) toggled per-call.
+// 11 params * 3 bits/param > 31, so the bytecode emits two `$changed`
+// ints in addition to `$default` (trailing `III`).
+[assembly: ComposeDefaults("FlexibleTopAppBarDefault",
+    "!title", "modifier", "subtitle", "navigationIcon", "actions",
+    "titleHorizontalAlignment", "collapsedHeight", "expandedHeight",
+    "windowInsets", "colors", "scrollBehavior")]
+
+// androidx.compose.material3.AppBarKt.BottomAppBar-qhFBPw4 (RowScope actions
+// + optional FAB + scrollBehavior overload — the most flexible of the four
+// `BottomAppBar` overloads; the older variants are intentionally not bound):
+// 9 user params; bit 0 (actions) always provided. Optional FAB slot
+// (bit 2) toggled per-call by BottomAppBar.Render.
+[assembly: ComposeDefaults("BottomAppBarDefault",
+    "!actions", "modifier", "floatingActionButton", "containerColor",
+    "contentColor", "tonalElevation", "contentPadding", "windowInsets",
+    "scrollBehavior")]
+
+// androidx.compose.material3.AppBarKt.FlexibleBottomAppBar-wBhsO_E:
+// 9 user params; bit 8 (content) always provided.
+[assembly: ComposeDefaults("FlexibleBottomAppBarDefault",
+    "modifier", "containerColor", "contentColor", "contentPadding",
+    "horizontalArrangement", "expandedHeight", "windowInsets",
+    "scrollBehavior", "!content")]
+
+// androidx.compose.material3.TabRowKt.{Primary,Secondary}ScrollableTabRow-qhFBPw4:
+// 9 user params; bits 0 (selectedTabIndex) and 8 (tabs) always provided.
+[assembly: ComposeDefaults("PrimaryScrollableTabRowDefault",
+    "!selectedTabIndex", "modifier", "scrollState", "containerColor",
+    "contentColor", "edgePadding", "indicator", "divider", "!tabs")]
+
+// androidx.compose.material3.TabKt.Tab-bogVsAg (ColumnScope content
+// overload — alternative to the text/icon `Tab-wqdebIU`): 8 user
+// params; bits 0 (selected), 1 (onClick), 7 (content) always provided.
+[assembly: ComposeDefaults("TabContentDefault",
+    "!selected", "!onClick", "modifier", "enabled", "selectedContentColor",
+    "unselectedContentColor", "interactionSource", "!content")]
+
+// androidx.compose.material3.SnackbarKt.Snackbar-sDKtq54 (SnackbarData
+// overload — the one normally rendered inside SnackbarHost's default
+// content lambda): 9 user params; bit 0 (snackbarData) always provided.
+[assembly: ComposeDefaults("SnackbarFromDataDefault",
+    "!snackbarData", "modifier", "actionOnNewLine", "shape", "containerColor",
+    "contentColor", "actionColor", "actionContentColor",
+    "dismissActionContentColor")]

--- a/src/ComposeNet.Compose/CustomTab.cs
+++ b/src/ComposeNet.Compose/CustomTab.cs
@@ -1,0 +1,40 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>Tab</c> with fully custom content (the <c>Tab-bogVsAg</c>
+/// overload that takes a ColumnScope-receiver content lambda — useful
+/// when the text/icon slots on the regular <see cref="Tab"/> don't fit
+/// your layout, e.g. multi-line labels or a leading dot indicator):
+/// <code>
+/// new CustomTab(selected: tab == 0, onClick: () =&gt; tab.Value = 0)
+/// {
+///     new Column { new Text("Inbox"), new Text("5 unread") },
+/// }
+/// </code>
+/// Children are stacked vertically inside the tab's <c>ColumnScope</c>.
+/// </summary>
+public sealed class CustomTab : ComposableContainer
+{
+    readonly bool _selected;
+    readonly System.Action _onClick;
+
+    public CustomTab(bool selected, System.Action onClick)
+    {
+        _selected = selected;
+        _onClick  = onClick;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        var click = new ComposableLambda0(_onClick);
+        var content = new ComposableLambda3((scope, c) =>
+        {
+            using var _ = RenderContext.PushScope(scope);
+            RenderChildren(c);
+        });
+
+        ComposeBridges.TabContent(_selected, click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/FlexibleBottomAppBar.cs
+++ b/src/ComposeNet.Compose/FlexibleBottomAppBar.cs
@@ -1,0 +1,29 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>FlexibleBottomAppBar</c>. Like <see cref="BottomAppBar"/>
+/// but with a fully customizable expanded height and horizontal
+/// arrangement. The content slot is laid out in a <c>RowScope</c> and
+/// filled from this bar's children:
+/// <code>
+/// new FlexibleBottomAppBar
+/// {
+///     new IconButton(onClick: ...) { new Icon(painter, "Search") },
+///     new IconButton(onClick: ...) { new Icon(painter, "Settings") },
+/// }
+/// </code>
+/// </summary>
+public sealed class FlexibleBottomAppBar : ComposableContainer
+{
+    internal override void Render(IComposer composer)
+    {
+        var content = new ComposableLambda3((scope, c) =>
+        {
+            using var _ = RenderContext.PushScope(scope);
+            RenderChildren(c);
+        });
+        ComposeBridges.FlexibleBottomAppBar(BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/LargeFlexibleTopAppBar.cs
+++ b/src/ComposeNet.Compose/LargeFlexibleTopAppBar.cs
@@ -1,0 +1,49 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>LargeFlexibleTopAppBar</c> — a two-row top app bar
+/// similar to <see cref="LargeTopAppBar"/> but with a configurable
+/// expanded height and an optional second-line <see cref="Subtitle"/>
+/// slot.
+/// </summary>
+public sealed class LargeFlexibleTopAppBar : ComposableNode
+{
+    /// <summary>Required: the bar's title slot.</summary>
+    public ComposableNode? Title { get; set; }
+
+    /// <summary>Optional: second-line slot below the title.</summary>
+    public ComposableNode? Subtitle { get; set; }
+
+    /// <summary>Optional: leading slot.</summary>
+    public ComposableNode? NavigationIcon { get; set; }
+
+    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
+    public ComposableNode? Actions { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Title is null)
+            throw new System.InvalidOperationException(
+                "LargeFlexibleTopAppBar.Title is required (the Kotlin parameter has no default).");
+
+        var title = new ComposableLambda2(c => Title.Render(c));
+        ComposableLambda2? subtitle = Subtitle is null ? null
+            : new ComposableLambda2(c => Subtitle.Render(c));
+        ComposableLambda2? nav = NavigationIcon is null ? null
+            : new ComposableLambda2(c => NavigationIcon.Render(c));
+        ComposableLambda3? actions = Actions is null ? null
+            : new ComposableLambda3(c => Actions.Render(c));
+
+        int defaults = (int)FlexibleTopAppBarDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Modifier;
+        if (subtitle is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Subtitle;
+        if (nav      is not null) defaults &= ~(int)FlexibleTopAppBarDefault.NavigationIcon;
+        if (actions  is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Actions;
+
+        ComposeBridges.LargeFlexibleTopAppBar(
+            title, modifier, subtitle, nav, actions, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/MediumFlexibleTopAppBar.cs
+++ b/src/ComposeNet.Compose/MediumFlexibleTopAppBar.cs
@@ -1,0 +1,49 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>MediumFlexibleTopAppBar</c> — a two-row top app bar
+/// similar to <see cref="MediumTopAppBar"/> but with a configurable
+/// expanded height and an optional second-line <see cref="Subtitle"/>
+/// slot.
+/// </summary>
+public sealed class MediumFlexibleTopAppBar : ComposableNode
+{
+    /// <summary>Required: the bar's title slot.</summary>
+    public ComposableNode? Title { get; set; }
+
+    /// <summary>Optional: second-line slot below the title.</summary>
+    public ComposableNode? Subtitle { get; set; }
+
+    /// <summary>Optional: leading slot, typically a menu / back button.</summary>
+    public ComposableNode? NavigationIcon { get; set; }
+
+    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
+    public ComposableNode? Actions { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Title is null)
+            throw new System.InvalidOperationException(
+                "MediumFlexibleTopAppBar.Title is required (the Kotlin parameter has no default).");
+
+        var title = new ComposableLambda2(c => Title.Render(c));
+        ComposableLambda2? subtitle = Subtitle is null ? null
+            : new ComposableLambda2(c => Subtitle.Render(c));
+        ComposableLambda2? nav = NavigationIcon is null ? null
+            : new ComposableLambda2(c => NavigationIcon.Render(c));
+        ComposableLambda3? actions = Actions is null ? null
+            : new ComposableLambda3(c => Actions.Render(c));
+
+        int defaults = (int)FlexibleTopAppBarDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Modifier;
+        if (subtitle is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Subtitle;
+        if (nav      is not null) defaults &= ~(int)FlexibleTopAppBarDefault.NavigationIcon;
+        if (actions  is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Actions;
+
+        ComposeBridges.MediumFlexibleTopAppBar(
+            title, modifier, subtitle, nav, actions, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/PrimaryScrollableTabRow.cs
+++ b/src/ComposeNet.Compose/PrimaryScrollableTabRow.cs
@@ -1,0 +1,22 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>PrimaryScrollableTabRow</c>. Like
+/// <see cref="PrimaryTabRow"/> but tabs are laid out at their natural
+/// width and the row scrolls horizontally — useful for primary
+/// destinations when there are too many tabs to fit on one screen.
+/// </summary>
+public sealed class PrimaryScrollableTabRow : ComposableContainer
+{
+    readonly int _selectedTabIndex;
+    public PrimaryScrollableTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
+
+    internal override void Render(IComposer composer)
+    {
+        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        ComposeBridges.PrimaryScrollableTabRow(
+            _selectedTabIndex, BuildModifier(), scrollState: null, tabs, composer);
+    }
+}

--- a/src/ComposeNet.Compose/SecondaryScrollableTabRow.cs
+++ b/src/ComposeNet.Compose/SecondaryScrollableTabRow.cs
@@ -1,0 +1,22 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>SecondaryScrollableTabRow</c>. Like
+/// <see cref="SecondaryTabRow"/> but tabs are laid out at their natural
+/// width and the row scrolls horizontally — useful for secondary
+/// sub-navigation when there are too many tabs to fit on one screen.
+/// </summary>
+public sealed class SecondaryScrollableTabRow : ComposableContainer
+{
+    readonly int _selectedTabIndex;
+    public SecondaryScrollableTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
+
+    internal override void Render(IComposer composer)
+    {
+        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        ComposeBridges.SecondaryScrollableTabRow(
+            _selectedTabIndex, BuildModifier(), scrollState: null, tabs, composer);
+    }
+}

--- a/src/ComposeNet.Compose/SnackbarHost.cs
+++ b/src/ComposeNet.Compose/SnackbarHost.cs
@@ -21,7 +21,9 @@ namespace ComposeNet;
 /// requires Kotlin coroutines and isn't yet wired up in this binding.
 /// For most cases, render a <see cref="Snackbar"/> directly into the
 /// <see cref="Scaffold.SnackbarHost"/> slot, gated by a
-/// <see cref="MutableState{T}"/>.
+/// <see cref="MutableState{T}"/>. When external code (Kotlin/Java) drives
+/// the host state, this host paints whatever the state has queued via
+/// the M3 <c>Snackbar(SnackbarData)</c> overload.
 /// </remarks>
 public sealed class SnackbarHost : ComposableNode
 {
@@ -32,12 +34,14 @@ public sealed class SnackbarHost : ComposableNode
     internal override void Render(IComposer composer)
     {
         // SnackbarHost's Function3 receives the current SnackbarData as p0.
-        // The suspending `showSnackbar` trigger on SnackbarHostState isn't
-        // bridged yet, so this lambda would only fire if a Java/Kotlin
-        // caller enqueued data. Render nothing rather than a blank Snackbar
-        // surface — once the `Snackbar(snackbarData)` overload is bridged
-        // we can forward to it here.
-        var snackbar = new ComposableLambda3((_, _) => { });
+        // Forward it to the M3 default — Snackbar(snackbarData) — so an
+        // externally-driven host state actually paints. The lambda is a
+        // no-op when p0 is null (no queued data).
+        var snackbar = new ComposableLambda3((data, c) =>
+        {
+            if (data == IntPtr.Zero) return;
+            ComposeBridges.SnackbarFromData(data, modifier: null, composer: c);
+        });
 
         ComposeBridges.SnackbarHost(
             hostState: ((Java.Lang.Object)_hostState.Jvm).Handle,

--- a/src/ComposeNet.Compose/TopAppBar.cs
+++ b/src/ComposeNet.Compose/TopAppBar.cs
@@ -4,21 +4,31 @@ namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>TopAppBar</c>. <see cref="Title"/> is required;
-/// <see cref="NavigationIcon"/> and <see cref="Actions"/> are optional
-/// slots:
+/// <see cref="Subtitle"/>, <see cref="NavigationIcon"/>, and
+/// <see cref="Actions"/> are optional slots:
 /// <code>
 /// new TopAppBar
 /// {
 ///     Title          = new Text("My App"),
+///     Subtitle       = new Text("Inbox"),
 ///     NavigationIcon = new IconButton(onClick: ...) { new Text("☰") },
 ///     Actions        = new Row { new IconButton(...) { new Text("⋮") } },
 /// }
 /// </code>
+/// When <see cref="Subtitle"/> is set, the bar is rendered via the
+/// newer two-line <c>TopAppBar-cJHQLPU</c> overload; otherwise it uses
+/// the single-line <c>TopAppBar-GHTll3U</c> overload.
 /// </summary>
 public sealed class TopAppBar : ComposableNode
 {
     /// <summary>Required: the bar's title slot.</summary>
     public ComposableNode? Title { get; set; }
+
+    /// <summary>
+    /// Optional: second-line slot below the title. Setting this routes
+    /// to the M3 two-line TopAppBar overload.
+    /// </summary>
+    public ComposableNode? Subtitle { get; set; }
 
     /// <summary>Optional: leading slot, typically a menu / back button.</summary>
     public ComposableNode? NavigationIcon { get; set; }
@@ -37,13 +47,27 @@ public sealed class TopAppBar : ComposableNode
             : new ComposableLambda2(c => NavigationIcon.Render(c));
         ComposableLambda3? actions = Actions is null ? null
             : new ComposableLambda3(c => Actions.Render(c));
-
-        int defaults = (int)TopAppBarDefault.All;
         var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)TopAppBarDefault.Modifier;
-        if (nav      is not null) defaults &= ~(int)TopAppBarDefault.NavigationIcon;
-        if (actions  is not null) defaults &= ~(int)TopAppBarDefault.Actions;
 
-        ComposeBridges.TopAppBar(title, modifier, nav, actions, defaults, composer);
+        if (Subtitle is not null)
+        {
+            var subtitle = new ComposableLambda2(c => Subtitle.Render(c));
+
+            int defaults = (int)TopAppBarSubtitleDefault.All;
+            if (modifier is not null) defaults &= ~(int)TopAppBarSubtitleDefault.Modifier;
+            if (nav      is not null) defaults &= ~(int)TopAppBarSubtitleDefault.NavigationIcon;
+            if (actions  is not null) defaults &= ~(int)TopAppBarSubtitleDefault.Actions;
+
+            ComposeBridges.TopAppBarWithSubtitle(
+                title, subtitle, modifier, nav, actions, defaults, composer);
+            return;
+        }
+
+        int defaults0 = (int)TopAppBarDefault.All;
+        if (modifier is not null) defaults0 &= ~(int)TopAppBarDefault.Modifier;
+        if (nav      is not null) defaults0 &= ~(int)TopAppBarDefault.NavigationIcon;
+        if (actions  is not null) defaults0 &= ~(int)TopAppBarDefault.Actions;
+
+        ComposeBridges.TopAppBar(title, modifier, nav, actions, defaults0, composer);
     }
 }

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -28,7 +28,7 @@ public class MainActivity : ComposeActivity
             var dateState   = Remember(() => new DatePickerState());
             var timeState   = Remember(() => new TimePickerState(initialHour: 9, initialMinute: 30));
 
-            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Pickers" };
+            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Pickers", "App bars" };
 
             // Per-tab content. Only the current tab's column is added to
             // the screen — keeps the sample short enough to fit on one
@@ -37,7 +37,10 @@ public class MainActivity : ComposeActivity
             {
                 0 => new Column
                 {
-                    new TabRow(selectedTabIndex: sub.Value)
+                    // PrimaryScrollableTabRow lets the row scroll horizontally
+                    // when tabs don't fit; CustomTab is the ColumnScope-content
+                    // overload (multi-line label inside the tab).
+                    new PrimaryScrollableTabRow(selectedTabIndex: sub.Value)
                     {
                         new Tab(selected: sub.Value == 0, onClick: () => sub.Value = 0)
                         {
@@ -51,6 +54,11 @@ public class MainActivity : ComposeActivity
                         {
                             Text = new Text("List"),
                             Icon = new Text("📋"),
+                        },
+                        new CustomTab(selected: sub.Value == 3, onClick: () => sub.Value = 3)
+                        {
+                            new Text("Custom"),
+                            new Text($"count={count}"),
                         },
                     },
                     sub.Value switch
@@ -75,7 +83,7 @@ public class MainActivity : ComposeActivity
                                 },
                             },
                         },
-                        _ => new Column
+                        2 => (ComposableNode)new Column
                         {
                             new ListItem
                             {
@@ -100,6 +108,13 @@ public class MainActivity : ComposeActivity
                                     Content = new Text("✉"),
                                 },
                             },
+                        },
+                        _ => new Column
+                        {
+                            new Text("CustomTab uses the Tab-bogVsAg overload"),
+                            new Text("(ColumnScope-receiver content lambda)."),
+                            new Text($"Current count: {count}"),
+                            new Button(onClick: () => count++) { new Text("+1") },
                         },
                     },
                 },
@@ -232,7 +247,7 @@ public class MainActivity : ComposeActivity
                         },
                     },
                 },
-                _ => new Column
+                4 => (ComposableNode)new Column
                 {
                     new Text("Dialogs and sheets"),
                     new Row
@@ -247,6 +262,62 @@ public class MainActivity : ComposeActivity
                     new Text($"Picked date: {pickedDate}"),
                     new Text($"Picked time: {pickedTime}"),
                 },
+                _ => new Column
+                {
+                    // Inline samples of the M3 app-bar family bound by
+                    // ComposeNet — normally these live in Scaffold.TopBar /
+                    // Scaffold.BottomBar, but we drop them inline here just
+                    // so all variants are visible side-by-side.
+                    new Text("TopAppBar variants"),
+                    new MediumFlexibleTopAppBar
+                    {
+                        Title    = new Text("MediumFlexibleTopAppBar"),
+                        Subtitle = new Text($"count={count}"),
+                    },
+                    new LargeFlexibleTopAppBar
+                    {
+                        Title    = new Text("LargeFlexibleTopAppBar"),
+                        Subtitle = new Text($"count={count}"),
+                        Actions  = new Row
+                        {
+                            new IconButton(onClick: () => count++) { new Text("+") },
+                        },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("SecondaryScrollableTabRow"),
+                    new SecondaryScrollableTabRow(selectedTabIndex: sub.Value)
+                    {
+                        new Tab(selected: sub.Value == 0, onClick: () => sub.Value = 0) { Text = new Text("One") },
+                        new Tab(selected: sub.Value == 1, onClick: () => sub.Value = 1) { Text = new Text("Two") },
+                        new Tab(selected: sub.Value == 2, onClick: () => sub.Value = 2) { Text = new Text("Three") },
+                        new Tab(selected: sub.Value == 3, onClick: () => sub.Value = 3) { Text = new Text("Four") },
+                        new Tab(selected: sub.Value == 4, onClick: () => sub.Value = 4) { Text = new Text("Five") },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("BottomAppBar (actions only)"),
+                    new BottomAppBar
+                    {
+                        new IconButton(onClick: () => count--) { new Text("−") },
+                        new IconButton(onClick: () => count.Value = 0) { new Text("0") },
+                        new IconButton(onClick: () => count++) { new Text("+") },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("BottomAppBar (with FAB slot)"),
+                    new BottomAppBar
+                    {
+                        FloatingActionButton = new FloatingActionButton(onClick: () => count++)
+                        {
+                            new Text("+"),
+                        },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("FlexibleBottomAppBar"),
+                    new FlexibleBottomAppBar
+                    {
+                        new IconButton(onClick: () => count++) { new Text("+") },
+                        new IconButton(onClick: () => count--) { new Text("−") },
+                    },
+                },
             };
 
             return new MaterialTheme
@@ -255,9 +326,12 @@ public class MainActivity : ComposeActivity
                 {
                     new Scaffold
                     {
-                        TopBar = new CenterAlignedTopAppBar
+                        // The main TopAppBar uses the new Subtitle slot
+                        // (routes to the M3 two-line TopAppBar-cJHQLPU overload).
+                        TopBar = new TopAppBar
                         {
-                            Title = new Text(tabNames[tab.Value]),
+                            Title    = new Text(tabNames[tab.Value]),
+                            Subtitle = new Text($"count={count}  ·  sub={sub}"),
                         },
                         SnackbarHost = showSnack.Value
                             ? new Snackbar
@@ -298,6 +372,11 @@ public class MainActivity : ComposeActivity
                             {
                                 Icon  = new Text("📅"),
                                 Label = new Text("Pickers"),
+                            },
+                            new NavigationBarItem(selected: tab.Value == 5, onClick: () => tab.Value = 5)
+                            {
+                                Icon  = new Text("📐"),
+                                Label = new Text("Bars"),
                             },
                         },
                         Body = new Column

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -388,11 +388,11 @@ public class MainActivity : ComposeActivity
                         new Tab(selected: sub.Value == 4, onClick: () => sub.Value = 4) { Text = new Text("Five") },
                     },
                     new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
-                    new Text("BottomAppBar (actions only)"),
+                    new Text($"BottomAppBar (actions only) — count is {count}"),
                     new BottomAppBar
                     {
                         new IconButton(onClick: () => count--) { new Text("−") },
-                        new IconButton(onClick: () => count.Value = 0) { new Text("0") },
+                        new IconButton(onClick: () => count.Value = 0) { new Text("↺") },
                         new IconButton(onClick: () => count++) { new Text("+") },
                     },
                     new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },


### PR DESCRIPTION
Closes #13.

Follow-up to #32 that finishes binding the remaining non-internal public composables in `androidx.compose.material3.{AppBarKt, TabRowKt, TabKt, SnackbarKt}`. Adds nine raw-JNI bridges + matching `[ComposeDefaults]` enums and six new one-class-per-file facades.

### New facades

| Class | Backed by |
|---|---|
| `BottomAppBar` | `BottomAppBar-qhFBPw4` (RowScope actions + optional FAB + scrollBehavior — the most flexible of the four `BottomAppBar` overloads) |
| `FlexibleBottomAppBar` | `FlexibleBottomAppBar-wBhsO_E` |
| `MediumFlexibleTopAppBar` | `MediumFlexibleTopAppBar-eXZ4JBQ` |
| `LargeFlexibleTopAppBar` | `LargeFlexibleTopAppBar-eXZ4JBQ` |
| `PrimaryScrollableTabRow` | `PrimaryScrollableTabRow-qhFBPw4` |
| `SecondaryScrollableTabRow` | `SecondaryScrollableTabRow-qhFBPw4` |
| `CustomTab` | `Tab-bogVsAg` (ColumnScope content container — alternative to the Text/Icon-slot regular `Tab`) |

### Extended facades

- **`TopAppBar`** gains an optional `Subtitle` slot. When set, the bar renders via the M3 two-line `TopAppBar-cJHQLPU` overload; when unset, the existing `TopAppBar-GHTll3U` path is unchanged.
- **`SnackbarHost`** wires its content lambda to the new `Snackbar(SnackbarData)` bridge so an externally-driven `SnackbarHostState` actually paints (previously a no-op pending this overload).

### Notes

- The Flexible top app bars hit a new generator code path: 11 user params × 3 bits each exceeds 31, so the bytecode emits two `$changed` ints in addition to `$default` (trailing `III`). The existing `ComposeBridgeGenerator` already handles arbitrary `$changed` groups, so no generator changes were needed.
- `CustomTab` is a separate class rather than a `Content` property on `Tab` (per rubber-duck feedback — silently shadowing `Text`/`Icon` would be a footgun).
- `PrimaryScrollableTabRow`/`SecondaryScrollableTabRow` declare `IntPtr? scrollState` so the generator's auto-mask leaves the `$default` bit set and Kotlin allocates the default `ScrollState`.

### Out of scope

- State holders: `rememberTopAppBarState`, `rememberBottomAppBarState`, `BottomAppBarState(...)` — support APIs needed only when wiring `scrollBehavior`, which stays defaulted in these facades.
- The legacy 3-arg `BottomAppBar` overloads (`-Snr_uVM`, `-1oL4kX8`, `-e-3WI5M`) — superseded by `-qhFBPw4`.
- `TwoRowsTopAppBar-eXZ4JBQ` — low-level override hook used internally by Medium/Large; not part of the public-control surface.

### Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 26 passed
- `dotnet build src/ComposeNet.Compose` — succeeded
- `dotnet build src/ComposeNet.Sample` — succeeded