### PR TITLE
Bind ModalWideNavigationRail (issue #5 follow-up)

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -833,6 +833,38 @@ internal static partial class ComposeBridges
         Defaults  = typeof(WideNavigationRailDefault))]
     public static partial void WideNavigationRail(IModifier? modifier, IFunction2 content, IComposer composer);
 
+    // androidx.compose.material3.WideNavigationRailKt.ModalWideNavigationRail-k3FuEkE.
+    // The "-k3FuEkE" hash comes from the @JvmInline value-class Dp param
+    // (collapsedShadowElevation). 12 user params + 3 trailing ints
+    // ($changed, $changed1, $default). The facade always supplies
+    // `state` (via the bound RememberWideNavigationRailState),
+    // `hideOnCollapse` (true so the rail unmounts visually on collapse),
+    // and `content`. Shape / colors / elevation / windowInsets /
+    // arrangement / properties remain Kotlin defaults.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/WideNavigationRailKt",
+        JvmName   = "ModalWideNavigationRail-k3FuEkE",
+        Signature = "(Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/material3/WideNavigationRailState;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/WideNavigationRailColors;" +
+                    "Lkotlin/jvm/functions/Function2;F" +
+                    "Landroidx/compose/foundation/layout/WindowInsets;" +
+                    "Landroidx/compose/foundation/layout/Arrangement$Vertical;" +
+                    "Landroidx/compose/material3/ModalWideNavigationRailProperties;" +
+                    "Lkotlin/jvm/functions/Function2;" +
+                    "Landroidx/compose/runtime/Composer;III)V",
+        Defaults  = typeof(ModalWideNavigationRailDefault))]
+    public static partial void ModalWideNavigationRail(
+        IModifier?  modifier,
+        IntPtr      state,
+        bool        hideOnCollapse,
+        IFunction2? header,
+        IFunction2  content,
+        int         defaults,
+        IComposer   composer);
+
     // Modifier-chain extensions. These are non-@Composable Kotlin
     // extension functions on Modifier; their JNI signatures end in
     // `I L<marker>` (the $default bitmask plus a synthetic-overload

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -338,6 +338,15 @@ using ComposeNet;
     "!selected", "!onClick", "!icon", "label", "railExpanded",
     "modifier", "enabled", "iconPosition", "colors", "interactionSource")]
 
