### PR TITLE
Fix three XML doc-comment warnings

### DIFF
--- a/src/ComposeNet.Compose/ComposableContainer.cs
+++ b/src/ComposeNet.Compose/ComposableContainer.cs
@@ -32,7 +32,7 @@ public abstract class ComposableContainer : ComposableNode, IEnumerable
     public void Add(Modifier modifier) => Modifier = modifier;
     IEnumerator IEnumerable.GetEnumerator() => _children.GetEnumerator();
 
-    /// <summary>Internal accessor for <see cref="Render"/> impls.</summary>
+    /// <summary>Internal accessor for <c>Render</c> impls.</summary>
     private protected IReadOnlyList<ComposableNode> Children => _children;
 
     /// <summary>

--- a/src/ComposeNet.Compose/ModalNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/ModalNavigationDrawer.cs
@@ -15,7 +15,7 @@ namespace ComposeNet;
 /// natively. Driving open/close from C# requires Kotlin
 /// <c>suspend</c> calls (<c>DrawerState.open()</c> /
 /// <c>close()</c>), so this facade exposes only swipe-to-toggle
-/// behavior using a <see cref="RememberDrawerState"/>-backed state.
+/// behavior using a <c>rememberDrawerState</c>-backed state.
 /// </remarks>
 public sealed class ModalNavigationDrawer : ComposableNode
 {

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -15,9 +15,10 @@ internal static class Attributes
             /// Apply at assembly scope to generate a named-bit
             /// <c>[Flags] internal enum &lt;EnumName&gt;</c> from the
             /// parameter shape of <typeparamref name="T"/>'s static
-            /// method <paramref name="methodName"/>. Bit numbers match
-            /// the Kotlin parameter index in the bytecode — the position
-            /// the <c>$default</c> bitmask expects.
+            /// method named by the constructor's <c>methodName</c>
+            /// argument. Bit numbers match the Kotlin parameter index
+            /// in the bytecode — the position the <c>$default</c>
+            /// bitmask expects.
             /// </summary>
             [global::System.AttributeUsage(global::System.AttributeTargets.Assembly,
                                            AllowMultiple = true)]


### PR DESCRIPTION
CI was emitting three doc-comment warnings on `ComposeNet.Compose`. They were all cosmetic but noisy enough to drown out real signals, so cleaning them up keeps `0 Warning(s)` as the baseline.

- **`ComposableContainer.cs:35`** — `<see cref="Render"/>` couldn't resolve from the derived class context (`Render` is `internal abstract` on `ComposableNode`). Switched to plain `<c>Render</c>` since the prose just wants to point at the method by name.
- **`ModalNavigationDrawer.cs:18`** — `cref="RememberDrawerState"` pointed at something that doesn't exist as a type; the actual API is `NavigationDrawerKt.RememberDrawerState(...)`. Replaced with `<c>rememberDrawerState</c>` to match the prose style already used a few lines above in the same comment.
- **Generated `ComposeDefaultsAttribute<T>` (CS1734)** — the type-level doc had `<paramref name="methodName"/>`, but `paramref` on a type only resolves against a primary constructor's parameters, and this attribute uses a regular ctor. Reworded to reference the constructor's `methodName` argument in prose.

Verified with `dotnet build src/ComposeNet.Compose`: `0 Warning(s)`, `0 Error(s)`.