### PR TITLE
Bind LazyColumn, LazyRow, LazyVerticalGrid, LazyHorizontalGrid

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -266,12 +266,12 @@ method**; call the generated C# entry point instead (see
   ```csharp
   new Column { new Text("Hi"), new Button(onClick: …) { new Text("Tap") } }
   ```
-- Wrap Kotlin lambdas with `ComposableLambda0/1/2/3` (existing
+- Wrap Kotlin lambdas with `ComposableLambda0/1/2/3/4` (existing
   helpers — don't hand-roll new lambda adapters).
-- **Never construct `ComposableLambda2` / `ComposableLambda3` directly
-  inside a `Render(IComposer composer)` body.** Route every
-  `@Composable` slot lambda through `ComposableLambdas.Wrap2` /
-  `ComposableLambdas.Wrap3` so Compose's own `composableLambda` factory
+- **Never construct `ComposableLambda2` / `ComposableLambda3` /
+  `ComposableLambda4` directly inside a `Render(IComposer composer)`
+  body.** Route every `@Composable` slot lambda through the
+  appropriate helper in `ComposableLambdas` so Compose's own factory
   owns identity across recompositions. `SubcomposeLayout`-backed
   composables (`Scaffold`, `BottomSheetScaffold`, `ModalNavigationDrawer`,
   …) cache subcomposed content keyed by lambda identity; a fresh
@@ -280,17 +280,33 @@ method**; call the generated C# entry point instead (see
   (see #42). The helpers derive a unique slot-table key from
   `[CallerLineNumber]` + `[CallerFilePath]` automatically — no key
   argument needed.
+
+  Two helper families exist because Compose has two factory functions
+  that are not interchangeable:
+
+  | Helper | Factory it calls | When to use |
+  |--------|------------------|-------------|
+  | `Wrap2(composer, …)` / `Wrap3(composer, …)` | `composableLambda(composer, key, tracked, block)` | The lambda is built and invoked **synchronously inside the same composition pass** as `Render` — content slots like `topBar`, `title`, button content, `Column`/`Row`/`Box` children. The factory writes the wrapper into the active composer's slot table. |
+  | `Instantiate4(…)` (no composer param) | `composableLambdaInstance(key, tracked, block)` | The lambda is built during `Render` but **invoked later, outside the current composition** — `LazyListScope.items` / `LazyGridScope.items` `itemContent`, which Compose realizes at measure time inside the lazy list's `rememberLazyListItemProviderLambda`. The composer captured by the closure is no longer active by then, so calling `composableLambda(composer, …)` crashes with "Expected applyChanges() to have been called". `Instantiate4` skips the slot table and just allocates — exactly what Kotlin's inline `LazyListScope.items(…)` expands to. |
+
   ```csharp
   // Wrong — fresh identity every recomposition:
   var content = new ComposableLambda3(c => RenderChildren(c));
   // Right — stable identity owned by the runtime:
   var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+
+  // Wrong — Wrap4 would need a composer, but the call site (inside
+  // scope.Items) runs at measure time, after the outer composer is stale:
+  itemContent: new ComposableLambda4((_, idx, c) => …)
+  // Right — composer-less factory, safe to call from a DSL builder:
+  itemContent: ComposableLambdas.Instantiate4((_, idx, c) => …)
   ```
-  `ComposableLambda0` (onClick) and `ComposableLambda1`
-  (onValueChange / onCheckedChange) callbacks are **not** `@Composable`
-  and must stay raw — wrapping them would inject
-  `startRestartGroup`/`endRestartGroup` machinery into code that runs
-  outside composition.
+
+  `ComposableLambda0` (onClick), `ComposableLambda1` (onValueChange /
+  onCheckedChange / LazyListScope / LazyGridScope DSL builders) callbacks
+  are **not** `@Composable` and must stay raw — wrapping them would
+  inject `startRestartGroup`/`endRestartGroup` machinery into code that
+  runs outside composition.
 - **Sibling `Render()` calls inside a loop need per-position slot
   keys.** `ComposableContainer.RenderChildren` already wraps each child
   in `composer.StartReplaceableGroup(i)` / `EndReplaceableGroup()`. Any

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -127,7 +127,12 @@ generator fill it in.
    (e.g. `Modifier.padding`, `RoundedCornerShape`), declare the params
    positionally — the generator treats the first user param as an
    extension receiver only when both it's `IntPtr` and the first JNI
-   sigParam is an object (`L`).
+   sigParam is an object (`L`). For stripped Kotlin constructors whose
+   parameters were mangled by inline-class compilation
+   (e.g. `GridCells.Adaptive(Dp)`), set `JvmName = "<init>"`; the
+   generator emits `GetMethodID` + `NewObject` and wraps the returned
+   handle with `Java.Lang.Object.GetObject<TReturn>(.., TransferLocalRef)`
+   so the declared C# return type is the constructed object, not `void`.
 2. **If** the underlying `@Composable` has at least one defaultable
    Kotlin parameter (i.e. the JNI signature has a trailing `$default`
    `I` slot after `$changed`), set `Defaults = typeof(XxxDefault)` and
@@ -190,6 +195,22 @@ receiver slot because the first sigParam is `L`. For a non-extension
 plain static (e.g. `RoundedCornerShape(Dp)` whose signature starts
 with `F`, not `L`), the first user param is just a regular argument.
 
+Example (Kotlin constructor — `JvmName = "<init>"`):
+```csharp
+[ComposeBridge(
+    Class     = "androidx/compose/foundation/lazy/grid/GridCells$Adaptive",
+    JvmName   = "<init>",
+    Signature = "(F)V")]
+internal static partial IGridCells GridCellsAdaptive(float minSizeDp);
+```
+The signature must end with `V` (JVM constructors return void at the
+bytecode level even though the call hands back a handle), and the C#
+return type must be non-`void` — that's the type the generator passes
+to `Java.Lang.Object.GetObject<T>(.., TransferLocalRef)`. Ctor bridges
+cannot declare a Composer parameter, `Defaults`, or `InstanceField`
+(the generator rejects each with CN2006). All user params map
+positionally to ctor argument slots; there is no extension receiver.
+
 ### Conventions the generator relies on
 
 - For `@Composable` bridges, `composer` is the **last** C# parameter.
@@ -231,7 +252,7 @@ with `F`, not `L`), the first user param is just a regular argument.
 
 `ModifierHandle` (a managed-side `IModifier? → IntPtr` conversion) and
 `ModifierCompanionInstance` (a static field lookup, not a method
-invocation) don't fit any of the four `[ComposeBridge]` shapes and
+invocation) don't fit any of the five `[ComposeBridge]` shapes and
 remain raw JNI. Two-step bridges like `ModifierClipRoundedCorners`
 (which composes `RoundedCornerShape` + `ClipKt.clip` and manages an
 intermediate `Shape` local ref) also stay hand-written — their shape
@@ -246,6 +267,7 @@ isn't a single Kotlin call.
 | CN2003  | Bridge partial-method param doesn't match any Kotlin name.  |
 | CN2004  | `[ComposeBridge]` has a malformed JNI signature.            |
 | CN2005  | `Defaults` disagrees with the JNI `$default` slot.          |
+| CN2006  | Constructor bridge shape requirements not met.              |
 
 **When you add a new generator diagnostic, also update this table in
 `.github/copilot-instructions.md` (and the matching table for the

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ as C# types:
 | Category    | Composables                                                                                       |
 | ----------- | ------------------------------------------------------------------------------------------------- |
 | Layout      | `Column`, `MaterialTheme`, `Surface`, `Card`                                                      |
+| Lazy lists  | `LazyColumn<T>`, `LazyRow<T>`, `LazyVerticalGrid<T>`, `LazyHorizontalGrid<T>` (+ `GridCells`)     |
 | Buttons     | `Button`, `IconButton`, `FloatingActionButton`                                                    |
 | Text        | `Text`, `TextField`, `OutlinedTextField`                                                          |
 | Chips       | `AssistChip`, `FilterChip`, `InputChip`, `SuggestionChip`                                         |

--- a/src/ComposeNet.Compose/ComposableLambda4.cs
+++ b/src/ComposeNet.Compose/ComposableLambda4.cs
@@ -1,0 +1,30 @@
+using Android.Runtime;
+using AndroidX.Compose.Runtime;
+using Kotlin.Jvm.Functions;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Function4&lt;Scope, T, Composer, Integer, Unit&gt; — the shape Compose's
+/// <c>LazyListScope.items</c> and <c>LazyGridScope.items</c> use for
+/// their per-item content lambda. <c>p0</c> is the lazy item / grid item
+/// scope (raw <see cref="System.IntPtr"/>), <c>p1</c> is the boxed
+/// per-item value (an <see cref="Java.Lang.Integer"/> index for the
+/// count-based overload, or the boxed user item for the list-based one),
+/// <c>p2</c> is the composer, <c>p3</c> is <c>$changed</c>.
+/// </summary>
+[Register("composenet/compose/ComposableLambda4")]
+internal sealed class ComposableLambda4 : Java.Lang.Object, IFunction4
+{
+    readonly System.Action<IntPtr, Java.Lang.Object?, IComposer> _body;
+
+    public ComposableLambda4(System.Action<IntPtr, Java.Lang.Object?, IComposer> body) => _body = body;
+
+    public Java.Lang.Object? Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1, Java.Lang.Object? p2, Java.Lang.Object? p3)
+    {
+        System.ArgumentNullException.ThrowIfNull(p2);
+        var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p2);
+        _body(p0?.Handle ?? IntPtr.Zero, p1, composer);
+        return null;
+    }
+}

