### PR TITLE
Bind Button & IconButton variants (#55)

### DIFF
--- a/src/ComposeNet.Compose/Checkbox.cs
+++ b/src/ComposeNet.Compose/Checkbox.cs
@@ -6,7 +6,7 @@ namespace ComposeNet;
 /// <summary>
 /// Material 3 <c>Checkbox</c>:
 /// <code>
-/// new Checkbox(checked: state.Value, onCheckedChange: v => state.Value = v)
+/// new Checkbox(@checked: state.Value, onCheckedChange: v => state.Value = v)
 /// </code>
 /// </summary>
 public sealed class Checkbox : ComposableNode

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -241,6 +241,64 @@ internal static partial class ComposeBridges
     public static partial void Button(IFunction0 onClick, IModifier? modifier,
                                       IFunction3 content, IComposer composer);
 
+    // androidx.compose.material3.ButtonKt.OutlinedButton — same Kotlin
+    // signature as Button (10 user params with shape/colors/elevation/
+    // border/contentPadding/interactionSource), so it reuses ButtonDefault.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/ButtonKt",
+        JvmName   = "OutlinedButton",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/ButtonColors;" +
+                    "Landroidx/compose/material3/ButtonElevation;Landroidx/compose/foundation/BorderStroke;" +
+                    "Landroidx/compose/foundation/layout/PaddingValues;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(ButtonDefault))]
+    public static partial void OutlinedButton(IFunction0 onClick, IModifier? modifier,
+                                              IFunction3 content, IComposer composer);
+
+    // androidx.compose.material3.ButtonKt.TextButton — same shape as Button.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/ButtonKt",
+        JvmName   = "TextButton",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/ButtonColors;" +
+                    "Landroidx/compose/material3/ButtonElevation;Landroidx/compose/foundation/BorderStroke;" +
+                    "Landroidx/compose/foundation/layout/PaddingValues;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(ButtonDefault))]
+    public static partial void TextButton(IFunction0 onClick, IModifier? modifier,
+                                          IFunction3 content, IComposer composer);
+
+    // androidx.compose.material3.ButtonKt.ElevatedButton — same shape as Button.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/ButtonKt",
+        JvmName   = "ElevatedButton",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/ButtonColors;" +
+                    "Landroidx/compose/material3/ButtonElevation;Landroidx/compose/foundation/BorderStroke;" +
+                    "Landroidx/compose/foundation/layout/PaddingValues;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(ButtonDefault))]
+    public static partial void ElevatedButton(IFunction0 onClick, IModifier? modifier,
+                                              IFunction3 content, IComposer composer);
+
+    // androidx.compose.material3.ButtonKt.FilledTonalButton — same shape as Button.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/ButtonKt",
+        JvmName   = "FilledTonalButton",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;Landroidx/compose/material3/ButtonColors;" +
+                    "Landroidx/compose/material3/ButtonElevation;Landroidx/compose/foundation/BorderStroke;" +
+                    "Landroidx/compose/foundation/layout/PaddingValues;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(ButtonDefault))]
+    public static partial void FilledTonalButton(IFunction0 onClick, IModifier? modifier,
+                                                 IFunction3 content, IComposer composer);
+
     // androidx.compose.material3.IconButtonKt.IconButton
     [ComposeBridge(
         Class     = "androidx/compose/material3/IconButtonKt",
@@ -252,6 +310,111 @@ internal static partial class ComposeBridges
         Defaults  = typeof(IconButtonDefault))]
     public static partial void IconButton(IFunction0 onClick, IModifier? modifier,
                                           IFunction2 content, IComposer composer);
+
+    // androidx.compose.material3.IconButtonKt.FilledIconButton — adds Shape
+    // before colors compared to plain IconButton (7 user params).
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/IconButtonKt",
+        JvmName   = "FilledIconButton",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/IconButtonColors;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(FilledIconButtonDefault))]
+    public static partial void FilledIconButton(IFunction0 onClick, IModifier? modifier,
+                                                IFunction2 content, IComposer composer);
+
+    // androidx.compose.material3.IconButtonKt.FilledTonalIconButton — same
+    // signature as FilledIconButton.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/IconButtonKt",
+        JvmName   = "FilledTonalIconButton",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/IconButtonColors;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(FilledIconButtonDefault))]
+    public static partial void FilledTonalIconButton(IFunction0 onClick, IModifier? modifier,
+                                                     IFunction2 content, IComposer composer);
+
+    // androidx.compose.material3.IconButtonKt.OutlinedIconButton — adds
+    // BorderStroke between colors and interactionSource (8 user params).
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/IconButtonKt",
+        JvmName   = "OutlinedIconButton",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/IconButtonColors;" +
+                    "Landroidx/compose/foundation/BorderStroke;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(OutlinedIconButtonDefault))]
+    public static partial void OutlinedIconButton(IFunction0 onClick, IModifier? modifier,
+                                                  IFunction2 content, IComposer composer);
+
+    // androidx.compose.material3.IconButtonKt.IconToggleButton — toggle
+    // shape: leading boolean checked + Function1 onCheckedChange instead of
+    // a Function0 onClick (7 user params).
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/IconButtonKt",
+        JvmName   = "IconToggleButton",
+        Signature = "(ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/material3/IconToggleButtonColors;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(IconToggleButtonDefault))]
+    public static partial void IconToggleButton(bool @checked, IFunction1 onCheckedChange,
+                                                IModifier? modifier, IFunction2 content,
+                                                IComposer composer);
+
+    // androidx.compose.material3.IconButtonKt.FilledIconToggleButton — adds
+    // Shape between enabled and colors compared to plain IconToggleButton
+    // (8 user params).
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/IconButtonKt",
+        JvmName   = "FilledIconToggleButton",
+        Signature = "(ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/IconToggleButtonColors;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(FilledIconToggleButtonDefault))]
+    public static partial void FilledIconToggleButton(bool @checked, IFunction1 onCheckedChange,
+                                                      IModifier? modifier, IFunction2 content,
+                                                      IComposer composer);
+
+    // androidx.compose.material3.IconButtonKt.FilledTonalIconToggleButton —
+    // same signature as FilledIconToggleButton.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/IconButtonKt",
+        JvmName   = "FilledTonalIconToggleButton",
+        Signature = "(ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/IconToggleButtonColors;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(FilledIconToggleButtonDefault))]
+    public static partial void FilledTonalIconToggleButton(bool @checked, IFunction1 onCheckedChange,
+                                                           IModifier? modifier, IFunction2 content,
+                                                           IComposer composer);
+
+    // androidx.compose.material3.IconButtonKt.OutlinedIconToggleButton —
+    // adds BorderStroke between colors and interactionSource (9 user params).
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/IconButtonKt",
+        JvmName   = "OutlinedIconToggleButton",
+        Signature = "(ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/IconToggleButtonColors;" +
+                    "Landroidx/compose/foundation/BorderStroke;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(OutlinedIconToggleButtonDefault))]
+    public static partial void OutlinedIconToggleButton(bool @checked, IFunction1 onCheckedChange,
+                                                        IModifier? modifier, IFunction2 content,
+                                                        IComposer composer);
 
     // androidx.compose.material3.FloatingActionButtonKt.FloatingActionButton-X-z6DiA
     [ComposeBridge(

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -96,6 +96,40 @@ using ComposeNet;
 [assembly: ComposeDefaults("IconButtonDefault",
     "!onClick", "modifier", "enabled", "colors", "interactionSource", "!content")]
 
+// androidx.compose.material3.IconButtonKt.{FilledIconButton,FilledTonalIconButton}:
+// 7 user params, bit 0 = onClick, bit 6 = content (both provided).
+// Filled and FilledTonal variants share the same Kotlin signature so they
+// reuse one enum.
+[assembly: ComposeDefaults("FilledIconButtonDefault",
+    "!onClick", "modifier", "enabled", "shape", "colors",
+    "interactionSource", "!content")]
+
+// androidx.compose.material3.IconButtonKt.OutlinedIconButton: 8 user
+// params, bit 0 = onClick, bit 7 = content (both provided).
+[assembly: ComposeDefaults("OutlinedIconButtonDefault",
+    "!onClick", "modifier", "enabled", "shape", "colors", "border",
+    "interactionSource", "!content")]
+
+// androidx.compose.material3.IconButtonKt.IconToggleButton: 7 user params,
+// bits 0 (checked), 1 (onCheckedChange), 6 (content) always provided.
+[assembly: ComposeDefaults("IconToggleButtonDefault",
+    "!checked", "!onCheckedChange", "modifier", "enabled", "colors",
+    "interactionSource", "!content")]
+
+// androidx.compose.material3.IconButtonKt.{FilledIconToggleButton,FilledTonalIconToggleButton}:
+// 8 user params, bits 0 (checked), 1 (onCheckedChange), 7 (content)
+// always provided. Filled and FilledTonal share one enum.
+[assembly: ComposeDefaults("FilledIconToggleButtonDefault",
+    "!checked", "!onCheckedChange", "modifier", "enabled", "shape",
+    "colors", "interactionSource", "!content")]
+
+// androidx.compose.material3.IconButtonKt.OutlinedIconToggleButton:
+// 9 user params, bits 0 (checked), 1 (onCheckedChange), 8 (content)
+// always provided.
+[assembly: ComposeDefaults("OutlinedIconToggleButtonDefault",
+    "!checked", "!onCheckedChange", "modifier", "enabled", "shape",
+    "colors", "border", "interactionSource", "!content")]
+
 // androidx.compose.material3.FloatingActionButtonKt.FloatingActionButton-X-z6DiA:
 // 8 user params, bit 0 = onClick, bit 7 = content (both provided).
 [assembly: ComposeDefaults("FloatingActionButtonDefault",

--- a/src/ComposeNet.Compose/ElevatedButton.cs
+++ b/src/ComposeNet.Compose/ElevatedButton.cs
@@ -1,0 +1,20 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ElevatedButton</c>. Same shape as <see cref="Button"/>:
+/// <code>new ElevatedButton(onClick: () => Save()) { new Text("Save") }</code>
+/// </summary>
+public sealed class ElevatedButton : ComposableContainer
+{
+    readonly System.Action _onClick;
+    public ElevatedButton(System.Action onClick) => _onClick = onClick;
+
+    internal override void Render(IComposer composer)
+    {
+        var click   = new ComposableLambda0(_onClick);
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+        ComposeBridges.ElevatedButton(click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/FilledIconButton.cs
+++ b/src/ComposeNet.Compose/FilledIconButton.cs
@@ -1,0 +1,20 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>FilledIconButton</c>. Same shape as <see cref="IconButton"/>:
+/// <code>new FilledIconButton(onClick: () => Save()) { new Text("✓") }</code>
+/// </summary>
+public sealed class FilledIconButton : ComposableContainer
+{
+    readonly System.Action _onClick;
+    public FilledIconButton(System.Action onClick) => _onClick = onClick;
+
+    internal override void Render(IComposer composer)
+    {
+        var click   = new ComposableLambda0(_onClick);
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        ComposeBridges.FilledIconButton(click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/FilledIconToggleButton.cs
+++ b/src/ComposeNet.Compose/FilledIconToggleButton.cs
@@ -1,0 +1,26 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>FilledIconToggleButton</c>. Same shape as <see cref="IconToggleButton"/>.
+/// </summary>
+public sealed class FilledIconToggleButton : ComposableContainer
+{
+    readonly bool _checked;
+    readonly System.Action<bool> _onCheckedChange;
+
+    public FilledIconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
+    {
+        _checked = @checked;
+        _onCheckedChange = onCheckedChange;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        var onChange = new ComposableLambda1(v =>
+            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        ComposeBridges.FilledIconToggleButton(_checked, onChange, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/FilledTonalButton.cs
+++ b/src/ComposeNet.Compose/FilledTonalButton.cs
@@ -1,0 +1,20 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>FilledTonalButton</c>. Same shape as <see cref="Button"/>:
+/// <code>new FilledTonalButton(onClick: () => Apply()) { new Text("Apply") }</code>
+/// </summary>
+public sealed class FilledTonalButton : ComposableContainer
+{
+    readonly System.Action _onClick;
+    public FilledTonalButton(System.Action onClick) => _onClick = onClick;
+
+    internal override void Render(IComposer composer)
+    {
+        var click   = new ComposableLambda0(_onClick);
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+        ComposeBridges.FilledTonalButton(click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/FilledTonalIconButton.cs
+++ b/src/ComposeNet.Compose/FilledTonalIconButton.cs
@@ -1,0 +1,19 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>FilledTonalIconButton</c>. Same shape as <see cref="IconButton"/>.
+/// </summary>
+public sealed class FilledTonalIconButton : ComposableContainer
+{
+    readonly System.Action _onClick;
+    public FilledTonalIconButton(System.Action onClick) => _onClick = onClick;
+
+    internal override void Render(IComposer composer)
+    {
+        var click   = new ComposableLambda0(_onClick);
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        ComposeBridges.FilledTonalIconButton(click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/FilledTonalIconToggleButton.cs
+++ b/src/ComposeNet.Compose/FilledTonalIconToggleButton.cs
@@ -1,0 +1,26 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>FilledTonalIconToggleButton</c>. Same shape as <see cref="IconToggleButton"/>.
+/// </summary>
+public sealed class FilledTonalIconToggleButton : ComposableContainer
+{
+    readonly bool _checked;
+    readonly System.Action<bool> _onCheckedChange;
+
+    public FilledTonalIconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
+    {
+        _checked = @checked;
+        _onCheckedChange = onCheckedChange;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        var onChange = new ComposableLambda1(v =>
+            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        ComposeBridges.FilledTonalIconToggleButton(_checked, onChange, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/IconToggleButton.cs
+++ b/src/ComposeNet.Compose/IconToggleButton.cs
@@ -5,7 +5,7 @@ namespace ComposeNet;
 /// <summary>
 /// Material 3 <c>IconToggleButton</c>:
 /// <code>
-/// new IconToggleButton(checked: state.Value, onCheckedChange: v => state.Value = v) { new Text("★") }
+/// new IconToggleButton(@checked: state.Value, onCheckedChange: v => state.Value = v) { new Text("★") }
 /// </code>
 /// </summary>
 public sealed class IconToggleButton : ComposableContainer

--- a/src/ComposeNet.Compose/IconToggleButton.cs
+++ b/src/ComposeNet.Compose/IconToggleButton.cs
@@ -1,0 +1,29 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>IconToggleButton</c>:
+/// <code>
+/// new IconToggleButton(checked: state.Value, onCheckedChange: v => state.Value = v) { new Text("★") }
+/// </code>
+/// </summary>
+public sealed class IconToggleButton : ComposableContainer
+{
+    readonly bool _checked;
+    readonly System.Action<bool> _onCheckedChange;
+
+    public IconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
+    {
+        _checked = @checked;
+        _onCheckedChange = onCheckedChange;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        var onChange = new ComposableLambda1(v =>
+            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        ComposeBridges.IconToggleButton(_checked, onChange, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/OutlinedButton.cs
+++ b/src/ComposeNet.Compose/OutlinedButton.cs
@@ -1,0 +1,22 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>OutlinedButton</c>. Same shape as <see cref="Button"/> —
+/// constructor takes an <c>onClick</c> and content goes through the
+/// collection initializer:
+/// <code>new OutlinedButton(onClick: () => count++) { new Text("Cancel") }</code>
+/// </summary>
+public sealed class OutlinedButton : ComposableContainer
+{
+    readonly System.Action _onClick;
+    public OutlinedButton(System.Action onClick) => _onClick = onClick;
+
+    internal override void Render(IComposer composer)
+    {
+        var click   = new ComposableLambda0(_onClick);
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+        ComposeBridges.OutlinedButton(click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/OutlinedIconButton.cs
+++ b/src/ComposeNet.Compose/OutlinedIconButton.cs
@@ -1,0 +1,19 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>OutlinedIconButton</c>. Same shape as <see cref="IconButton"/>.
+/// </summary>
+public sealed class OutlinedIconButton : ComposableContainer
+{
+    readonly System.Action _onClick;
+    public OutlinedIconButton(System.Action onClick) => _onClick = onClick;
+
+    internal override void Render(IComposer composer)
+    {
+        var click   = new ComposableLambda0(_onClick);
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        ComposeBridges.OutlinedIconButton(click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/OutlinedIconToggleButton.cs
+++ b/src/ComposeNet.Compose/OutlinedIconToggleButton.cs
@@ -1,0 +1,26 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>OutlinedIconToggleButton</c>. Same shape as <see cref="IconToggleButton"/>.
+/// </summary>
+public sealed class OutlinedIconToggleButton : ComposableContainer
+{
+    readonly bool _checked;
+    readonly System.Action<bool> _onCheckedChange;
+
+    public OutlinedIconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
+    {
+        _checked = @checked;
+        _onCheckedChange = onCheckedChange;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        var onChange = new ComposableLambda1(v =>
+            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
+        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
+        ComposeBridges.OutlinedIconToggleButton(_checked, onChange, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Compose/Switch.cs
+++ b/src/ComposeNet.Compose/Switch.cs
@@ -6,7 +6,7 @@ namespace ComposeNet;
 /// <summary>
 /// Material 3 <c>Switch</c>:
 /// <code>
-/// new Switch(checked: state.Value, onCheckedChange: v => state.Value = v)
+/// new Switch(@checked: state.Value, onCheckedChange: v => state.Value = v)
 /// </code>
 /// </summary>
 public sealed class Switch : ComposableNode

--- a/src/ComposeNet.Compose/TextButton.cs
+++ b/src/ComposeNet.Compose/TextButton.cs
@@ -1,0 +1,20 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>TextButton</c>. Same shape as <see cref="Button"/>:
+/// <code>new TextButton(onClick: () => Navigate()) { new Text("Cancel") }</code>
+/// </summary>
+public sealed class TextButton : ComposableContainer
+{
+    readonly System.Action _onClick;
+    public TextButton(System.Action onClick) => _onClick = onClick;
+
+    internal override void Render(IComposer composer)
+    {
+        var click   = new ComposableLambda0(_onClick);
+        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+        ComposeBridges.TextButton(click, BuildModifier(), content, composer);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -41,6 +41,10 @@ public class MainActivity : ComposeActivity
             var sliderVal   = Remember(() => new MutableState<float>(0.5f));
             var rangeStart  = Remember(() => new MutableState<float>(0.25f));
             var rangeEnd    = Remember(() => new MutableState<float>(0.75f));
+            var iconToggle1 = Remember(() => new MutableState<bool>(false));
+            var iconToggle2 = Remember(() => new MutableState<bool>(true));
+            var iconToggle3 = Remember(() => new MutableState<bool>(false));
+            var iconToggle4 = Remember(() => new MutableState<bool>(true));
 
             var menuOpen      = Remember(() => new MutableState<bool>(false));
             var menuSelection = Remember(() => new MutableState<string>("(none)"));
@@ -159,6 +163,39 @@ public class MainActivity : ComposeActivity
                 },
                 1 => new Column
                 {
+                    new Text("Button fill styles"),
+                    new Button(onClick: () => count++) { new Text("Filled") },
+                    new ElevatedButton(onClick: () => count++) { new Text("Elevated") },
+                    new FilledTonalButton(onClick: () => count++) { new Text("Filled tonal") },
+                    new OutlinedButton(onClick: () => count++) { new Text("Outlined") },
+                    new TextButton(onClick: () => count++) { new Text("Text") },
+
+                    new Text("Icon button fill styles"),
+                    new Row
+                    {
+                        new IconButton(onClick: () => count++) { new Text("☆") },
+                        new FilledIconButton(onClick: () => count++) { new Text("★") },
+                        new FilledTonalIconButton(onClick: () => count++) { new Text("◆") },
+                        new OutlinedIconButton(onClick: () => count++) { new Text("◇") },
+                    },
+
+                    new Text("Icon toggle buttons"),
+                    new Row
+                    {
+                        new IconToggleButton(@checked: iconToggle1.Value,
+                            onCheckedChange: v => iconToggle1.Value = v)
+                        { new Text(iconToggle1.Value ? "★" : "☆") },
+                        new FilledIconToggleButton(@checked: iconToggle2.Value,
+                            onCheckedChange: v => iconToggle2.Value = v)
+                        { new Text(iconToggle2.Value ? "★" : "☆") },
+                        new FilledTonalIconToggleButton(@checked: iconToggle3.Value,
+                            onCheckedChange: v => iconToggle3.Value = v)
+                        { new Text(iconToggle3.Value ? "◆" : "◇") },
+                        new OutlinedIconToggleButton(@checked: iconToggle4.Value,
+                            onCheckedChange: v => iconToggle4.Value = v)
+                        { new Text(iconToggle4.Value ? "◆" : "◇") },
+                    },
+
                     new Text("Chips, FAB, tooltip"),
                     new AssistChip(onClick: () => count++)
                     {


### PR DESCRIPTION
Closes #55.

Adds the missing Material 3 button-family composables — five filled button styles for `ButtonKt` and the full filled / tonal / outlined icon-button + icon-toggle-button family for `IconButtonKt`:

| Composable | Kt class |
|---|---|
| `OutlinedButton` | `ButtonKt` |
| `TextButton` | `ButtonKt` |
| `ElevatedButton` | `ButtonKt` |
| `FilledTonalButton` | `ButtonKt` |
| `FilledIconButton` | `IconButtonKt` |
| `FilledTonalIconButton` | `IconButtonKt` |
| `OutlinedIconButton` | `IconButtonKt` |
| `IconToggleButton` | `IconButtonKt` |
| `FilledIconToggleButton` | `IconButtonKt` |
| `FilledTonalIconToggleButton` | `IconButtonKt` |
| `OutlinedIconToggleButton` | `IconButtonKt` |

## How it lands

I confirmed via the binding metadata that **none** of these methods survive the binder today (every `ButtonKt`/`IconButtonKt` overload uses inline-class params — `Color`, `Dp`, `TextUnit`, `Shape` extension funs — so they all get hash-mangled and stripped). So each new function gets a `[ComposeBridge]` partial in `ComposeBridges.cs` and the source generator emits the JNI plumbing.

Verified the precise JNI signatures from the bytecode of `androidx.compose.material3.material3-android.aar:1.4.0.3` with `javap -s -public`.

### Defaults

* The four `ButtonKt` variants share `Button`'s 10-parameter `$default` shape (`onClick, modifier, enabled, shape, colors, elevation, border, contentPadding, interactionSource, content`), so they all reuse the existing `ButtonDefault`.
* `IconButtonKt` gets five new declarative `[ComposeDefaults]` enums (the Filled/FilledTonal pairs share an enum since their Kotlin signatures are identical):
  * `FilledIconButtonDefault` — Filled & FilledTonal IconButton
  * `OutlinedIconButtonDefault`
  * `IconToggleButtonDefault`
  * `FilledIconToggleButtonDefault` — Filled & FilledTonal IconToggleButton
  * `OutlinedIconToggleButtonDefault`

### Facade

Each new facade is in its own `.cs` file, derives from `ComposableContainer`, and routes its content lambda through `ComposableLambdas.Wrap2/Wrap3` so it matches the existing `IconButton`/`Button` shape. Toggle variants take `bool @checked + Action<bool> onCheckedChange`, mirroring `Switch`/`Checkbox` — issue #55 explicitly called this out as the preferred shape.

### Sample

Buttons tab now shows:

* a vertical stack of `Button` / `ElevatedButton` / `FilledTonalButton` / `OutlinedButton` / `TextButton` so the five fill styles can be compared visually
* a row of `IconButton` / `FilledIconButton` / `FilledTonalIconButton` / `OutlinedIconButton`
* a row of all four `*IconToggleButton` variants, each wired to its own `MutableState<bool>` so you can tap to toggle and watch the icon character flip

## Build

* `dotnet test src/ComposeNet.SourceGenerators.Tests` — 37/37 pass (no new generator tests needed; the existing CN2xxx coverage already exercises the shape these bridges use).
* `dotnet build src/ComposeNet.Compose` — clean.
* `dotnet build src/ComposeNet.Sample` — clean.

## Future work

Per the existing `ComposeDefaults.cs` comment, when [dotnet/java-interop#1440](https://github.com/dotnet/java-interop/pull/1440) lands and exposes the inline-class overloads, every bridge added here can be deleted in favor of `[assembly: ComposeDefaults<ButtonKt>("OutlinedButton", "ButtonDefault")]` (etc.) and a direct generated-binding call in each facade.