### PR TITLE
ci: run source generator tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,19 @@ jobs:
       - name: Build
         run: dotnet build ComposeNet.slnx -bl:ComposeNet.binlog
 
+      - name: Test source generators
+        run: dotnet test src/ComposeNet.SourceGenerators.Tests --no-build --logger "console;verbosity=normal" --logger "trx;LogFileName=test-results.trx"
+
       - name: Upload binlog
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ComposeNet.binlog
           path: ComposeNet.binlog
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/TestResults/*.trx'


### PR DESCRIPTION
The `Build` workflow previously ran only `dotnet build ComposeNet.slnx`, which compiled the `ComposeNet.SourceGenerators.Tests` xUnit assembly but never executed it. A red generator test would have shipped green.

## Fix

Add a dedicated **Test source generators** step after the build that runs:

```sh
dotnet test src/ComposeNet.SourceGenerators.Tests --no-build \
  --logger "console;verbosity=normal" \
  --logger "trx;LogFileName=test-results.trx"
```

- `--no-build` reuses the binaries produced by the existing `dotnet build ComposeNet.slnx` step (verified locally — the slnx already includes the test project, so the test DLL lands in `bin/Debug/net10.0/` before the test step runs).
- Test failures fail the job (default `dotnet test` exit-code behavior — nothing swallowed).
- On failure, the `.trx` is uploaded as a `test-results` artifact via `actions/upload-artifact@v4` so we can diagnose without re-running.
- The existing `Upload binlog` step (`if: always()`) is untouched.

## Verification

Locally:

```
dotnet build ComposeNet.slnx -bl:ComposeNet.binlog   # same as CI
dotnet test  src/ComposeNet.SourceGenerators.Tests --no-build ...
# Total tests: 49, Passed: 49
```

## Out of scope

No caching, no matrix splits — strictly "run the tests." Other CI improvements are tracked separately.