--- a/src/ComposeNet.Compose/ComposableLambdas.cs
+++ b/src/ComposeNet.Compose/ComposableLambdas.cs
@@ -8,37 +8,43 @@ namespace ComposeNet;
 
 /// <summary>
 /// Helpers that wrap <see cref="ComposableLambda2"/> /
-/// <see cref="ComposableLambda3"/> @Composable content lambdas through
-/// Compose's own <c>ComposableLambdaKt.ComposableLambda</c> factory so
-/// the runtime owns lambda identity across recompositions.
+/// <see cref="ComposableLambda3"/> / <see cref="ComposableLambda4"/>
+/// @Composable content lambdas through one of Compose's two factory
+/// functions so the runtime owns lambda identity across recompositions.
 ///
-/// <para>The factory does, internally:</para>
-/// <list type="number">
-///   <item><description><c>composer.startReplaceableGroup(key)</c></description></item>
-///   <item><description>Looks up a remembered slot; on first reach it
-///     stores a fresh <c>ComposableLambdaImpl(key, tracked)</c>, otherwise
-///     it reuses the stored instance.</description></item>
-///   <item><description>Updates the impl's <c>block</c> field to point
-///     at the fresh inner <see cref="ComposableLambda2"/> /
-///     <see cref="ComposableLambda3"/> we just allocated.</description></item>
-///   <item><description><c>composer.endReplaceableGroup()</c></description></item>
-///   <item><description>Returns the stable impl.</description></item>
+/// <para>Two factories exist and they are not interchangeable:</para>
+/// <list type="bullet">
+///   <item><description><c>ComposableLambdaKt.ComposableLambda(composer,
+///     key, tracked, block)</c> — used by <see cref="Wrap2"/> /
+///     <see cref="Wrap3(IComposer, Action{IComposer}, int, string)"/>.
+///     Stores/retrieves the wrapper from the current composition's slot
+///     table at the given key; requires an *active* composer. Use for
+///     content slots that are evaluated synchronously during the outer
+///     composition pass (e.g. <c>topBar</c>, <c>title</c>, button
+///     content).</description></item>
+///   <item><description><c>ComposableLambdaKt.ComposableLambdaInstance(
+///     key, tracked, block)</c> — used by <see cref="Instantiate4"/> and
+///     by <c>ComposeActivity.SetContent</c>. Allocates a fresh wrapper
+///     each call without touching any composer; safe to invoke from
+///     outside composition. Use for content that runs at measure time
+///     or in a subcomposition (e.g. <c>LazyListScope.items</c> /
+///     <c>LazyGridScope.items</c> <c>itemContent</c>, which Compose
+///     realizes inside the lazy list's
+///     <c>rememberLazyListItemProviderLambda</c> long after the outer
+///     <c>Render</c> has returned).</description></item>
 /// </list>
 ///
-/// <para>The result is an <see cref="IComposableLambda"/> whose identity
-/// is stable across recompositions even though we allocate a fresh
-/// inner adapter each call — exactly what
-/// <c>SubcomposeLayout</c> needs to keep its per-lambda-identity content
-/// cache from thrashing.</para>
-///
 /// <para><b>Convention:</b> never construct
