### PR TITLE
Return Kotlin.Unit.Instance from ComposableLambda{0,1,2,3}

### DIFF
--- a/src/ComposeNet.Compose/ComposableLambda0.cs
+++ b/src/ComposeNet.Compose/ComposableLambda0.cs
@@ -13,5 +13,11 @@ internal sealed class ComposableLambda0 : Java.Lang.Object, IFunction0
 {
     readonly System.Action _body;
     public ComposableLambda0(System.Action body) => _body = body;
-    public Java.Lang.Object? Invoke() { _body(); return null; }
+
+    // Kotlin Function0<Unit> contractually returns Unit.INSTANCE. Returning
+    // Java null happens to work today because every Compose call site we
+    // touch discards the result, but a future compose-compiler / K2 emit
+    // may chain `.let { }` / `.also { }` on the result and add an
+    // Intrinsics.checkNotNullExpressionValue. See issue #43.
+    public Java.Lang.Object Invoke() { _body(); return global::Kotlin.Unit.Instance!; }
 }

--- a/src/ComposeNet.Compose/ComposableLambda1.cs
+++ b/src/ComposeNet.Compose/ComposableLambda1.cs
@@ -14,9 +14,11 @@ internal sealed class ComposableLambda1 : Java.Lang.Object, IFunction1
     readonly System.Action<Java.Lang.Object?> _body;
     public ComposableLambda1(System.Action<Java.Lang.Object?> body) => _body = body;
 
-    public Java.Lang.Object? Invoke(Java.Lang.Object? p0)
+    // Kotlin Function1<T, Unit> contractually returns Unit.INSTANCE. See
+    // ComposableLambda0 / issue #43 for the rationale.
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0)
     {
         _body(p0);
-        return null;
+        return global::Kotlin.Unit.Instance!;
     }
 }

--- a/src/ComposeNet.Compose/ComposableLambda2.cs
+++ b/src/ComposeNet.Compose/ComposableLambda2.cs
@@ -15,11 +15,13 @@ internal sealed class ComposableLambda2 : Java.Lang.Object, IFunction2
     readonly System.Action<IComposer> _body;
     public ComposableLambda2(System.Action<IComposer> body) => _body = body;
 
-    public Java.Lang.Object? Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1)
+    // Kotlin Function2<Composer, Int, Unit> contractually returns
+    // Unit.INSTANCE. See ComposableLambda0 / issue #43 for the rationale.
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1)
     {
         System.ArgumentNullException.ThrowIfNull(p0);
         var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p0);
         _body(composer);
-        return null;
+        return global::Kotlin.Unit.Instance!;
     }
 }

--- a/src/ComposeNet.Compose/ComposableLambda3.cs
+++ b/src/ComposeNet.Compose/ComposableLambda3.cs
@@ -27,11 +27,13 @@ internal sealed class ComposableLambda3 : Java.Lang.Object, IFunction3
 
     public ComposableLambda3(System.Action<IntPtr, IComposer> body) => _body = body;
 
-    public Java.Lang.Object? Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1, Java.Lang.Object? p2)
+    // Kotlin Function3<Scope, Composer, Int, Unit> contractually returns
+    // Unit.INSTANCE. See ComposableLambda0 / issue #43 for the rationale.
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1, Java.Lang.Object? p2)
     {
         System.ArgumentNullException.ThrowIfNull(p1);
         var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p1);
         _body(p0?.Handle ?? IntPtr.Zero, composer);
-        return null;
+        return global::Kotlin.Unit.Instance!;
     }
 }


### PR DESCRIPTION
Addresses item 4 of #43.

Kotlin `Function0/1/2/3<..., Unit>` contractually returns `Unit.INSTANCE`. Returning Java `null` happens to work today because every Compose call site we touch discards the result, but a future compose-compiler / K2 emit may chain `.let { }` / `.also { }` on the result and add an `Intrinsics.checkNotNullExpressionValue`. Match the Kotlin contract.

### Why this PR doesn't do item 3 (the hoist)

On closer inspection, the premise was wrong. The Kotlin compose-compiler doesn't wrap `SegmentedButton(shape = itemShape(...), ...)` in an extra outer group either — each `@Composable` already opens its own restart group internally via its bytecode header, and the two calls are siblings in the caller's group. Wrapping the pair in `composer.StartReplaceableGroup() / EndReplaceableGroup()` would make our slot layout *more* different from Kotlin's, not less, and just adds a slot-table entry per `SegmentedButton` for no gain.

#49 already fixed the observable crash from #42, and the hoist isn't reachable from any repro — defer until there's evidence it matters.

### Validation

- `dotnet build src/ComposeNet.Compose` — clean (3 pre-existing XML-comment warnings)
- `dotnet build src/ComposeNet.Sample` — clean
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 32/32 pass