### PR TITLE
Use [ComposeFacade] for 9 more facades

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -971,6 +971,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/layout/WindowInsets;" +
                     "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(NavigationRailDefault))]
+    [ComposeFacade]
     public static partial void NavigationRail(IModifier? modifier, IFunction3 content, IComposer composer);
 
     // androidx.compose.material3.NavigationRailKt.NavigationRailItem
@@ -1118,6 +1119,7 @@ internal static partial class ComposeBridges
                     "Lkotlin/jvm/functions/Function2;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(WideNavigationRailDefault))]
+    [ComposeFacade]
     public static partial void WideNavigationRail(IModifier? modifier, IFunction2 content, IComposer composer);
 
     // androidx.compose.material3.WideNavigationRailKt.ModalWideNavigationRail-k3FuEkE.
@@ -1290,6 +1292,7 @@ internal static partial class ComposeBridges
         JvmName   = "TabRow-pAZo6Ak",
         Signature = TabRowSig,
         Defaults  = typeof(TabRowDefault))]
+    [ComposeFacade]
     public static partial void TabRow(
         int        selectedTabIndex,
         IModifier? modifier,
@@ -1301,6 +1304,7 @@ internal static partial class ComposeBridges
         JvmName   = "PrimaryTabRow-pAZo6Ak",
         Signature = TabRowSig,
         Defaults  = typeof(TabRowDefault))]
+    [ComposeFacade]
     public static partial void PrimaryTabRow(
         int        selectedTabIndex,
         IModifier? modifier,
@@ -1312,6 +1316,7 @@ internal static partial class ComposeBridges
         JvmName   = "SecondaryTabRow-pAZo6Ak",
         Signature = TabRowSig,
         Defaults  = typeof(TabRowDefault))]
+    [ComposeFacade]
     public static partial void SecondaryTabRow(
         int        selectedTabIndex,
         IModifier? modifier,
@@ -1327,6 +1332,7 @@ internal static partial class ComposeBridges
                     "Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;" +
                     "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(ScrollableTabRowDefault))]
+    [ComposeFacade]
     public static partial void ScrollableTabRow(
         int        selectedTabIndex,
         IModifier? modifier,
@@ -1477,6 +1483,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/BorderStroke;" +
                     "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V",
         Defaults  = typeof(DropdownMenuDefault))]
+    [ComposeFacade]
     public static partial void DropdownMenu(
         bool        expanded,
         IFunction0  onDismissRequest,
@@ -1730,6 +1737,7 @@ internal static partial class ComposeBridges
                     "Lkotlin/jvm/functions/Function3;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(FlexibleBottomAppBarDefault))]
+    [ComposeFacade(Scope = "Row")]
     public static partial void FlexibleBottomAppBar(
         IModifier? modifier,
         IFunction3 content,
@@ -1781,6 +1789,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(TabContentDefault))]
+    [ComposeFacade(ClassName = "CustomTab", Scope = "Column")]
     public static partial void TabContent(
         bool       selected,
         IFunction0 onClick,

--- a/src/ComposeNet.Compose/CustomTab.cs
+++ b/src/ComposeNet.Compose/CustomTab.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -15,26 +13,4 @@ namespace ComposeNet;
 /// </code>
 /// Children are stacked vertically inside the tab's <c>ColumnScope</c>.
 /// </summary>
-public sealed class CustomTab : ComposableContainer
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public CustomTab(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var click = new ComposableLambda0(_onClick);
-        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
-        {
-            using var _ = RenderContext.PushScope(scope, ScopeKind.Column);
-            RenderChildren(c);
-        });
-
-        ComposeBridges.TabContent(_selected, click, BuildModifier(), content, composer);
-    }
-}
+public sealed partial class CustomTab;

--- a/src/ComposeNet.Compose/DropdownMenu.cs
+++ b/src/ComposeNet.Compose/DropdownMenu.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -23,21 +21,4 @@ namespace ComposeNet;
 /// }
 /// </code>
 /// </summary>
-public sealed class DropdownMenu : ComposableContainer
-{
-    readonly bool _expanded;
-    readonly System.Action _onDismissRequest;
-
-    public DropdownMenu(bool expanded, System.Action onDismissRequest)
-    {
-        _expanded = expanded;
-        _onDismissRequest = onDismissRequest;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var content   = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
-        ComposeBridges.DropdownMenu(_expanded, onDismiss, BuildModifier(), content, composer);
-    }
-}
+public sealed partial class DropdownMenu;

--- a/src/ComposeNet.Compose/FlexibleBottomAppBar.cs
+++ b/src/ComposeNet.Compose/FlexibleBottomAppBar.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -15,15 +13,4 @@ namespace ComposeNet;
 /// }
 /// </code>
 /// </summary>
-public sealed class FlexibleBottomAppBar : ComposableContainer
-{
-    internal override void Render(IComposer composer)
-    {
-        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
-        {
-            using var _ = RenderContext.PushScope(scope, ScopeKind.Row);
-            RenderChildren(c);
-        });
-        ComposeBridges.FlexibleBottomAppBar(BuildModifier(), content, composer);
-    }
-}
+public sealed partial class FlexibleBottomAppBar;

--- a/src/ComposeNet.Compose/NavigationRail.cs
+++ b/src/ComposeNet.Compose/NavigationRail.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -12,15 +10,8 @@ namespace ComposeNet;
 ///     new NavigationRailItem(selected: tab == 1, onClick: ...) { Icon = ..., Label = ... },
 /// }
 /// </code>