-/// <see cref="ComposableLambda2"/> / <see cref="ComposableLambda3"/>
-/// directly inside a <c>Render</c> method — always route through
-/// <see cref="Wrap2"/> / <see cref="Wrap3(IComposer, Action{IComposer}, int, string)"/>.
-/// The non-@Composable adapters <see cref="ComposableLambda0"/> /
-/// <see cref="ComposableLambda1"/> (onClick / onValueChange callbacks)
-/// are NOT wrapped — they run outside composition and would crash
-/// inside Compose's restart-group machinery.</para>
+/// <see cref="ComposableLambda2"/> / <see cref="ComposableLambda3"/> /
+/// <see cref="ComposableLambda4"/> directly inside a <c>Render</c>
+/// method — always route through <see cref="Wrap2"/> /
+/// <see cref="Wrap3(IComposer, Action{IComposer}, int, string)"/> /
+/// <see cref="Instantiate4"/>. The non-@Composable adapters
+/// <see cref="ComposableLambda0"/> / <see cref="ComposableLambda1"/>
+/// (onClick / onValueChange callbacks, plus the LazyListScope /
+/// LazyGridScope DSL builders which are *not* @Composable) are NOT
+/// wrapped — they run outside composition and would crash inside
+/// Compose's restart-group machinery.</para>
 /// </summary>
 internal static class ComposableLambdas
 {
@@ -88,4 +94,30 @@ internal static class ComposableLambdas
         => (IFunction3)ComposableLambdaKt.ComposableLambda(
             composer, HashCode.Combine(line, file), tracked: true,
             block: new ComposableLambda3(body));
+
+    /// <summary>
+    /// Build an identity-stable <see cref="IFunction4"/> wrapper for the
+    /// <c>Function4&lt;LazyItemScope, Int, Composer, Int, Unit&gt;</c>
+    /// @Composable shape used by <c>LazyListScope.items</c> and
+    /// <c>LazyGridScope.items</c> <c>itemContent</c>. <c>p0</c> is the
+    /// lazy item scope handle, <c>p1</c> is the boxed item index,
+    /// <c>p2</c> is the composer.
+    ///
+    /// <para>Uses <c>ComposableLambdaInstance</c> (not
+    /// <c>ComposableLambda</c>) because the lazy list DSL builder runs
+    /// at measure time inside the list's
+    /// <c>rememberLazyListItemProviderLambda</c>, *not* inside the outer
+    /// <c>Render</c>'s composition pass. There is no active composer at
+    /// the call site, so we can't look up a slot-table entry — the
+    /// <c>Instance</c> factory allocates a fresh wrapper without one,
+    /// which is exactly what Kotlin's inline
+    /// <c>LazyListScope.items(...)</c> extension expands to.</para>
+    /// </summary>
+    public static IFunction4 Instantiate4(
+        Action<IntPtr, Java.Lang.Object?, IComposer> body,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => (IFunction4)ComposableLambdaKt.ComposableLambdaInstance(
+            key: HashCode.Combine(line, file), tracked: true,
+            block: new ComposableLambda4(body));
 }

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -2,7 +2,6 @@ using Android.Runtime;
 using AndroidX.Compose.Foundation.Lazy.Grid;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI;
-using Java.Interop;
 using Kotlin.Jvm.Functions;
 
 namespace ComposeNet;
@@ -52,32 +51,16 @@ internal static partial class ComposeBridges
     // androidx.compose.foundation.lazy.grid.GridCells$Adaptive — the
     // only constructor takes a Dp (`@JvmInline value class Dp(val value: Float)`),
     // mangled to `<init>(F)V` in bytecode, and the binder strips it.
-    // Hand-written because the [ComposeBridge] generator only handles
-    // static methods, not constructors. `GridCells.Fixed(int)` doesn't
-    // need a bridge (no inline-class mangling); the binder exposes its
-    // ctor directly.
-    static IntPtr s_gridCellsAdaptiveClass;
-    static IntPtr s_gridCellsAdaptiveCtor;
-
-    internal static unsafe IGridCells GridCellsAdaptive(float minSizeDp)
-    {
-        // Guard on the ctor handle (last field written) so a concurrent
-        // first-call can't observe a non-zero class handle while the
-        // ctor ID is still null and crash inside NewObject.
-        if (s_gridCellsAdaptiveCtor == IntPtr.Zero)
-        {
-            IntPtr local = JNIEnv.FindClass("androidx/compose/foundation/lazy/grid/GridCells$Adaptive");
-            IntPtr globalCls = JNIEnv.NewGlobalRef(local);
-            JNIEnv.DeleteLocalRef(local);
-            IntPtr ctor = JNIEnv.GetMethodID(globalCls, "<init>", "(F)V");
-            s_gridCellsAdaptiveClass = globalCls;
-            s_gridCellsAdaptiveCtor  = ctor;
-        }
-        JValue* args = stackalloc JValue[1];
-        args[0] = new JValue(minSizeDp);
-        IntPtr handle = JNIEnv.NewObject(s_gridCellsAdaptiveClass, s_gridCellsAdaptiveCtor, args);
-        return Java.Lang.Object.GetObject<IGridCells>(handle, JniHandleOwnership.TransferLocalRef)!;
-    }
+    // The source generator's constructor shape emits FindClass +
+    // GetMethodID("<init>") + NewObject + Java.Lang.Object.GetObject<T>
+    // with TransferLocalRef. `GridCells.Fixed(int)` doesn't need a
+    // bridge (no inline-class mangling); the binder exposes its ctor
+    // directly.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/lazy/grid/GridCells$Adaptive",
+        JvmName   = "<init>",
+        Signature = "(F)V")]
+    internal static partial IGridCells GridCellsAdaptive(float minSizeDp);
 
     // androidx.compose.foundation.layout.PaddingKt — the Dp-taking
     // overloads have hashed JVM names from the inline-class compiler

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1,4 +1,5 @@
 using Android.Runtime;
+using AndroidX.Compose.Foundation.Lazy.Grid;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI;
 using Java.Interop;
@@ -46,6 +47,36 @@ internal static partial class ComposeBridges
         // Returning a NEW local ref each call so callers can DeleteLocalRef
         // it uniformly while walking the op chain.
         return JNIEnv.NewLocalRef(s_modifierCompanionInstance);
+    }
+
+    // androidx.compose.foundation.lazy.grid.GridCells$Adaptive — the
+    // only constructor takes a Dp (`@JvmInline value class Dp(val value: Float)`),
+    // mangled to `<init>(F)V` in bytecode, and the binder strips it.
+    // Hand-written because the [ComposeBridge] generator only handles
+    // static methods, not constructors. `GridCells.Fixed(int)` doesn't
+    // need a bridge (no inline-class mangling); the binder exposes its
+    // ctor directly.
+    static IntPtr s_gridCellsAdaptiveClass;
+    static IntPtr s_gridCellsAdaptiveCtor;
+
+    internal static unsafe IGridCells GridCellsAdaptive(float minSizeDp)
+    {
+        // Guard on the ctor handle (last field written) so a concurrent
+        // first-call can't observe a non-zero class handle while the
+        // ctor ID is still null and crash inside NewObject.
+        if (s_gridCellsAdaptiveCtor == IntPtr.Zero)
+        {
+            IntPtr local = JNIEnv.FindClass("androidx/compose/foundation/lazy/grid/GridCells$Adaptive");
+            IntPtr globalCls = JNIEnv.NewGlobalRef(local);
+            JNIEnv.DeleteLocalRef(local);
+            IntPtr ctor = JNIEnv.GetMethodID(globalCls, "<init>", "(F)V");
+            s_gridCellsAdaptiveClass = globalCls;
+            s_gridCellsAdaptiveCtor  = ctor;
+        }
+        JValue* args = stackalloc JValue[1];
+        args[0] = new JValue(minSizeDp);
+        IntPtr handle = JNIEnv.NewObject(s_gridCellsAdaptiveClass, s_gridCellsAdaptiveCtor, args);
+        return Java.Lang.Object.GetObject<IGridCells>(handle, JniHandleOwnership.TransferLocalRef)!;
     }
 
     // androidx.compose.foundation.layout.PaddingKt — the Dp-taking
@@ -97,6 +128,33 @@ internal static partial class ComposeBridges
         JvmName   = "fillMaxSize",
         Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
     internal static partial IntPtr ModifierFillMaxSize(IntPtr modifier, float fraction);
+
+    // androidx.compose.foundation.layout.SizeKt — Dp-taking sizing
+    // modifiers. The JVM names are mangled like padding's because
+    // `Dp` is an inline class (`@JvmInline value class Dp(val value: Float)`).
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "height-3ABfNKs",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierHeight(IntPtr modifier, float dp);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "width-3ABfNKs",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierWidth(IntPtr modifier, float dp);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "size-3ABfNKs",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierSizeAll(IntPtr modifier, float dp);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "size-VpY3zN4",
+        Signature = "(Landroidx/compose/ui/Modifier;FF)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierSizeWH(IntPtr modifier, float width, float height);
 
     // androidx.compose.foundation.layout.WindowInsetsPadding_androidKt —
     // Modifier extensions that read WindowInsets from CompositionLocals

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -27,6 +27,8 @@
 // this comment can be deleted.
 
 using AndroidX.Compose.Foundation.Layout;
+using AndroidX.Compose.Foundation.Lazy;
+using AndroidX.Compose.Foundation.Lazy.Grid;
 using AndroidX.Compose.Material3;
 using ComposeNet;
 
