### PR TITLE
Stabilize ComposableLambda identity + add per-sibling slot keys (#42 H1+H2)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -268,6 +268,42 @@ method**; call the generated C# entry point instead (see
   ```
 - Wrap Kotlin lambdas with `ComposableLambda0/1/2/3` (existing
   helpers — don't hand-roll new lambda adapters).
+- **Never construct `ComposableLambda2` / `ComposableLambda3` directly
+  inside a `Render(IComposer composer)` body.** Route every
+  `@Composable` slot lambda through `ComposableLambdas.Wrap2` /
+  `ComposableLambdas.Wrap3` so Compose's own `composableLambda` factory
+  owns identity across recompositions. `SubcomposeLayout`-backed
+  composables (`Scaffold`, `BottomSheetScaffold`, `ModalNavigationDrawer`,
+  …) cache subcomposed content keyed by lambda identity; a fresh
+  `new ComposableLambda*(...)` every pass thrashes that cache and
+  causes `LayoutNode` insert ops to land at the wrong index
+  (see #42). The helpers derive a unique slot-table key from
+  `[CallerLineNumber]` + `[CallerFilePath]` automatically — no key
+  argument needed.
+  ```csharp
+  // Wrong — fresh identity every recomposition:
+  var content = new ComposableLambda3(c => RenderChildren(c));
+  // Right — stable identity owned by the runtime:
+  var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+  ```
+  `ComposableLambda0` (onClick) and `ComposableLambda1`
+  (onValueChange / onCheckedChange) callbacks are **not** `@Composable`
+  and must stay raw — wrapping them would inject
+  `startRestartGroup`/`endRestartGroup` machinery into code that runs
+  outside composition.
+- **Sibling `Render()` calls inside a loop need per-position slot
+  keys.** `ComposableContainer.RenderChildren` already wraps each child
+  in `composer.StartReplaceableGroup(i)` / `EndReplaceableGroup()`. Any
+  custom loop that calls `Children[i].Render(c)` directly — e.g. the
+  segmented-row scope loops in `SingleChoiceSegmentedButtonRow`,
+  `MultiChoiceSegmentedButtonRow`, or `SegmentedButton`'s label slot —
+  must do the same, otherwise same-type siblings collide on a single
+  group key and Compose disambiguates by position only (brittle
+  combined with any identity churn).
+- The single call to `ComposableLambdaKt.ComposableLambdaInstance` in
+  `ComposeActivity.SetContent` is the right shape there — it's the
+  call-from-anywhere factory for the root content lambda, which runs
+  outside an active composition. Leave it alone.
 - Multi-slot composables (e.g. `AlertDialog`) expose **named slot
   properties** set via object-initializer syntax, not extra
   collection-init Add overloads. Pattern: start `defaults =

--- a/src/ComposeNet.Compose/AlertDialog.cs
+++ b/src/ComposeNet.Compose/AlertDialog.cs
@@ -52,16 +52,16 @@ public sealed class AlertDialog : ComposableNode
                 "AlertDialog.ConfirmButton is required (the Kotlin parameter has no default).");
 
         var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var confirm   = new ComposableLambda2(c => ConfirmButton.Render(c));
+        var confirm   = ComposableLambdas.Wrap2(composer, c => ConfirmButton.Render(c));
 
-        ComposableLambda2? dismissBtn = DismissButton is null ? null
-            : new ComposableLambda2(c => DismissButton.Render(c));
-        ComposableLambda2? icon = Icon is null ? null
-            : new ComposableLambda2(c => Icon.Render(c));
-        ComposableLambda2? title = Title is null ? null
-            : new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? text = Text is null ? null
-            : new ComposableLambda2(c => Text.Render(c));
+        var dismissBtn = DismissButton is null ? null
+            : ComposableLambdas.Wrap2(composer, c => DismissButton.Render(c));
+        var icon = Icon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
+        var title = Title is null ? null
+            : ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var text = Text is null ? null
+            : ComposableLambdas.Wrap2(composer, c => Text.Render(c));
 
         // Start from "default everything" and clear the bit for each
         // optional slot the user actually supplied.

--- a/src/ComposeNet.Compose/AssistChip.cs
+++ b/src/ComposeNet.Compose/AssistChip.cs
@@ -31,9 +31,9 @@ public sealed class AssistChip : ComposableNode
                 "AssistChip.Label is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var label = new ComposableLambda2(c => Label.Render(c));
-        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
-        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
+        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
 
         int defaults = (int)AssistChipDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/Badge.cs
+++ b/src/ComposeNet.Compose/Badge.cs
@@ -15,7 +15,7 @@ public sealed class Badge : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3((scope, c) =>
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
             using var _ = RenderContext.PushScope(scope);
             RenderChildren(c);

--- a/src/ComposeNet.Compose/BadgedBox.cs
+++ b/src/ComposeNet.Compose/BadgedBox.cs
@@ -28,8 +28,8 @@ public sealed class BadgedBox : ComposableNode
             throw new System.InvalidOperationException(
                 "BadgedBox requires both Badge and Content.");
 
-        var badge   = new ComposableLambda3(c => Badge.Render(c));
-        var content = new ComposableLambda3(c => Content.Render(c));
+        var badge   = ComposableLambdas.Wrap3(composer, c => Badge.Render(c));
+        var content = ComposableLambdas.Wrap3(composer, c => Content.Render(c));
 
         ComposeBridges.BadgedBox(badge, BuildModifier(), content, composer);
     }

--- a/src/ComposeNet.Compose/BottomAppBar.cs
+++ b/src/ComposeNet.Compose/BottomAppBar.cs
@@ -23,13 +23,13 @@ public sealed class BottomAppBar : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var actions = new ComposableLambda3((scope, c) =>
+        var actions = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
             using var _ = RenderContext.PushScope(scope);
             RenderChildren(c);
         });
-        ComposableLambda2? fab = FloatingActionButton is null ? null
-            : new ComposableLambda2(c => FloatingActionButton.Render(c));
+        var fab = FloatingActionButton is null ? null
+            : ComposableLambdas.Wrap2(composer, c => FloatingActionButton.Render(c));
 
         ComposeBridges.BottomAppBar(actions, BuildModifier(), fab, composer);
     }

--- a/src/ComposeNet.Compose/BottomSheetScaffold.cs
+++ b/src/ComposeNet.Compose/BottomSheetScaffold.cs
@@ -37,13 +37,13 @@ public sealed class BottomSheetScaffold : ComposableContainer
             p3:                 0,
             _changed:           3);
 
