### PR TITLE
ci: cache .NET SDK config and android workload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
           path: |
             /usr/share/dotnet/sdk-manifests
             /usr/share/dotnet/metadata
-            /usr/share/dotnet/library-packs
             /usr/share/dotnet/packs/Microsoft.Android.*
           key: dotnet-workload-${{ runner.os }}-${{ hashFiles('global.json') }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,17 +22,14 @@ jobs:
         run: sudo chown -R "$USER" /usr/share/dotnet
 
       - name: Cache android workload
-        id: workload-cache
         uses: actions/cache@v4
         with:
           path: |
             /usr/share/dotnet/sdk-manifests
-            /usr/share/dotnet/metadata
             /usr/share/dotnet/packs/Microsoft.Android.*
           key: dotnet-workload-${{ runner.os }}-${{ hashFiles('global.json') }}
 
       - name: Restore android workload
-        if: steps.workload-cache.outputs.cache-hit != 'true'
         run: dotnet workload restore
 
       - name: Cache NuGet packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,10 @@ jobs:
           path: |
             /usr/share/dotnet/sdk-manifests
             /usr/share/dotnet/packs/Microsoft.Android.*
-            /usr/share/dotnet/packs/Microsoft.NETCore.*
-            /usr/share/dotnet/packs/Microsoft.NET.Runtime.*
-          key: dotnet-workload-v2-${{ runner.os }}-${{ hashFiles('global.json') }}
+            /usr/share/dotnet/packs/Microsoft.NETCore.App.Runtime.Mono.android-*
+            /usr/share/dotnet/packs/Microsoft.NETCore.App.Runtime.AOT.*.Cross.android-*
+            /usr/share/dotnet/packs/Microsoft.NET.Runtime.Mono*
+          key: dotnet-workload-v4-${{ runner.os }}-${{ hashFiles('global.json') }}
 
       - name: Restore android workload
         run: dotnet workload restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
           path: |
             /usr/share/dotnet/sdk-manifests
             /usr/share/dotnet/packs/Microsoft.Android.*
+            /usr/share/dotnet/packs/Microsoft.NETCore.*
+            /usr/share/dotnet/packs/Microsoft.NET.Runtime.*
           key: dotnet-workload-${{ runner.os }}-${{ hashFiles('global.json') }}
 
       - name: Restore android workload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,32 +13,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache .NET SDK and workloads
-        id: dotnet-cache
-        uses: actions/cache@v4
-        with:
-          path: /usr/share/dotnet
-          key: dotnet-${{ runner.os }}-${{ hashFiles('global.json') }}
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 
-      - name: Prune unused .NET versions
-        if: steps.dotnet-cache.outputs.cache-hit != 'true'
-        run: |
-          set -eu
-          for dir in \
-            /usr/share/dotnet/sdk \
-            /usr/share/dotnet/shared/Microsoft.NETCore.App \
-            /usr/share/dotnet/shared/Microsoft.AspNetCore.App; do
-            [ -d "$dir" ] || continue
-            sudo find "$dir" -mindepth 1 -maxdepth 1 -type d ! -name '10.*' -exec rm -rf {} +
-          done
+      - name: Take ownership of /usr/share/dotnet
+        run: sudo chown -R "$USER" /usr/share/dotnet
+
+      - name: Cache android workload
+        id: workload-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/share/dotnet/sdk-manifests
+            /usr/share/dotnet/metadata
+            /usr/share/dotnet/library-packs
+            /usr/share/dotnet/packs/Microsoft.Android.*
+          key: dotnet-workload-${{ runner.os }}-${{ hashFiles('global.json') }}
 
       - name: Restore android workload
-        if: steps.dotnet-cache.outputs.cache-hit != 'true'
+        if: steps.workload-cache.outputs.cache-hit != 'true'
         run: dotnet workload restore
 
       - name: Cache NuGet packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          global-json-file: global.json
+          dotnet-version: '10.0.x'
 
       - name: Install android workload
         run: dotnet workload install android
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.targets', 'global.json') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.targets') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,17 +22,19 @@ jobs:
         run: sudo chown -R "$USER" /usr/share/dotnet
 
       - name: Cache android workload
+        id: workload-cache
         uses: actions/cache@v4
         with:
           path: |
             /usr/share/dotnet/sdk-manifests
+            /usr/share/dotnet/metadata/workloads
             /usr/share/dotnet/packs/Microsoft.Android.*
             /usr/share/dotnet/packs/Microsoft.NETCore.App.Runtime.Mono.android-*
-            /usr/share/dotnet/packs/Microsoft.NETCore.App.Runtime.AOT.*.Cross.android-*
             /usr/share/dotnet/packs/Microsoft.NET.Runtime.Mono*