@@ -37,6 +39,23 @@ using ComposeNet;
 [assembly: ComposeDefaults<DividerKt>("VerticalDivider", "VerticalDividerDefault")]
 [assembly: ComposeDefaults<IconKt>("Icon", "IconDefault")]
 [assembly: ComposeDefaults<MaterialThemeKt>("MaterialTheme", "MaterialThemeDefault")]
+
+// androidx.compose.foundation.lazy.LazyDslKt — the LazyColumn / LazyRow
+// @Composable functions take no inline-class params (modifier/state/etc.
+// are all reference types or plain bools), so the binder exposes the
+// Kt class and the generic generator path Just Works. 9 optional params
+// per overload (modifier through overscrollEffect; content lambda is
+// skipped as IFunction1).
+[assembly: ComposeDefaults<LazyDslKt>("LazyColumn", "LazyColumnDefault")]
+[assembly: ComposeDefaults<LazyDslKt>("LazyRow", "LazyRowDefault")]
+
+// androidx.compose.foundation.lazy.grid.LazyGridDslKt — same story for
+// LazyVerticalGrid / LazyHorizontalGrid, but with a required first
+// `columns` / `rows` IGridCells param. The facade always supplies that
+// param and clears the bit (mirror of how Icon clears
+// IconDefault.ImageVector / IconDefault.ContentDescription).
+[assembly: ComposeDefaults<LazyGridDslKt>("LazyVerticalGrid", "LazyVerticalGridDefault")]
+[assembly: ComposeDefaults<LazyGridDslKt>("LazyHorizontalGrid", "LazyHorizontalGridDefault")]
 
 // androidx.compose.foundation.ImageKt.Image (Painter overload): all four
 // `Image` Kotlin overloads share the JVM name `Image` and only differ by

--- a/src/ComposeNet.Compose/GridCells.cs
+++ b/src/ComposeNet.Compose/GridCells.cs
@@ -1,0 +1,32 @@
+using AndroidX.Compose.Foundation.Lazy.Grid;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Factory helpers for <see cref="IGridCells"/>, the column/row-count
+/// strategy for <see cref="LazyVerticalGrid{T}"/> and
+/// <see cref="LazyHorizontalGrid{T}"/>. Mirrors the Kotlin sealed class
+/// <c>GridCells</c> with its <c>Fixed</c> and <c>Adaptive</c> subclasses:
+/// <code>
+/// new LazyVerticalGrid&lt;int&gt;(GridCells.Fixed(3), items, i =&gt; new Text($"{i}"))
+/// new LazyVerticalGrid&lt;int&gt;(GridCells.Adaptive(80f), items, i =&gt; new Text($"{i}"))
+/// </code>
+/// </summary>
+public static class GridCells
+{
+    /// <summary>
+    /// Lay out a fixed number of equally-sized cells across the cross
+    /// axis (column count for <see cref="LazyVerticalGrid{T}"/>, row
+    /// count for <see cref="LazyHorizontalGrid{T}"/>).
+    /// </summary>
+    public static IGridCells Fixed(int count) => new GridCellsFixed(count);
+
+    /// <summary>
+    /// Lay out as many equally-sized cells as fit, given a minimum cell
+    /// size (in dp) along the cross axis. The Kotlin
+    /// <c>GridCells.Adaptive(Dp)</c> constructor is stripped from the
+    /// binding (inline-class <c>Dp</c>), so this goes through a
+    /// hand-written JNI bridge in <c>ComposeBridges</c>.
+    /// </summary>
+    public static IGridCells Adaptive(float minSizeDp) => ComposeBridges.GridCellsAdaptive(minSizeDp);
+}

