### PR TITLE
Fix SegmentedButtonRow $default/$changed slot routing (#42 H6)

### DIFF
--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -283,7 +283,13 @@ using ComposeNet;
 
 // androidx.compose.material3.SegmentedButtonKt.{Single,Multi}ChoiceSegmentedButtonRow-uFdPcIQ:
 // 3 user params, bit 2 (content) always provided. Both row variants
-// share the same signature so they reuse one enum.
+// share the same signature so they reuse one enum. The JNI descriptor
+// is `(...;Composer;II)V` — two trailing `I` slots, so the row HAS a
+// `$default` slot (3 user params → 1 `$changed` group → trailingInts=2
+// > expectedChangedSlots=1). The bound binding's parameter names are
+// misleading: the binder labels position 4 as `p4` ($changed) and
+// position 5 as `_changed` ($default). Call sites pass this enum's
+// mask to the `_changed:` named arg, which is positionally `$default`.
 [assembly: ComposeDefaults("SegmentedButtonRowDefault",
     "modifier", "space", "!content")]
 

--- a/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
@@ -28,6 +28,14 @@ public sealed class MultiChoiceSegmentedButtonRow : ComposableContainer
         int defaults = (int)SegmentedButtonRowDefault.All;
         if (modifier is not null) defaults &= ~(int)SegmentedButtonRowDefault.Modifier;
 
+        // The bound binding's parameter names are misleading. The JNI
+        // descriptor is `(...;Composer;II)V` — two trailing `I` slots —
+        // and the Kotlin layout for a `@Composable` with defaults is
+        // `(...userParams, Composer, $changed, $default)`. So
+        // positionally `p4` is `$changed` and `_changed` is the
+        // `$default` mask. Pass `0` for `$changed` (pessimistic — every
+        // param treated as new) and the `SegmentedButtonRowDefault`
+        // bitmask for `$default`.
         SegmentedButtonKt.MultiChoiceSegmentedButtonRow(
             modifier:  modifier,
             space:     0f,

--- a/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
@@ -37,6 +37,14 @@ public sealed class SingleChoiceSegmentedButtonRow : ComposableContainer
         int defaults = (int)SegmentedButtonRowDefault.All;
         if (modifier is not null) defaults &= ~(int)SegmentedButtonRowDefault.Modifier;
 
+        // The bound binding's parameter names are misleading. The JNI
+        // descriptor is `(...;Composer;II)V` — two trailing `I` slots —
+        // and the Kotlin layout for a `@Composable` with defaults is
+        // `(...userParams, Composer, $changed, $default)`. So
+        // positionally `p4` is `$changed` and `_changed` is the
+        // `$default` mask. Pass `0` for `$changed` (pessimistic — every
+        // param treated as new) and the `SegmentedButtonRowDefault`
+        // bitmask for `$default`.
         SegmentedButtonKt.SingleChoiceSegmentedButtonRow(
             modifier:  modifier,
             space:     0f,


### PR DESCRIPTION
Implements hypothesis **H6** from the investigation of #42 (full analysis in [this comment](https://github.com/jonathanpeppers/compose-net/issues/42#issuecomment-4625348225)). One of three parallel fixes — sibling sessions own H1+H2 and H5.

## Investigation

Decompiled `Xamarin.AndroidX.Compose.Material3Android.dll` 1.4.0.3 with `ilspycmd` to look at the actual binding for `SegmentedButtonKt.{Single,Multi}ChoiceSegmentedButtonRow`. Both have the same shape:

```csharp
[Register("SingleChoiceSegmentedButtonRow-uFdPcIQ",
  "(Landroidx/compose/ui/Modifier;FLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V", "")]
public unsafe static void SingleChoiceSegmentedButtonRow(
    IModifier? modifier, float space, IFunction3 content,
    IComposer? _composer, int p4, int _changed)
```

JNI descriptor `(LModifier;FLFunction3;LComposer;II)V`:
- 3 user params (`modifier`, `space`, `content`)
- 1 `Composer`
- **2** trailing `I` slots

By the rule in `ComposeBridgeGenerator.cs`:
- `expectedChangedSlots = ceil(3/10) = 1`
- `trailingInts = 2`
- `signatureHasDefault = (2 > 1) = true`

So the row **does** have a `$default` slot. Kotlin's `@Composable` layout is `(...userParams, Composer, $changed, $default)`, which means **positionally**:

| Position | Binder name | Kotlin slot                     |
|---------:|:-----------:|:--------------------------------|
| 0–2      | various     | user params                     |
| 3        | `_composer` | `$composer`                     |
| 4        | `p4`        | **`$changed`**                  |
| 5        | `_changed`  | **`$default`** (misleading name)|

So the existing code:

```csharp
SegmentedButtonKt.SingleChoiceSegmentedButtonRow(
    ..., _composer: composer, p4: 0, _changed: defaults);
```

is **already correct**:
- `p4: 0` → `$changed = 0` (pessimistic — Compose treats every param as new).
- `_changed: defaults` → `$default = defaults` (the `SegmentedButtonRowDefault` mask).

## Outcome — case (b) per the assignment

H6's behavioral claim ("`_changed` really is `$changed`, so we're feeding a `$default` mask into the wrong slot") is **incorrect** for these bindings — the binder just chose a confusing name for the `$default` slot. No code-behavior change is needed.

This PR is documentation-only:

- Adds an identical clarifying comment above both `*ChoiceSegmentedButtonRow.Render` call sites explaining the binder-naming quirk so this doesn't get re-flagged in a future audit.
- Tightens the existing `SegmentedButtonRowDefault` comment in `ComposeDefaults.cs` to spell out the same mapping and the bit count (3 user params → 1 `$changed` group → `trailingInts = 2` → `$default` present).

No new bridge, no new enum, no generator change.

## Verification

- ✅ `dotnet test src/ComposeNet.SourceGenerators.Tests` — 32/32 passed (no generator changes).
- ✅ `dotnet build src/ComposeNet.Compose` — clean (3 pre-existing XML-doc warnings, unrelated).
- ✅ `dotnet build src/ComposeNet.Sample` — clean.

## Constraints respected

- Did **not** touch `Scaffold.cs` (H5, sibling session).
- Did **not** touch `ComposableLambda*.cs` (H1+H2, sibling session).
- Did **not** touch `SegmentedButton.cs` (H3, deferred to #43).

Refs #42.