+/// <c>NavigationRailItem</c> (unlike <see cref="NavigationBarItem"/>) is
+/// a top-level static, not a <c>ColumnScope</c> extension, so children
+/// render directly without a published scope receiver.
 /// </summary>
-public sealed class NavigationRail : ComposableContainer
-{
-    internal override void Render(IComposer composer)
-    {
-        // NavigationRailItem (unlike NavigationBarItem) is a top-level
-        // static, not a ColumnScope extension — so we don't need to
-        // publish the scope. Children can render directly.
-        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
-        ComposeBridges.NavigationRail(BuildModifier(), content, composer);
-    }
-}
+public sealed partial class NavigationRail;

--- a/src/ComposeNet.Compose/PrimaryTabRow.cs
+++ b/src/ComposeNet.Compose/PrimaryTabRow.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -8,14 +6,4 @@ namespace ComposeNet;
 /// under the selected tab). Use when the tabs are the top-level
 /// destination switcher of a screen.
 /// </summary>
-public sealed class PrimaryTabRow : ComposableContainer
-{
-    readonly int _selectedTabIndex;
-    public PrimaryTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
-
-    internal override void Render(IComposer composer)
-    {
-        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.PrimaryTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
-    }
-}
+public sealed partial class PrimaryTabRow;

--- a/src/ComposeNet.Compose/ScrollableTabRow.cs
+++ b/src/ComposeNet.Compose/ScrollableTabRow.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -8,14 +6,4 @@ namespace ComposeNet;
 /// horizontally — useful when there are too many tabs to fit on one
 /// screen.
 /// </summary>
-public sealed class ScrollableTabRow : ComposableContainer
-{
-    readonly int _selectedTabIndex;
-    public ScrollableTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
-
-    internal override void Render(IComposer composer)
-    {
-        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.ScrollableTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
-    }
-}
+public sealed partial class ScrollableTabRow;

--- a/src/ComposeNet.Compose/SecondaryTabRow.cs
+++ b/src/ComposeNet.Compose/SecondaryTabRow.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -7,14 +5,4 @@ namespace ComposeNet;
 /// <see cref="TabRow"/> with the secondary indicator style (full-width
 /// underline). Use for tab groups nested inside a screen.
 /// </summary>
-public sealed class SecondaryTabRow : ComposableContainer
-{
-    readonly int _selectedTabIndex;
-    public SecondaryTabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
-
-    internal override void Render(IComposer composer)
-    {
-        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.SecondaryTabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
-    }
-}
+public sealed partial class SecondaryTabRow;

--- a/src/ComposeNet.Compose/TabRow.cs
+++ b/src/ComposeNet.Compose/TabRow.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -20,14 +18,4 @@ namespace ComposeNet;
 /// }
 /// </code>
 /// </summary>
-public sealed class TabRow : ComposableContainer
-{
-    readonly int _selectedTabIndex;
-    public TabRow(int selectedTabIndex) => _selectedTabIndex = selectedTabIndex;
-
-    internal override void Render(IComposer composer)
-    {
-        var tabs = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.TabRow(_selectedTabIndex, BuildModifier(), tabs, composer);
-    }
-}
+public sealed partial class TabRow;

--- a/src/ComposeNet.Compose/WideNavigationRail.cs
+++ b/src/ComposeNet.Compose/WideNavigationRail.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -19,15 +17,7 @@ namespace ComposeNet;
 ///     },
 /// }
 /// </code>
+/// <c>WideNavigationRailItem</c> is a top-level static (not a scope
+/// extension), so children render directly without a published scope.
 /// </summary>
-public sealed class WideNavigationRail : ComposableContainer
-{
-    internal override void Render(IComposer composer)
-    {
-        // WideNavigationRailItem is a top-level static (not a scope
-        // extension), so we don't need to publish a receiver scope —
-        // children render directly.
-        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.WideNavigationRail(BuildModifier(), content, composer);
-    }
-}
+public sealed partial class WideNavigationRail;


### PR DESCRIPTION
Now that #76 has landed the `[ComposeFacade]` generator, this PR sweeps through the remaining hand-written facades and migrates every one that fits the Phase 1 contract (modifier + onClick + content + primitives). Each migration replaces a ~30-line hand-written `Render()` body with a 3-line `partial class` stub that keeps the `<summary>` XML doc as the single source of truth.

## What's migrated

Nine facades, all backed by existing `[ComposeBridge]` declarations in `ComposeBridges.cs`:

- `NavigationRail`, `WideNavigationRail`
- `TabRow`, `PrimaryTabRow`, `SecondaryTabRow`, `ScrollableTabRow`
- `FlexibleBottomAppBar` (uses `Scope = "Row"`)
- `CustomTab` (uses `ClassName = "CustomTab"` + `Scope = "Column"` since the bridge is named `TabContent`)
- `DropdownMenu`

Net -114 lines, no behavior change. After this PR the project has 26 generated facades and 76 still hand-written.

## Why the rest stay hand-written (for now)

The remaining facades each hit a gap in the Phase 1 generator contract. Filed #78 with a phased roadmap covering `IFunction1` callbacks, multi-slot named properties, state-handle params, custom scope kinds, theme-default fallbacks, and `PainterResource`-style finally blocks. Implementing phases 2-7 from that issue would let another 67 facades collapse to stubs.

## Verification

- `dotnet build src/ComposeNet.Sample` succeeds
- `dotnet test src/ComposeNet.SourceGenerators.Tests` - 49/49 pass