--- a/src/ComposeNet.Compose/LazyColumn.cs
+++ b/src/ComposeNet.Compose/LazyColumn.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using AndroidX.Compose.Foundation.Lazy;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Foundation <c>LazyColumn</c> — the lazy equivalent of <see cref="Column"/>.
+/// Only the items currently visible (plus a small lookahead) are
+/// composed and laid out, so it's the right choice any time the child
+/// count exceeds what fits on screen.
+///
+/// The facade is data-driven instead of collection-init: you pass the
+/// items list and a per-item content callback at construction time.
+/// Compose handles scrolling automatically — no scroll-state plumbing
+/// required for the common case.
+///
+/// <code>
+/// new LazyColumn&lt;int&gt;(
+///     items: Enumerable.Range(0, 1000).ToList(),
+///     itemContent: i =&gt; new Text($"Row {i}"))
+/// </code>
+///
+/// Set <see cref="State"/> (typically the result of a remembered
+/// <see cref="LazyListState"/>) to read scroll position or drive
+/// programmatic scrolling. When left null Compose creates its own
+/// internal state via the Kotlin default <c>rememberLazyListState()</c>.
+/// </summary>
+public sealed class LazyColumn<T> : ComposableNode
+{
+    readonly IReadOnlyList<T> _items;
+    readonly Func<T, ComposableNode> _itemContent;
+
+    public LazyColumn(IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
+    {
+        _items       = items       ?? throw new ArgumentNullException(nameof(items));
+        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+    }
+
+    /// <summary>
+    /// Optional scroll state. Leave null to let Compose substitute its
+    /// own remembered state.
+    /// </summary>
+    public LazyListState? State { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+        var content  = new ComposableLambda1(scopeObj =>
+        {
+            var scope = Android.Runtime.Extensions.JavaCast<ILazyListScope>(scopeObj!);
+            // contentType is non-nullable in Kotlin (defaults to { null }),
+            // so we always provide a stub; key is nullable and we pass null
+            // to keep the Compose-default positional keying.
+            // itemContent IS @Composable but runs at measure time inside the
+            // lazy list's SubcomposeLayout, so route through Instantiate4
+            // (composer-less ComposableLambdaInstance) — Wrap4 would crash
+            // because there's no active composer once the DSL builder runs.
+            scope.Items(
+                _items.Count,
+                key:         null,
+                contentType: new ComposableLambda1(_ => { }),
+                itemContent: ComposableLambdas.Instantiate4((_, indexBoxed, comp) =>
+                {
+                    var i = ((Java.Lang.Integer)indexBoxed!).IntValue();
+                    _itemContent(_items[i]).Render(comp);
+                }));
+        });
+
+        int defaults = (int)LazyColumnDefault.All;
+        if (modifier is not null) defaults &= ~(int)LazyColumnDefault.Modifier;
+        if (State    is not null) defaults &= ~(int)LazyColumnDefault.State;
+
+        LazyDslKt.LazyColumn(
+            modifier:            modifier,
+            state:               State,
+            contentPadding:      null,
+            reverseLayout:       false,
+            verticalArrangement: null,
+            horizontalAlignment: null,
+            flingBehavior:       null,
+            userScrollEnabled:   true,
+            overscrollEffect:    null,
+            content:             content,
+            _composer:           composer,
+            p11:                 0,
+            _changed:            defaults);
+    }
+}

--- a/src/ComposeNet.Compose/LazyHorizontalGrid.cs
+++ b/src/ComposeNet.Compose/LazyHorizontalGrid.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using AndroidX.Compose.Foundation.Lazy.Grid;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Foundation <c>LazyHorizontalGrid</c> — lazy 2D grid that scrolls
+/// horizontally. Cells are arranged into <see cref="GridCells.Fixed"/>
+/// rows (count) or <see cref="GridCells.Adaptive"/> rows (minimum cell
+/// height in dp); items flow top-to-bottom, left-to-right.
+///
+/// <code>
+/// new LazyHorizontalGrid&lt;int&gt;(
+///     rows:        GridCells.Fixed(2),
+///     items:       items,
+///     itemContent: i =&gt; new Text($"{i}"))
+/// </code>
+/// </summary>
+public sealed class LazyHorizontalGrid<T> : ComposableNode
+{
+    readonly IGridCells _rows;
+    readonly IReadOnlyList<T> _items;
+    readonly Func<T, ComposableNode> _itemContent;
+
+    public LazyHorizontalGrid(IGridCells rows, IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
+    {
+        _rows        = rows        ?? throw new ArgumentNullException(nameof(rows));
+        _items       = items       ?? throw new ArgumentNullException(nameof(items));
+        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+    }
+
+    /// <summary>
+    /// Optional scroll state. Leave null to let Compose substitute its
+    /// own remembered state.
+    /// </summary>
+    public LazyGridState? State { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+        var content  = new ComposableLambda1(scopeObj =>
+        {
+            var scope = Android.Runtime.Extensions.JavaCast<ILazyGridScope>(scopeObj!);
+            scope.Items(
+                _items.Count,
+                key:         null,
+                span:        null,
+                contentType: new ComposableLambda1(_ => { }),
+                p4:          ComposableLambdas.Instantiate4((_, indexBoxed, comp) =>
+                {
+                    var i = ((Java.Lang.Integer)indexBoxed!).IntValue();
+                    _itemContent(_items[i]).Render(comp);
+                }));
+        });
+
+        int defaults = (int)LazyHorizontalGridDefault.All & ~(int)LazyHorizontalGridDefault.Rows;
+        if (modifier is not null) defaults &= ~(int)LazyHorizontalGridDefault.Modifier;
+        if (State    is not null) defaults &= ~(int)LazyHorizontalGridDefault.State;
+
+        LazyGridDslKt.LazyHorizontalGrid(
+            rows:                  _rows,
+            modifier:              modifier,
+            state:                 State,
+            contentPadding:        null,
+            reverseLayout:         false,
+            horizontalArrangement: null,
+            verticalArrangement:   null,
+            flingBehavior:         null,
+            userScrollEnabled:     true,
+            overscrollEffect:      null,
+            content:               content,
+            _composer:             composer,
+            p12:                   0,
+            _changed:              0,
+            _changed1:             defaults);
+    }
+}

--- a/src/ComposeNet.Compose/LazyRow.cs
+++ b/src/ComposeNet.Compose/LazyRow.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using AndroidX.Compose.Foundation.Lazy;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Foundation <c>LazyRow</c> — horizontal mirror of <see cref="LazyColumn{T}"/>.
+/// Use when the item count along the horizontal axis exceeds the screen
+/// width (chip rows, image carousels, etc.).
+///
+/// <code>
+/// new LazyRow&lt;Photo&gt;(items: photos, itemContent: p =&gt; new Image(p.Url))
+/// </code>
+/// </summary>
+public sealed class LazyRow<T> : ComposableNode
+{
+    readonly IReadOnlyList<T> _items;
+    readonly Func<T, ComposableNode> _itemContent;
+
+    public LazyRow(IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
+    {
+        _items       = items       ?? throw new ArgumentNullException(nameof(items));
+        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+    }
+
+    /// <summary>
+    /// Optional scroll state. Leave null to let Compose substitute its
+    /// own remembered state.
+    /// </summary>
+    public LazyListState? State { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+        var content  = new ComposableLambda1(scopeObj =>
+        {
+            var scope = Android.Runtime.Extensions.JavaCast<ILazyListScope>(scopeObj!);
+            scope.Items(
+                _items.Count,
+                key:         null,
+                contentType: new ComposableLambda1(_ => { }),
+                itemContent: ComposableLambdas.Instantiate4((_, indexBoxed, comp) =>
+                {
+                    var i = ((Java.Lang.Integer)indexBoxed!).IntValue();
+                    _itemContent(_items[i]).Render(comp);
+                }));
+        });
+
+        int defaults = (int)LazyRowDefault.All;
+        if (modifier is not null) defaults &= ~(int)LazyRowDefault.Modifier;
+        if (State    is not null) defaults &= ~(int)LazyRowDefault.State;
+
+        LazyDslKt.LazyRow(
+            modifier:              modifier,
+            state:                 State,
+            contentPadding:        null,
+            reverseLayout:         false,
+            horizontalArrangement: null,
+            verticalAlignment:     null,
+            flingBehavior:         null,
+            userScrollEnabled:     true,
+            overscrollEffect:      null,
+            content:               content,
+            _composer:             composer,
+            p11:                   0,
+            _changed:              defaults);
+    }
+}

--- a/src/ComposeNet.Compose/LazyVerticalGrid.cs
+++ b/src/ComposeNet.Compose/LazyVerticalGrid.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using Android.Runtime;
+using AndroidX.Compose.Foundation.Lazy.Grid;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Foundation <c>LazyVerticalGrid</c> — lazy 2D grid that scrolls
+/// vertically. Cells are arranged into <see cref="GridCells.Fixed"/>
+/// columns (count) or <see cref="GridCells.Adaptive"/> columns (minimum
+/// cell width in dp); items flow left-to-right, top-to-bottom.
+///
+/// <code>
+/// new LazyVerticalGrid&lt;int&gt;(
+///     columns:     GridCells.Fixed(3),
+///     items:       Enumerable.Range(0, 50).ToList(),
+///     itemContent: i =&gt; new Card { new Text($"Cell {i}") })
+/// </code>
+/// </summary>
+public sealed class LazyVerticalGrid<T> : ComposableNode
+{
+    readonly IGridCells _columns;
+    readonly IReadOnlyList<T> _items;
+    readonly Func<T, ComposableNode> _itemContent;
+
+    public LazyVerticalGrid(IGridCells columns, IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
+    {
+        _columns     = columns     ?? throw new ArgumentNullException(nameof(columns));
+        _items       = items       ?? throw new ArgumentNullException(nameof(items));
+        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+    }
+
+    /// <summary>
+    /// Optional scroll state. Leave null to let Compose substitute its
+    /// own remembered state.
+    /// </summary>
+    public LazyGridState? State { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+        var content  = new ComposableLambda1(scopeObj =>
+        {
+            var scope = Android.Runtime.Extensions.JavaCast<ILazyGridScope>(scopeObj!);
+            // span: null = 1 cell per item (the Compose default).
+            scope.Items(
+                _items.Count,
+                key:         null,
+                span:        null,
+                contentType: new ComposableLambda1(_ => { }),
+                p4:          ComposableLambdas.Instantiate4((_, indexBoxed, comp) =>
+                {
+                    var i = ((Java.Lang.Integer)indexBoxed!).IntValue();
+                    _itemContent(_items[i]).Render(comp);
+                }));
+        });
+
+        // Start from "use all defaults", then clear the columns bit
+        // (always supplied) and any other params the caller customized.
+        int defaults = (int)LazyVerticalGridDefault.All & ~(int)LazyVerticalGridDefault.Columns;
+        if (modifier is not null) defaults &= ~(int)LazyVerticalGridDefault.Modifier;
+        if (State    is not null) defaults &= ~(int)LazyVerticalGridDefault.State;
+
+        // 11 user params → Compose splits $changed into two ints
+        // (p12, _changed) and $default lives in the trailing _changed1.
+        LazyGridDslKt.LazyVerticalGrid(
+            columns:               _columns,
+            modifier:              modifier,
+            state:                 State,
+            contentPadding:        null,
+            reverseLayout:         false,
+            verticalArrangement:   null,
+            horizontalArrangement: null,
+            flingBehavior:         null,
+            userScrollEnabled:     true,
+            overscrollEffect:      null,
+            content:               content,
+            _composer:             composer,
+            p12:                   0,
+            _changed:              0,
+            _changed1:             defaults);
+    }
+}

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -142,6 +142,47 @@ public sealed class Modifier
         Append(h => ComposeBridges.ModifierFillMaxSize(h, fraction));
 
     /// <summary>
+    /// <c>Modifier.height(dp)</c> — sets a fixed height in dp.
+    /// Required to give vertically-scrolling content (e.g.
+    /// <see cref="LazyColumn{T}"/>) a bounded viewport when it lives
+    /// inside an unbounded parent like a regular <see cref="Column"/>.
+    /// </summary>
+    public Modifier Height(int dp)
+    {
+        var f = (float)dp;
+        return Append(h => ComposeBridges.ModifierHeight(h, f));
+    }
+
+    /// <summary>
+    /// <c>Modifier.width(dp)</c> — sets a fixed width in dp.
+    /// </summary>
+    public Modifier Width(int dp)
+    {
+        var f = (float)dp;
+        return Append(h => ComposeBridges.ModifierWidth(h, f));
+    }
+
+    /// <summary>
+    /// <c>Modifier.size(dp)</c> — sets both width and height to the
+    /// same value in dp.
+    /// </summary>
+    public Modifier Size(int dp)
+    {
+        var f = (float)dp;
+        return Append(h => ComposeBridges.ModifierSizeAll(h, f));
+    }
+
+    /// <summary>
+    /// <c>Modifier.size(width, height)</c> in dp.
+    /// </summary>
+    public Modifier Size(int widthDp, int heightDp)
+    {
+        var w = (float)widthDp;
+        var h = (float)heightDp;
+        return Append(curr => ComposeBridges.ModifierSizeWH(curr, w, h));
+    }
+
+    /// <summary>
     /// <c>Modifier.padding(paddingValues)</c> — pads using the
     /// <c>PaddingValues</c> handle a layout (e.g. <see cref="Scaffold"/>)
     /// passes to its content lambda. Internal: only Scaffold-shaped

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -53,7 +53,7 @@ public class MainActivity : ComposeActivity
             // filter without binding InputTransformation.
             var searchQuery   = Remember(() => new MutableState<string>(""));
 
-            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars" };
+            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy" };
 
             // Per-tab content. Only the current tab's column is added to
             // the screen — keeps the sample short enough to fit on one
@@ -370,7 +370,7 @@ public class MainActivity : ComposeActivity
                         },
                     },
                 },
-                _ => new Column
+                7 => new Column
                 {
                     // Inline samples of the M3 app-bar family bound by
                     // ComposeNet — normally these live in Scaffold.TopBar /
@@ -424,6 +424,59 @@ public class MainActivity : ComposeActivity
                     {
                         new IconButton(onClick: () => count++) { new Text("+") },
                         new IconButton(onClick: () => count--) { new Text("−") },
+                    },
+                },
+                _ => new Column
+                {
+                    // Lazy lists — bound through LazyDslKt / LazyGridDslKt.
+                    // Each LazyColumn / LazyVerticalGrid takes the items
+                    // list + a per-item callback. Compose lazily composes
+                    // only the visible window, so 1000 rows costs about
+                    // the same as 20.
+                    new Text("LazyColumn (1000 rows)"),
+                    new LazyColumn<int>(
+                        items:       System.Linq.Enumerable.Range(0, 1000).ToList(),
+                        itemContent: i => new Text($"Row {i:D4}"))
+                    {
+                        Modifier = Modifier.Companion.FillMaxWidth().Height(220),
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("LazyRow (carousel)"),
+                    new LazyRow<int>(
+                        items:       System.Linq.Enumerable.Range(0, 50).ToList(),
+                        itemContent: i => new Card
+                        {
+                            Modifier.Companion.Padding(4).Size(80),
+                            new Text($"#{i}"),
+                        })
+                    {
+                        Modifier = Modifier.Companion.FillMaxWidth(),
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("LazyVerticalGrid (Fixed 3)"),
+                    new LazyVerticalGrid<int>(
+                        columns:     GridCells.Fixed(3),
+                        items:       System.Linq.Enumerable.Range(0, 60).ToList(),
+                        itemContent: i => new Card
+                        {
+                            Modifier.Companion.Padding(4),
+                            new Text($"Cell {i}"),
+                        })
+                    {
+                        Modifier = Modifier.Companion.FillMaxWidth().Height(220),
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("LazyVerticalGrid (Adaptive 96dp)"),
+                    new LazyVerticalGrid<int>(
+                        columns:     GridCells.Adaptive(96f),
+                        items:       System.Linq.Enumerable.Range(0, 40).ToList(),
+                        itemContent: i => new Card
+                        {
+                            Modifier.Companion.Padding(4),
+                            new Text($"A {i}"),
+                        })
+                    {
+                        Modifier = Modifier.Companion.FillMaxWidth().Height(220),
                     },
                 },
             };
@@ -592,6 +645,11 @@ public class MainActivity : ComposeActivity
                                 {
                                     Text = new Text("Bars"),
                                     Icon = new Text("📐"),
+                                },
+                                new Tab(selected: tab.Value == 8, onClick: () => tab.Value = 8)
+                                {
+                                    Text = new Text("Lazy"),
+                                    Icon = new Text("🪟"),
                                 },
                             },
                             tabContent,

--- a/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -26,7 +26,9 @@ public class BridgeGeneratorTests
                 public static unsafe void CallVoidMethod(System.IntPtr inst, System.IntPtr m, Android.Runtime.JValue* args) { }
                 public static unsafe System.IntPtr CallStaticObjectMethod(System.IntPtr cls, System.IntPtr m, Android.Runtime.JValue* args) => default;
                 public static unsafe System.IntPtr CallObjectMethod(System.IntPtr inst, System.IntPtr m, Android.Runtime.JValue* args) => default;
+                public static unsafe System.IntPtr NewObject(System.IntPtr cls, System.IntPtr m, Android.Runtime.JValue* args) => default;
             }
+            public enum JniHandleOwnership { TransferLocalRef = 0 }
             public readonly struct JValue
             {
                 public JValue(System.IntPtr v) { } public JValue(bool v) { } public JValue(int v) { }
@@ -41,7 +43,14 @@ public class BridgeGeneratorTests
                 public JValue(long v) { } public JValue(float v) { } public JValue(double v) { }
             }
         }