-          key: dotnet-workload-v4-${{ runner.os }}-${{ hashFiles('global.json') }}
+          key: dotnet-workload-v5-${{ runner.os }}-${{ hashFiles('global.json') }}
 
       - name: Restore android workload
+        if: steps.workload-cache.outputs.cache-hit != 'true'
         run: dotnet workload restore
 
       - name: Cache NuGet packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,24 +18,8 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Take ownership of /usr/share/dotnet
-        run: sudo chown -R "$USER" /usr/share/dotnet
-
-      - name: Cache android workload
-        id: workload-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            /usr/share/dotnet/sdk-manifests
-            /usr/share/dotnet/metadata/workloads
-            /usr/share/dotnet/packs/Microsoft.Android.*
-            /usr/share/dotnet/packs/Microsoft.NETCore.App.Runtime.Mono.android-*
-            /usr/share/dotnet/packs/Microsoft.NET.Runtime.Mono*
-          key: dotnet-workload-v5-${{ runner.os }}-${{ hashFiles('global.json') }}
-
-      - name: Restore android workload
-        if: steps.workload-cache.outputs.cache-hit != 'true'
-        run: dotnet workload restore
+      - name: Install android workload
+        run: dotnet workload install android
 
       - name: Cache NuGet packages
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/*.slnx', 'global.json') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.targets', 'global.json') }}
           restore-keys: |
             nuget-${{ runner.os }}-
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET 10
+      - name: Cache .NET SDK and workloads
+        id: dotnet-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/share/dotnet
+          key: dotnet-${{ runner.os }}-${{ hashFiles('global.json') }}
+
+      - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          global-json-file: global.json
 
-      - name: Install android workload
-        run: dotnet workload install android
+      - name: Prune unused .NET versions
+        if: steps.dotnet-cache.outputs.cache-hit != 'true'
+        run: |
+          set -eu
+          for dir in \
+            /usr/share/dotnet/sdk \
+            /usr/share/dotnet/shared/Microsoft.NETCore.App \
+            /usr/share/dotnet/shared/Microsoft.AspNetCore.App; do
+            [ -d "$dir" ] || continue
+            sudo find "$dir" -mindepth 1 -maxdepth 1 -type d ! -name '10.*' -exec rm -rf {} +
+          done
+
+      - name: Restore android workload
+        if: steps.dotnet-cache.outputs.cache-hit != 'true'
+        run: dotnet workload restore
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '**/*.slnx', 'global.json') }}
+          restore-keys: |
+            nuget-${{ runner.os }}-
 
       - name: Build
         run: dotnet build ComposeNet.slnx -bl:ComposeNet.binlog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
             /usr/share/dotnet/packs/Microsoft.Android.*
             /usr/share/dotnet/packs/Microsoft.NETCore.*
             /usr/share/dotnet/packs/Microsoft.NET.Runtime.*
-          key: dotnet-workload-${{ runner.os }}-${{ hashFiles('global.json') }}
+          key: dotnet-workload-v2-${{ runner.os }}-${{ hashFiles('global.json') }}
 
       - name: Restore android workload
         run: dotnet workload restore

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestFeature"
+  },
+  "workloadVersion": "10.0.300.3"
+}

--- a/global.json
+++ b/global.json
@@ -1,7 +1,0 @@
-{
-  "sdk": {
-    "version": "10.0.300",
-    "rollForward": "latestFeature"
-  },
-  "workloadVersion": "10.0.300.3"
-}


### PR DESCRIPTION
Pins the .NET SDK + workload set via `global.json` and adds two caches to the build workflow:

- **`/usr/share/dotnet` cache** keyed on `global.json` — covers SDK install + android workload packs in a single cache, future-proof against new folder names. On cold runs, prunes non-10.x SDKs and runtimes under `sdk/` and `shared/Microsoft.{NETCore,AspNetCore}.App/` before save to keep the cache size down. Leaves `packs/`, `host/`, `templates/`, etc. untouched.
- **`~/.nuget/packages` cache** keyed on `**/*.csproj` + `**/*.slnx` + `global.json`.

`dotnet workload restore` replaces the previous `dotnet workload install android` — with `workloadVersion` pinned in `global.json`, restore is deterministic. Both restore steps (`dotnet workload restore` and re-downloading the SDK via `setup-dotnet`) are skipped via `if:` on a cache hit.

### Expected savings on warm runs
- Workload install: ~23s → ~0s
- NuGet restore: ~7s → ~2s

Total: ~25–30s warm-path savings.

### Verification
- [ ] First CI run = cache miss (cold path, same speed as today, populates cache).
- [ ] Push empty commit to trigger a second run; confirm `Restore android workload` is skipped and wall-clock drops by ~20–25s.