### PR TITLE
Bump Compose UI.Graphics to 1.11.2.1, port colors to ColorKt

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,16 +21,18 @@
     <PackageReference Update="Xamarin.AndroidX.Activity.Compose" Version="1.13.0" />
 
     <!-- AndroidX Compose -->
-    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation" Version="1.11.1.1" />
-    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Android" Version="1.11.1.1" />
-    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Layout" Version="1.11.1.1" />
-    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Layout.Android" Version="1.11.1.1" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation" Version="1.11.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Android" Version="1.11.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Layout" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Layout.Android" Version="1.11.2" />
     <PackageReference Update="Xamarin.AndroidX.Compose.Material3" Version="1.4.0.2" />
     <PackageReference Update="Xamarin.AndroidX.Compose.Material3Android" Version="1.4.0.3" />
-    <PackageReference Update="Xamarin.AndroidX.Compose.Runtime" Version="1.11.1.1" />
-    <PackageReference Update="Xamarin.AndroidX.Compose.Runtime.Android" Version="1.11.1.1" />
-    <PackageReference Update="Xamarin.AndroidX.Compose.UI" Version="1.11.1.1" />
-    <PackageReference Update="Xamarin.AndroidX.Compose.UI.Android" Version="1.11.1.1" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Runtime" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Runtime.Android" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.UI" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.UI.Android" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.UI.Graphics" Version="1.11.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.UI.Graphics.Android" Version="1.11.2.1" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ dotnet test src/ComposeNet.SourceGenerators.Tests
 
 ## Progress
 
-Upstream `Xamarin.AndroidX.Compose.*` 1.11.1.1 (and `Material3` 1.4.0.x) now
+Upstream `Xamarin.AndroidX.Compose.*` 1.11.2.x (and `Material3` 1.4.0.x) now
 ship real bindings, so the per-binding projects this repo originally needed
 have been deleted. The sample and facade reference the official NuGets
 directly. The historical context behind the in-repo bindings is preserved in
@@ -195,7 +195,7 @@ Confirmed on device:
 - Click → `count++` → recomposition → visible count update.
 
 The facade ([`ComposeNet.Compose`](src/ComposeNet.Compose)) and sample
-reference the official `Xamarin.AndroidX.Compose.*` 1.11.1.1 and
+reference the official `Xamarin.AndroidX.Compose.*` 1.11.2.x and
 `Xamarin.AndroidX.Compose.Material3` 1.4.0.x NuGets directly. The
 historical context behind the previously in-repo `<AndroidMavenLibrary>`
 binding projects (now deleted) is preserved in [NOTES.md](NOTES.md).

--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Android.Graphics;
+using AndroidX.Compose.UI.Graphics;
 using ComposeNet;
 
 namespace ComposeNet.Samples.Jetchat;
@@ -27,10 +27,11 @@ public static class Conversation
     // Material 3 surface-variant-ish greys, picked to approximate
     // Jetchat's bubble palette without binding MaterialTheme.colorScheme
     // (issue #61). "Me" bubbles get the primary-container shade, others
-    // get the surface-variant shade.
-    static readonly Color MeBubbleColor    = new Color(0xD0, 0xE4, 0xFF);
-    static readonly Color OtherBubbleColor = new Color(0xED, 0xED, 0xED);
-    static readonly Color AvatarTileColor  = new Color(0xE0, 0xE0, 0xE0);
+    // get the surface-variant shade. Stored as packed Compose Color
+    // longs (see AndroidX.Compose.UI.Graphics.ColorKt.Color).
+    static readonly long MeBubbleColor    = ColorKt.Color(red: 0xD0, green: 0xE4, blue: 0xFF, alpha: 0xFF);
+    static readonly long OtherBubbleColor = ColorKt.Color(red: 0xED, green: 0xED, blue: 0xED, alpha: 0xFF);
+    static readonly long AvatarTileColor  = ColorKt.Color(red: 0xE0, green: 0xE0, blue: 0xE0, alpha: 0xFF);
 
 
     /// <summary>Materialize the conversation tree for one composition pass.</summary>

--- a/samples/Jetchat/README.md
+++ b/samples/Jetchat/README.md
@@ -63,8 +63,10 @@ Phase 1 of this branch landed the facade gaps Jetchat needed:
 - **Sizing modifiers**: `Modifier.Size(int)`, `Size(int, int)`,
   `Width(int)`, `Height(int)`.
 - **Background / Border / Clickable**: surfaced existing bridges as