-        namespace Java.Lang { public class Object { public System.IntPtr Handle => default; } }
+        namespace Java.Lang
+        {
+            public class Object
+            {
+                public System.IntPtr Handle => default;
+                public static T? GetObject<T>(System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) where T : class => default;
+            }
+        }
         namespace AndroidX.Compose.Runtime { public interface IComposer { } }
         namespace Kotlin.Jvm.Functions
         {
@@ -925,5 +934,139 @@ public class BridgeGeneratorTests
 
         var (_, diags, _) = Run(code);
         Assert.Contains(diags, d => d.Id == "CN2005");
+    }
+
+    [Fact]
+    public void Constructor_GeneratesNewObjectAndGetObjectWrap()
+    {
+        // Mirrors androidx.compose.foundation.lazy.grid.GridCells$Adaptive(Dp) —
+        // a stripped Kotlin ctor whose single Dp parameter compiles down to F.
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public interface IGridCells { }
+                public class GridCellsAdaptiveImpl : global::Java.Lang.Object, IGridCells { }
+
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/lazy/grid/GridCells$Adaptive",
+                        JvmName = "<init>",
+                        Signature = "(F)V")]
+                    internal static partial GridCellsAdaptiveImpl GridCellsAdaptive(float minSizeDp);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Class lookup unchanged; method ID uses GetMethodID with "<init>".
+        Assert.Contains("FindClass(\"androidx/compose/foundation/lazy/grid/GridCells$Adaptive\")", emitted);
+        Assert.Contains("GetMethodID(", emitted);
+        Assert.Contains("\"<init>\"", emitted);
+        Assert.DoesNotContain("GetStaticMethodID", emitted);
+
+        // Single arg slot for the Dp value; no Composer, no $default.
+        Assert.Contains("global::Android.Runtime.JValue[1]", emitted);
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(minSizeDp)", emitted);
+        Assert.DoesNotContain("args[1]", emitted);
+        Assert.DoesNotContain("Composer", emitted);
+        Assert.DoesNotContain("new global::Android.Runtime.JValue(defaults)", emitted);
+
+        // NewObject + GetObject<T> wrap with TransferLocalRef.
+        Assert.Contains("global::Android.Runtime.JNIEnv.NewObject(", emitted);
+        Assert.Contains("global::Java.Lang.Object.GetObject<global::ComposeNet.GridCellsAdaptiveImpl>(", emitted);
+        Assert.Contains("global::Android.Runtime.JniHandleOwnership.TransferLocalRef", emitted);
+        Assert.DoesNotContain("CallStaticObjectMethod", emitted);
+        Assert.DoesNotContain("CallStaticVoidMethod", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Constructor_VoidReturn_ReportsCN2006()
+    {
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class = "x/Y", JvmName = "<init>", Signature = "(F)V")]
+                    internal static partial void Bad(float v);
+                }
+            }
+            """;
+        var (_, diags, _) = Run(code);
+        Assert.Contains(diags, d => d.Id == "CN2006");
+    }
+
+    [Fact]
+    public void Constructor_WithComposer_ReportsCN2006()
+    {
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public class Thing : global::Java.Lang.Object { }
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class = "x/Y", JvmName = "<init>", Signature = "(F)V")]
+                    internal static partial Thing Bad(float v, global::AndroidX.Compose.Runtime.IComposer composer);
+                }
+            }
+            """;
+        var (_, diags, _) = Run(code);
+        Assert.Contains(diags, d => d.Id == "CN2006");
+    }
+
+    [Fact]
+    public void Constructor_WithDefaults_ReportsCN2006()
+    {
+        var code = """
+            using ComposeNet;
+
+            [assembly: ComposeDefaults("ThingDefault", "v")]
+
+            namespace ComposeNet
+            {
+                public class Thing : global::Java.Lang.Object { }
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class = "x/Y", JvmName = "<init>", Signature = "(F)V", Defaults = typeof(ThingDefault))]
+                    internal static partial Thing Bad(float v);
+                }
+            }
+            """;
+        var (_, diags, _) = Run(code);
+        Assert.Contains(diags, d => d.Id == "CN2006");
+    }
+
+    [Fact]
+    public void Constructor_NonVoidSignature_ReportsCN2006()
+    {
+        // JVM ctors must return V at the bytecode level.
+        var code = """
+            using ComposeNet;
+
+            namespace ComposeNet
+            {
+                public class Thing : global::Java.Lang.Object { }
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class = "x/Y", JvmName = "<init>", Signature = "(F)Lx/Y;")]
+                    internal static partial Thing Bad(float v);
+                }
+            }
+            """;
+        var (_, diags, _) = Run(code);
+        Assert.Contains(diags, d => d.Id == "CN2006");
     }
 }