-        var sheet   = new ComposableLambda3(c => SheetContent.Render(c));
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var sheet   = ComposableLambdas.Wrap3(composer, c => SheetContent.Render(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
 
-        ComposableLambda2? dragHandle = SheetDragHandle is null ? null
-            : new ComposableLambda2(c => SheetDragHandle.Render(c));
-        ComposableLambda2? topBar = TopBar is null ? null
-            : new ComposableLambda2(c => TopBar.Render(c));
+        var dragHandle = SheetDragHandle is null ? null
+            : ComposableLambdas.Wrap2(composer, c => SheetDragHandle.Render(c));
+        var topBar = TopBar is null ? null
+            : ComposableLambdas.Wrap2(composer, c => TopBar.Render(c));
 
         int defaults = (int)BottomSheetScaffoldDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/Box.cs
+++ b/src/ComposeNet.Compose/Box.cs
@@ -15,7 +15,7 @@ public sealed class Box : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var modifier = BuildModifier();
-        var content  = new ComposableLambda3(c => RenderChildren(c));
+        var content  = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
 
         int defaults = (int)BoxDefault.All;
         if (modifier is not null) defaults &= ~(int)BoxDefault.Modifier;

--- a/src/ComposeNet.Compose/Button.cs
+++ b/src/ComposeNet.Compose/Button.cs
@@ -15,7 +15,7 @@ public sealed class Button : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var click   = new ComposableLambda0(_onClick);
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.Button(click, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/Card.cs
+++ b/src/ComposeNet.Compose/Card.cs
@@ -14,7 +14,7 @@ public sealed class Card : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.Card(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/CenterAlignedTopAppBar.cs
+++ b/src/ComposeNet.Compose/CenterAlignedTopAppBar.cs
@@ -24,11 +24,11 @@ public sealed class CenterAlignedTopAppBar : ComposableNode
             throw new System.InvalidOperationException(
                 "CenterAlignedTopAppBar.Title is required (the Kotlin parameter has no default).");
 
-        var title = new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? nav = NavigationIcon is null ? null
-            : new ComposableLambda2(c => NavigationIcon.Render(c));
-        ComposableLambda3? actions = Actions is null ? null
-            : new ComposableLambda3(c => Actions.Render(c));
+        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var nav = NavigationIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
+        var actions = Actions is null ? null
+            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
 
         int defaults = (int)TopAppBarDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/Column.cs
+++ b/src/ComposeNet.Compose/Column.cs
@@ -9,7 +9,7 @@ public sealed class Column : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var modifier = BuildModifier();
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         int defaults = (int)ColumnDefault.All;
         if (modifier is not null) defaults &= ~(int)ColumnDefault.Modifier;
         ColumnKt.Column(

--- a/src/ComposeNet.Compose/ComposableContainer.cs
+++ b/src/ComposeNet.Compose/ComposableContainer.cs
@@ -37,12 +37,21 @@ public abstract class ComposableContainer : ComposableNode, IEnumerable
 
     /// <summary>
     /// Renders this container's children sequentially into
-    /// <paramref name="composer"/>. Containers call this from inside
-    /// their content lambda.
+    /// <paramref name="composer"/>, wrapping each child in a per-index
+    /// <c>StartReplaceableGroup(i)</c> so sibling renders get distinct
+    /// slot-table group keys. Without this, three sibling
+    /// <c>SegmentedButton</c>s (same C# call site → same group key)
+    /// rely on Compose's positional disambiguation, which combined with
+    /// lambda-identity churn elsewhere can land Reuse/Move ops at the
+    /// wrong tree index.
     /// </summary>
     private protected void RenderChildren(IComposer composer)
     {
         for (int i = 0; i < _children.Count; i++)
-            _children[i].Render(composer);
+        {
+            composer.StartReplaceableGroup(i);
+            try { _children[i].Render(composer); }
+            finally { composer.EndReplaceableGroup(); }
+        }
     }
 }

--- a/src/ComposeNet.Compose/ComposableLambdas.cs
+++ b/src/ComposeNet.Compose/ComposableLambdas.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Runtime.CompilerServices;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.Runtime.Internal;
+using Kotlin.Jvm.Functions;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Helpers that wrap <see cref="ComposableLambda2"/> /
+/// <see cref="ComposableLambda3"/> @Composable content lambdas through
+/// Compose's own <c>ComposableLambdaKt.ComposableLambda</c> factory so
+/// the runtime owns lambda identity across recompositions.
+///
+/// <para>The factory does, internally:</para>
+/// <list type="number">
+///   <item><description><c>composer.startReplaceableGroup(key)</c></description></item>
+///   <item><description>Looks up a remembered slot; on first reach it
+///     stores a fresh <c>ComposableLambdaImpl(key, tracked)</c>, otherwise
+///     it reuses the stored instance.</description></item>
+///   <item><description>Updates the impl's <c>block</c> field to point
+///     at the fresh inner <see cref="ComposableLambda2"/> /
+///     <see cref="ComposableLambda3"/> we just allocated.</description></item>
+///   <item><description><c>composer.endReplaceableGroup()</c></description></item>
+///   <item><description>Returns the stable impl.</description></item>
+/// </list>
+///
+/// <para>The result is an <see cref="IComposableLambda"/> whose identity
+/// is stable across recompositions even though we allocate a fresh
+/// inner adapter each call — exactly what
+/// <c>SubcomposeLayout</c> needs to keep its per-lambda-identity content
+/// cache from thrashing.</para>
+///
+/// <para><b>Convention:</b> never construct
+/// <see cref="ComposableLambda2"/> / <see cref="ComposableLambda3"/>
+/// directly inside a <c>Render</c> method — always route through
+/// <see cref="Wrap2"/> / <see cref="Wrap3(IComposer, Action{IComposer}, int, string)"/>.
+/// The non-@Composable adapters <see cref="ComposableLambda0"/> /
+/// <see cref="ComposableLambda1"/> (onClick / onValueChange callbacks)
+/// are NOT wrapped — they run outside composition and would crash
+/// inside Compose's restart-group machinery.</para>
+/// </summary>
+internal static class ComposableLambdas
+{
+    /// <summary>
+    /// Wrap an <see cref="Action{IComposer}"/> as an identity-stable
+    /// <see cref="IFunction2"/> (the Function2&lt;Composer, Int, Unit&gt;
+    /// @Composable content-slot shape used by <c>topBar</c>,
+    /// <c>bottomBar</c>, <c>title</c>, <c>icon</c>, etc.).
+    /// </summary>
+    public static IFunction2 Wrap2(
+        IComposer composer,
+        Action<IComposer> body,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => (IFunction2)ComposableLambdaKt.ComposableLambda(
+            composer, HashCode.Combine(line, file), tracked: true,
+            block: new ComposableLambda2(body));
+
+    /// <summary>
+    /// Wrap an <see cref="Action{IComposer}"/> as an identity-stable
+    /// <see cref="IFunction3"/> (the Function3&lt;Scope, Composer, Int, Unit&gt;
+    /// @Composable content-slot shape used by <c>Column</c> / <c>Row</c> /
+    /// <c>Box</c> / <c>Button</c> bodies). The scope receiver is discarded.
+    /// </summary>
+    public static IFunction3 Wrap3(
+        IComposer composer,
+        Action<IComposer> body,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => (IFunction3)ComposableLambdaKt.ComposableLambda(
+            composer, HashCode.Combine(line, file), tracked: true,
+            block: new ComposableLambda3(body));
+
+    /// <summary>
+    /// Wrap an <see cref="Action{IntPtr, IComposer}"/> as an
+    /// identity-stable <see cref="IFunction3"/> that receives the raw
+    /// scope handle (RowScope, ColumnScope, SegmentedButtonRowScope,
+    /// etc.) — for containers whose children need to forward the scope
+    /// to a scope-extension Kotlin static (e.g.
+    /// <c>RowScope.NavigationBarItem</c>).
+    /// </summary>
+    public static IFunction3 Wrap3(
+        IComposer composer,
+        Action<IntPtr, IComposer> body,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => (IFunction3)ComposableLambdaKt.ComposableLambda(
+            composer, HashCode.Combine(line, file), tracked: true,
+            block: new ComposableLambda3(body));
+}

--- a/src/ComposeNet.Compose/CustomTab.cs
+++ b/src/ComposeNet.Compose/CustomTab.cs
@@ -29,7 +29,7 @@ public sealed class CustomTab : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var click = new ComposableLambda0(_onClick);
-        var content = new ComposableLambda3((scope, c) =>
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
             using var _ = RenderContext.PushScope(scope);
             RenderChildren(c);

--- a/src/ComposeNet.Compose/DatePickerDialog.cs
+++ b/src/ComposeNet.Compose/DatePickerDialog.cs
@@ -33,10 +33,10 @@ public sealed class DatePickerDialog : ComposableNode
                 "DatePickerDialog.Body is required (the dialog's content slot).");
 
         var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var confirm   = new ComposableLambda2(c => ConfirmButton.Render(c));
-        var content   = new ComposableLambda3(c => Body.Render(c));
-        ComposableLambda2? dismiss = DismissButton is null ? null
-            : new ComposableLambda2(c => DismissButton.Render(c));
+        var confirm   = ComposableLambdas.Wrap2(composer, c => ConfirmButton.Render(c));
+        var content   = ComposableLambdas.Wrap3(composer, c => Body.Render(c));
+        var dismiss = DismissButton is null ? null
+            : ComposableLambdas.Wrap2(composer, c => DismissButton.Render(c));
 
         int defaults = (int)DatePickerDialogDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
+++ b/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
@@ -17,7 +17,7 @@ public sealed class DismissibleDrawerSheet : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         var color = ContainerColor != 0L
             ? ContainerColor
             : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;

--- a/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
@@ -45,9 +45,8 @@ public sealed class DismissibleNavigationDrawer : ComposableNode
             p3:                  0,
             _changed:            0);
 
-        var drawer  = new ComposableLambda2(c => Drawer.Render(c));
-        var content = new ComposableLambda2(c => Content.Render(c));
-
+        var drawer  = ComposableLambdas.Wrap2(composer, c => Drawer.Render(c));
+        var content = ComposableLambdas.Wrap2(composer, c => Content.Render(c));
         // Param order: drawerContent (0, provided), modifier (1, def),
         // drawerState (2, provided), gesturesEnabled (3, provided),
         // content (4, provided). $default = 0b00010 = 2.

--- a/src/ComposeNet.Compose/DropdownMenu.cs
+++ b/src/ComposeNet.Compose/DropdownMenu.cs
@@ -37,7 +37,7 @@ public sealed class DropdownMenu : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var content   = new ComposableLambda3(c => RenderChildren(c));
+        var content   = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.DropdownMenu(_expanded, onDismiss, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/DropdownMenuItem.cs
+++ b/src/ComposeNet.Compose/DropdownMenuItem.cs
@@ -39,14 +39,14 @@ public sealed class DropdownMenuItem : ComposableNode
 
     internal override void Render(IComposer composer)
     {
-        var text    = new ComposableLambda2(c => _text.Render(c));
+        var text    = ComposableLambdas.Wrap2(composer, c => _text.Render(c));
         var onClick = new ComposableLambda0(_onClick);
         var modifier = BuildModifier();
 
-        ComposableLambda2? leading = LeadingIcon is null ? null
-            : new ComposableLambda2(c => LeadingIcon.Render(c));
-        ComposableLambda2? trailing = TrailingIcon is null ? null
-            : new ComposableLambda2(c => TrailingIcon.Render(c));
+        Kotlin.Jvm.Functions.IFunction2? leading = LeadingIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        Kotlin.Jvm.Functions.IFunction2? trailing = TrailingIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
 
         int defaults = (int)DropdownMenuItemDefault.All;
         if (modifier is not null) defaults &= ~(int)DropdownMenuItemDefault.Modifier;

--- a/src/ComposeNet.Compose/ElevatedAssistChip.cs
+++ b/src/ComposeNet.Compose/ElevatedAssistChip.cs
@@ -27,9 +27,9 @@ public sealed class ElevatedAssistChip : ComposableNode
                 "ElevatedAssistChip.Label is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var label = new ComposableLambda2(c => Label.Render(c));
-        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
-        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
+        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
 
         // ElevatedAssistChip's parameter order matches AssistChip exactly,
         // so we reuse AssistChipDefault for the $default bitmask.

--- a/src/ComposeNet.Compose/ElevatedCard.cs
+++ b/src/ComposeNet.Compose/ElevatedCard.cs
@@ -11,7 +11,7 @@ public sealed class ElevatedCard : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.ElevatedCard(content, composer);
     }
 }

--- a/src/ComposeNet.Compose/ElevatedFilterChip.cs
+++ b/src/ComposeNet.Compose/ElevatedFilterChip.cs
@@ -33,9 +33,9 @@ public sealed class ElevatedFilterChip : ComposableNode
                 "ElevatedFilterChip.Label is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var label = new ComposableLambda2(c => Label.Render(c));
-        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
-        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
+        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
 
         int defaults = (int)FilterChipDefault.All;
         if (leading  is not null) defaults &= ~(int)FilterChipDefault.LeadingIcon;

--- a/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
+++ b/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
@@ -24,8 +24,8 @@ public sealed class ElevatedSuggestionChip : ComposableNode
                 "ElevatedSuggestionChip.Label is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var label = new ComposableLambda2(c => Label.Render(c));
-        ComposableLambda2? icon = Icon is null ? null : new ComposableLambda2(c => Icon.Render(c));
+        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
+        var icon = Icon is null ? null : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
 
         int defaults = (int)SuggestionChipDefault.All;
         if (icon is not null) defaults &= ~(int)SuggestionChipDefault.Icon;

--- a/src/ComposeNet.Compose/ExpandedDockedSearchBar.cs
+++ b/src/ComposeNet.Compose/ExpandedDockedSearchBar.cs
@@ -35,8 +35,8 @@ public sealed class ExpandedDockedSearchBar : ComposableContainer
                 "ExpandedDockedSearchBar.InputField is required (the Kotlin parameter has no default).");
 
         var stateHandle = SearchBar.ResolveStateHandle(_state, composer);
-        var inputField  = new ComposableLambda2(c => InputField.Render(c));
-        var content     = new ComposableLambda3(c => RenderChildren(c));
+        var inputField  = ComposableLambdas.Wrap2(composer, c => InputField.Render(c));
+        var content     = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.ExpandedDockedSearchBar(stateHandle, inputField, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/ExpandedFullScreenSearchBar.cs
+++ b/src/ComposeNet.Compose/ExpandedFullScreenSearchBar.cs
@@ -36,8 +36,8 @@ public sealed class ExpandedFullScreenSearchBar : ComposableContainer
                 "ExpandedFullScreenSearchBar.InputField is required (the Kotlin parameter has no default).");
 
         var stateHandle = SearchBar.ResolveStateHandle(_state, composer);
-        var inputField  = new ComposableLambda2(c => InputField.Render(c));
-        var content     = new ComposableLambda3(c => RenderChildren(c));
+        var inputField  = ComposableLambdas.Wrap2(composer, c => InputField.Render(c));
+        var content     = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.ExpandedFullScreenSearchBar(stateHandle, inputField, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/FilterChip.cs
+++ b/src/ComposeNet.Compose/FilterChip.cs
@@ -33,9 +33,9 @@ public sealed class FilterChip : ComposableNode
                 "FilterChip.Label is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var label = new ComposableLambda2(c => Label.Render(c));
-        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
-        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
+        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
 
         int defaults = (int)FilterChipDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/FlexibleBottomAppBar.cs
+++ b/src/ComposeNet.Compose/FlexibleBottomAppBar.cs
@@ -19,7 +19,7 @@ public sealed class FlexibleBottomAppBar : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3((scope, c) =>
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
             using var _ = RenderContext.PushScope(scope);
             RenderChildren(c);

--- a/src/ComposeNet.Compose/FloatingActionButton.cs
+++ b/src/ComposeNet.Compose/FloatingActionButton.cs
@@ -11,7 +11,7 @@ public sealed class FloatingActionButton : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var click   = new ComposableLambda0(_onClick);
-        var content = new ComposableLambda2(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.FloatingActionButton(click, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/IconButton.cs
+++ b/src/ComposeNet.Compose/IconButton.cs
@@ -14,7 +14,7 @@ public sealed class IconButton : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var click   = new ComposableLambda0(_onClick);
-        var content = new ComposableLambda2(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.IconButton(click, BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/InputChip.cs
+++ b/src/ComposeNet.Compose/InputChip.cs
@@ -31,10 +31,10 @@ public sealed class InputChip : ComposableNode
                 "InputChip.Label is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var label = new ComposableLambda2(c => Label.Render(c));
-        ComposableLambda2? leading  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
-        ComposableLambda2? avatar   = Avatar       is null ? null : new ComposableLambda2(c => Avatar.Render(c));
-        ComposableLambda2? trailing = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
+        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        var avatar   = Avatar       is null ? null : ComposableLambdas.Wrap2(composer, c => Avatar.Render(c));
+        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
 
         int defaults = (int)InputChipDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/LargeFlexibleTopAppBar.cs
+++ b/src/ComposeNet.Compose/LargeFlexibleTopAppBar.cs
@@ -28,13 +28,13 @@ public sealed class LargeFlexibleTopAppBar : ComposableNode
             throw new System.InvalidOperationException(
                 "LargeFlexibleTopAppBar.Title is required (the Kotlin parameter has no default).");
 
-        var title = new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? subtitle = Subtitle is null ? null
-            : new ComposableLambda2(c => Subtitle.Render(c));
-        ComposableLambda2? nav = NavigationIcon is null ? null
-            : new ComposableLambda2(c => NavigationIcon.Render(c));
-        ComposableLambda3? actions = Actions is null ? null
-            : new ComposableLambda3(c => Actions.Render(c));
+        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var subtitle = Subtitle is null ? null
+            : ComposableLambdas.Wrap2(composer, c => Subtitle.Render(c));
+        var nav = NavigationIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
+        var actions = Actions is null ? null
+            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
 
         int defaults = (int)FlexibleTopAppBarDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/LargeTopAppBar.cs
+++ b/src/ComposeNet.Compose/LargeTopAppBar.cs
@@ -24,11 +24,11 @@ public sealed class LargeTopAppBar : ComposableNode
             throw new System.InvalidOperationException(
                 "LargeTopAppBar.Title is required (the Kotlin parameter has no default).");
 
-        var title = new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? nav = NavigationIcon is null ? null
-            : new ComposableLambda2(c => NavigationIcon.Render(c));
-        ComposableLambda3? actions = Actions is null ? null
-            : new ComposableLambda3(c => Actions.Render(c));
+        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var nav = NavigationIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
+        var actions = Actions is null ? null
+            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
 
         int defaults = (int)TwoRowsTopAppBarDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/LeadingIconTab.cs
+++ b/src/ComposeNet.Compose/LeadingIconTab.cs
@@ -31,8 +31,8 @@ public sealed class LeadingIconTab : ComposableNode
                 "LeadingIconTab.Text and Icon are both required (the Kotlin parameters have no defaults).");
 
         var click = new ComposableLambda0(_onClick);
-        var text  = new ComposableLambda2(c => Text.Render(c));
-        var icon  = new ComposableLambda2(c => Icon.Render(c));
+        var text  = ComposableLambdas.Wrap2(composer, c => Text.Render(c));
+        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
 
         ComposeBridges.LeadingIconTab(_selected, click, text, icon, BuildModifier(), composer);
     }

--- a/src/ComposeNet.Compose/ListItem.cs
+++ b/src/ComposeNet.Compose/ListItem.cs
@@ -40,11 +40,11 @@ public sealed class ListItem : ComposableNode
             throw new System.InvalidOperationException(
                 "ListItem.Headline is required (the Kotlin parameter has no default).");
 
-        var headline = new ComposableLambda2(c => Headline.Render(c));
-        ComposableLambda2? overline   = Overline   is null ? null : new ComposableLambda2(c => Overline.Render(c));
-        ComposableLambda2? supporting = Supporting is null ? null : new ComposableLambda2(c => Supporting.Render(c));
-        ComposableLambda2? leading    = Leading    is null ? null : new ComposableLambda2(c => Leading.Render(c));
-        ComposableLambda2? trailing   = Trailing   is null ? null : new ComposableLambda2(c => Trailing.Render(c));
+        var headline = ComposableLambdas.Wrap2(composer, c => Headline.Render(c));
+        var overline   = Overline   is null ? null : ComposableLambdas.Wrap2(composer, c => Overline.Render(c));
+        var supporting = Supporting is null ? null : ComposableLambdas.Wrap2(composer, c => Supporting.Render(c));
+        var leading    = Leading    is null ? null : ComposableLambdas.Wrap2(composer, c => Leading.Render(c));
+        var trailing   = Trailing   is null ? null : ComposableLambdas.Wrap2(composer, c => Trailing.Render(c));
 
         int defaults = (int)ListItemDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/MaterialTheme.cs
+++ b/src/ComposeNet.Compose/MaterialTheme.cs
@@ -14,7 +14,7 @@ public sealed class MaterialTheme : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var scheme  = DynamicTonalPaletteKt.DynamicLightColorScheme(Android.App.Application.Context);
-        var content = new ComposableLambda2(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         MaterialThemeKt.MaterialTheme(
             colorScheme: scheme,
             shapes:      null,

--- a/src/ComposeNet.Compose/MediumFlexibleTopAppBar.cs
+++ b/src/ComposeNet.Compose/MediumFlexibleTopAppBar.cs
@@ -28,13 +28,13 @@ public sealed class MediumFlexibleTopAppBar : ComposableNode
             throw new System.InvalidOperationException(
                 "MediumFlexibleTopAppBar.Title is required (the Kotlin parameter has no default).");
 
-        var title = new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? subtitle = Subtitle is null ? null
-            : new ComposableLambda2(c => Subtitle.Render(c));
-        ComposableLambda2? nav = NavigationIcon is null ? null
-            : new ComposableLambda2(c => NavigationIcon.Render(c));
-        ComposableLambda3? actions = Actions is null ? null
-            : new ComposableLambda3(c => Actions.Render(c));
+        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var subtitle = Subtitle is null ? null
+            : ComposableLambdas.Wrap2(composer, c => Subtitle.Render(c));
+        var nav = NavigationIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
+        var actions = Actions is null ? null
+            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
 
         int defaults = (int)FlexibleTopAppBarDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/MediumTopAppBar.cs
+++ b/src/ComposeNet.Compose/MediumTopAppBar.cs
@@ -24,11 +24,11 @@ public sealed class MediumTopAppBar : ComposableNode
             throw new System.InvalidOperationException(
                 "MediumTopAppBar.Title is required (the Kotlin parameter has no default).");
 
-        var title = new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? nav = NavigationIcon is null ? null
-            : new ComposableLambda2(c => NavigationIcon.Render(c));
-        ComposableLambda3? actions = Actions is null ? null
-            : new ComposableLambda3(c => Actions.Render(c));
+        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var nav = NavigationIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
+        var actions = Actions is null ? null
+            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
 
         int defaults = (int)TwoRowsTopAppBarDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/ModalBottomSheet.cs
+++ b/src/ComposeNet.Compose/ModalBottomSheet.cs
@@ -46,9 +46,9 @@ public sealed class ModalBottomSheet : ComposableContainer
             _changed:              3);
 
         var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var content   = new ComposableLambda3(c => RenderChildren(c));
-        ComposableLambda2? dragHandle = DragHandle is null ? null
-            : new ComposableLambda2(c => DragHandle.Render(c));
+        var content   = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+        var dragHandle = DragHandle is null ? null
+            : ComposableLambdas.Wrap2(composer, c => DragHandle.Render(c));
 
         int defaults = (int)ModalBottomSheetDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/ModalDrawerSheet.cs
+++ b/src/ComposeNet.Compose/ModalDrawerSheet.cs
@@ -22,7 +22,7 @@ public sealed class ModalDrawerSheet : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         var color = ContainerColor != 0L
             ? ContainerColor
             : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;

--- a/src/ComposeNet.Compose/ModalNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/ModalNavigationDrawer.cs
@@ -52,9 +52,8 @@ public sealed class ModalNavigationDrawer : ComposableNode
             p3:                  0,
             _changed:            0);
 
-        var drawer  = new ComposableLambda2(c => Drawer.Render(c));
-        var content = new ComposableLambda2(c => Content.Render(c));
-
+        var drawer  = ComposableLambdas.Wrap2(composer, c => Drawer.Render(c));
+        var content = ComposableLambdas.Wrap2(composer, c => Content.Render(c));
         // Param order: drawerContent (0, provided), modifier (1, def),
         // drawerState (2, provided), gesturesEnabled (3, provided),
         // scrimColor (4, def — 0L is not a valid color sentinel),

--- a/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
@@ -13,14 +13,16 @@ public sealed class MultiChoiceSegmentedButtonRow : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3((scope, c) =>
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
             using var _    = RenderContext.PushScope(scope);
             using var rows = RenderContext.PushRow(Children.Count);
             for (int i = 0; i < Children.Count; i++)
             {
                 rows.SetIndex(i);
-                Children[i].Render(c);
+                c.StartReplaceableGroup(i);
+                try { Children[i].Render(c); }
+                finally { c.EndReplaceableGroup(); }
             }
         });
 

--- a/src/ComposeNet.Compose/NavigationBar.cs
+++ b/src/ComposeNet.Compose/NavigationBar.cs
@@ -26,7 +26,7 @@ public sealed class NavigationBar : ComposableContainer
         // Capture the RowScope receiver (p0 of the Function3) and publish
         // it so child NavigationBarItems can pass it to their underlying
         // RowScope-extension static.
-        var content = new ComposableLambda3((scope, c) =>
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
             using var _ = RenderContext.PushScope(scope);
             RenderChildren(c);

--- a/src/ComposeNet.Compose/NavigationBarItem.cs
+++ b/src/ComposeNet.Compose/NavigationBarItem.cs
@@ -33,8 +33,8 @@ public sealed class NavigationBarItem : ComposableNode
                 "NavigationBarItem.Icon is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var icon  = new ComposableLambda2(c => Icon.Render(c));
-        ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
+        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
+        var label = Label is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
 
         int defaults = (int)NavigationBarItemDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/NavigationRail.cs
+++ b/src/ComposeNet.Compose/NavigationRail.cs
@@ -20,7 +20,7 @@ public sealed class NavigationRail : ComposableContainer
         // NavigationRailItem (unlike NavigationBarItem) is a top-level
         // static, not a ColumnScope extension — so we don't need to
         // publish the scope. Children can render directly.
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.NavigationRail(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/NavigationRailItem.cs
+++ b/src/ComposeNet.Compose/NavigationRailItem.cs
@@ -30,8 +30,8 @@ public sealed class NavigationRailItem : ComposableNode
                 "NavigationRailItem.Icon is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var icon  = new ComposableLambda2(c => Icon.Render(c));
-        ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
+        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
+        var label = Label is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
 
         int defaults = (int)NavigationRailItemDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/OutlinedCard.cs
+++ b/src/ComposeNet.Compose/OutlinedCard.cs
@@ -10,7 +10,7 @@ public sealed class OutlinedCard : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         ComposeBridges.OutlinedCard(content, composer);
     }
 }

--- a/src/ComposeNet.Compose/PermanentDrawerSheet.cs
+++ b/src/ComposeNet.Compose/PermanentDrawerSheet.cs
@@ -17,7 +17,7 @@ public sealed class PermanentDrawerSheet : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
         var color = ContainerColor != 0L
             ? ContainerColor
             : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;

--- a/src/ComposeNet.Compose/PermanentNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/PermanentNavigationDrawer.cs
@@ -32,9 +32,8 @@ public sealed class PermanentNavigationDrawer : ComposableNode
             throw new System.InvalidOperationException(
                 "PermanentNavigationDrawer.Content is required.");
 
-        var drawer  = new ComposableLambda2(c => Drawer.Render(c));
-        var content = new ComposableLambda2(c => Content.Render(c));
-
+        var drawer  = ComposableLambdas.Wrap2(composer, c => Drawer.Render(c));
+        var content = ComposableLambdas.Wrap2(composer, c => Content.Render(c));
         // Param order: drawerContent (bit 0, provided), modifier (bit 1,
         // defaulted), content (bit 2, provided). $default = 0b010 = 2.
         NavigationDrawerKt.PermanentNavigationDrawer(

--- a/src/ComposeNet.Compose/PrimaryScrollableTabRow.cs
+++ b/src/ComposeNet.Compose/PrimaryScrollableTabRow.cs
@@ -15,7 +15,7 @@ public sealed class PrimaryScrollableTabRow : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.PrimaryScrollableTabRow(
             selectedTabIndex: _selectedTabIndex,
             modifier:         BuildModifier(),

--- a/src/ComposeNet.Compose/PrimaryTabRow.cs
+++ b/src/ComposeNet.Compose/PrimaryTabRow.cs
@@ -15,7 +15,7 @@ public sealed class PrimaryTabRow : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.PrimaryTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
     }
 }

--- a/src/ComposeNet.Compose/Row.cs
+++ b/src/ComposeNet.Compose/Row.cs
@@ -16,7 +16,7 @@ public sealed class Row : ComposableContainer
     internal override void Render(IComposer composer)
     {
         var modifier = BuildModifier();
-        var content  = new ComposableLambda3(c => RenderChildren(c));
+        var content  = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
 
         int defaults = (int)RowDefault.All;
         if (modifier is not null) defaults &= ~(int)RowDefault.Modifier;

--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -55,7 +55,7 @@ public sealed class Scaffold : ComposableNode
         // node, mirroring Kotlin's
         // `Column(Modifier.padding(paddingValues)) { ... }`.
         var body = Body;
-        var content = new ComposableLambda3((paddingHandle, c) =>
+        var content = ComposableLambdas.Wrap3(composer, (paddingHandle, c) =>
         {
             body.PrependModifier(Modifier.Companion.Padding(paddingHandle));
             body.Render(c);
@@ -68,10 +68,10 @@ public sealed class Scaffold : ComposableNode
         // recomposition — a flip in slot type triggers a runtime
         // ClassCastException. Emit nothing when the user didn't supply
         // a slot; functionally identical to M3's `{}` default.
-        var topBar = new ComposableLambda2(c => TopBar?.Render(c));
-        var bottomBar = new ComposableLambda2(c => BottomBar?.Render(c));
-        var snackbarHost = new ComposableLambda2(c => SnackbarHost?.Render(c));
-        var fab = new ComposableLambda2(c => FloatingActionButton?.Render(c));
+        var topBar = ComposableLambdas.Wrap2(composer, c => TopBar?.Render(c));
+        var bottomBar = ComposableLambdas.Wrap2(composer, c => BottomBar?.Render(c));
+        var snackbarHost = ComposableLambdas.Wrap2(composer, c => SnackbarHost?.Render(c));
+        var fab = ComposableLambdas.Wrap2(composer, c => FloatingActionButton?.Render(c));
 
         int defaults = (int)ScaffoldDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/ScrollableTabRow.cs
+++ b/src/ComposeNet.Compose/ScrollableTabRow.cs
@@ -15,7 +15,7 @@ public sealed class ScrollableTabRow : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.ScrollableTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
     }
 }

--- a/src/ComposeNet.Compose/SearchBar.cs
+++ b/src/ComposeNet.Compose/SearchBar.cs
@@ -48,7 +48,7 @@ public sealed class SearchBar : ComposableNode
                 "SearchBar.InputField is required (the Kotlin parameter has no default).");
 
         var stateHandle = ResolveStateHandle(_state, composer);
-        var inputField  = new ComposableLambda2(c => InputField.Render(c));
+        var inputField  = ComposableLambdas.Wrap2(composer, c => InputField.Render(c));
         ComposeBridges.SearchBar(stateHandle, inputField, BuildModifier(), composer);
     }
 

--- a/src/ComposeNet.Compose/SearchBarInputField.cs
+++ b/src/ComposeNet.Compose/SearchBarInputField.cs
@@ -90,9 +90,9 @@ public sealed class SearchBarInputField : ComposableNode
             ? (Kotlin.Jvm.Functions.IFunction1)NoOpSearchCallback.Instance
             : new ComposableLambda1(p => OnSearch(p?.ToString() ?? ""));
 
-        var placeholder  = Placeholder  is null ? null : new ComposableLambda2(c => Placeholder.Render(c));
-        var leadingIcon  = LeadingIcon  is null ? null : new ComposableLambda2(c => LeadingIcon.Render(c));
-        var trailingIcon = TrailingIcon is null ? null : new ComposableLambda2(c => TrailingIcon.Render(c));
+        var placeholder  = Placeholder  is null ? null : ComposableLambdas.Wrap2(composer, c => Placeholder.Render(c));
+        var leadingIcon  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        var trailingIcon = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
 
         ComposeBridges.SearchBarDefaultsInputField(
             textPeer.Handle,

--- a/src/ComposeNet.Compose/SecondaryScrollableTabRow.cs
+++ b/src/ComposeNet.Compose/SecondaryScrollableTabRow.cs
@@ -15,7 +15,7 @@ public sealed class SecondaryScrollableTabRow : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.SecondaryScrollableTabRow(
             selectedTabIndex: _selectedTabIndex,
             modifier:         BuildModifier(),

--- a/src/ComposeNet.Compose/SecondaryTabRow.cs
+++ b/src/ComposeNet.Compose/SecondaryTabRow.cs
@@ -14,7 +14,7 @@ public sealed class SecondaryTabRow : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.SecondaryTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
     }
 }

--- a/src/ComposeNet.Compose/SegmentedButton.cs
+++ b/src/ComposeNet.Compose/SegmentedButton.cs
@@ -53,13 +53,17 @@ public sealed class SegmentedButton : ComposableContainer
             throw new System.InvalidOperationException(
                 "SegmentedButton requires at least one child (the label slot has no Kotlin default).");
 
-        var label = new ComposableLambda2(c =>
+        var label = ComposableLambdas.Wrap2(composer, c =>
         {
             for (int i = 0; i < Children.Count; i++)
-                Children[i].Render(c);
+            {
+                c.StartReplaceableGroup(i);
+                try { Children[i].Render(c); }
+                finally { c.EndReplaceableGroup(); }
+            }
         });
         var iconNode = Icon;
-        ComposableLambda2? icon = iconNode is null ? null : new ComposableLambda2(c => iconNode.Render(c));
+        var icon = iconNode is null ? null : ComposableLambdas.Wrap2(composer, c => iconNode.Render(c));
         var modifier = BuildModifier();
 
         var scope = RenderContext.CurrentScope;

--- a/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
@@ -22,14 +22,16 @@ public sealed class SingleChoiceSegmentedButtonRow : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda3((scope, c) =>
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
             using var _    = RenderContext.PushScope(scope);
             using var rows = RenderContext.PushRow(Children.Count);
             for (int i = 0; i < Children.Count; i++)
             {
                 rows.SetIndex(i);
-                Children[i].Render(c);
+                c.StartReplaceableGroup(i);
+                try { Children[i].Render(c); }
+                finally { c.EndReplaceableGroup(); }
             }
         });
 

--- a/src/ComposeNet.Compose/Snackbar.cs
+++ b/src/ComposeNet.Compose/Snackbar.cs
@@ -30,11 +30,11 @@ public sealed class Snackbar : ComposableNode
             throw new System.InvalidOperationException(
                 "Snackbar.Body is required (the Kotlin content lambda has no default).");
 
-        var content = new ComposableLambda2(c => Body.Render(c));
-        ComposableLambda2? action = Action is null ? null
-            : new ComposableLambda2(c => Action.Render(c));
-        ComposableLambda2? dismiss = DismissAction is null ? null
-            : new ComposableLambda2(c => DismissAction.Render(c));
+        var content = ComposableLambdas.Wrap2(composer, c => Body.Render(c));
+        var action = Action is null ? null
+            : ComposableLambdas.Wrap2(composer, c => Action.Render(c));
+        var dismiss = DismissAction is null ? null
+            : ComposableLambdas.Wrap2(composer, c => DismissAction.Render(c));
 
         int defaults = (int)SnackbarDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/SnackbarHost.cs
+++ b/src/ComposeNet.Compose/SnackbarHost.cs
@@ -37,7 +37,7 @@ public sealed class SnackbarHost : ComposableNode
         // Forward it to the M3 default — Snackbar(snackbarData) — so an
         // externally-driven host state actually paints. The lambda is a
         // no-op when p0 is null (no queued data).
-        var snackbar = new ComposableLambda3((data, c) =>
+        var snackbar = ComposableLambdas.Wrap3(composer, (data, c) =>
         {
             if (data == IntPtr.Zero) return;
             ComposeBridges.SnackbarFromData(data, modifier: null, composer: c);

--- a/src/ComposeNet.Compose/SuggestionChip.cs
+++ b/src/ComposeNet.Compose/SuggestionChip.cs
@@ -24,8 +24,8 @@ public sealed class SuggestionChip : ComposableNode
                 "SuggestionChip.Label is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var label = new ComposableLambda2(c => Label.Render(c));
-        ComposableLambda2? icon = Icon is null ? null : new ComposableLambda2(c => Icon.Render(c));
+        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
+        var icon = Icon is null ? null : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
 
         int defaults = (int)SuggestionChipDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/Surface.cs
+++ b/src/ComposeNet.Compose/Surface.cs
@@ -10,7 +10,7 @@ public sealed class Surface : ComposableContainer
 {
     internal override void Render(IComposer composer)
     {
-        var content = new ComposableLambda2(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.Surface(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/Tab.cs
+++ b/src/ComposeNet.Compose/Tab.cs
@@ -29,8 +29,8 @@ public sealed class Tab : ComposableNode
     internal override void Render(IComposer composer)
     {
         var click = new ComposableLambda0(_onClick);
-        ComposableLambda2? text = Text is null ? null : new ComposableLambda2(c => Text.Render(c));
-        ComposableLambda2? icon = Icon is null ? null : new ComposableLambda2(c => Icon.Render(c));
+        var text = Text is null ? null : ComposableLambdas.Wrap2(composer, c => Text.Render(c));
+        var icon = Icon is null ? null : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
 
         int defaults = (int)TabDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/TabRow.cs
+++ b/src/ComposeNet.Compose/TabRow.cs
@@ -27,7 +27,7 @@ public sealed class TabRow : ComposableContainer
 
     internal override void Render(IComposer composer)
     {
-        var tabs = new ComposableLambda2(c => RenderChildren(c));
+        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.TabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
     }
 }

--- a/src/ComposeNet.Compose/TimePickerDialog.cs
+++ b/src/ComposeNet.Compose/TimePickerDialog.cs
@@ -30,13 +30,13 @@ public sealed class TimePickerDialog : ComposableNode
                 "TimePickerDialog.Body is required (the dialog's content slot).");
 
         var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var confirm   = new ComposableLambda2(c => ConfirmButton.Render(c));
-        var dismiss   = new ComposableLambda2(c => DismissButton.Render(c));
-        var content   = new ComposableLambda3(c => Body.Render(c));
-        ComposableLambda2? title = Title is null ? null
-            : new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? toggle = ModeToggleButton is null ? null
-            : new ComposableLambda2(c => ModeToggleButton.Render(c));
+        var confirm   = ComposableLambdas.Wrap2(composer, c => ConfirmButton.Render(c));
+        var dismiss   = ComposableLambdas.Wrap2(composer, c => DismissButton.Render(c));
+        var content   = ComposableLambdas.Wrap3(composer, c => Body.Render(c));
+        var title = Title is null ? null
+            : ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var toggle = ModeToggleButton is null ? null
+            : ComposableLambdas.Wrap2(composer, c => ModeToggleButton.Render(c));
 
         int defaults = (int)TimePickerDialogDefault.All;
         var modifier = BuildModifier();

--- a/src/ComposeNet.Compose/Tooltip.cs
+++ b/src/ComposeNet.Compose/Tooltip.cs
@@ -32,8 +32,8 @@ public sealed class Tooltip : ComposableNode
         var positionProvider = ComposeBridges.RememberPlainTooltipPositionProvider(composer);
         var stateHandle      = ComposeBridges.RememberTooltipState(_isPersistent, composer);
 
-        var tooltip = new ComposableLambda3(c => Tip.Render(c));
-        var anchor  = new ComposableLambda2(c => Anchor.Render(c));
+        var tooltip = ComposableLambdas.Wrap3(composer, c => Tip.Render(c));
+        var anchor  = ComposableLambdas.Wrap2(composer, c => Anchor.Render(c));
 
         var modifier = BuildModifier();
         int defaults = (int)TooltipBoxDefault.All;

--- a/src/ComposeNet.Compose/TopAppBar.cs
+++ b/src/ComposeNet.Compose/TopAppBar.cs
@@ -42,16 +42,16 @@ public sealed class TopAppBar : ComposableNode
             throw new System.InvalidOperationException(
                 "TopAppBar.Title is required (the Kotlin parameter has no default).");
 
-        var title = new ComposableLambda2(c => Title.Render(c));
-        ComposableLambda2? nav = NavigationIcon is null ? null
-            : new ComposableLambda2(c => NavigationIcon.Render(c));
-        ComposableLambda3? actions = Actions is null ? null
-            : new ComposableLambda3(c => Actions.Render(c));
+        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
+        var nav = NavigationIcon is null ? null
+            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
+        var actions = Actions is null ? null
+            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
         var modifier = BuildModifier();
 
         if (Subtitle is not null)
         {
-            var subtitle = new ComposableLambda2(c => Subtitle.Render(c));
+            var subtitle = ComposableLambdas.Wrap2(composer, c => Subtitle.Render(c));
 
             int defaults = (int)TopAppBarSubtitleDefault.All;
             if (modifier is not null) defaults &= ~(int)TopAppBarSubtitleDefault.Modifier;

--- a/src/ComposeNet.Compose/TopSearchBar.cs
+++ b/src/ComposeNet.Compose/TopSearchBar.cs
@@ -26,7 +26,7 @@ public sealed class TopSearchBar : ComposableNode
                 "TopSearchBar.InputField is required (the Kotlin parameter has no default).");
 
         var stateHandle = SearchBar.ResolveStateHandle(_state, composer);
-        var inputField  = new ComposableLambda2(c => InputField.Render(c));
+        var inputField  = ComposableLambdas.Wrap2(composer, c => InputField.Render(c));
         ComposeBridges.TopSearchBar(stateHandle, inputField, BuildModifier(), composer);
     }
 }

--- a/src/ComposeNet.Compose/WideNavigationRail.cs
+++ b/src/ComposeNet.Compose/WideNavigationRail.cs
@@ -27,7 +27,7 @@ public sealed class WideNavigationRail : ComposableContainer
         // WideNavigationRailItem is a top-level static (not a scope
         // extension), so we don't need to publish a receiver scope —
         // children render directly.
-        var content = new ComposableLambda2(c => RenderChildren(c));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
         ComposeBridges.WideNavigationRail(BuildModifier(), content, composer);
     }
 }

--- a/src/ComposeNet.Compose/WideNavigationRailItem.cs
+++ b/src/ComposeNet.Compose/WideNavigationRailItem.cs
@@ -32,8 +32,8 @@ public sealed class WideNavigationRailItem : ComposableNode
                 "WideNavigationRailItem.Icon is required (the Kotlin parameter has no default).");
 
         var click = new ComposableLambda0(_onClick);
-        var icon  = new ComposableLambda2(c => Icon.Render(c));
-        ComposableLambda2? label = Label is null ? null : new ComposableLambda2(c => Label.Render(c));
+        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
+        var label = Label is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
 
         int defaults = (int)WideNavigationRailItemDefault.All;
         var modifier = BuildModifier();


### PR DESCRIPTION
Addresses **hypotheses 1 and 2** from the investigation of #42 — the `ArrayIndexOutOfBoundsException` at `LayoutNode.insertAt$ui` / `UiApplier.insertBottomUp` that fires on tab switch after interacting with the Misc tab's controls. Full analysis: https://github.com/jonathanpeppers/compose-net/issues/42#issuecomment-4625348225.

This is one of three parallel work-streams on #42; H4, H5, and H6 are intentionally untouched here and are owned elsewhere (see the "Out of scope" section below).

## H1 — lambda identity stability

Every facade `Render(IComposer)` previously allocated fresh `new ComposableLambda2(...)` / `new ComposableLambda3(...)` instances per pass and handed them to bound Material composables as `content` / `topBar` / `bottomBar` / etc. slots. `SubcomposeLayout` (under `Scaffold`, `ModalNavigationDrawer`, `BottomSheetScaffold`, …) caches subcomposed content keyed by **lambda identity** — a fresh identity every pass thrashes the cache, queued Reuse/Move ops fire against the old identity but execute against the new tree, and `LayoutNode.insertAt$ui` lands at the wrong index.

The new `ComposableLambdas.Wrap2` / `Wrap3` helpers route every `@Composable` slot lambda through Compose's own factory:

```csharp
public static IFunction2 Wrap2(
    IComposer composer,
    Action<IComposer> body,
    [CallerLineNumber] int line = 0,
    [CallerFilePath]   string file = "")
    => (IFunction2)ComposableLambdaKt.ComposableLambda(
        composer, HashCode.Combine(line, file), tracked: true,
        block: new ComposableLambda2(body));
```

`ComposableLambdaKt.ComposableLambda(composer, key, tracked, block)` does `startReplaceableGroup(key)` → look up remembered `ComposableLambdaImpl` → update its `block` field → `endReplaceableGroup()` → return the impl. The returned `IComposableLambda` is **identity-stable** across recompositions even though the inner block is reallocated each pass — exactly what `SubcomposeLayout` needs. The key is derived from `[CallerLineNumber]` + `[CallerFilePath]` for cross-file uniqueness with zero call-site boilerplate.

**Scope decision: only `ComposableLambda2` / `ComposableLambda3` sites are wrapped.** `ComposableLambda0` (`onClick`) and `ComposableLambda1` (`onValueChange` / `onCheckedChange`) are plain Kotlin callbacks, **not** `@Composable` — wrapping them via `composableLambda` would inject `startRestartGroup`/`endRestartGroup` machinery into code that runs outside composition. The single call to `ComposableLambdaKt.ComposableLambdaInstance` in `ComposeActivity.SetContent` is correct as-is (it's the call-from-anywhere factory for the root, where there is no active composer).

Touched ~50 facade files: AlertDialog, AssistChip, Badge, BadgedBox, BottomAppBar, BottomSheetScaffold, Box, Button, Card, CenterAlignedTopAppBar, Column, CustomTab, DatePickerDialog, DismissibleDrawerSheet, DismissibleNavigationDrawer, ElevatedAssistChip, ElevatedCard, ElevatedFilterChip, ElevatedSuggestionChip, FilterChip, FlexibleBottomAppBar, FloatingActionButton, IconButton, InputChip, LargeFlexibleTopAppBar, LargeTopAppBar, LeadingIconTab, ListItem, MaterialTheme, MediumFlexibleTopAppBar, MediumTopAppBar, ModalBottomSheet, ModalDrawerSheet, ModalNavigationDrawer, MultiChoiceSegmentedButtonRow, NavigationBar, NavigationBarItem, NavigationRail, NavigationRailItem, OutlinedCard, PermanentDrawerSheet, PermanentNavigationDrawer, PrimaryScrollableTabRow, PrimaryTabRow, Row, Scaffold, ScrollableTabRow, SecondaryScrollableTabRow, SecondaryTabRow, SegmentedButton, SingleChoiceSegmentedButtonRow, Snackbar, SnackbarHost, SuggestionChip, Surface, Tab, TabRow, TimePickerDialog, Tooltip, TopAppBar, WideNavigationRail, WideNavigationRailItem.

Nullable optional-slot locals changed from `ComposableLambda2?` / `ComposableLambda3?` to `var` (inferred `IFunction2?` / `IFunction3?`) — the bridge signatures already take the interface types.

## H2 — per-sibling slot keys

Sibling `Children[i].Render(c)` calls inside any loop previously shared a single C# call-site → single slot-table group key. Three sibling `SegmentedButton` renders compete on one key; Compose disambiguates positionally, which is brittle combined with any identity churn.

`ComposableContainer.RenderChildren` now wraps each child in `composer.StartReplaceableGroup(i)` / `composer.EndReplaceableGroup()`. Three custom sibling loops that don't go through `RenderChildren` get the same wrap inside the loop body:

- `SingleChoiceSegmentedButtonRow.Render`
- `MultiChoiceSegmentedButtonRow.Render`
- `SegmentedButton.Render` (the label-slot inner loop)

`StartReplaceableGroup(int)` is the "this position in the list" primitive — chosen over `StartMovableGroup`, which is for LazyColumn-style reorderable items.

## Convention update

Added a section in `.github/copilot-instructions.md` under "Facade conventions" mandating the helper usage and documenting why `ComposableLambda0`/`ComposableLambda1` stay raw and why `ComposeActivity.SetContent` is exempt.

## Validation

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — ✅ 32/32 passing.
- `dotnet build src/ComposeNet.Compose` — ✅ green (3 pre-existing unrelated XML-doc warnings).
- `dotnet build src/ComposeNet.Sample` — ✅ green (Android workload available, build succeeded with 0 warnings, 0 errors).
- **On-device runtime verification not performed in this session.** The actual `LayoutNode.insertAt$ui` repro lives at the intersection of H1+H2+H5+H6; this PR is one of three parallel work-streams.

## Out of scope (other work-streams)

- **H5** — `Scaffold.PrependModifier` mutation pattern — handled in a parallel session.
- **H6** — `SegmentedButtonRow` `_changed: defaults` lines — handled in a parallel session.
- **H4** — `ComposableLambda*.Invoke` return-value semantics — deferred to #43.

## Test plan

Once all three work-streams land, the manual repro from #42 is: open the sample, tap into the Misc tab, interact with the segmented buttons / switches, then switch back to another tab. The crash trace at `LayoutNode.insertAt$ui` / `UiApplier.insertBottomUp` should no longer reproduce.

Closes: none (issue #42 needs all three work-streams; this PR makes one of three required fixes).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>