### PR TITLE
Don't mutate Scaffold.Body during composition (#42 H5)

### DIFF
--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -49,16 +49,35 @@ public sealed class Scaffold : ComposableNode
 
         // Material 3's Scaffold passes PaddingValues as the first arg of
         // its content lambda — body must apply it to avoid rendering
-        // behind the top/bottom bars. Prepend a runtime
+        // behind the top/bottom bars. Compose a runtime
         // `Modifier.padding(values)` onto Body's existing chain so the
         // padding and Body's own modifiers compose on the same layout
         // node, mirroring Kotlin's
         // `Column(Modifier.padding(paddingValues)) { ... }`.
+        //
+        // ScaffoldLayout is a SubcomposeLayout, so this content callback
+        // runs once per measure pass (and again on remeasure), not once
+        // per composition. We snapshot-and-restore `body.Modifier`
+        // locally inside the lambda instead of using `PrependModifier`,
+        // which would leave mutated state on the user-supplied Body
+        // node between measure passes (see #42 H5). `Modifier` is a
+        // plain auto-property with no side effects, and composition
+        // is single-threaded, so the temporary mutation is invisible
+        // outside this synchronous block.
         var body = Body;
         var content = new ComposableLambda3((paddingHandle, c) =>
         {
-            body.PrependModifier(Modifier.Companion.Padding(paddingHandle));
-            body.Render(c);
+            var saved = body.Modifier;
+            var padding = Modifier.Companion.Padding(paddingHandle);
+            body.Modifier = saved is null ? padding : padding.Then(saved);
+            try
+            {
+                body.Render(c);
+            }
+            finally
+            {
+                body.Modifier = saved;
+            }
         });
 
         // Always pass non-null slot lambdas. Toggling between Compose's


### PR DESCRIPTION
Fixes hypothesis **H5** from the investigation of #42 (full analysis: https://github.com/jonathanpeppers/compose-net/issues/42#issuecomment-4625348225). One of three parallel fixes — **H1+H2** and **H6** are tracked in separate PRs.

## The bug

`Scaffold.Render` previously called `body.PrependModifier(...)` *inside* its `ComposableLambda3` content callback:

```csharp
var content = new ComposableLambda3((paddingHandle, c) =>
{
    body.PrependModifier(Modifier.Companion.Padding(paddingHandle));
    body.Render(c);
});
```

Material 3's `ScaffoldLayout` is a `SubcomposeLayout`, so that lambda runs **once per measure pass** (and again on remeasure), not once per composition. Each invocation mutates `body._prepended` — state on the user-supplied `Body` node — during composition. `PrependModifier` uses replace semantics, but the field is only cleared by `BuildModifier`; if `Body`'s `Render` is a wrapper that doesn't consume the modifier (e.g. `MaterialTheme`, drawer sheets — see the caveat in `PrependModifier`'s xmldoc), the padding leaks past the lambda and lands on whatever calls `Body` next.

Not the believed root cause of the `ArrayIndexOutOfBoundsException` in #42 (H1/H2/H6 rank higher), but a real latent bug and plausible secondary trigger.

## The fix — Option 1 (snapshot + restore)

```csharp
var content = new ComposableLambda3((paddingHandle, c) =>
{
    var saved = body.Modifier;
    var padding = Modifier.Companion.Padding(paddingHandle);
    body.Modifier = saved is null ? padding : padding.Then(saved);
    try     { body.Render(c); }
    finally { body.Modifier = saved; }
});
```

- `Modifier` is a plain auto-property (no events, no INPC).
- Composition is single-threaded.
- `padding.Then(saved)` runs padding ops first, then the user's ops — preserves the exact ordering `PrependModifier` had on consumption by `BuildModifier`.
- `Modifier.Then` rejects null, hence the `saved is null` guard.
- `try`/`finally` restores `body.Modifier` even if `body.Render` or the JNI/Compose interop underneath throws.

### Why not the other options

- **Wrap `body` in a `Box`** with the padding modifier — allocates a layout node per measure pass and changes the slot-table identity of the body subtree vs. today's behaviour.
- **Plumb `PaddingValues` through a `ComposableNode` overload** — most disciplined long-term fix, but touches every container facade. Out of scope for H5.
- **`PrependModifier` with `try`/`finally` restore** — `_prepended` is `private`; restoring it from outside `ComposableNode` would require a new public/internal API for a single call site.

## Sibling sites

`grep -n PrependModifier src/ComposeNet.Compose` confirms `Scaffold.cs` is the **only** in-lambda mutator. `AppendModifier` has zero callers anywhere. No other facade has this anti-pattern, so no other files are touched.

`Append/PrependModifier` themselves remain on `ComposableNode` — they're public API; removing them is out of scope for H5 and would be a breaking change.

## Out of scope (explicitly not touched)

- `ComposableLambda*.cs` — owned by **H1+H2** (#43).
- `_changed: defaults` lines in `SingleChoiceSegmentedButtonRow.cs` / `MultiChoiceSegmentedButtonRow.cs` — owned by **H6**.
- `Scaffold`'s slot-default bitmask logic.

## Validation

- ✅ `dotnet test src/ComposeNet.SourceGenerators.Tests` — 32/32 passed.
- ✅ `dotnet build src/ComposeNet.Compose` — 0 errors (3 pre-existing unrelated XML-doc warnings).
- ✅ `dotnet build src/ComposeNet.Sample` — 0 errors, 0 warnings (Android workload was available locally).

A regression test would ideally assert that `Scaffold.Body.Modifier` is unchanged after the content lambda runs N times, but the existing test project only targets `net10.0` with synthetic compilations for the source generators — adding a facade-level test for this would require new test infrastructure outside H5's scope.

---

**Follow-up:** #46 tracks the perf cleanup (Option 3 from the H5 prompt — plumb `PaddingValues` through `ComposableNode` to avoid per-measure `Modifier` chain allocations). Out of scope for H5 but obsoletes this snapshot/restore once it lands.