--- a/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
@@ -90,7 +90,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             });
         }
 
-        // Detect the JNI signature "shape". Four supported today:
+        // Detect the JNI signature "shape". Five supported today:
         //   1. ComposableWithDefault — ...Composer;I+ trailing (multiple Is).
         //   2. ComposableNoDefault   — ...Composer;I  trailing (single I).
         //   3. ExtensionWithDefault  — non-@Composable Kotlin extension
@@ -101,20 +101,58 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         //      class with no Composer slot and no $default bitmask; just
         //      (args…)Return. Used for Modifier-chain helpers and other
         //      synchronous Kotlin utilities (e.g. RoundedCornerShape).
-        int composerSigIdx = -1;
-        for (int i = 0; i < sigParams.Count; i++)
+        //   5. Constructor           — JvmName is "<init>". Emits
+        //      GetMethodID + NewObject and wraps the returned handle via
+        //      Java.Lang.Object.GetObject<TReturn>(.., TransferLocalRef).
+        //      Used for stripped Kotlin ctors whose parameters were
+        //      mangled by inline-class compilation (e.g.
+        //      GridCells.Adaptive(Dp)).
+        bool isConstructor = jvmName == "<init>";
+        if (isConstructor)
         {
-            if (sigParams[i].Code == 'L' && sigParams[i].ClassName == "androidx/compose/runtime/Composer")
+            // Ctor-specific validation: no Composer, no $default, no
+            // InstanceField, no Defaults attr, non-void return,
+            // signature must end with `V`.
+            if (instanceField is not null)
+                return ConstructorError(loc, method.Name, "InstanceField is not valid with a constructor bridge");
+            if (defaultsType is not null)
+                return ConstructorError(loc, method.Name, "Defaults is not valid with a constructor bridge");
+            for (int i = 0; i < method.Parameters.Length; i++)
             {
-                composerSigIdx = i;
-                break;
+                if (ComposeDefaultsGenerator.IsComposer(method.Parameters[i].Type))
+                    return ConstructorError(loc, method.Name, "constructors have no Composer slot — remove the IComposer parameter");
+            }
+            if (method.ReturnsVoid)
+                return ConstructorError(loc, method.Name, "return type must be the constructed object, not void");
+            // Signature must end with `V` (JVM constructors return void at
+            // the bytecode level even though NewObject hands back a handle).
+            if (!signature.EndsWith(")V", StringComparison.Ordinal))
+                return ConstructorError(loc, method.Name, "JNI signature must end with ')V' (constructors return void at the bytecode level)");
+        }
+
+        int composerSigIdx = -1;
+        if (!isConstructor)
+        {
+            for (int i = 0; i < sigParams.Count; i++)
+            {
+                if (sigParams[i].Code == 'L' && sigParams[i].ClassName == "androidx/compose/runtime/Composer")
+                {
+                    composerSigIdx = i;
+                    break;
+                }
             }
         }
         bool hasComposerSlot = composerSigIdx >= 0;
 
         bool extensionWithDefault = false;
         bool signatureHasDefault;
-        if (hasComposerSlot)
+        if (isConstructor)
+        {
+            // Ctor shape never has $default or extension marker — every
+            // C# user param maps positionally to a JNI slot.
+            signatureHasDefault = false;
+        }
+        else if (hasComposerSlot)
         {
             // Kotlin's @Composable codegen emits ceil(userParams/10) (min 1)
             // $changed groups, and one $default slot iff at least one
@@ -273,7 +311,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             receiverParam = userParams[0];
             userParams = userParams.Skip(1).ToArray();
         }