-  public `Modifier` methods (`Background(Android.Graphics.Color)`,
-  `Border(int, Android.Graphics.Color, int = 0)`, `Clickable(Action)`).
+  public `Modifier` methods (`Background(long)` / `Border(int, long, int = 0)`
+  taking a packed Compose `Color` long built via
+  `AndroidX.Compose.UI.Graphics.ColorKt.Color(...)`, and
+  `Clickable(Action)`).
 - **Shape clipping**: `Modifier.Clip(int cornerDp)` — two-step JNI
   helper that constructs a `RoundedCornerShape` and applies
   `ClipKt.clip` in one fluent op.

--- a/src/ComposeNet.Compose/ComposeNet.Compose.csproj
+++ b/src/ComposeNet.Compose/ComposeNet.Compose.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Android" />
     <PackageReference Include="Xamarin.AndroidX.Compose.UI" />
     <PackageReference Include="Xamarin.AndroidX.Compose.UI.Android" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.UI.Graphics" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.UI.Graphics.Android" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Foundation" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Foundation.Android" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Foundation.Layout" />

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -1,4 +1,3 @@
-using Android.Graphics;
 using Android.Runtime;
 using AndroidX.Compose.UI;
 using Java.Interop;
@@ -213,35 +212,35 @@ public sealed class Modifier
 
     /// <summary>
     /// <c>Modifier.background(color)</c> — paints a flat fill behind the
-    /// composable using a <c>RectangleShape</c>. Takes an
-    /// <see cref="Android.Graphics.Color"/>; use one of the named
-    /// constants (<c>Color.Blue</c>, <c>Color.Transparent</c>, …) or
-    /// <c>Color.Argb(a, r, g, b)</c> / <c>Color.ParseColor("#…")</c>.
-    /// (Temporary: should be <c>androidx.compose.ui.graphics.Color</c>
-    /// once dotnet/android-libraries#1437 lands.)
+    /// composable using a <c>RectangleShape</c>. Takes a packed Compose
+    /// <c>androidx.compose.ui.graphics.Color</c> value (a <c>ULong</c>
+    /// surfaced as a <c>long</c> in the binding because Color is a Kotlin
+    /// <c>@JvmInline value class</c>). Build one with
+    /// <see cref="AndroidX.Compose.UI.Graphics.ColorKt.Color(int)"/> from
+    /// an <c>0xAARRGGBB</c> int, or
+    /// <see cref="AndroidX.Compose.UI.Graphics.ColorKt.Color(int, int, int, int)"/>
+    /// from per-channel bytes.
     /// </summary>
-    public Modifier Background(Color color)
-    {
-        long packed = PackComposeColor(color);
-        return Append(curr => ComposeBridges.ModifierBackground(curr, packed));
-    }
+    public Modifier Background(long color) =>
+        Append(curr => ComposeBridges.ModifierBackground(curr, color));
 
     /// <summary>
     /// <c>Modifier.border(width, color, shape)</c> — draws a stroke
     /// around the composable. <paramref name="widthDp"/> is the stroke
-    /// width in density-independent pixels.
+    /// width in density-independent pixels. <paramref name="color"/> is a
+    /// packed Compose <c>Color</c> long (see
+    /// <see cref="Background(long)"/> for how to build one).
     /// <paramref name="cornerRadiusDp"/> defaults to <c>0</c> for a
     /// rectangular stroke; pass a positive value to match a
     /// <see cref="Clip(int)"/> earlier in the chain so the corners
     /// align (otherwise the rectangular stroke gets sliced by a rounded
     /// clip and you see jagged corner stubs).
     /// </summary>
-    public Modifier Border(int widthDp, Color color, int cornerRadiusDp = 0)
+    public Modifier Border(int widthDp, long color, int cornerRadiusDp = 0)
     {
-        var width   = (float)widthDp;
-        long packed = PackComposeColor(color);
+        var width = (float)widthDp;
         if (cornerRadiusDp <= 0)
-            return Append(curr => ComposeBridges.ModifierBorder(curr, width, packed, null));
+            return Append(curr => ComposeBridges.ModifierBorder(curr, width, color, null));
 
         var radius = (float)cornerRadiusDp;
         return Append(curr =>
@@ -249,7 +248,7 @@ public sealed class Modifier
             IntPtr shape = ComposeBridges.RoundedCornerShape(radius);
             try
             {
-                return ComposeBridges.ModifierBorder(curr, width, packed, shape);
+                return ComposeBridges.ModifierBorder(curr, width, color, shape);
             }
             finally
             {
@@ -258,12 +257,6 @@ public sealed class Modifier
             }
         });
     }