+// androidx.compose.material3.WideNavigationRailKt.ModalWideNavigationRail-k3FuEkE:
+// 12 user params; bits 1 (state) and 11 (content) always provided by the
+// facade. The facade also always sets `hideOnCollapse=true`, but we keep
+// that bit as an enum member because future overloads may toggle it.
+[assembly: ComposeDefaults("ModalWideNavigationRailDefault",
+    "modifier", "!state", "hideOnCollapse", "collapsedShape", "expandedShape",
+    "colors", "header", "collapsedShadowElevation", "windowInsets", "arrangement",
+    "properties", "!content")]
+
 // androidx.compose.material3.ProgressIndicatorKt.LinearProgressIndicator-rIrjwxo
 // (indeterminate, no progress callback). 5 user params, all optional.
 [assembly: ComposeDefaults("LinearProgressIndicatorDefault",

--- a/src/ComposeNet.Compose/ModalWideNavigationRail.cs
+++ b/src/ComposeNet.Compose/ModalWideNavigationRail.cs
@@ -33,6 +33,7 @@ namespace ComposeNet;
 ///
 /// <code>
 /// var show = Remember(() =&gt; new MutableState&lt;bool&gt;(false));
+/// var tab  = Remember(() =&gt; new MutableNumberState&lt;int&gt;(0));
 /// new Row
 /// {
 ///     new Button(onClick: () =&gt; show.Value = true) { new Text("Menu") },
@@ -40,7 +41,7 @@ namespace ComposeNet;
 ///         ? new ModalWideNavigationRail
 ///         {
 ///             Header = new Text("Sections"),
-///             new WideNavigationRailItem(selected: tab == 0, onClick: () =&gt; { tab.Value = 0; show.Value = false; })
+///             new WideNavigationRailItem(selected: tab.Value == 0, onClick: () =&gt; { tab.Value = 0; show.Value = false; })
 ///             {
 ///                 Icon  = new Text("🏠"),
 ///                 Label = new Text("Home"),

--- a/src/ComposeNet.Compose/ModalWideNavigationRail.cs
+++ b/src/ComposeNet.Compose/ModalWideNavigationRail.cs
@@ -1,0 +1,100 @@
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ModalWideNavigationRail</c> — the modal-overlay variant
+/// of <see cref="WideNavigationRail"/>. Drawn on top of the host screen
+/// with a scrim, suitable for narrow-width adaptive layouts. Stripped
+/// from the binding because <c>collapsedShadowElevation</c> is a
+/// <c>Dp</c> <c>@JvmInline value class</c> (hashed JVM name
+/// <c>-k3FuEkE</c>); reached via <see cref="ComposeBridges"/>.
+///
+/// <para>The Kotlin signature has no <c>onDismissRequest</c> callback —
+/// dismissal is driven internally by the rail's
+/// <c>WideNavigationRailState</c>. Because that state's
+/// <c>expand</c>/<c>collapse</c>/<c>snapTo</c> methods are Kotlin
+/// suspend functions, and the facade does not have a
+/// <c>LaunchedEffect</c>/coroutine-scope story yet, this facade ships
+/// with two practical limitations callers should know about:</para>
+/// <list type="bullet">
+///   <item>The rail always remembers its state with
+///   <c>WideNavigationRailValue.Expanded</c>, so it opens immediately
+///   when mounted.</item>
+///   <item>When the user dismisses by tapping the scrim, the rail
+///   visually disappears (because <c>hideOnCollapse=true</c>) but the
+///   C# facade has no way to observe the collapse. Drive close gestures
+///   from your own <see cref="MutableState{T}"/>-of-<see cref="bool"/>
+///   gate by mirroring the <see cref="ModalBottomSheet"/> pattern:
+///   wrap the instance in a ternary and add a button inside the rail
+///   content that flips the gate.</item>
+/// </list>
+///
+/// <code>
+/// var show = Remember(() =&gt; new MutableState&lt;bool&gt;(false));
+/// new Row
+/// {
+///     new Button(onClick: () =&gt; show.Value = true) { new Text("Menu") },
+///     show.Value
+///         ? new ModalWideNavigationRail
+///         {
+///             Header = new Text("Sections"),
+///             new WideNavigationRailItem(selected: tab == 0, onClick: () =&gt; { tab.Value = 0; show.Value = false; })
+///             {
+///                 Icon  = new Text("🏠"),
+///                 Label = new Text("Home"),
+///             },
+///         }
+///         : null,
+/// };
+/// </code>
+/// </summary>
+public sealed class ModalWideNavigationRail : ComposableContainer
+{
+    /// <summary>Optional header slot drawn at the top of the rail (e.g. a logo or menu button).</summary>
+    public ComposableNode? Header { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        if (Children.Count == 0)
+            throw new System.InvalidOperationException(
+                "ModalWideNavigationRail requires at least one child (the content slot has no Kotlin default).");
+
+        // Bound C# call — RememberWideNavigationRailState is NOT stripped.
+        // initialValue=Expanded so the rail opens immediately on mount;
+        // the visibility-toggle pattern (see XML doc) controls mount/unmount.
+        // _changed=0 because we provide initialValue.
+        var stateObj = WideNavigationRailStateKt.RememberWideNavigationRailState(
+            initialValue: WideNavigationRailValue.Expanded,
+            _composer:    composer,
+            p2:           0,
+            _changed:     0);
+        var stateHandle = ((Java.Lang.Object)stateObj).Handle;
+
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        var headerNode = Header;
+        var header = headerNode is null ? null
+            : ComposableLambdas.Wrap2(composer, c => headerNode.Render(c));
+
+        // Start from "default everything" and clear the bit for each
+        // optional slot the user actually supplied. `state` and `content`
+        // are not enum members (always provided), so they're not in `All`.
+        // `hideOnCollapse` IS an enum member and we always pass true, so
+        // we always clear its bit.
+        int defaults = (int)ModalWideNavigationRailDefault.All;
+        var modifier = BuildModifier();
+        if (modifier is not null) defaults &= ~(int)ModalWideNavigationRailDefault.Modifier;
+        defaults &= ~(int)ModalWideNavigationRailDefault.HideOnCollapse;
+        if (header   is not null) defaults &= ~(int)ModalWideNavigationRailDefault.Header;
+
+        ComposeBridges.ModalWideNavigationRail(
+            modifier:        modifier,
+            state:           stateHandle,
+            hideOnCollapse:  true,
+            header:          header,
+            content:         content,
+            defaults:        defaults,
+            composer:        composer);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -375,14 +375,17 @@ public class MainActivity : ComposeActivity
                     new Text($"ModalWideNavigationRail (selected: {modalRailIdx})"),
                     new Row
                     {
-                        new Button(onClick: () => showModalRail.Value = true) { new Text("Open modal rail") },
+                        new Button(onClick: () => showModalRail.Value = !showModalRail.Value)
+                        {
+                            new Text(showModalRail.Value ? "Hide modal rail" : "Open modal rail"),
+                        },
                     },
                     // Visibility-toggle pattern (see ModalWideNavigationRail
                     // XML doc): mounting the rail opens it; the "Close"
                     // item dismisses it. Scrim taps visually hide the rail
-                    // but can't notify C# yet (no onDismissRequest /
-                    // coroutine support), so a second "Open" tap requires
-                    // first toggling showModalRail off.
+                    // but can't notify C# (no onDismissRequest / coroutine
+                    // support), so the toggle button above is the escape
+                    // hatch for re-mounting after a scrim dismiss.
                     showModalRail.Value
                         ? new ModalWideNavigationRail
                         {

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -31,6 +31,8 @@ public class MainActivity : ComposeActivity
             var multiBold   = Remember(() => new MutableState<bool>(false));
             var multiItalic = Remember(() => new MutableState<bool>(false));
             var railIdx     = Remember(() => new MutableNumberState<int>(0));
+            var showModalRail = Remember(() => new MutableState<bool>(false));
+            var modalRailIdx  = Remember(() => new MutableNumberState<int>(0));
 
             var checkbox    = Remember(() => new MutableState<bool>(true));
             var switchOn    = Remember(() => new MutableState<bool>(false));
@@ -369,6 +371,49 @@ public class MainActivity : ComposeActivity
                             },
                         },
                     },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text($"ModalWideNavigationRail (selected: {modalRailIdx})"),
+                    new Row
+                    {
+                        new Button(onClick: () => showModalRail.Value = true) { new Text("Open modal rail") },
+                    },
+                    // Visibility-toggle pattern (see ModalWideNavigationRail
+                    // XML doc): mounting the rail opens it; the "Close"
+                    // item dismisses it. Scrim taps visually hide the rail
+                    // but can't notify C# yet (no onDismissRequest /
+                    // coroutine support), so a second "Open" tap requires
+                    // first toggling showModalRail off.
+                    showModalRail.Value
+                        ? new ModalWideNavigationRail
+                        {
+                            new WideNavigationRailItem(
+                                selected: modalRailIdx.Value == 0,
+                                onClick:  () => { modalRailIdx.Value = 0; showModalRail.Value = false; })
+                            {
+                                Icon  = new Text("🏠"),
+                                Label = new Text("Home"),
+                            },
+                            new WideNavigationRailItem(
+                                selected: modalRailIdx.Value == 1,
+                                onClick:  () => { modalRailIdx.Value = 1; showModalRail.Value = false; })
+                            {
+                                Icon  = new Text("🔍"),
+                                Label = new Text("Search"),
+                            },
+                            new WideNavigationRailItem(
+                                selected: modalRailIdx.Value == 2,
+                                onClick:  () => { modalRailIdx.Value = 2; showModalRail.Value = false; })
+                            {
+                                Icon  = new Text("⚙"),
+                                Label = new Text("Settings"),
+                            },
+                            new WideNavigationRailItem(selected: false, onClick: () => showModalRail.Value = false)
+                            {
+                                Icon  = new Text("✕"),
+                                Label = new Text("Close"),
+                            },
+                        }
+                        : (ComposableNode?)null,
                 },
                 _ => new Column
                 {


### PR DESCRIPTION
Completes the remaining actionable item from #5 that was deferred in #33.

#33 already shipped `CircularProgressIndicator`, `LinearProgressIndicator`,
`SegmentedButton` + both rows, `WideNavigationRail`, and
`WideNavigationRailItem`. This change adds `ModalWideNavigationRail` —
the modal-overlay variant. `SecureTextField` is still deferred on the
`TextFieldState` story (out of scope).

## What's added

- **Bridge.** `[ComposeBridge] ModalWideNavigationRail` targets the
  stripped `androidx/compose/material3/WideNavigationRailKt::ModalWideNavigationRail-k3FuEkE`
  JVM name. The hash comes from the `Dp` `@JvmInline value class` on
  `collapsedShadowElevation`; once dotnet/java-interop#1440 lands the
  bridge can be swapped for a direct binding call.
- **Defaults enum.** `[ComposeDefaults] ModalWideNavigationRailDefault`
  with `state` and `content` marked `!` (the facade always supplies
  these — they are not enum members and not in `All`).
- **Facade.** New `ModalWideNavigationRail` class (`ComposableContainer`
  with optional `Header` slot). Uses the bound (non-stripped)
  `WideNavigationRailStateKt.RememberWideNavigationRailState` for the
  state holder, so no extra bridge is needed there.
- **Sample.** A "Modal rail" button on the Misc tab demonstrates the
  visibility-toggle pattern with an internal "Close" item.

## Documented limitations

`WideNavigationRailState`s `expand` / `collapse` / `snapTo` methods are
Kotlin `suspend` functions. We don't have a `LaunchedEffect` /
coroutine story for C# yet, so:

1. The facade always remembers state with
   `WideNavigationRailValue.Expanded`, so the rail opens immediately
   when mounted.
2. Scrim-tap dismissal hides the rail visually (because
   `hideOnCollapse = true`) but cannot notify C#. Callers gate
   visibility on their own `MutableState<bool>` and add an internal
   close button — the sample shows the pattern, and the XML doc on
   `ModalWideNavigationRail` calls this out explicitly.

## Known risk

The Misc tab still trips compose-net#42 ("LayoutNode insertAt
ArrayIndexOutOfBoundsException") when switching tabs after interacting
with several Misc widgets. `ModalWideNavigationRail` may share the same
underlying `$changed = 0` / lambda-identity story; tracked separately
in that issue.

## Verified

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 32/32 pass.
- `dotnet build src/ComposeNet.Compose` — 0 errors.
- `dotnet build src/ComposeNet.Sample` — 0 errors, 0 warnings.

Closes the modal-rail part of #5.