-        else if (!hasComposerSlot && !extensionWithDefault &&
+        else if (!hasComposerSlot && !extensionWithDefault && !isConstructor &&
                  userParams.Length > 0 && sigParams.Count > 0 &&
                  userParams[0].Type.SpecialType == SpecialType.System_IntPtr &&
                  sigParams[0].Code == 'L' && sigParams[0].ArrayDepth == 0)
@@ -335,10 +373,15 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
 
         var source = Emit(method, attr, className, jvmName, signature, defaultsEnumName, sigParams,
             kotlinNames, userParams, userBitOf, receiverParam, callerProvidesDefaults, hasDefaultSlot,
-            hasComposerSlot, extensionWithDefault, instanceField);
+            hasComposerSlot, extensionWithDefault, instanceField, isConstructor);
         var hint = $"ComposeNet.{method.ContainingType.Name}.{method.Name}.g.cs";
         return new GenerationResult(source, hint, Array.Empty<Diagnostic>());
     }
+
+    static GenerationResult ConstructorError(Location loc, string methodName, string message) =>
+        new(null, null, new[] {
+            Diagnostic.Create(Diagnostics.BridgeConstructorShape, loc, methodName, message)
+        });
 
     /// <summary>
     /// Number of trailing <c>I</c> params that represent <c>$changed</c>
@@ -370,7 +413,8 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         bool hasDefaultSlot,
         bool hasComposerSlot,
         bool extensionWithDefault,
-        string? instanceField)
+        string? instanceField,
+        bool isConstructor)
     {
         var sb = new StringBuilder();
         sb.AppendLine("// <auto-generated/>");
@@ -407,7 +451,13 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         sb.Append("        if (s_").Append(sym).AppendLine("_method == global::System.IntPtr.Zero)");
         sb.AppendLine("        {");
         sb.Append("            s_").Append(sym).Append("_class = global::Android.Runtime.JNIEnv.FindClass(\"").Append(className).AppendLine("\");");
-        if (instanceField is null)
+        if (isConstructor)
+        {
+            // Constructor ID lookup is GetMethodID with name "<init>".
+            sb.Append("            s_").Append(sym).Append("_method = global::Android.Runtime.JNIEnv.GetMethodID(s_")
+              .Append(sym).Append("_class, \"").Append(jvmName).Append("\", \"").Append(signature).AppendLine("\");");
+        }
+        else if (instanceField is null)
         {
             sb.Append("            s_").Append(sym).Append("_method = global::Android.Runtime.JNIEnv.GetStaticMethodID(s_")
               .Append(sym).Append("_class, \"").Append(jvmName).Append("\", \"").Append(signature).AppendLine("\");");
@@ -524,15 +574,32 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         // Call.
         var callTarget = instanceField is null ? $"s_{sym}_class" : $"s_{sym}_instance";
         bool returnsValue = !method.ReturnsVoid;
-        string callMethod;
-        if (returnsValue)
-            callMethod = instanceField is null ? "CallStaticObjectMethod" : "CallObjectMethod";
+        if (isConstructor)
+        {
+            // Constructor shape: NewObject + wrap handle into the C#
+            // return type. Java.Lang.Object.GetObject<T>(handle,
+            // TransferLocalRef) consumes the local ref so we don't need
+            // to DeleteLocalRef it here.
+            var returnTypeFq = method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+                    | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers));
+            sb.Append("                var __handle = global::Android.Runtime.JNIEnv.NewObject(s_")
+              .Append(sym).Append("_class, s_").Append(sym).AppendLine("_method, args);");
+            sb.Append("                return global::Java.Lang.Object.GetObject<")
+              .Append(returnTypeFq).AppendLine(">(__handle, global::Android.Runtime.JniHandleOwnership.TransferLocalRef)!;");
+        }
         else
-            callMethod = instanceField is null ? "CallStaticVoidMethod" : "CallVoidMethod";
-        sb.Append("                ");
-        if (returnsValue) sb.Append("return ");
-        sb.Append("global::Android.Runtime.JNIEnv.").Append(callMethod).Append('(').Append(callTarget)
-          .Append(", s_").Append(sym).AppendLine("_method, args);");
+        {
+            string callMethod;
+            if (returnsValue)
+                callMethod = instanceField is null ? "CallStaticObjectMethod" : "CallObjectMethod";
+            else
+                callMethod = instanceField is null ? "CallStaticVoidMethod" : "CallVoidMethod";
+            sb.Append("                ");
+            if (returnsValue) sb.Append("return ");
+            sb.Append("global::Android.Runtime.JNIEnv.").Append(callMethod).Append('(').Append(callTarget)
+              .Append(", s_").Append(sym).AppendLine("_method, args);");
+        }
         sb.AppendLine("            }");
         sb.AppendLine("        }");
 

--- a/src/ComposeNet.SourceGenerators/Diagnostics.cs
+++ b/src/ComposeNet.SourceGenerators/Diagnostics.cs
@@ -67,4 +67,12 @@ internal static class Diagnostics
         category: "ComposeNet",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor BridgeConstructorShape = new(
+        id: "CN2006",
+        title: "[ComposeBridge] constructor shape requirements not met",
+        messageFormat: "Constructor bridge '{0}': {1}",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }


### PR DESCRIPTION
Fixes #15.

The Foundation lazy-list family was missing from the C# facade. This adds generic `LazyColumn<T>`, `LazyRow<T>`, `LazyVerticalGrid<T>`, and `LazyHorizontalGrid<T>` that take an `IReadOnlyList<T>` plus a `Func<T, ComposableNode>` per-item callback:

```csharp
new LazyColumn<int>(
    items:       Enumerable.Range(0, 1000).ToList(),
    itemContent: i => new Text($"Row {i}"))
{
    Modifier = Modifier.Companion.FillMaxWidth().Height(220),
}
```

## How it's wired

`LazyDslKt` / `LazyGridDslKt` are already exposed by the binder, so all four facades route through them and only contribute a `[ComposeDefaults]` declaration (for the `$default` bitmask enum). The grids' first param (`columns` / `rows`) is required, so the facade always clears that bit in the mask — same precedent as `Icon` clearing `ImageVector`.

The `GridCells` factory needed two paths: `GridCells.Fixed(int)` calls the bound `GridCellsFixed` ctor directly; `GridCells.Adaptive(float)` takes a `Dp` inline-class param whose ctor is stripped by the binder, so it goes through a hand-written JNI bridge that calls `<init>(F)V` on `androidx/compose/foundation/lazy/grid/GridCells$Adaptive`. The ctor handle is the lazy-init guard so a concurrent first call can't observe a cached class with a null method ID.

`SizeKt.Height/Width/Size` were also missing — needed to bound the lazy-list viewport for the sample. Added as four `[ComposeBridge]` declarations (their JVM names are mangled by the `Dp` inline class) plus `Modifier.Height(int)`, `.Width(int)`, `.Size(int)`, `.Size(int,int)`.

`ComposableLambda4` is new — `Function4<Scope, Int, Composer, Int, Unit>` is what `LazyListScope.items` and `LazyGridScope.items` use for their per-item content lambda. The adapter forwards the scope as a raw `IntPtr` (it's only used as a receiver inside the body), casts the composer, and unboxes the `Integer` index.

## Sample

A new "Lazy" tab in `MainActivity.cs` demos all four variants:
- `LazyColumn` with 1000 rows
- `LazyRow` 50-item Card carousel
- `LazyVerticalGrid` `Fixed(3)` over 60 cells
- `LazyVerticalGrid` `Adaptive(96f)` over 40 cells

## Build status

- `dotnet build src/ComposeNet.Compose` — clean (3 pre-existing warnings)
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 32/32 pass
- `dotnet build src/ComposeNet.Sample` — clean Android build