-
-    // Pack an Android.Graphics.Color into the 64-bit value Kotlin's
-    // @JvmInline value class Color(val value: ULong) uses: ARGB int in
-    // the upper 32 bits, sRGB color-space id (0) in the lower 32 bits.
-    static long PackComposeColor(Color color) =>
-        unchecked((long)((ulong)(uint)color.ToArgb() << 32));
 
     /// <summary>
     /// <c>Modifier.clip(RoundedCornerShape(<paramref name="cornerRadiusDp"/>))</c> —

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -216,10 +216,13 @@ public sealed class Modifier
     /// <c>androidx.compose.ui.graphics.Color</c> value (a <c>ULong</c>
     /// surfaced as a <c>long</c> in the binding because Color is a Kotlin
     /// <c>@JvmInline value class</c>). Build one with
-    /// <see cref="AndroidX.Compose.UI.Graphics.ColorKt.Color(int)"/> from
-    /// an <c>0xAARRGGBB</c> int, or
     /// <see cref="AndroidX.Compose.UI.Graphics.ColorKt.Color(int, int, int, int)"/>
-    /// from per-channel bytes.
+    /// from per-channel bytes (recommended), or
+    /// <see cref="AndroidX.Compose.UI.Graphics.ColorKt.Color(int)"/> from an
+    /// <c>0xAARRGGBB</c> int — note that opaque-alpha hex literals like
+    /// <c>0xFF1976D2</c> are <c>uint</c> in C#, so they need an
+    /// <c>unchecked((int)0xFF1976D2)</c> cast to compile against the
+    /// <c>int</c> overload.
     /// </summary>
     public Modifier Background(long color) =>
         Append(curr => ComposeBridges.ModifierBackground(curr, color));

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -1,6 +1,6 @@
-using Android.Graphics;
 using Android.OS;
 using AndroidX.Compose.Material3;
+using AndroidX.Compose.UI.Graphics;
 using ComposeNet;
 
 namespace ComposeNet.Sample;
@@ -106,8 +106,8 @@ public class MainActivity : ComposeActivity
                             {
                                 Modifier = Modifier.Companion
                                     .Clip(12)
-                                    .Background(Color.Argb(0xFF, 0x19, 0x76, 0xD2))
-                                    .Border(2, Color.Argb(0xFF, 0x0D, 0x47, 0xA1), cornerRadiusDp: 12)
+                                    .Background(ColorKt.Color(red: 0x19, green: 0x76, blue: 0xD2, alpha: 0xFF))
+                                    .Border(2, ColorKt.Color(red: 0x0D, green: 0x47, blue: 0xA1, alpha: 0xFF), cornerRadiusDp: 12)
                                     .Clickable(() => count++)
                                     .Padding(horizontalDp: 16, verticalDp: 8),
                             },


### PR DESCRIPTION
`Xamarin.AndroidX.Compose.UI.Graphics` 1.11.2.1 finally binds the Compose `Color` type that we'd been hand-packing from `Android.Graphics.Color` (the temporary workaround called out in `Modifier.cs` and tracked as dotnet/android-libraries#1437). This swaps to the real bindings.

## What changed

- `Modifier.Background` and `Modifier.Border` now take a packed Compose `Color` `long` directly, the same value Kotlin's `@JvmInline value class Color(val value: ULong)` uses and that `ComposeBridges.Modifier{Background,Border}` already expect. The hand-rolled `PackComposeColor(Android.Graphics.Color)` helper is gone.
- Call sites build colors via the now-bound `AndroidX.Compose.UI.Graphics.ColorKt.Color(int red, int green, int blue, int alpha)` factory, so the only `Color`-typed thing in the facade and samples is the Compose one. `using Android.Graphics;` is dropped from `Modifier.cs`, `MainActivity.cs`, and `samples/Jetchat/Conversation.cs`.

## Package version coupling

`UI.Graphics` 1.11.2.1 transitively requires `Compose.UI.Unit [1.11.2, 1.11.3)`, which version-locks the rest of the 1.11.x stack to 1.11.2. There's no `.1` revision yet on UI / UI.Android / Foundation.Layout{,.Android} / Runtime{,.Android} / UI.Unit{,.Android}, so those move to plain `1.11.2`; `Foundation{,.Android}` and `UI.Graphics{,.Android}` go to `1.11.2.1`. Material3 1.4.0.x is unchanged because its dependencies on the 1.11.x stack are minimum-version constraints.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` -- 37/37 passing.
- `dotnet build src/ComposeNet.Compose`, `src/ComposeNet.Sample`, and `samples/Jetchat` all clean (only the pre-existing XML-cref warnings unrelated to this change).