### PR TITLE
Extend [ComposeFacade] for Phases 2, 3, 6, 7 (issue #78)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -317,8 +317,12 @@ The generator classifies each user param of the bridge:
 |-----------------------------------------|---------------------------------------------------|
 | `AndroidX.Compose.UI.IModifier?`        | Passed as `BuildModifier()` — no ctor param      |
 | `IFunction0` (onClick-style)            | Surfaced as a `System.Action` ctor parameter      |
-| `IFunction2` content                    | Wrapped via `ComposableLambdas.Wrap2(…)`          |
-| `IFunction3` content                    | Wrapped via `ComposableLambdas.Wrap3(…)`          |
+| `IFunction1` + `[Callback(typeof(T))]`  | Surfaced as `Action<T>` ctor; supports `bool`, `string`, `float` |
+| `IFunction2` content (non-nullable, sole content slot) | Wrapped via `ComposableLambdas.Wrap2(…)` — container shape |
+| `IFunction3` content (non-nullable, sole content slot) | Wrapped via `ComposableLambdas.Wrap3(…)` — container shape |
+| `IFunction2?` / `IFunction3?` (any nullable, OR `[Slot]`, OR >1 content slot) | Surfaced as a named `ComposableNode?` property — multi-slot leaf shape |
+| `IntPtr` with name ending in `Scope`    | Kotlin extension receiver; auto-bound to `RenderContext.CurrentScope` (no ctor slot) |
+| `IntPtr` + `[PainterResource]`          | Synthetic `int painterResourceId` ctor arg + `PainterResource` resolution + try/finally |
 | Primitive (`string`, `int`, `long`, `bool`, `float`, `double`)  | Surfaced as a ctor parameter, stored in `_<name>` |
 | Anything else (callbacks, handles, etc.) | Rejected with CN3002                              |
 
@@ -327,6 +331,30 @@ an `IFunction3`, the generator passes its first arg into
 `RenderContext.PushScope(scope, ScopeKind.Row|Column)` so child
 composables that need a `RowScope`/`ColumnScope` receiver pick it up.
 
+`[ComposeFacade(DefaultColorFromTheme = "secondaryContainer")]` opt-in
+(Phase 6): the matching `long` user param is reclassified as a
+`ContainerColor` property. The render body falls back to
+`MaterialTheme.Instance.GetColorScheme(composer, 0).<Slot>` when the
+caller leaves it at `0L`. Use `ColorParameter` to disambiguate when
+the bridge has more than one `long` user param; otherwise the sole
+`long` is auto-picked.
+
+Parameter-level attributes the generator recognizes:
+
+- `[Slot("PropertyName")]` — rename the generated property for an
+  `IFunction2` / `IFunction3` slot (default = `PascalCase` of the
+  Kotlin parameter name). Also forces the bridge into multi-slot
+  shape even if only one content lambda is present.
+- `[Callback(typeof(T))]` — surface an `IFunction1` user param as a
+  typed `Action<T>` ctor slot. `T` must be `bool`, `string`, or
+  `float`; the generator emits the appropriate `Java.Lang.Boolean`
+  / `Java.Lang.Float` unboxing or `ToString()` adapter.
+- `[PainterResource]` — annotate the `IntPtr` user param that takes
+  the resolved Painter handle. The facade exposes a synthetic
+  `int painterResourceId` ctor arg in its place and emits the
+  `PainterResource(id, composer)` + try/finally + `DeleteLocalRef`
+  preamble around the bridge call.
+
 Each facade is emitted to a unique hint name
 (`ComposeNet.Facade.<ClassName>.g.cs`) so the `[CallerFilePath]` +
 `[CallerLineNumber]` slot keys baked into `ComposableLambdas.Wrap*`
@@ -334,14 +362,52 @@ stay distinct per facade.
 
 ### When to use it
 
-Only when the bridge fits the Phase 1 shapes above. Multi-slot
-composables (`AlertDialog`, `Scaffold`, `ModalBottomSheet`),
-callback-bearing leafs (`Checkbox`, `Slider`, `Switch`,
-`RadioButton`), scope-consuming facades (`Tab`, `NavigationBarItem`,
-`SegmentedButton`), and anything calling a Kt method directly (not
-via `ComposeBridges`) stay hand-written. Trying to apply
-`[ComposeFacade]` to them will emit CN3002 (unsupported parameter)
-or CN3003 (scope misuse) at build time.
+The generator now supports a wide range of facade shapes (Phases 1,
+2, 3, 6, 7 are implemented):
+
+- **Phase 1** — container with content lambda + ctor primitives
+  (`Button`, `Card`, `Text`, `Column`, `Row`, `Box`).
+- **Phase 2** — callbacks via `[Callback(typeof(T))]` for
+  `IFunction1` user params (`TextField`, `OutlinedTextField`,
+  `IconToggleButton` family).
+- **Phase 3** — multi-slot leafs with named `ComposableNode?`
+  properties (`AlertDialog`, `AssistChip`, `ListItem`, `Snackbar`,
+  `BadgedBox`, `Tab`, `NavigationBarItem`, the top-app-bar family).
+- **Phase 6** — `[ComposeFacade(DefaultColorFromTheme = "...")]`
+  for drawer sheets and similar containers that fall back to a
+  `ColorScheme` slot when the caller doesn't override.
+- **Phase 7** — `[PainterResource]` resource-id-style facades
+  (`Image`, the Painter overload of `Icon`).
+
+Facades that still stay hand-written are the ones the generator
+can't model:
+
+- State-holder facades that need `remember*State` resolution and a
+  `Jvm` round-trip (`DatePicker`, `TimePicker`, `SearchBar`,
+  `SnackbarHost`, `ModalBottomSheet`). These are Phase 4 work.
+- Scope facades whose bodies do non-trivial work beyond
+  `RenderContext.PushScope` (`SegmentedButton`,
+  `SingleChoice`/`MultiChoiceSegmentedButtonRow`, the segmented
+  scrollable tab rows).
+- Facades that call a bound binding method directly (no underlying
+  `[ComposeBridge]` to attach to) — `WideNavigationRailItem`,
+  `DropdownMenuItem`, `Icon` (`ImageVector` overload).
+- Facades that branch between two bridges based on an optional
+  slot (`TopAppBar` — Subtitle toggles between `TopAppBar-GHTll3U`
+  and `MediumFlexibleTopAppBar-eXZ4JBQ`).
+- Drawer facades with a `confirmStateChange` adapter
+  (`ModalNavigationDrawer`, `DismissibleNavigationDrawer`,
+  `PermanentNavigationDrawer`, `ModalWideNavigationRail`).
+- Container+slot facades like `BottomAppBar` whose required
+  Function3 is the container's content but also has an optional
+  Function2 slot — the generator's multi-slot rule (any nullable
+  Function2/3 → leaf) doesn't model this hybrid.
+
+Trying to apply `[ComposeFacade]` to an unsupported bridge will
+emit CN3002 (unsupported parameter), CN3003 (scope misuse), CN3005
+(invalid callback type), CN3006 (slot conflict), CN3007 (color
+theme binding failed), or CN3008 (painter misuse) at build time —
+back out the attribute and write the facade by hand.
 
 ### Adding a new generated facade
 
@@ -370,14 +436,16 @@ end-to-end recipe is:
    the closest sibling for "same shape as X" facades. **Do not omit
    the stub** — without it the generated class has no XML docs.
 4. **Build the sample** (`dotnet build src/ComposeNet.Sample`) to
-   verify the bridge + facade compile together. The Phase 1 shapes
-   are validated at build time; CN3001-CN3004 will fire if the
-   generator can't accept the bridge.
+   verify the bridge + facade compile together. The supported
+   shapes are validated at build time; CN3001-CN3008 will fire if
+   the generator can't accept the bridge.
 5. **If CN3002 fires**, the bridge has a parameter outside the
-   table above — either a non-content `IFunction1` callback, a
-   value-class handle, or the manual `int defaults` hatch. Stop
-   here, drop `[ComposeFacade]`, and write the facade by hand
-   (delete the stub or expand it into a full hand-written class).
+   table above — either an unmarked `IFunction1` callback, a
+   value-class handle, or some other unsupported type. Either add
+   the right marker attribute (`[Callback]` / `[Slot]` /
+   `[PainterResource]`) or back out the attribute and write the
+   facade by hand (delete the stub or expand it into a full
+   hand-written class).
 6. **Use the facade from the sample** (`MainActivity.cs` or one of
    the screen files) and confirm the rendered tree matches what a
    hand-written facade would have produced.
@@ -390,6 +458,10 @@ end-to-end recipe is:
 | CN3002  | Bridge parameter type isn't a supported facade slot.               |
 | CN3003  | `Scope` is set but bridge has no `IFunction3` content slot.        |
 | CN3004  | `[ComposeFacade]` without an accompanying `[ComposeBridge]`.       |
+| CN3005  | `[Callback(typeof(T))]` target type is unsupported (must be `bool`, `string`, or `float`). |
+| CN3006  | `[Slot]` placement conflicts with the facade's classified shape.   |
+| CN3007  | `DefaultColorFromTheme` cannot bind to any `long` user param (or `ColorParameter` is ambiguous / missing). |
+| CN3008  | `[PainterResource]` annotates a non-`IntPtr` parameter.            |
 
 ### Migration rule
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -459,7 +459,7 @@ end-to-end recipe is:
 | CN3003  | `Scope` is set but bridge has no `IFunction3` content slot.        |
 | CN3004  | `[ComposeFacade]` without an accompanying `[ComposeBridge]`.       |
 | CN3005  | `[Callback(typeof(T))]` target type is unsupported (must be `bool`, `string`, or `float`). |
-| CN3006  | `[Slot]` placement conflicts with the facade's classified shape.   |
+| CN3006  | `[Slot]` placement conflicts with the facade's classified shape, `[Callback]` placed on a non-`IFunction1` param, multiple `[PainterResource]` params on one bridge, or `int defaults` declared without a resolvable `Defaults` enum. |
 | CN3007  | `DefaultColorFromTheme` cannot bind to any `long` user param (or `ColorParameter` is ambiguous / missing). |
 | CN3008  | `[PainterResource]` annotates a non-`IntPtr` parameter.            |
 

--- a/src/ComposeNet.Compose/AlertDialog.cs
+++ b/src/ComposeNet.Compose/AlertDialog.cs
@@ -1,12 +1,13 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>AlertDialog</c>. The canonical multi-slot facade —
-/// <see cref="ConfirmButton"/> is required, and any of
-/// <see cref="DismissButton"/>, <see cref="Icon"/>, <see cref="Title"/>,
-/// and <see cref="Text"/> may be supplied via C# object-initializer
-/// syntax. Slots left <c>null</c> are reported as defaulted through the
-/// <c>$default</c> bitmask so Compose substitutes the Kotlin defaults.
+/// Material 3 <c>AlertDialog</c>. The first composable in the facade to
+/// use <em>named slot properties</em> instead of a single collection
+/// initializer: <c>ConfirmButton</c> is required, and any of
+/// <c>DismissButton</c>, <c>Icon</c>, <c>Title</c>, and <c>Text</c> may
+/// be supplied via C# object-initializer syntax. Slots left <c>null</c>
+/// are reported as defaulted through the <c>$default</c> bitmask so
+/// Compose substitutes the Kotlin defaults.
 ///
 /// <code>
 /// new AlertDialog(onDismissRequest: () => show.Value = false)
@@ -17,5 +18,9 @@ namespace ComposeNet;
 ///     DismissButton = new Button(onClick: ...) { new Text("Cancel") },
 /// }
 /// </code>
+///
+/// This shape is the template that <c>ModalBottomSheet</c>,
+/// <c>DatePickerDialog</c>, <c>TimePickerDialog</c>, and the tooltip
+/// composables will follow once their <c>*State</c> bridges land.
 /// </summary>
 public sealed partial class AlertDialog;

--- a/src/ComposeNet.Compose/AlertDialog.cs
+++ b/src/ComposeNet.Compose/AlertDialog.cs
@@ -1,11 +1,8 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>AlertDialog</c>. The first composable in the facade to
-/// use <em>named slot properties</em> instead of a single collection
-/// initializer: <see cref="ConfirmButton"/> is required, and any of
+/// Material 3 <c>AlertDialog</c>. The canonical multi-slot facade —
+/// <see cref="ConfirmButton"/> is required, and any of
 /// <see cref="DismissButton"/>, <see cref="Icon"/>, <see cref="Title"/>,
 /// and <see cref="Text"/> may be supplied via C# object-initializer
 /// syntax. Slots left <c>null</c> are reported as defaulted through the
@@ -20,68 +17,5 @@ namespace ComposeNet;
 ///     DismissButton = new Button(onClick: ...) { new Text("Cancel") },
 /// }
 /// </code>
-///
-/// This shape is the template that <c>ModalBottomSheet</c>,
-/// <c>DatePickerDialog</c>, <c>TimePickerDialog</c>, and the tooltip
-/// composables will follow once their <c>*State</c> bridges land.
 /// </summary>
-public sealed class AlertDialog : ComposableNode
-{
-    readonly System.Action _onDismissRequest;
-    public AlertDialog(System.Action onDismissRequest) => _onDismissRequest = onDismissRequest;
-
-    /// <summary>Required: the affirmative-action button (typically <see cref="ComposeNet.Button"/>).</summary>
-    public ComposableNode? ConfirmButton { get; set; }
-
-    /// <summary>Optional: secondary button rendered alongside <see cref="ConfirmButton"/>.</summary>
-    public ComposableNode? DismissButton { get; set; }
-
-    /// <summary>Optional: leading icon shown above the title.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    /// <summary>Optional: dialog title.</summary>
-    public ComposableNode? Title { get; set; }
-
-    /// <summary>Optional: dialog body / supporting text.</summary>
-    public ComposableNode? Text { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (ConfirmButton is null)
-            throw new System.InvalidOperationException(
-                "AlertDialog.ConfirmButton is required (the Kotlin parameter has no default).");
-
-        var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var confirm   = ComposableLambdas.Wrap2(composer, c => ConfirmButton.Render(c));
-
-        var dismissBtn = DismissButton is null ? null
-            : ComposableLambdas.Wrap2(composer, c => DismissButton.Render(c));
-        var icon = Icon is null ? null
-            : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-        var title = Title is null ? null
-            : ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var text = Text is null ? null
-            : ComposableLambdas.Wrap2(composer, c => Text.Render(c));
-
-        // Start from "default everything" and clear the bit for each
-        // optional slot the user actually supplied.
-        int defaults = (int)AlertDialogDefault.All;
-        var modifier = BuildModifier();
-        if (modifier   is not null) defaults &= ~(int)AlertDialogDefault.Modifier;
-        if (dismissBtn is not null) defaults &= ~(int)AlertDialogDefault.DismissButton;
-        if (icon       is not null) defaults &= ~(int)AlertDialogDefault.Icon;
-        if (title      is not null) defaults &= ~(int)AlertDialogDefault.Title;
-        if (text       is not null) defaults &= ~(int)AlertDialogDefault.Text;
-
-        ComposeBridges.AlertDialog(
-            onDismissRequest: onDismiss,
-            confirmButton:    confirm,
-            modifier:         modifier,
-            dismissButton:    dismissBtn,
-            icon:             icon,
-            title:            title,
-            text:             text,
-            defaults:         defaults,
-            composer:         composer);
-    }
-}
+public sealed partial class AlertDialog;

--- a/src/ComposeNet.Compose/AssistChip.cs
+++ b/src/ComposeNet.Compose/AssistChip.cs
@@ -1,9 +1,8 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>AssistChip</c>. <see cref="Label"/> is required;
-/// <see cref="LeadingIcon"/> and <see cref="TrailingIcon"/> are optional
-/// slots:
+/// Material 3 <c>AssistChip</c>. <c>Label</c> is required;
+/// <c>LeadingIcon</c> and <c>TrailingIcon</c> are optional slots:
 /// <code>
 /// new AssistChip(onClick: ...) { Label = new Text("Filter") }
 /// </code>

--- a/src/ComposeNet.Compose/AssistChip.cs
+++ b/src/ComposeNet.Compose/AssistChip.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -10,37 +8,4 @@ namespace ComposeNet;
 /// new AssistChip(onClick: ...) { Label = new Text("Filter") }
 /// </code>
 /// </summary>
-public sealed class AssistChip : ComposableNode
-{
-    readonly System.Action _onClick;
-    public AssistChip(System.Action onClick) => _onClick = onClick;
-
-    /// <summary>Required: chip text.</summary>
-    public ComposableNode? Label { get; set; }
-
-    /// <summary>Optional: leading slot (e.g. icon).</summary>
-    public ComposableNode? LeadingIcon { get; set; }
-
-    /// <summary>Optional: trailing slot.</summary>
-    public ComposableNode? TrailingIcon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Label is null)
-            throw new System.InvalidOperationException(
-                "AssistChip.Label is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
-        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
-
-        int defaults = (int)AssistChipDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)AssistChipDefault.Modifier;
-        if (leading  is not null) defaults &= ~(int)AssistChipDefault.LeadingIcon;
-        if (trailing is not null) defaults &= ~(int)AssistChipDefault.TrailingIcon;
-
-        ComposeBridges.AssistChip(click, label, modifier, leading, trailing, defaults, composer);
-    }
-}
+public sealed partial class AssistChip;

--- a/src/ComposeNet.Compose/BadgedBox.cs
+++ b/src/ComposeNet.Compose/BadgedBox.cs
@@ -1,9 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>BadgedBox</c>. Wraps a <see cref="Content"/> node
+/// Material 3 <c>BadgedBox</c>. Wraps a <c>Content</c> node
 /// (typically an <see cref="Icon"/>) and overlays a <see cref="Badge"/>
 /// on its top-end corner:
 /// <code>
@@ -14,23 +12,4 @@ namespace ComposeNet;
 /// }
 /// </code>
 /// </summary>
-public sealed class BadgedBox : ComposableNode
-{
-    /// <summary>Required: the badge to overlay on the content.</summary>
-    public ComposableNode? Badge { get; set; }
-
-    /// <summary>Required: the underlying content the badge attaches to.</summary>
-    public ComposableNode? Content { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Badge is null || Content is null)
-            throw new System.InvalidOperationException(
-                "BadgedBox requires both Badge and Content.");
-
-        var badge   = ComposableLambdas.Wrap3(composer, c => Badge.Render(c));
-        var content = ComposableLambdas.Wrap3(composer, c => Content.Render(c));
-
-        ComposeBridges.BadgedBox(badge, BuildModifier(), content, composer);
-    }
-}
+public sealed partial class BadgedBox;

--- a/src/ComposeNet.Compose/BadgedBox.cs
+++ b/src/ComposeNet.Compose/BadgedBox.cs
@@ -2,7 +2,7 @@ namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>BadgedBox</c>. Wraps a <c>Content</c> node
-/// (typically an <see cref="Icon"/>) and overlays a <see cref="Badge"/>
+/// (typically an <see cref="Icon"/>) and overlays a <c>Badge</c>
 /// on its top-end corner:
 /// <code>
 /// new BadgedBox

--- a/src/ComposeNet.Compose/CenterAlignedTopAppBar.cs
+++ b/src/ComposeNet.Compose/CenterAlignedTopAppBar.cs
@@ -1,41 +1,8 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>CenterAlignedTopAppBar</c> — same shape as
-/// <see cref="TopAppBar"/> but centers the <see cref="Title"/>
-/// horizontally between the navigation icon and actions.
+/// <see cref="TopAppBar"/> but centers the <c>Title</c> horizontally
+/// between the navigation icon and actions.
 /// </summary>
-public sealed class CenterAlignedTopAppBar : ComposableNode
-{
-    /// <summary>Required: the bar's title slot, rendered centered.</summary>
-    public ComposableNode? Title { get; set; }
-
-    /// <summary>Optional: leading slot.</summary>
-    public ComposableNode? NavigationIcon { get; set; }
-
-    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
-    public ComposableNode? Actions { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Title is null)
-            throw new System.InvalidOperationException(
-                "CenterAlignedTopAppBar.Title is required (the Kotlin parameter has no default).");
-
-        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var nav = NavigationIcon is null ? null
-            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
-        var actions = Actions is null ? null
-            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
-
-        int defaults = (int)TopAppBarDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)TopAppBarDefault.Modifier;
-        if (nav      is not null) defaults &= ~(int)TopAppBarDefault.NavigationIcon;
-        if (actions  is not null) defaults &= ~(int)TopAppBarDefault.Actions;
-
-        ComposeBridges.CenterAlignedTopAppBar(title, modifier, nav, actions, defaults, composer);
-    }
-}
+public sealed partial class CenterAlignedTopAppBar;

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -402,7 +402,8 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(IconToggleButtonDefault))]
-    public static partial void IconToggleButton(bool @checked, IFunction1 onCheckedChange,
+    [ComposeFacade]
+    public static partial void IconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                 IModifier? modifier, IFunction2 content,
                                                 IComposer composer);
 
@@ -418,7 +419,8 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(FilledIconToggleButtonDefault))]
-    public static partial void FilledIconToggleButton(bool @checked, IFunction1 onCheckedChange,
+    [ComposeFacade]
+    public static partial void FilledIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                       IModifier? modifier, IFunction2 content,
                                                       IComposer composer);
 
@@ -433,7 +435,8 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(FilledIconToggleButtonDefault))]
-    public static partial void FilledTonalIconToggleButton(bool @checked, IFunction1 onCheckedChange,
+    [ComposeFacade]
+    public static partial void FilledTonalIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                            IModifier? modifier, IFunction2 content,
                                                            IComposer composer);
 
@@ -449,7 +452,8 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(OutlinedIconToggleButtonDefault))]
-    public static partial void OutlinedIconToggleButton(bool @checked, IFunction1 onCheckedChange,
+    [ComposeFacade]
+    public static partial void OutlinedIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                         IModifier? modifier, IFunction2 content,
                                                         IComposer composer);
 
@@ -493,8 +497,9 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/graphics/ColorFilter;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(ImageDefault))]
+    [ComposeFacade]
     public static partial void Image(
-        IntPtr     painter,
+        [PainterResource] IntPtr painter,
         string?    contentDescription,
         IModifier? modifier,
         int        defaults,
@@ -539,7 +544,8 @@ internal static partial class ComposeBridges
         JvmName   = "TextField",
         Signature = TextFieldStringSig,
         Defaults  = typeof(TextFieldDefault))]
-    public static partial void TextField(string value, IFunction1 onValueChange,
+    [ComposeFacade]
+    public static partial void TextField(string value, [Callback(typeof(string))] IFunction1 onValueChange,
                                          IModifier? modifier, IComposer composer);
 
     [ComposeBridge(
@@ -547,7 +553,8 @@ internal static partial class ComposeBridges
         JvmName   = "OutlinedTextField",
         Signature = TextFieldStringSig,
         Defaults  = typeof(TextFieldDefault))]
-    public static partial void OutlinedTextField(string value, IFunction1 onValueChange,
+    [ComposeFacade]
+    public static partial void OutlinedTextField(string value, [Callback(typeof(string))] IFunction1 onValueChange,
                                                  IModifier? modifier, IComposer composer);
 
     // androidx.compose.material3.AndroidAlertDialog_androidKt.AlertDialog-Oix01E0
@@ -562,6 +569,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/window/DialogProperties;" +
                     "Landroidx/compose/runtime/Composer;III)V",
         Defaults  = typeof(AlertDialogDefault))]
+    [ComposeFacade]
     public static partial void AlertDialog(
         IFunction0  onDismissRequest,
         IFunction2  confirmButton,
@@ -808,6 +816,7 @@ internal static partial class ComposeBridges
         JvmName   = "AssistChip",
         Signature = AssistChipSig,
         Defaults  = typeof(AssistChipDefault))]
+    [ComposeFacade]
     public static partial void AssistChip(
         IFunction0  onClick,
         IFunction2  label,
@@ -822,6 +831,7 @@ internal static partial class ComposeBridges
         JvmName   = "ElevatedAssistChip",
         Signature = AssistChipSig,
         Defaults  = typeof(AssistChipDefault))]
+    [ComposeFacade]
     public static partial void ElevatedAssistChip(
         IFunction0  onClick,
         IFunction2  label,
@@ -846,6 +856,7 @@ internal static partial class ComposeBridges
         JvmName   = "FilterChip",
         Signature = FilterChipSig,
         Defaults  = typeof(FilterChipDefault))]
+    [ComposeFacade]
     public static partial void FilterChip(
         bool        selected,
         IFunction0  onClick,
@@ -861,6 +872,7 @@ internal static partial class ComposeBridges
         JvmName   = "ElevatedFilterChip",
         Signature = FilterChipSig,
         Defaults  = typeof(FilterChipDefault))]
+    [ComposeFacade]
     public static partial void ElevatedFilterChip(
         bool        selected,
         IFunction0  onClick,
@@ -884,6 +896,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Landroidx/compose/runtime/Composer;III)V",
         Defaults  = typeof(InputChipDefault))]
+    [ComposeFacade]
     public static partial void InputChip(
         bool        selected,
         IFunction0  onClick,
@@ -909,6 +922,7 @@ internal static partial class ComposeBridges
         JvmName   = "SuggestionChip",
         Signature = SuggestionChipSig,
         Defaults  = typeof(SuggestionChipDefault))]
+    [ComposeFacade]
     public static partial void SuggestionChip(
         IFunction0  onClick,
         IFunction2  label,
@@ -922,6 +936,7 @@ internal static partial class ComposeBridges
         JvmName   = "ElevatedSuggestionChip",
         Signature = SuggestionChipSig,
         Defaults  = typeof(SuggestionChipDefault))]
+    [ComposeFacade]
     public static partial void ElevatedSuggestionChip(
         IFunction0  onClick,
         IFunction2  label,
@@ -952,6 +967,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(NavigationBarItemDefault))]
+    [ComposeFacade]
     public static partial void NavigationBarItem(
         IntPtr      rowScope,
         bool        selected,
@@ -985,6 +1001,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(NavigationRailItemDefault))]
+    [ComposeFacade]
     public static partial void NavigationRailItem(
         bool        selected,
         IFunction0  onClick,
@@ -1005,6 +1022,7 @@ internal static partial class ComposeBridges
         JvmName   = "ModalDrawerSheet-afqeVBk",
         Signature = DrawerSheetSig,
         Defaults  = typeof(DrawerSheetDefault))]
+    [ComposeFacade(DefaultColorFromTheme = "secondaryContainer")]
     public static partial void ModalDrawerSheet(IFunction3 content, long drawerContainerColor, IComposer composer);
 
     [ComposeBridge(
@@ -1012,6 +1030,7 @@ internal static partial class ComposeBridges
         JvmName   = "DismissibleDrawerSheet-afqeVBk",
         Signature = DrawerSheetSig,
         Defaults  = typeof(DrawerSheetDefault))]
+    [ComposeFacade(DefaultColorFromTheme = "secondaryContainer")]
     public static partial void DismissibleDrawerSheet(IFunction3 content, long drawerContainerColor, IComposer composer);
 
     [ComposeBridge(
@@ -1019,6 +1038,7 @@ internal static partial class ComposeBridges
         JvmName   = "PermanentDrawerSheet-afqeVBk",
         Signature = DrawerSheetSig,
         Defaults  = typeof(DrawerSheetDefault))]
+    [ComposeFacade(DefaultColorFromTheme = "secondaryContainer")]
     public static partial void PermanentDrawerSheet(IFunction3 content, long drawerContainerColor, IComposer composer);
 
     // androidx.compose.material3.SegmentedButtonKt.SegmentedButton
@@ -1232,6 +1252,7 @@ internal static partial class ComposeBridges
         JvmName   = "CenterAlignedTopAppBar-GHTll3U",
         Signature = TopAppBarSig,
         Defaults  = typeof(TopAppBarDefault))]
+    [ComposeFacade]
     public static partial void CenterAlignedTopAppBar(
         IFunction2  title,
         IModifier?  modifier,
@@ -1255,6 +1276,7 @@ internal static partial class ComposeBridges
         JvmName   = "MediumTopAppBar-oKE7A98",
         Signature = TwoRowsTopAppBarSig,
         Defaults  = typeof(TwoRowsTopAppBarDefault))]
+    [ComposeFacade]
     public static partial void MediumTopAppBar(
         IFunction2  title,
         IModifier?  modifier,
@@ -1268,6 +1290,7 @@ internal static partial class ComposeBridges
         JvmName   = "LargeTopAppBar-oKE7A98",
         Signature = TwoRowsTopAppBarSig,
         Defaults  = typeof(TwoRowsTopAppBarDefault))]
+    [ComposeFacade]
     public static partial void LargeTopAppBar(
         IFunction2  title,
         IModifier?  modifier,
@@ -1350,6 +1373,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(TabDefault))]
+    [ComposeFacade]
     public static partial void Tab(
         bool        selected,
         IFunction0  onClick,
@@ -1372,6 +1396,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(LeadingIconTabDefault))]
+    [ComposeFacade]
     public static partial void LeadingIconTab(
         bool       selected,
         IFunction0 onClick,
@@ -1391,11 +1416,12 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/graphics/Shape;JJJJ" +
                     "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(SnackbarDefault))]
+    [ComposeFacade]
     public static partial void Snackbar(
         IModifier?  modifier,
         IFunction2? action,
         IFunction2? dismissAction,
-        IFunction2  content,
+        [Slot("Body")] IFunction2 content,
         int         defaults,
         IComposer   composer);
 
@@ -1437,6 +1463,7 @@ internal static partial class ComposeBridges
         Signature = "(Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;" +
                     "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(BadgedBoxDefault))]
+    [ComposeFacade]
     public static partial void BadgedBox(
         IFunction3 badge,
         IModifier? modifier,
@@ -1456,13 +1483,14 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/material3/ListItemColors;FF" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(ListItemDefault))]
+    [ComposeFacade]
     public static partial void ListItem(
-        IFunction2  headlineContent,
+        [Slot("Headline")]   IFunction2  headlineContent,
         IModifier?  modifier,
-        IFunction2? overlineContent,
-        IFunction2? supportingContent,
-        IFunction2? leadingContent,
-        IFunction2? trailingContent,
+        [Slot("Overline")]   IFunction2? overlineContent,
+        [Slot("Supporting")] IFunction2? supportingContent,
+        [Slot("Leading")]    IFunction2? leadingContent,
+        [Slot("Trailing")]   IFunction2? trailingContent,
         int         defaults,
         IComposer   composer);
 
@@ -1678,6 +1706,7 @@ internal static partial class ComposeBridges
         JvmName   = "MediumFlexibleTopAppBar-eXZ4JBQ",
         Signature = FlexibleTopAppBarSig,
         Defaults  = typeof(FlexibleTopAppBarDefault))]
+    [ComposeFacade]
     public static partial void MediumFlexibleTopAppBar(
         IFunction2  title,
         IModifier?  modifier,
@@ -1692,6 +1721,7 @@ internal static partial class ComposeBridges
         JvmName   = "LargeFlexibleTopAppBar-eXZ4JBQ",
         Signature = FlexibleTopAppBarSig,
         Defaults  = typeof(FlexibleTopAppBarDefault))]
+    [ComposeFacade]
     public static partial void LargeFlexibleTopAppBar(
         IFunction2  title,
         IModifier?  modifier,

--- a/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
+++ b/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
@@ -1,8 +1,9 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>DismissibleDrawerSheet</c>. Same shape as
-/// <see cref="ModalDrawerSheet"/>; designed for the inline (non-modal)
-/// dismissible drawer pattern.
+/// Material 3 <c>DismissibleDrawerSheet</c> — the panel shown by a
+/// dismissible-style navigation drawer. <c>ContainerColor</c>
+/// defaults to <c>0L</c>, which falls back to the active theme's
+/// <c>secondaryContainer</c>.
 /// </summary>
 public sealed partial class DismissibleDrawerSheet;

--- a/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
+++ b/src/ComposeNet.Compose/DismissibleDrawerSheet.cs
@@ -1,26 +1,8 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>DismissibleDrawerSheet</c> — the panel shown by a
-/// dismissible-style navigation drawer.
+/// Material 3 <c>DismissibleDrawerSheet</c>. Same shape as
+/// <see cref="ModalDrawerSheet"/>; designed for the inline (non-modal)
+/// dismissible drawer pattern.
 /// </summary>
-public sealed class DismissibleDrawerSheet : ComposableContainer
-{
-    /// <summary>
-    /// Optional container color. <c>0L</c> (the default) uses the
-    /// active theme's <c>secondaryContainer</c>.
-    /// </summary>
-    public long ContainerColor { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
-        var color = ContainerColor != 0L
-            ? ContainerColor
-            : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;
-        ComposeBridges.DismissibleDrawerSheet(content, color, composer);
-    }
-}
+public sealed partial class DismissibleDrawerSheet;

--- a/src/ComposeNet.Compose/ElevatedAssistChip.cs
+++ b/src/ComposeNet.Compose/ElevatedAssistChip.cs
@@ -1,42 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ElevatedAssistChip</c> — same API surface as
-/// <see cref="AssistChip"/> but uses shadow elevation for emphasis.
+/// Material 3 <c>ElevatedAssistChip</c>. Same shape as
+/// <see cref="AssistChip"/>; no <c>Modifier</c> parameter.
 /// </summary>
-public sealed class ElevatedAssistChip : ComposableNode
-{
-    readonly System.Action _onClick;
-    public ElevatedAssistChip(System.Action onClick) => _onClick = onClick;
-
-    /// <summary>Required: chip text.</summary>
-    public ComposableNode? Label { get; set; }
-
-    /// <summary>Optional: leading slot (e.g. icon).</summary>
-    public ComposableNode? LeadingIcon  { get; set; }
-
-    /// <summary>Optional: trailing slot.</summary>
-    public ComposableNode? TrailingIcon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Label is null)
-            throw new System.InvalidOperationException(
-                "ElevatedAssistChip.Label is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
-        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
-
-        // ElevatedAssistChip's parameter order matches AssistChip exactly,
-        // so we reuse AssistChipDefault for the $default bitmask.
-        int defaults = (int)AssistChipDefault.All;
-        if (leading  is not null) defaults &= ~(int)AssistChipDefault.LeadingIcon;
-        if (trailing is not null) defaults &= ~(int)AssistChipDefault.TrailingIcon;
-
-        ComposeBridges.ElevatedAssistChip(click, label, leading, trailing, defaults, composer);
-    }
-}
+public sealed partial class ElevatedAssistChip;

--- a/src/ComposeNet.Compose/ElevatedAssistChip.cs
+++ b/src/ComposeNet.Compose/ElevatedAssistChip.cs
@@ -1,7 +1,7 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ElevatedAssistChip</c>. Same shape as
-/// <see cref="AssistChip"/>; no <c>Modifier</c> parameter.
+/// Material 3 <c>ElevatedAssistChip</c> — same API surface as
+/// <see cref="AssistChip"/> but uses shadow elevation for emphasis.
 /// </summary>
 public sealed partial class ElevatedAssistChip;

--- a/src/ComposeNet.Compose/ElevatedFilterChip.cs
+++ b/src/ComposeNet.Compose/ElevatedFilterChip.cs
@@ -1,46 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ElevatedFilterChip</c> — same API surface as
-/// <see cref="FilterChip"/> but uses shadow elevation for emphasis.
+/// Material 3 <c>ElevatedFilterChip</c>. Same shape as
+/// <see cref="FilterChip"/>; no <c>Modifier</c> parameter.
 /// </summary>
-public sealed class ElevatedFilterChip : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public ElevatedFilterChip(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Required: chip text.</summary>
-    public ComposableNode? Label { get; set; }
-
-    /// <summary>Optional: leading slot (e.g. icon).</summary>
-    public ComposableNode? LeadingIcon  { get; set; }
-
-    /// <summary>Optional: trailing slot.</summary>
-    public ComposableNode? TrailingIcon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Label is null)
-            throw new System.InvalidOperationException(
-                "ElevatedFilterChip.Label is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
-        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
-
-        int defaults = (int)FilterChipDefault.All;
-        if (leading  is not null) defaults &= ~(int)FilterChipDefault.LeadingIcon;
-        if (trailing is not null) defaults &= ~(int)FilterChipDefault.TrailingIcon;
-
-        ComposeBridges.ElevatedFilterChip(_selected, click, label, leading, trailing, defaults, composer);
-    }
-}
+public sealed partial class ElevatedFilterChip;

--- a/src/ComposeNet.Compose/ElevatedFilterChip.cs
+++ b/src/ComposeNet.Compose/ElevatedFilterChip.cs
@@ -1,7 +1,7 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ElevatedFilterChip</c>. Same shape as
-/// <see cref="FilterChip"/>; no <c>Modifier</c> parameter.
+/// Material 3 <c>ElevatedFilterChip</c> — same API surface as
+/// <see cref="FilterChip"/> but uses shadow elevation for emphasis.
 /// </summary>
 public sealed partial class ElevatedFilterChip;

--- a/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
+++ b/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
@@ -1,7 +1,7 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ElevatedSuggestionChip</c>. Same shape as
-/// <see cref="SuggestionChip"/>; no <c>Modifier</c> parameter.
+/// Material 3 <c>ElevatedSuggestionChip</c> — like
+/// <see cref="SuggestionChip"/> but uses shadow elevation for emphasis.
 /// </summary>
 public sealed partial class ElevatedSuggestionChip;

--- a/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
+++ b/src/ComposeNet.Compose/ElevatedSuggestionChip.cs
@@ -1,35 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ElevatedSuggestionChip</c> — like
-/// <see cref="SuggestionChip"/> but uses shadow elevation for emphasis.
+/// Material 3 <c>ElevatedSuggestionChip</c>. Same shape as
+/// <see cref="SuggestionChip"/>; no <c>Modifier</c> parameter.
 /// </summary>
-public sealed class ElevatedSuggestionChip : ComposableNode
-{
-    readonly System.Action _onClick;
-    public ElevatedSuggestionChip(System.Action onClick) => _onClick = onClick;
-
-    /// <summary>Required: chip text.</summary>
-    public ComposableNode? Label { get; set; }
-
-    /// <summary>Optional: leading slot.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Label is null)
-            throw new System.InvalidOperationException(
-                "ElevatedSuggestionChip.Label is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-        var icon = Icon is null ? null : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-
-        int defaults = (int)SuggestionChipDefault.All;
-        if (icon is not null) defaults &= ~(int)SuggestionChipDefault.Icon;
-
-        ComposeBridges.ElevatedSuggestionChip(click, label, icon, defaults, composer);
-    }
-}
+public sealed partial class ElevatedSuggestionChip;

--- a/src/ComposeNet.Compose/FilledIconToggleButton.cs
+++ b/src/ComposeNet.Compose/FilledIconToggleButton.cs
@@ -1,26 +1,6 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>FilledIconToggleButton</c>. Same shape as <see cref="IconToggleButton"/>.
 /// </summary>
-public sealed class FilledIconToggleButton : ComposableContainer
-{
-    readonly bool _checked;
-    readonly System.Action<bool> _onCheckedChange;
-
-    public FilledIconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
-    {
-        _checked = @checked;
-        _onCheckedChange = onCheckedChange;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onChange = new ComposableLambda1(v =>
-            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
-        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.FilledIconToggleButton(_checked, onChange, BuildModifier(), content, composer);
-    }
-}
+public sealed partial class FilledIconToggleButton;

--- a/src/ComposeNet.Compose/FilledTonalIconToggleButton.cs
+++ b/src/ComposeNet.Compose/FilledTonalIconToggleButton.cs
@@ -1,26 +1,6 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>FilledTonalIconToggleButton</c>. Same shape as <see cref="IconToggleButton"/>.
 /// </summary>
-public sealed class FilledTonalIconToggleButton : ComposableContainer
-{
-    readonly bool _checked;
-    readonly System.Action<bool> _onCheckedChange;
-
-    public FilledTonalIconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
-    {
-        _checked = @checked;
-        _onCheckedChange = onCheckedChange;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onChange = new ComposableLambda1(v =>
-            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
-        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.FilledTonalIconToggleButton(_checked, onChange, BuildModifier(), content, composer);
-    }
-}
+public sealed partial class FilledTonalIconToggleButton;

--- a/src/ComposeNet.Compose/FilterChip.cs
+++ b/src/ComposeNet.Compose/FilterChip.cs
@@ -1,7 +1,7 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>FilterChip</c>. Adds a <c>selected</c> ctor argument to
-/// the <see cref="AssistChip"/> shape.
+/// Material 3 <c>FilterChip</c>. Renders as either selected or unselected;
+/// the <c>onClick</c> handler typically toggles the bound boolean state.
 /// </summary>
 public sealed partial class FilterChip;

--- a/src/ComposeNet.Compose/FilterChip.cs
+++ b/src/ComposeNet.Compose/FilterChip.cs
@@ -1,48 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>FilterChip</c>. Renders as either selected or unselected;
-/// the <c>onClick</c> handler typically toggles the bound boolean state.
+/// Material 3 <c>FilterChip</c>. Adds a <c>selected</c> ctor argument to
+/// the <see cref="AssistChip"/> shape.
 /// </summary>
-public sealed class FilterChip : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public FilterChip(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Required: chip text.</summary>
-    public ComposableNode? Label { get; set; }
-
-    /// <summary>Optional: leading slot (typically the check / unselected icon).</summary>
-    public ComposableNode? LeadingIcon { get; set; }
-
-    /// <summary>Optional: trailing slot.</summary>
-    public ComposableNode? TrailingIcon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Label is null)
-            throw new System.InvalidOperationException(
-                "FilterChip.Label is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
-        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
-
-        int defaults = (int)FilterChipDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)FilterChipDefault.Modifier;
-        if (leading  is not null) defaults &= ~(int)FilterChipDefault.LeadingIcon;
-        if (trailing is not null) defaults &= ~(int)FilterChipDefault.TrailingIcon;
-
-        ComposeBridges.FilterChip(_selected, click, label, modifier, leading, trailing, defaults, composer);
-    }
-}
+public sealed partial class FilterChip;

--- a/src/ComposeNet.Compose/IconToggleButton.cs
+++ b/src/ComposeNet.Compose/IconToggleButton.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -8,22 +6,4 @@ namespace ComposeNet;
 /// new IconToggleButton(@checked: state.Value, onCheckedChange: v => state.Value = v) { new Text("★") }
 /// </code>
 /// </summary>
-public sealed class IconToggleButton : ComposableContainer
-{
-    readonly bool _checked;
-    readonly System.Action<bool> _onCheckedChange;
-
-    public IconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
-    {
-        _checked = @checked;
-        _onCheckedChange = onCheckedChange;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onChange = new ComposableLambda1(v =>
-            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
-        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.IconToggleButton(_checked, onChange, BuildModifier(), content, composer);
-    }
-}
+public sealed partial class IconToggleButton;

--- a/src/ComposeNet.Compose/Image.cs
+++ b/src/ComposeNet.Compose/Image.cs
@@ -1,6 +1,3 @@
-using Android.Runtime;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -13,42 +10,8 @@ namespace ComposeNet;
 /// the drawable-resource entry point — that's what most apps want
 /// anyway.
 /// </summary>
-public sealed class Image : ComposableNode
+public sealed partial class Image
 {
-    readonly int _resourceId;
-    readonly string? _contentDescription;
-
-    /// <summary>Render an Android drawable resource (resolved via <c>painterResource</c>).</summary>
-    public Image(int drawableResourceId, string? contentDescription = null)
-    {
-        _resourceId = drawableResourceId;
-        _contentDescription = contentDescription;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var modifier = BuildModifier();
-
-        // bit 0 (painter) is marked `!` in the declarative attribute so
-        // it isn't part of `All`. bit 1 (contentDescription) is always
-        // cleared — we forward the caller's value, including null,
-        // which Compose treats as "decorative" (no semantics node).
-        int defaults = (int)ImageDefault.All & ~(int)ImageDefault.ContentDescription;
-        if (modifier is not null) defaults &= ~(int)ImageDefault.Modifier;
-
-        IntPtr painterRef = ComposeBridges.PainterResource(_resourceId, composer);
-        try
-        {
-            ComposeBridges.Image(
-                painter:            painterRef,
-                contentDescription: _contentDescription,
-                modifier:           modifier,
-                defaults:           defaults,
-                composer:           composer);
-        }
-        finally
-        {
-            JNIEnv.DeleteLocalRef(painterRef);
-        }
-    }
+    /// <summary>Render an Android drawable resource with no content description (decorative).</summary>
+    public Image(int painterResourceId) : this(painterResourceId, null) { }
 }

--- a/src/ComposeNet.Compose/Image.cs
+++ b/src/ComposeNet.Compose/Image.cs
@@ -13,5 +13,5 @@ namespace ComposeNet;
 public sealed partial class Image
 {
     /// <summary>Render an Android drawable resource with no content description (decorative).</summary>
-    public Image(int painterResourceId) : this(painterResourceId, null) { }
+    public Image(int drawableResourceId) : this(drawableResourceId, null) { }
 }

--- a/src/ComposeNet.Compose/InputChip.cs
+++ b/src/ComposeNet.Compose/InputChip.cs
@@ -1,7 +1,7 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>InputChip</c>. Adds an <c>Avatar</c> slot in addition
-/// to the leading/trailing slots common to the chip family.
+/// Material 3 <c>InputChip</c>. Adds an <c>Avatar</c> slot in
+/// addition to the leading/trailing slots common to the chip family.
 /// </summary>
 public sealed partial class InputChip;

--- a/src/ComposeNet.Compose/InputChip.cs
+++ b/src/ComposeNet.Compose/InputChip.cs
@@ -1,48 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>InputChip</c>. Adds an <see cref="Avatar"/> slot in
-/// addition to the leading/trailing slots common to the chip family.
+/// Material 3 <c>InputChip</c>. Adds an <c>Avatar</c> slot in addition
+/// to the leading/trailing slots common to the chip family.
 /// </summary>
-public sealed class InputChip : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public InputChip(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Required: chip text.</summary>
-    public ComposableNode? Label { get; set; }
-
-    public ComposableNode? LeadingIcon  { get; set; }
-    public ComposableNode? Avatar       { get; set; }
-    public ComposableNode? TrailingIcon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Label is null)
-            throw new System.InvalidOperationException(
-                "InputChip.Label is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-        var leading  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
-        var avatar   = Avatar       is null ? null : ComposableLambdas.Wrap2(composer, c => Avatar.Render(c));
-        var trailing = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
-
-        int defaults = (int)InputChipDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)InputChipDefault.Modifier;
-        if (leading  is not null) defaults &= ~(int)InputChipDefault.LeadingIcon;
-        if (avatar   is not null) defaults &= ~(int)InputChipDefault.Avatar;
-        if (trailing is not null) defaults &= ~(int)InputChipDefault.TrailingIcon;
-
-        ComposeBridges.InputChip(_selected, click, label, modifier, leading, avatar, trailing, defaults, composer);
-    }
-}
+public sealed partial class InputChip;

--- a/src/ComposeNet.Compose/LargeFlexibleTopAppBar.cs
+++ b/src/ComposeNet.Compose/LargeFlexibleTopAppBar.cs
@@ -1,49 +1,8 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>LargeFlexibleTopAppBar</c> — a two-row top app bar
 /// similar to <see cref="LargeTopAppBar"/> but with a configurable
-/// expanded height and an optional second-line <see cref="Subtitle"/>
-/// slot.
+/// expanded height and an optional second-line <c>Subtitle</c> slot.
 /// </summary>
-public sealed class LargeFlexibleTopAppBar : ComposableNode
-{
-    /// <summary>Required: the bar's title slot.</summary>
-    public ComposableNode? Title { get; set; }
-
-    /// <summary>Optional: second-line slot below the title.</summary>
-    public ComposableNode? Subtitle { get; set; }
-
-    /// <summary>Optional: leading slot.</summary>
-    public ComposableNode? NavigationIcon { get; set; }
-
-    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
-    public ComposableNode? Actions { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Title is null)
-            throw new System.InvalidOperationException(
-                "LargeFlexibleTopAppBar.Title is required (the Kotlin parameter has no default).");
-
-        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var subtitle = Subtitle is null ? null
-            : ComposableLambdas.Wrap2(composer, c => Subtitle.Render(c));
-        var nav = NavigationIcon is null ? null
-            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
-        var actions = Actions is null ? null
-            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
-
-        int defaults = (int)FlexibleTopAppBarDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Modifier;
-        if (subtitle is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Subtitle;
-        if (nav      is not null) defaults &= ~(int)FlexibleTopAppBarDefault.NavigationIcon;
-        if (actions  is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Actions;
-
-        ComposeBridges.LargeFlexibleTopAppBar(
-            title, modifier, subtitle, nav, actions, defaults, composer);
-    }
-}
+public sealed partial class LargeFlexibleTopAppBar;

--- a/src/ComposeNet.Compose/LargeTopAppBar.cs
+++ b/src/ComposeNet.Compose/LargeTopAppBar.cs
@@ -1,7 +1,8 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>LargeTopAppBar</c> — a two-row top app bar with the
-/// largest collapsed title.
+/// Material 3 <c>LargeTopAppBar</c> — a taller variant of
+/// <see cref="MediumTopAppBar"/> that gives the title a full-width row
+/// when expanded. Same slots as <see cref="TopAppBar"/>.
 /// </summary>
 public sealed partial class LargeTopAppBar;

--- a/src/ComposeNet.Compose/LargeTopAppBar.cs
+++ b/src/ComposeNet.Compose/LargeTopAppBar.cs
@@ -1,41 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>LargeTopAppBar</c> — a taller variant of
-/// <see cref="MediumTopAppBar"/> that gives the title a full-width row
-/// when expanded. Same slots as <see cref="TopAppBar"/>.
+/// Material 3 <c>LargeTopAppBar</c> — a two-row top app bar with the
+/// largest collapsed title.
 /// </summary>
-public sealed class LargeTopAppBar : ComposableNode
-{
-    /// <summary>Required: the bar's title slot.</summary>
-    public ComposableNode? Title { get; set; }
-
-    /// <summary>Optional: leading slot.</summary>
-    public ComposableNode? NavigationIcon { get; set; }
-
-    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
-    public ComposableNode? Actions { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Title is null)
-            throw new System.InvalidOperationException(
-                "LargeTopAppBar.Title is required (the Kotlin parameter has no default).");
-
-        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var nav = NavigationIcon is null ? null
-            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
-        var actions = Actions is null ? null
-            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
-
-        int defaults = (int)TwoRowsTopAppBarDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Modifier;
-        if (nav      is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.NavigationIcon;
-        if (actions  is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Actions;
-
-        ComposeBridges.LargeTopAppBar(title, modifier, nav, actions, defaults, composer);
-    }
-}
+public sealed partial class LargeTopAppBar;

--- a/src/ComposeNet.Compose/LeadingIconTab.cs
+++ b/src/ComposeNet.Compose/LeadingIconTab.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -7,33 +5,4 @@ namespace ComposeNet;
 /// icon and text are required and laid out side-by-side (icon first)
 /// instead of stacked vertically.
 /// </summary>
-public sealed class LeadingIconTab : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public LeadingIconTab(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Required: tab label slot.</summary>
-    public ComposableNode? Text { get; set; }
-
-    /// <summary>Required: tab icon slot, rendered before the text.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Text is null || Icon is null)
-            throw new System.InvalidOperationException(
-                "LeadingIconTab.Text and Icon are both required (the Kotlin parameters have no defaults).");
-
-        var click = new ComposableLambda0(_onClick);
-        var text  = ComposableLambdas.Wrap2(composer, c => Text.Render(c));
-        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-
-        ComposeBridges.LeadingIconTab(_selected, click, text, icon, BuildModifier(), composer);
-    }
-}
+public sealed partial class LeadingIconTab;

--- a/src/ComposeNet.Compose/ListItem.cs
+++ b/src/ComposeNet.Compose/ListItem.cs
@@ -2,9 +2,8 @@ namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>ListItem</c>. A row in a list with a required
-/// <c>Headline</c> and four optional content slots
-/// (<c>Overline</c>, <c>Supporting</c>, <c>Leading</c>,
-/// <c>Trailing</c>):
+/// <c>Headline</c> and four optional content slots (<c>Overline</c>,
+/// <c>Supporting</c>, <c>Leading</c>, <c>Trailing</c>):
 /// <code>
 /// new ListItem
 /// {

--- a/src/ComposeNet.Compose/ListItem.cs
+++ b/src/ComposeNet.Compose/ListItem.cs
@@ -1,12 +1,10 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>ListItem</c>. A row in a list with a required
-/// <see cref="Headline"/> and four optional content slots
-/// (<see cref="Overline"/>, <see cref="Supporting"/>,
-/// <see cref="Leading"/>, <see cref="Trailing"/>):
+/// <c>Headline</c> and four optional content slots
+/// (<c>Overline</c>, <c>Supporting</c>, <c>Leading</c>,
+/// <c>Trailing</c>):
 /// <code>
 /// new ListItem
 /// {
@@ -17,43 +15,4 @@ namespace ComposeNet;
 /// }
 /// </code>
 /// </summary>
-public sealed class ListItem : ComposableNode
-{
-    /// <summary>Required: primary text slot.</summary>
-    public ComposableNode? Headline { get; set; }
-
-    /// <summary>Optional: text rendered above the headline.</summary>
-    public ComposableNode? Overline { get; set; }
-
-    /// <summary>Optional: secondary text rendered below the headline.</summary>
-    public ComposableNode? Supporting { get; set; }
-
-    /// <summary>Optional: leading slot, typically an icon or avatar.</summary>
-    public ComposableNode? Leading { get; set; }
-
-    /// <summary>Optional: trailing slot.</summary>
-    public ComposableNode? Trailing { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Headline is null)
-            throw new System.InvalidOperationException(
-                "ListItem.Headline is required (the Kotlin parameter has no default).");
-
-        var headline = ComposableLambdas.Wrap2(composer, c => Headline.Render(c));
-        var overline   = Overline   is null ? null : ComposableLambdas.Wrap2(composer, c => Overline.Render(c));
-        var supporting = Supporting is null ? null : ComposableLambdas.Wrap2(composer, c => Supporting.Render(c));
-        var leading    = Leading    is null ? null : ComposableLambdas.Wrap2(composer, c => Leading.Render(c));
-        var trailing   = Trailing   is null ? null : ComposableLambdas.Wrap2(composer, c => Trailing.Render(c));
-
-        int defaults = (int)ListItemDefault.All;
-        var modifier = BuildModifier();
-        if (modifier   is not null) defaults &= ~(int)ListItemDefault.Modifier;
-        if (overline   is not null) defaults &= ~(int)ListItemDefault.OverlineContent;
-        if (supporting is not null) defaults &= ~(int)ListItemDefault.SupportingContent;
-        if (leading    is not null) defaults &= ~(int)ListItemDefault.LeadingContent;
-        if (trailing   is not null) defaults &= ~(int)ListItemDefault.TrailingContent;
-
-        ComposeBridges.ListItem(headline, modifier, overline, supporting, leading, trailing, defaults, composer);
-    }
-}
+public sealed partial class ListItem;

--- a/src/ComposeNet.Compose/MediumFlexibleTopAppBar.cs
+++ b/src/ComposeNet.Compose/MediumFlexibleTopAppBar.cs
@@ -1,49 +1,8 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>MediumFlexibleTopAppBar</c> — a two-row top app bar
 /// similar to <see cref="MediumTopAppBar"/> but with a configurable
-/// expanded height and an optional second-line <see cref="Subtitle"/>
-/// slot.
+/// expanded height and an optional second-line <c>Subtitle</c> slot.
 /// </summary>
-public sealed class MediumFlexibleTopAppBar : ComposableNode
-{
-    /// <summary>Required: the bar's title slot.</summary>
-    public ComposableNode? Title { get; set; }
-
-    /// <summary>Optional: second-line slot below the title.</summary>
-    public ComposableNode? Subtitle { get; set; }
-
-    /// <summary>Optional: leading slot, typically a menu / back button.</summary>
-    public ComposableNode? NavigationIcon { get; set; }
-
-    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
-    public ComposableNode? Actions { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Title is null)
-            throw new System.InvalidOperationException(
-                "MediumFlexibleTopAppBar.Title is required (the Kotlin parameter has no default).");
-
-        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var subtitle = Subtitle is null ? null
-            : ComposableLambdas.Wrap2(composer, c => Subtitle.Render(c));
-        var nav = NavigationIcon is null ? null
-            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
-        var actions = Actions is null ? null
-            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
-
-        int defaults = (int)FlexibleTopAppBarDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Modifier;
-        if (subtitle is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Subtitle;
-        if (nav      is not null) defaults &= ~(int)FlexibleTopAppBarDefault.NavigationIcon;
-        if (actions  is not null) defaults &= ~(int)FlexibleTopAppBarDefault.Actions;
-
-        ComposeBridges.MediumFlexibleTopAppBar(
-            title, modifier, subtitle, nav, actions, defaults, composer);
-    }
-}
+public sealed partial class MediumFlexibleTopAppBar;

--- a/src/ComposeNet.Compose/MediumTopAppBar.cs
+++ b/src/ComposeNet.Compose/MediumTopAppBar.cs
@@ -1,7 +1,8 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>MediumTopAppBar</c> — a two-row top app bar with a
-/// larger collapsed title than <see cref="TopAppBar"/>.
+/// Material 3 <c>MediumTopAppBar</c> — a two-row top app bar that
+/// collapses to a single row as the underlying scroll behavior
+/// progresses. Same slots as <see cref="TopAppBar"/>.
 /// </summary>
 public sealed partial class MediumTopAppBar;

--- a/src/ComposeNet.Compose/MediumTopAppBar.cs
+++ b/src/ComposeNet.Compose/MediumTopAppBar.cs
@@ -1,41 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>MediumTopAppBar</c> — a two-row top app bar that
-/// collapses to a single row as the underlying scroll behavior
-/// progresses. Same slots as <see cref="TopAppBar"/>.
+/// Material 3 <c>MediumTopAppBar</c> — a two-row top app bar with a
+/// larger collapsed title than <see cref="TopAppBar"/>.
 /// </summary>
-public sealed class MediumTopAppBar : ComposableNode
-{
-    /// <summary>Required: the bar's title slot.</summary>
-    public ComposableNode? Title { get; set; }
-
-    /// <summary>Optional: leading slot.</summary>
-    public ComposableNode? NavigationIcon { get; set; }
-
-    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
-    public ComposableNode? Actions { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Title is null)
-            throw new System.InvalidOperationException(
-                "MediumTopAppBar.Title is required (the Kotlin parameter has no default).");
-
-        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var nav = NavigationIcon is null ? null
-            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
-        var actions = Actions is null ? null
-            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
-
-        int defaults = (int)TwoRowsTopAppBarDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Modifier;
-        if (nav      is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.NavigationIcon;
-        if (actions  is not null) defaults &= ~(int)TwoRowsTopAppBarDefault.Actions;
-
-        ComposeBridges.MediumTopAppBar(title, modifier, nav, actions, defaults, composer);
-    }
-}
+public sealed partial class MediumTopAppBar;

--- a/src/ComposeNet.Compose/ModalDrawerSheet.cs
+++ b/src/ComposeNet.Compose/ModalDrawerSheet.cs
@@ -1,14 +1,14 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ModalDrawerSheet</c> — the panel shown by a modal-style
-/// navigation drawer. Lays out children as a Column. Typically holds nav
-/// items; in this facade any <see cref="ComposableNode"/> works.
+/// Material 3 <c>ModalDrawerSheet</c> — the panel shown by a
+/// modal-style navigation drawer. Lays out children as a Column.
+/// Typically holds nav items; in this facade any
+/// <see cref="ComposableNode"/> works.
+///
+/// <c>ContainerColor</c> defaults to <c>0L</c>, which the facade
+/// resolves to the active
+/// <c>MaterialTheme.colorScheme.secondaryContainer</c> — visibly
+/// distinct from <c>surface</c>; pass any other value to override.
 /// </summary>
-/// <remarks>
-/// <see cref="ContainerColor"/> defaults to <c>0L</c>, which resolves to
-/// <c>MaterialTheme.colorScheme.secondaryContainer</c> (visibly distinct
-/// from <c>surface</c>). Set to any non-zero packed Compose <c>Color</c> to
-/// override.
-/// </remarks>
 public sealed partial class ModalDrawerSheet;

--- a/src/ComposeNet.Compose/ModalDrawerSheet.cs
+++ b/src/ComposeNet.Compose/ModalDrawerSheet.cs
@@ -1,31 +1,14 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ModalDrawerSheet</c> — the panel shown by a
-/// modal-style navigation drawer. Lays out children as a Column.
-/// Typically holds nav items; in this facade any
-/// <see cref="ComposableNode"/> works.
+/// Material 3 <c>ModalDrawerSheet</c> — the panel shown by a modal-style
+/// navigation drawer. Lays out children as a Column. Typically holds nav
+/// items; in this facade any <see cref="ComposableNode"/> works.
 /// </summary>
-public sealed class ModalDrawerSheet : ComposableContainer
-{
-    /// <summary>
-    /// Optional container color (Compose <c>Color</c> as a packed
-    /// <c>long</c>). <c>0L</c> (the default) uses the active
-    /// <c>MaterialTheme.colorScheme.secondaryContainer</c>, which is
-    /// visibly distinct from <c>surface</c>; pass any other value to
-    /// override.
-    /// </summary>
-    public long ContainerColor { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
-        var color = ContainerColor != 0L
-            ? ContainerColor
-            : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;
-        ComposeBridges.ModalDrawerSheet(content, color, composer);
-    }
-}
+/// <remarks>
+/// <see cref="ContainerColor"/> defaults to <c>0L</c>, which resolves to
+/// <c>MaterialTheme.colorScheme.secondaryContainer</c> (visibly distinct
+/// from <c>surface</c>). Set to any non-zero packed Compose <c>Color</c> to
+/// override.
+/// </remarks>
+public sealed partial class ModalDrawerSheet;

--- a/src/ComposeNet.Compose/NavigationBarItem.cs
+++ b/src/ComposeNet.Compose/NavigationBarItem.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -7,48 +5,6 @@ namespace ComposeNet;
 /// <see cref="NavigationBar"/> — the Kotlin static method takes a
 /// <c>RowScope</c> extension receiver, which the parent
 /// <see cref="NavigationBar"/> publishes via <c>RenderContext</c>.
-/// <see cref="Icon"/> is required; <see cref="Label"/> is optional.
+/// <c>Icon</c> is required; <c>Label</c> is optional.
 /// </summary>
-public sealed class NavigationBarItem : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public NavigationBarItem(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Required: item icon.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    /// <summary>Optional: item label.</summary>
-    public ComposableNode? Label { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Icon is null)
-            throw new System.InvalidOperationException(
-                "NavigationBarItem.Icon is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-        var label = Label is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-
-        int defaults = (int)NavigationBarItemDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)NavigationBarItemDefault.Modifier;
-        if (label    is not null) defaults &= ~(int)NavigationBarItemDefault.Label;
-
-        ComposeBridges.NavigationBarItem(
-            rowScope: RenderContext.CurrentScope,
-            selected: _selected,
-            onClick:  click,
-            icon:     icon,
-            modifier: modifier,
-            label:    label,
-            defaults: defaults,
-            composer: composer);
-    }
-}
+public sealed partial class NavigationBarItem;

--- a/src/ComposeNet.Compose/NavigationRailItem.cs
+++ b/src/ComposeNet.Compose/NavigationRailItem.cs
@@ -2,6 +2,7 @@ namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>NavigationRailItem</c>. Used inside
-/// <see cref="NavigationRail"/>.
+/// <see cref="NavigationRail"/>. <c>Icon</c> is required;
+/// <c>Label</c> is optional.
 /// </summary>
 public sealed partial class NavigationRailItem;

--- a/src/ComposeNet.Compose/NavigationRailItem.cs
+++ b/src/ComposeNet.Compose/NavigationRailItem.cs
@@ -1,43 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>NavigationRailItem</c>. Used inside
 /// <see cref="NavigationRail"/>.
 /// </summary>
-public sealed class NavigationRailItem : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public NavigationRailItem(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Required: item icon.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    /// <summary>Optional: item label.</summary>
-    public ComposableNode? Label { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Icon is null)
-            throw new System.InvalidOperationException(
-                "NavigationRailItem.Icon is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-        var label = Label is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-
-        int defaults = (int)NavigationRailItemDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)NavigationRailItemDefault.Modifier;
-        if (label    is not null) defaults &= ~(int)NavigationRailItemDefault.Label;
-
-        ComposeBridges.NavigationRailItem(_selected, click, icon, modifier, label, defaults, composer);
-    }
-}
+public sealed partial class NavigationRailItem;

--- a/src/ComposeNet.Compose/OutlinedIconToggleButton.cs
+++ b/src/ComposeNet.Compose/OutlinedIconToggleButton.cs
@@ -1,26 +1,6 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>OutlinedIconToggleButton</c>. Same shape as <see cref="IconToggleButton"/>.
 /// </summary>
-public sealed class OutlinedIconToggleButton : ComposableContainer
-{
-    readonly bool _checked;
-    readonly System.Action<bool> _onCheckedChange;
-
-    public OutlinedIconToggleButton(bool @checked, System.Action<bool> onCheckedChange)
-    {
-        _checked = @checked;
-        _onCheckedChange = onCheckedChange;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onChange = new ComposableLambda1(v =>
-            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
-        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        ComposeBridges.OutlinedIconToggleButton(_checked, onChange, BuildModifier(), content, composer);
-    }
-}
+public sealed partial class OutlinedIconToggleButton;

--- a/src/ComposeNet.Compose/OutlinedTextField.cs
+++ b/src/ComposeNet.Compose/OutlinedTextField.cs
@@ -1,19 +1,16 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>OutlinedTextField</c>. Same binding contract as
-/// <see cref="TextField"/>.
+/// Material 3 <c>OutlinedTextField</c>. Same binding contract as <see cref="TextField"/>.
 /// </summary>
-public sealed class OutlinedTextField : ComposableNode
+public sealed partial class OutlinedTextField
 {
-    readonly MutableState<string> _state;
-    public OutlinedTextField(MutableState<string> state) => _state = state;
-
-    internal override void Render(IComposer composer)
+    /// <summary>
+    /// Bind this <c>OutlinedTextField</c> to a <see cref="MutableState{T}"/> of <see cref="string"/>
+    /// so user edits trigger recomposition automatically.
+    /// </summary>
+    public OutlinedTextField(MutableState<string> state)
+        : this(state.Value ?? string.Empty, v => state.Value = v)
     {
-        var onChange = new ComposableLambda1(v => _state.Value = v?.ToString() ?? string.Empty);
-        ComposeBridges.OutlinedTextField(_state.Value ?? string.Empty, onChange, BuildModifier(), composer);
     }
 }

--- a/src/ComposeNet.Compose/OutlinedTextField.cs
+++ b/src/ComposeNet.Compose/OutlinedTextField.cs
@@ -1,7 +1,8 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>OutlinedTextField</c>. Same binding contract as <see cref="TextField"/>.
+/// Material 3 <c>OutlinedTextField</c>. Same binding contract as
+/// <see cref="TextField"/>.
 /// </summary>
 public sealed partial class OutlinedTextField
 {

--- a/src/ComposeNet.Compose/PermanentDrawerSheet.cs
+++ b/src/ComposeNet.Compose/PermanentDrawerSheet.cs
@@ -1,8 +1,9 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>PermanentDrawerSheet</c>. Same shape as
-/// <see cref="ModalDrawerSheet"/>; designed for the always-visible
-/// permanent navigation drawer pattern.
+/// Material 3 <c>PermanentDrawerSheet</c> — the always-visible panel
+/// shown by a <see cref="PermanentNavigationDrawer"/>.
+/// <c>ContainerColor</c> defaults to <c>0L</c>, which falls back to
+/// the active theme's <c>secondaryContainer</c>.
 /// </summary>
 public sealed partial class PermanentDrawerSheet;

--- a/src/ComposeNet.Compose/PermanentDrawerSheet.cs
+++ b/src/ComposeNet.Compose/PermanentDrawerSheet.cs
@@ -1,26 +1,8 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>PermanentDrawerSheet</c> — the always-visible panel
-/// shown by a <see cref="PermanentNavigationDrawer"/>.
+/// Material 3 <c>PermanentDrawerSheet</c>. Same shape as
+/// <see cref="ModalDrawerSheet"/>; designed for the always-visible
+/// permanent navigation drawer pattern.
 /// </summary>
-public sealed class PermanentDrawerSheet : ComposableContainer
-{
-    /// <summary>
-    /// Optional container color. <c>0L</c> (the default) uses the
-    /// active theme's <c>secondaryContainer</c>.
-    /// </summary>
-    public long ContainerColor { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        var content = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
-        var color = ContainerColor != 0L
-            ? ContainerColor
-            : AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;
-        ComposeBridges.PermanentDrawerSheet(content, color, composer);
-    }
-}
+public sealed partial class PermanentDrawerSheet;

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -194,7 +194,8 @@ ComposeNet.IconButton.IconButton(System.Action! onClick) -> void
 ComposeNet.IconToggleButton
 ComposeNet.IconToggleButton.IconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 ComposeNet.Image
-ComposeNet.Image.Image(int drawableResourceId, string? contentDescription = null) -> void
+ComposeNet.Image.Image(int painterResourceId) -> void
+ComposeNet.Image.Image(int painterResourceId, string? contentDescription) -> void
 ComposeNet.InputChip
 ComposeNet.InputChip.Avatar.get -> ComposeNet.ComposableNode?
 ComposeNet.InputChip.Avatar.set -> void
@@ -374,6 +375,7 @@ ComposeNet.OutlinedIconToggleButton
 ComposeNet.OutlinedIconToggleButton.OutlinedIconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 ComposeNet.OutlinedTextField
 ComposeNet.OutlinedTextField.OutlinedTextField(ComposeNet.MutableState<string!>! state) -> void
+ComposeNet.OutlinedTextField.OutlinedTextField(string! value, System.Action<string!>! onValueChange) -> void
 ComposeNet.PermanentDrawerSheet
 ComposeNet.PermanentDrawerSheet.ContainerColor.get -> long
 ComposeNet.PermanentDrawerSheet.ContainerColor.set -> void
@@ -481,6 +483,7 @@ ComposeNet.TextButton
 ComposeNet.TextButton.TextButton(System.Action! onClick) -> void
 ComposeNet.TextField
 ComposeNet.TextField.TextField(ComposeNet.MutableState<string!>! state) -> void
+ComposeNet.TextField.TextField(string! value, System.Action<string!>! onValueChange) -> void
 ComposeNet.TimePicker
 ComposeNet.TimePicker.TimePicker(ComposeNet.TimePickerState? state = null) -> void
 ComposeNet.TimePickerDialog

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -194,8 +194,8 @@ ComposeNet.IconButton.IconButton(System.Action! onClick) -> void
 ComposeNet.IconToggleButton
 ComposeNet.IconToggleButton.IconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 ComposeNet.Image
-ComposeNet.Image.Image(int painterResourceId) -> void
-ComposeNet.Image.Image(int painterResourceId, string? contentDescription) -> void
+ComposeNet.Image.Image(int drawableResourceId) -> void
+ComposeNet.Image.Image(int drawableResourceId, string? contentDescription) -> void
 ComposeNet.InputChip
 ComposeNet.InputChip.Avatar.get -> ComposeNet.ComposableNode?
 ComposeNet.InputChip.Avatar.set -> void

--- a/src/ComposeNet.Compose/Snackbar.cs
+++ b/src/ComposeNet.Compose/Snackbar.cs
@@ -2,7 +2,7 @@ namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>Snackbar</c>. A transient message bar typically
-/// rendered in <see cref="Scaffold.SnackbarHost"/>:
+/// rendered in <c>Scaffold.SnackbarHost</c>:
 /// <code>
 /// new Snackbar
 /// {

--- a/src/ComposeNet.Compose/Snackbar.cs
+++ b/src/ComposeNet.Compose/Snackbar.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -13,35 +11,4 @@ namespace ComposeNet;
 /// }
 /// </code>
 /// </summary>
-public sealed class Snackbar : ComposableNode
-{
-    /// <summary>Required: the message body slot.</summary>
-    public ComposableNode? Body { get; set; }
-
-    /// <summary>Optional: trailing action button (e.g. "Undo").</summary>
-    public ComposableNode? Action { get; set; }
-
-    /// <summary>Optional: dismiss action (e.g. close icon button).</summary>
-    public ComposableNode? DismissAction { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Body is null)
-            throw new System.InvalidOperationException(
-                "Snackbar.Body is required (the Kotlin content lambda has no default).");
-
-        var content = ComposableLambdas.Wrap2(composer, c => Body.Render(c));
-        var action = Action is null ? null
-            : ComposableLambdas.Wrap2(composer, c => Action.Render(c));
-        var dismiss = DismissAction is null ? null
-            : ComposableLambdas.Wrap2(composer, c => DismissAction.Render(c));
-
-        int defaults = (int)SnackbarDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)SnackbarDefault.Modifier;
-        if (action   is not null) defaults &= ~(int)SnackbarDefault.Action;
-        if (dismiss  is not null) defaults &= ~(int)SnackbarDefault.DismissAction;
-
-        ComposeBridges.Snackbar(modifier, action, dismiss, content, defaults, composer);
-    }
-}
+public sealed partial class Snackbar;

--- a/src/ComposeNet.Compose/SuggestionChip.cs
+++ b/src/ComposeNet.Compose/SuggestionChip.cs
@@ -1,7 +1,7 @@
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>SuggestionChip</c>. Only a single optional <c>Icon</c>
-/// slot (no trailing icon).
+/// Material 3 <c>SuggestionChip</c>. Single-icon variant — only an
+/// <c>Icon</c> slot is exposed (vs. AssistChip's leading + trailing).
 /// </summary>
 public sealed partial class SuggestionChip;

--- a/src/ComposeNet.Compose/SuggestionChip.cs
+++ b/src/ComposeNet.Compose/SuggestionChip.cs
@@ -1,37 +1,7 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>SuggestionChip</c>. Single-icon variant — only an
-/// <see cref="Icon"/> slot is exposed (vs. AssistChip's leading + trailing).
+/// Material 3 <c>SuggestionChip</c>. Only a single optional <c>Icon</c>
+/// slot (no trailing icon).
 /// </summary>
-public sealed class SuggestionChip : ComposableNode
-{
-    readonly System.Action _onClick;
-    public SuggestionChip(System.Action onClick) => _onClick = onClick;
-
-    /// <summary>Required: chip text.</summary>
-    public ComposableNode? Label { get; set; }
-
-    /// <summary>Optional: leading slot.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Label is null)
-            throw new System.InvalidOperationException(
-                "SuggestionChip.Label is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var label = ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-        var icon = Icon is null ? null : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-
-        int defaults = (int)SuggestionChipDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)SuggestionChipDefault.Modifier;
-        if (icon     is not null) defaults &= ~(int)SuggestionChipDefault.Icon;
-
-        ComposeBridges.SuggestionChip(click, label, modifier, icon, defaults, composer);
-    }
-}
+public sealed partial class SuggestionChip;

--- a/src/ComposeNet.Compose/Tab.cs
+++ b/src/ComposeNet.Compose/Tab.cs
@@ -1,43 +1,10 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>Tab</c>. Place inside a <see cref="TabRow"/> /
 /// <see cref="PrimaryTabRow"/> / <see cref="SecondaryTabRow"/> /
-/// <see cref="ScrollableTabRow"/>. <see cref="Text"/> and
-/// <see cref="Icon"/> are both optional but at least one should be
-/// supplied for the tab to be visible.
+/// <see cref="ScrollableTabRow"/>. <c>Text</c> and <c>Icon</c> are
+/// both optional but at least one should be supplied for the tab to
+/// be visible.
 /// </summary>
-public sealed class Tab : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public Tab(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Optional: tab label slot.</summary>
-    public ComposableNode? Text { get; set; }
-
-    /// <summary>Optional: tab icon slot.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        var click = new ComposableLambda0(_onClick);
-        var text = Text is null ? null : ComposableLambdas.Wrap2(composer, c => Text.Render(c));
-        var icon = Icon is null ? null : ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-
-        int defaults = (int)TabDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)TabDefault.Modifier;
-        if (text     is not null) defaults &= ~(int)TabDefault.Text;
-        if (icon     is not null) defaults &= ~(int)TabDefault.Icon;
-
-        ComposeBridges.Tab(_selected, click, modifier, text, icon, defaults, composer);
-    }
-}
+public sealed partial class Tab;

--- a/src/ComposeNet.Compose/Tab.cs
+++ b/src/ComposeNet.Compose/Tab.cs
@@ -3,8 +3,8 @@ namespace ComposeNet;
 /// <summary>
 /// Material 3 <c>Tab</c>. Place inside a <see cref="TabRow"/> /
 /// <see cref="PrimaryTabRow"/> / <see cref="SecondaryTabRow"/> /
-/// <see cref="ScrollableTabRow"/>. <c>Text</c> and <c>Icon</c> are
-/// both optional but at least one should be supplied for the tab to
-/// be visible.
+/// <c>ScrollableTabRow</c>. <c>Text</c> and <c>Icon</c> are both
+/// optional but at least one should be supplied for the tab to be
+/// visible.
 /// </summary>
 public sealed partial class Tab;

--- a/src/ComposeNet.Compose/TextField.cs
+++ b/src/ComposeNet.Compose/TextField.cs
@@ -1,20 +1,18 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>TextField</c> (filled variant). Bound to a
-/// <see cref="MutableState{T}"/> of <see cref="string"/> so user edits
-/// trigger recomposition.
+/// Material 3 <c>TextField</c> (filled variant). Pass a <c>value</c> + <c>onValueChange</c>
+/// pair, or use the <see cref="TextField(MutableState{string})"/> convenience ctor to bind
+/// to a <see cref="MutableState{T}"/> directly.
 /// </summary>
-public sealed class TextField : ComposableNode
+public sealed partial class TextField
 {
-    readonly MutableState<string> _state;
-    public TextField(MutableState<string> state) => _state = state;
-
-    internal override void Render(IComposer composer)
+    /// <summary>
+    /// Bind this <c>TextField</c> to a <see cref="MutableState{T}"/> of <see cref="string"/>
+    /// so user edits trigger recomposition automatically.
+    /// </summary>
+    public TextField(MutableState<string> state)
+        : this(state.Value ?? string.Empty, v => state.Value = v)
     {
-        var onChange = new ComposableLambda1(v => _state.Value = v?.ToString() ?? string.Empty);
-        ComposeBridges.TextField(_state.Value ?? string.Empty, onChange, BuildModifier(), composer);
     }
 }

--- a/src/ComposeNet.Compose/TextField.cs
+++ b/src/ComposeNet.Compose/TextField.cs
@@ -3,7 +3,7 @@ namespace ComposeNet;
 /// <summary>
 /// Material 3 <c>TextField</c> (filled variant). Pass a <c>value</c> + <c>onValueChange</c>
 /// pair, or use the <see cref="TextField(MutableState{string})"/> convenience ctor to bind
-/// to a <see cref="MutableState{T}"/> directly.
+/// to a <see cref="MutableState{T}"/> directly so user edits trigger recomposition.
 /// </summary>
 public sealed partial class TextField
 {

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -865,9 +865,9 @@ public class FacadeGeneratorTests
         var (output, diags, emitted) = Run(code, "Image");
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
-        Assert.Contains("public Image(int painterResourceId", emitted);
-        Assert.Contains("readonly int _painterResourceId;", emitted);
-        Assert.Contains("global::System.IntPtr __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_painterResourceId, composer);", emitted);
+        Assert.Contains("public Image(int drawableResourceId", emitted);
+        Assert.Contains("readonly int _drawableResourceId;", emitted);
+        Assert.Contains("global::System.IntPtr __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_drawableResourceId, composer);", emitted);
         Assert.Contains("try", emitted);
         Assert.Contains("finally", emitted);
         Assert.Contains("global::Android.Runtime.JNIEnv.DeleteLocalRef(__painterRef);", emitted);
@@ -922,5 +922,84 @@ public class FacadeGeneratorTests
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Callback_OnNonFunction1Param_ReportsCN3006()
+    {
+        var code = """
+            using System;
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Foo", JvmName="bar", Signature="()V")]
+                    [ComposeFacade]
+                    public static partial void Foo([Callback(typeof(bool))] IFunction0 onClick, IComposer composer);
+                }
+            }
+            """;
+        var (_, diags, _) = Run(code, "Foo");
+        Assert.Contains(diags, d => d.Id == "CN3006" && d.GetMessage().Contains("[Callback]") && d.GetMessage().Contains("IFunction1"));
+        Assert.DoesNotContain(diags, d => d.Id == "CN3005");
+    }
+
+    [Fact]
+    public void MultiplePainterResource_ReportsCN3006()
+    {
+        var code = """
+            using System;
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+
+            [assembly: ComposeDefaults("FooDefault", "!a", "!b")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Foo", JvmName="bar",
+                                   Signature="(Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(FooDefault))]
+                    [ComposeFacade]
+                    public static partial void Foo([PainterResource] IntPtr a, [PainterResource] IntPtr b,
+                        int defaults, IComposer composer);
+                }
+            }
+            """;
+        var (_, diags, _) = Run(code, "Foo");
+        Assert.Contains(diags, d => d.Id == "CN3006" && d.GetMessage().Contains("only be applied to one"));
+    }
+
+    [Fact]
+    public void CallerDefaults_WithoutDefaultsEnum_ReportsCN3006()
+    {
+        var code = """
+            using System;
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    // Bridge has `int defaults` but no `Defaults = typeof(...)` on [ComposeBridge].
+                    [ComposeBridge(Class="x/Foo", JvmName="bar",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V")]
+                    [ComposeFacade]
+                    public static partial void Foo(IFunction2 content, int defaults, IComposer composer);
+                }
+            }
+            """;
+        var (_, diags, _) = Run(code, "Foo");
+        Assert.Contains(diags, d => d.Id == "CN3006" && d.GetMessage().Contains("int defaults"));
     }
 }

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -48,9 +48,28 @@ public class FacadeGeneratorTests
                 public System.IntPtr Handle => default;
                 public static T? GetObject<T>(System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) where T : class => default;
             }
+            public sealed class Boolean : Object { public bool BooleanValue() => false; }
+            public sealed class Float : Object { public float FloatValue() => 0f; }
         }
         namespace AndroidX.Compose.Runtime { public interface IComposer { } }
         namespace AndroidX.Compose.UI { public interface IModifier { } }
+        namespace AndroidX.Compose.Material3
+        {
+            public sealed class ColorScheme
+            {
+                public long Primary { get; set; }
+                public long Surface { get; set; }
+                public long SecondaryContainer { get; set; }
+            }
+            public static class MaterialTheme
+            {
+                public static MaterialThemeImpl Instance => null!;
+            }
+            public sealed class MaterialThemeImpl
+            {
+                public ColorScheme GetColorScheme(AndroidX.Compose.Runtime.IComposer c, int n) => null!;
+            }
+        }
         namespace Kotlin.Jvm.Functions
         {
             public interface IFunction0 { }
@@ -65,6 +84,7 @@ public class FacadeGeneratorTests
             {
                 public ref struct ScopeFrame { public void Dispose() { } }
                 public static ScopeFrame PushScope(System.IntPtr scope, ScopeKind kind) => default;
+                public static System.IntPtr CurrentScope => default;
             }
             public abstract class ComposableNode
             {
@@ -78,6 +98,10 @@ public class FacadeGeneratorTests
             public sealed class ComposableLambda0 : Kotlin.Jvm.Functions.IFunction0
             {
                 public ComposableLambda0(System.Action body) { }
+            }
+            public sealed class ComposableLambda1 : Kotlin.Jvm.Functions.IFunction1
+            {
+                public ComposableLambda1(System.Action<object?> body) { }
             }
             public static class ComposableLambdas
             {
@@ -100,6 +124,7 @@ public class FacadeGeneratorTests
             public static partial class ComposeBridges
             {
                 public static System.IntPtr ModifierHandle(AndroidX.Compose.UI.IModifier? m) => default;
+                public static System.IntPtr PainterResource(int id, AndroidX.Compose.Runtime.IComposer composer) => default;
             }
         }
         """;
@@ -356,7 +381,7 @@ public class FacadeGeneratorTests
     }
 
     [Fact]
-    public void ManualDefaultsParam_EmitsCN3002()
+    public void AlertDialog_MultiSlotWithDefaultsMask()
     {
         var code = """
             using AndroidX.Compose.Runtime;
@@ -383,10 +408,23 @@ public class FacadeGeneratorTests
             }
             """;
 
-        var (_, diags, _) = Run(code, "AlertDialog");
-        var cn3002 = diags.Where(d => d.Id == "CN3002").ToArray();
-        Assert.NotEmpty(cn3002);
-        Assert.Contains(cn3002, d => d.GetMessage().Contains("defaults"));
+        var (output, diags, emitted) = Run(code, "AlertDialog");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // Leaf (not a container): required ConfirmButton property + null-check.
+        Assert.Contains("public sealed partial class AlertDialog : global::ComposeNet.ComposableNode", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? ConfirmButton { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? DismissButton { get; set; }", emitted);
+        Assert.Contains("if (ConfirmButton is null)", emitted);
+        // OnDismissRequest is a System.Action ctor param.
+        Assert.Contains("public AlertDialog(global::System.Action onDismissRequest)", emitted);
+        // Auto-mask logic touches each enum member the slot bit corresponds to.
+        Assert.Contains("int __defaults = (int)global::ComposeNet.AlertDialogDefault.All;", emitted);
+        Assert.Contains("if (__modifier is not null) __defaults &= ~(int)global::ComposeNet.AlertDialogDefault.Modifier;", emitted);
+        Assert.Contains("if (__dismissButton is not null) __defaults &= ~(int)global::ComposeNet.AlertDialogDefault.DismissButton;", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
     }
 
     [Fact]
@@ -526,6 +564,361 @@ public class FacadeGeneratorTests
         // not the override "MyButton" (which doesn't exist on ComposeBridges).
         Assert.Contains("global::ComposeNet.ComposeBridges.Button(", emitted);
         Assert.DoesNotContain("global::ComposeNet.ComposeBridges.MyButton(", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 2 — [Callback(typeof(T))] → Action<T> ctor
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Callback_BoolUnboxesViaJavaLangBoolean()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("IconToggleButtonDefault",
+                "!checked", "!onCheckedChange", "modifier", "enabled", "colors", "interactionSource", "!content")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/IconButtonKt", JvmName="IconToggleButton",
+                                   Signature="(ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZLandroidx/compose/material3/IconToggleButtonColors;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(IconToggleButtonDefault))]
+                    [ComposeFacade]
+                    public static partial void IconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
+                        IModifier? modifier, IFunction2 content, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "IconToggleButton");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("readonly global::System.Action<bool> _onCheckedChange;", emitted);
+        Assert.Contains("public IconToggleButton(bool @checked, global::System.Action<bool> onCheckedChange)", emitted);
+        Assert.Contains("new global::ComposeNet.ComposableLambda1(v => _onCheckedChange(v is global::Java.Lang.Boolean __b && __b.BooleanValue()));", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Callback_StringUnboxesViaToString()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("TextFieldDefault",
+                "!value", "!onValueChange", "modifier")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/TextFieldKt", JvmName="TextField",
+                                   Signature="(Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(TextFieldDefault))]
+                    [ComposeFacade]
+                    public static partial void TextField(string value, [Callback(typeof(string))] IFunction1 onValueChange,
+                        IModifier? modifier, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "TextField");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("readonly global::System.Action<string> _onValueChange;", emitted);
+        Assert.Contains("public TextField(string value, global::System.Action<string> onValueChange)", emitted);
+        Assert.Contains("new global::ComposeNet.ComposableLambda1(v => _onValueChange(v?.ToString() ?? string.Empty));", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Callback_UnsupportedTypeEmitsCN3005()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("FooDefault", "!a", "!cb", "modifier")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Kt", JvmName="Foo",
+                                   Signature="(ILkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(FooDefault))]
+                    [ComposeFacade]
+                    public static partial void Foo(int a, [Callback(typeof(int))] IFunction1 cb, IModifier? modifier, IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code, "Foo");
+        Assert.Contains(diags, d => d.Id == "CN3005");
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 3 — named slots
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void NamedSlots_RenameViaSlotAttribute()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("ListItemDefault",
+                "!headlineContent", "modifier", "overlineContent", "supportingContent",
+                "leadingContent", "trailingContent", "colors", "tonalElevation", "shadowElevation")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/ListItemKt", JvmName="ListItem",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/material3/ListItemColors;FFLandroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(ListItemDefault))]
+                    [ComposeFacade]
+                    public static partial void ListItem(
+                        [Slot("Headline")] IFunction2 headlineContent,
+                        IModifier? modifier,
+                        [Slot("Overline")] IFunction2? overlineContent,
+                        [Slot("Supporting")] IFunction2? supportingContent,
+                        [Slot("Leading")] IFunction2? leadingContent,
+                        [Slot("Trailing")] IFunction2? trailingContent,
+                        int defaults, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "ListItem");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Headline { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Overline { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Trailing { get; set; }", emitted);
+        Assert.Contains("if (Headline is null)", emitted);
+        Assert.Contains("if (__overlineContent is not null) __defaults &= ~(int)global::ComposeNet.ListItemDefault.OverlineContent;", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void BadgedBox_TwoRequiredFunction3Slots()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BadgedBoxDefault", "!badge", "modifier", "!content")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/BadgeKt", JvmName="BadgedBox",
+                                   Signature="(Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BadgedBoxDefault))]
+                    [ComposeFacade]
+                    public static partial void BadgedBox(IFunction3 badge, IModifier? modifier, IFunction3 content,
+                        int defaults, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "BadgedBox");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // Two required Function3 slots → both surface as properties, not RenderChildren.
+        Assert.Contains("public sealed partial class BadgedBox : global::ComposeNet.ComposableNode", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Badge { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Content { get; set; }", emitted);
+        Assert.Contains("if (Badge is null)", emitted);
+        Assert.Contains("if (Content is null)", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 6 — DefaultColorFromTheme
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void DefaultColorFromTheme_EmitsContainerColorProperty()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("DrawerSheetDefault", "!content", "drawerContainerColor")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/NavigationDrawerKt", JvmName="ModalDrawerSheet-afqeVBk",
+                                   Signature="(Lkotlin/jvm/functions/Function3;JLandroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(DrawerSheetDefault))]
+                    [ComposeFacade(DefaultColorFromTheme = "secondaryContainer")]
+                    public static partial void ModalDrawerSheet(IFunction3 content, long drawerContainerColor, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "ModalDrawerSheet");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("public long ContainerColor { get; set; }", emitted);
+        Assert.Contains("long __color = ContainerColor != 0L ? ContainerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;", emitted);
+        Assert.Contains("global::ComposeNet.ComposeBridges.ModalDrawerSheet(__content, __color, composer);", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void DefaultColorFromTheme_NoLongParamEmitsCN3007()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("CardDefault", "modifier", "!content")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Kt", JvmName="Card",
+                                   Signature="(Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(CardDefault))]
+                    [ComposeFacade(DefaultColorFromTheme = "secondaryContainer")]
+                    public static partial void Card(IModifier? modifier, IFunction3 content, IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code, "Card");
+        Assert.Contains(diags, d => d.Id == "CN3007");
+    }
+
+    // ---------------------------------------------------------------
+    // Phase 7 — PainterResource
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void PainterResource_EmitsTryFinallyDeleteLocalRef()
+    {
+        var code = """
+            using System;
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("ImageDefault", "!painter", "contentDescription", "modifier")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/foundation/ImageKt", JvmName="Image",
+                                   Signature="(Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(ImageDefault))]
+                    [ComposeFacade]
+                    public static partial void Image([PainterResource] IntPtr painter,
+                        string? contentDescription, IModifier? modifier,
+                        int defaults, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "Image");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("public Image(int painterResourceId", emitted);
+        Assert.Contains("readonly int _painterResourceId;", emitted);
+        Assert.Contains("global::System.IntPtr __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_painterResourceId, composer);", emitted);
+        Assert.Contains("try", emitted);
+        Assert.Contains("finally", emitted);
+        Assert.Contains("global::Android.Runtime.JNIEnv.DeleteLocalRef(__painterRef);", emitted);
+        // Bridge call inside try block — uses __painterRef for painter arg.
+        Assert.Contains("global::ComposeNet.ComposeBridges.Image(__painterRef", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ScopeReceiver_IntPtrEndingInScope_BindsToRenderContextCurrentScope()
+    {
+        var code = """
+            using System;
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("NavigationBarItemDefault",
+                "!selected", "!onClick", "!icon", "modifier",
+                "enabled", "label", "alwaysShowLabel", "colors", "interactionSource")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/NavigationBarKt", JvmName="NavigationBarItem",
+                                   Signature="(Landroidx/compose/foundation/layout/RowScope;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function2;ZLandroidx/compose/material3/NavigationBarItemColors;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(NavigationBarItemDefault))]
+                    [ComposeFacade]
+                    public static partial void NavigationBarItem(
+                        IntPtr rowScope, bool selected, IFunction0 onClick,
+                        IFunction2 icon, IModifier? modifier, IFunction2? label,
+                        int defaults, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "NavigationBarItem");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // ScopeReceiver is bound to RenderContext.CurrentScope (no ctor slot).
+        Assert.Contains("global::ComposeNet.ComposeBridges.NavigationBarItem(global::ComposeNet.RenderContext.CurrentScope,", emitted);
+        // Required Function2 (icon) becomes a named property (auto multi-slot).
+        Assert.Contains("public global::ComposeNet.ComposableNode? Icon", emitted);
+        // Optional Function2 (label) becomes a named property.
+        Assert.Contains("public global::ComposeNet.ComposableNode? Label", emitted);
+        // Ctor exposes only selected + onClick (rowScope is auto-bound).
+        Assert.Contains("public NavigationBarItem(bool selected, global::System.Action onClick)", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -150,6 +150,77 @@ internal static class Attributes
                 /// an <c>IFunction3 content</c> parameter.
                 /// </summary>
                 public string? Scope { get; set; }
+
+                /// <summary>
+                /// Phase 6 — name of a <c>ColorScheme</c> property (e.g.
+                /// <c>"secondaryContainer"</c>) to use as a runtime fallback
+                /// when the user leaves the bridge's container-color
+                /// parameter at its sentinel <c>0L</c>. The generator
+                /// emits a <c>long ContainerColor { get; set; }</c>
+                /// property and binds the named bridge param (see
+                /// <see cref="ColorParameter"/>) to
+                /// <c>ContainerColor != 0L ? ContainerColor :
+                /// MaterialTheme.Instance.GetColorScheme(composer,0).&lt;Slot&gt;</c>.
+                /// </summary>
+                public string? DefaultColorFromTheme { get; set; }
+
+                /// <summary>
+                /// Phase 6 — the name of the bridge's <c>long</c>
+                /// parameter that <see cref="DefaultColorFromTheme"/>
+                /// targets. Optional when the bridge has exactly one
+                /// <c>long</c> user parameter; required when there's
+                /// ambiguity.
+                /// </summary>
+                public string? ColorParameter { get; set; }
+            }
+
+            /// <summary>
+            /// Phase 3 — apply to a Kotlin-function bridge parameter to
+            /// override the C# property name the facade exposes for that
+            /// slot. Default is the parameter name PascalCased. Useful
+            /// when the Kotlin name reads awkwardly in C# (e.g.
+            /// <c>content</c> → <c>Body</c>,
+            /// <c>headlineContent</c> → <c>Headline</c>,
+            /// <c>tooltip</c> → <c>Tip</c>).
+            /// </summary>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class SlotAttribute : global::System.Attribute
+            {
+                public SlotAttribute(string propertyName) { }
+            }
+
+            /// <summary>
+            /// Phase 2 — apply to an <c>IFunction1</c> bridge parameter
+            /// to mark it as a typed C# callback. The facade gets an
+            /// <c>Action&lt;T&gt;</c> ctor parameter; the generated
+            /// <c>Render</c> body wraps it in a <c>ComposableLambda1</c>
+            /// that un-boxes the Kotlin value for <c>T</c>.
+            /// Supported <c>T</c>: <c>bool</c>, <c>string</c>, <c>float</c>.
+            /// </summary>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class CallbackAttribute : global::System.Attribute
+            {
+                public CallbackAttribute(global::System.Type valueType) { }
+            }
+
+            /// <summary>
+            /// Phase 7 — apply to an <c>int</c> bridge parameter to mark
+            /// it as an Android drawable resource id. The facade ctor
+            /// takes <c>int drawableResourceId</c>; <c>Render</c> calls
+            /// <c>ComposeBridges.PainterResource(id, composer)</c> to
+            /// resolve a <c>Painter</c> handle and wraps the bridge
+            /// invocation in <c>try</c> / <c>finally</c> +
+            /// <c>JNIEnv.DeleteLocalRef</c>. The bridge must also have
+            /// a sibling <c>IntPtr painter</c> parameter that the
+            /// generator forwards the resolved handle to.
+            /// </summary>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class PainterResourceAttribute : global::System.Attribute
+            {
+                public PainterResourceAttribute() { }
             }
         }
         """;

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -206,15 +206,15 @@ internal static class Attributes
             }
 
             /// <summary>
-            /// Phase 7 — apply to an <c>int</c> bridge parameter to mark
-            /// it as an Android drawable resource id. The facade ctor
-            /// takes <c>int drawableResourceId</c>; <c>Render</c> calls
+            /// Phase 7 — apply to the <c>IntPtr</c> bridge parameter
+            /// that takes the resolved <c>Painter</c> handle. The facade
+            /// replaces this parameter with a synthetic ctor argument
+            /// <c>int drawableResourceId</c>; <c>Render</c> calls
             /// <c>ComposeBridges.PainterResource(id, composer)</c> to
-            /// resolve a <c>Painter</c> handle and wraps the bridge
-            /// invocation in <c>try</c> / <c>finally</c> +
-            /// <c>JNIEnv.DeleteLocalRef</c>. The bridge must also have
-            /// a sibling <c>IntPtr painter</c> parameter that the
-            /// generator forwards the resolved handle to.
+            /// resolve the handle, forwards it to the annotated
+            /// parameter, and wraps the bridge invocation in
+            /// <c>try</c> / <c>finally</c> + <c>JNIEnv.DeleteLocalRef</c>.
+            /// At most one bridge parameter may carry <c>[PainterResource]</c>.
             /// </summary>
             [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
                                            AllowMultiple = false)]

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -11,24 +11,44 @@ namespace ComposeNet.SourceGenerators;
 
 /// <summary>
 /// Emits user-facing facade classes from <c>[ComposeFacade]</c>-decorated
-/// bridge methods on <c>ComposeNet.ComposeBridges</c>. The bridge already
-/// owns the JNI plumbing; the facade is a thin
+/// bridge methods on <c>ComposeNet.ComposeBridges</c>. The bridge owns
+/// the JNI plumbing; the facade is a thin
 /// <see cref="ComposableNode"/> / <see cref="ComposableContainer"/>
 /// wrapper that builds the bridge's user-controlled args (Action →
 /// <c>ComposableLambda0</c>, modifier → <c>BuildModifier()</c>, content
 /// → <c>ComposableLambdas.Wrap2/3</c>) and forwards through.
+///
+/// Phases supported (see issue #78):
+/// <list type="bullet">
+/// <item>Phase 1 — modifier, IFunction0 onClick, IFunction2/3 content,
+/// primitives, scope publication.</item>
+/// <item>Phase 2 — IFunction1 + <c>[Callback(typeof(T))]</c> → typed
+/// <c>Action&lt;T&gt;</c> ctor with JNI un-boxing.</item>
+/// <item>Phase 3 — multiple <c>IFunction2?</c> / <c>IFunction3?</c> slots
+/// surfaced as named <c>ComposableNode?</c> properties; required Fn2/3
+/// slots become required <c>ComposableNode</c> properties with a
+/// throwing null-check. Auto-mask emission against the bridge's
+/// <c>$default</c> enum.</item>
+/// <item>Phase 6 — <c>[ComposeFacade(DefaultColorFromTheme="...")]</c>
+/// adds a <c>long ContainerColor</c> property with a
+/// <c>MaterialTheme.colorScheme</c> fallback.</item>
+/// <item>Phase 7 — <c>[PainterResource]</c> on an <c>int</c> param
+/// emits the <c>painterResource()</c> + <c>try</c>/<c>finally</c>
+/// + <c>DeleteLocalRef</c> dance.</item>
+/// </list>
 /// </summary>
 [Generator(LanguageNames.CSharp)]
 public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 {
     const string FacadeAttributeMetadataName = "ComposeNet.ComposeFacadeAttribute";
     const string BridgeAttributeMetadataName = "ComposeNet.ComposeBridgeAttribute";
+    const string DeclarativeDefaultsAttributeMetadataName = "ComposeNet.ComposeDefaultsAttribute";
+    const string SlotAttributeMetadataName = "ComposeNet.SlotAttribute";
+    const string CallbackAttributeMetadataName = "ComposeNet.CallbackAttribute";
+    const string PainterResourceAttributeMetadataName = "ComposeNet.PainterResourceAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // Attributes.cs (shared) emits ComposeFacadeAttribute via
-        // ComposeDefaultsGenerator.RegisterPostInitializationOutput.
-
         var methods = context.SyntaxProvider
             .CreateSyntaxProvider(
                 predicate: static (node, _) =>
@@ -45,6 +65,10 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             var (ctx, compilation) = pair;
             var facadeAttr = compilation.GetTypeByMetadataName(FacadeAttributeMetadataName);
             var bridgeAttr = compilation.GetTypeByMetadataName(BridgeAttributeMetadataName);
+            var declarativeAttr = compilation.GetTypeByMetadataName(DeclarativeDefaultsAttributeMetadataName);
+            var slotAttr = compilation.GetTypeByMetadataName(SlotAttributeMetadataName);
+            var callbackAttr = compilation.GetTypeByMetadataName(CallbackAttributeMetadataName);
+            var painterAttr = compilation.GetTypeByMetadataName(PainterResourceAttributeMetadataName);
             if (facadeAttr is null) return;
 
             var method = (IMethodSymbol)ctx.SemanticModel.GetDeclaredSymbol((MethodDeclarationSyntax)ctx.Node)!;
@@ -52,7 +76,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, facadeAttr));
             if (attr is null) return;
 
-            var result = Build(method, attr, bridgeAttr);
+            var ctxObj = new Context(method, attr, bridgeAttr, declarativeAttr, slotAttr, callbackAttr, painterAttr, compilation);
+            var result = Build(ctxObj);
             foreach (var diag in result.Diagnostics)
                 spc.ReportDiagnostic(diag);
             if (result.Source is { } source && result.HintName is { } hint)
@@ -60,13 +85,39 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         });
     }
 
-    static GenerationResult Build(IMethodSymbol method, AttributeData attr, INamedTypeSymbol? bridgeAttr)
+    sealed class Context
     {
+        public IMethodSymbol Method { get; }
+        public AttributeData Attr { get; }
+        public INamedTypeSymbol? BridgeAttr { get; }
+        public INamedTypeSymbol? DeclarativeAttr { get; }
+        public INamedTypeSymbol? SlotAttr { get; }
+        public INamedTypeSymbol? CallbackAttr { get; }
+        public INamedTypeSymbol? PainterAttr { get; }
+        public Compilation Compilation { get; }
+
+        public Context(IMethodSymbol method, AttributeData attr, INamedTypeSymbol? bridgeAttr,
+            INamedTypeSymbol? declarativeAttr, INamedTypeSymbol? slotAttr, INamedTypeSymbol? callbackAttr,
+            INamedTypeSymbol? painterAttr, Compilation compilation)
+        {
+            Method = method;
+            Attr = attr;
+            BridgeAttr = bridgeAttr;
+            DeclarativeAttr = declarativeAttr;
+            SlotAttr = slotAttr;
+            CallbackAttr = callbackAttr;
+            PainterAttr = painterAttr;
+            Compilation = compilation;
+        }
+    }
+
+    static GenerationResult Build(Context c)
+    {
+        var method = c.Method;
+        var attr = c.Attr;
         var loc = attr.ApplicationSyntaxReference?.GetSyntax().GetLocation() ?? Location.None;
 
-        // CN3001 — facade can only attach to ComposeBridges methods. The
-        // emitter assumes the bridge call target is
-        // global::ComposeNet.ComposeBridges.<name>.
+        // CN3001 — facade must attach to ComposeBridges.
         var container = method.ContainingType;
         if (container.Name != "ComposeBridges" ||
             container.ContainingNamespace?.ToDisplayString() != "ComposeNet")
@@ -74,19 +125,25 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             return Fail(Diagnostics.FacadeWrongContainingType, loc, method.Name, container.ToDisplayString());
         }
 
-        // CN3004 — facade is a thin wrapper around the bridge body; the
-        // bridge attribute must be present or the bridge call won't compile.
-        if (bridgeAttr is not null &&
-            !method.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, bridgeAttr)))
+        // CN3004 — paired with [ComposeBridge].
+        AttributeData? bridge = null;
+        if (c.BridgeAttr is not null)
         {
-            return Fail(Diagnostics.FacadeMissingBridge, loc, method.Name);
+            bridge = method.GetAttributes()
+                .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.BridgeAttr));
+            if (bridge is null)
+            {
+                return Fail(Diagnostics.FacadeMissingBridge, loc, method.Name);
+            }
         }
 
         string className = ReadString(attr, "ClassName") ?? method.Name;
         string? scope = ReadString(attr, "Scope");
+        string? themeColor = ReadString(attr, "DefaultColorFromTheme");
+        string? colorParameter = ReadString(attr, "ColorParameter");
 
-        // Identify the composer slot (must be the trailing parameter for
-        // @Composable bridges — the only shape facade generation supports).
+        // Composer is the trailing param for @Composable bridges (the only
+        // shape facade generation supports).
         var csParams = method.Parameters;
         if (csParams.Length == 0 || !ComposeDefaultsGenerator.IsComposer(csParams[csParams.Length - 1].Type))
         {
@@ -96,103 +153,227 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         var composerParam = csParams[csParams.Length - 1];
         var userParams = csParams.Take(csParams.Length - 1).ToArray();
 
-        // Walk user params and classify each. The classifier rejects
-        // anything outside the documented Phase 1 shapes (e.g. IFunction1
-        // callbacks, value-class handles, manual `int defaults` hatch).
+        // Look up the bridge's Defaults enum so Phase 3 can emit the
+        // matching auto-mask code.
+        DefaultsInfo? defaults = null;
+        INamedTypeSymbol? defaultsType = bridge is null ? null : ReadType(bridge, "Defaults");
+        if (defaultsType is not null && c.DeclarativeAttr is not null)
+        {
+            defaults = DefaultsInfo.TryRead(c.Compilation, c.DeclarativeAttr, defaultsType.Name);
+        }
+
+        // Look up a sibling "defaults: int" param the caller manages. If
+        // present, the bridge does NOT auto-mask — the facade owns every
+        // bit. (We still support Phase 1 bridges that don't have this
+        // param: those rely on bridge-side auto-mask logic.)
+        bool callerProvidesDefaults = false;
+        IParameterSymbol? defaultsParam = null;
+        if (userParams.Length > 0)
+        {
+            var last = userParams[userParams.Length - 1];
+            if (last.Type.SpecialType == SpecialType.System_Int32 && last.Name == "defaults")
+            {
+                callerProvidesDefaults = true;
+                defaultsParam = last;
+                userParams = userParams.Take(userParams.Length - 1).ToArray();
+            }
+        }
+
+        // Classify each user param.
         var slots = new List<FacadeSlot>(userParams.Length);
-        IParameterSymbol? modifierParam = null;
-        IParameterSymbol? contentParam = null;
-        int contentArity = 0; // 2 = Wrap2, 3 = Wrap3
         var diags = new List<Diagnostic>();
+        int fnContentCount = 0;
 
         foreach (var p in userParams)
         {
-            // The bridge generator treats a trailing `int defaults` (just
-            // before composer) as a caller-controlled $default mask. Surface
-            // would leak that low-level knob into the public ctor, so we
-            // refuse to generate a facade for it.
-            if (p.Name == "defaults" && p.Type.SpecialType == SpecialType.System_Int32)
-            {
-                diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc,
-                    method.Name, p.Name, "int (caller-controlled $default mask)"));
-                continue;
-            }
-
-            if (IsModifier(p.Type))
-            {
-                if (modifierParam is not null)
-                {
-                    diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc,
-                        method.Name, p.Name, "duplicate IModifier? parameter"));
-                    continue;
-                }
-                modifierParam = p;
-                slots.Add(new FacadeSlot(p, FacadeSlotKind.Modifier));
-                continue;
-            }
-
-            var funcArity = KotlinFunctionArity(p.Type);
-            if (funcArity == 0)
-            {
-                slots.Add(new FacadeSlot(p, FacadeSlotKind.OnClick));
-                continue;
-            }
-            if (funcArity == 2 || funcArity == 3)
-            {
-                if (contentParam is not null)
-                {
-                    diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc,
-                        method.Name, p.Name, $"multiple content lambdas (IFunction{funcArity}) — only a single content slot is supported"));
-                    continue;
-                }
-                contentParam = p;
-                contentArity = funcArity;
-                slots.Add(new FacadeSlot(p, funcArity == 2 ? FacadeSlotKind.Content2 : FacadeSlotKind.Content3));
-                continue;
-            }
-            if (funcArity > 0)
-            {
-                diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc,
-                    method.Name, p.Name, $"IFunction{funcArity} (callback / non-content lambda)"));
-                continue;
-            }
-
-            if (IsPrimitiveCtorType(p.Type))
-            {
-                slots.Add(new FacadeSlot(p, FacadeSlotKind.Primitive));
-                continue;
-            }
-
-            diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc,
-                method.Name, p.Name, p.Type.ToDisplayString()));
+            var slot = Classify(p, c, method.Name, loc, diags);
+            if (slot is null) continue;
+            slots.Add(slot.Value);
+            if (slot.Value.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3)
+                fnContentCount++;
         }
 
-        if (!string.IsNullOrEmpty(scope) && contentArity != 3)
+        // Multi-slot detection: if any Fn2/3 slot is nullable, or any has
+        // an explicit [Slot], OR there's >1 Fn2/3 slot, treat the facade
+        // as a multi-slot LEAF (named properties). Otherwise stick with
+        // the Phase 1 "container with children" shape.
+        bool hasMultiSlot = slots.Any(s => s.IsNullableSlot || s.HasSlotAttribute) || fnContentCount > 1;
+        if (hasMultiSlot)
         {
-            diags.Add(Diagnostic.Create(Diagnostics.FacadeScopeMisuse, loc, method.Name, scope ?? "?"));
+            // Re-classify the Fn2/Fn3 slots into property slots (the
+            // generator picks one shape per bridge; mixing is invalid).
+            for (int i = 0; i < slots.Count; i++)
+            {
+                var s = slots[i];
+                if (s.Kind is FacadeSlotKind.Content2)
+                    slots[i] = s.WithKind(s.Param.NullableAnnotation == NullableAnnotation.Annotated
+                        ? FacadeSlotKind.NamedFunction2 : FacadeSlotKind.RequiredFunction2);
+                else if (s.Kind is FacadeSlotKind.Content3)
+                    slots[i] = s.WithKind(s.Param.NullableAnnotation == NullableAnnotation.Annotated
+                        ? FacadeSlotKind.NamedFunction3 : FacadeSlotKind.RequiredFunction3);
+            }
         }
 
-        if (!string.IsNullOrEmpty(scope) && scope != "Row" && scope != "Column")
+        // Scope only makes sense with a Phase 1 Content3 (container shape).
+        if (!string.IsNullOrEmpty(scope))
         {
-            diags.Add(Diagnostic.Create(Diagnostics.FacadeScopeMisuse, loc, method.Name, scope!));
+            if (hasMultiSlot || !slots.Any(s => s.Kind == FacadeSlotKind.Content3))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeScopeMisuse, loc, method.Name, scope ?? "?"));
+            }
+            else if (!IsKnownScopeKind(c.Compilation, scope!))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeScopeMisuse, loc, method.Name, scope!));
+            }
         }
 
+        // Phase 6 — bind DefaultColorFromTheme to a `long` user param.
+        FacadeSlot? colorSlot = null;
+        if (!string.IsNullOrEmpty(themeColor))
+        {
+            var longSlots = slots
+                .Select((s, i) => (s, i))
+                .Where(t => t.s.Param.Type.SpecialType == SpecialType.System_Int64)
+                .ToArray();
+            FacadeSlot? picked = null;
+            if (!string.IsNullOrEmpty(colorParameter))
+            {
+                var match = longSlots.FirstOrDefault(t => t.s.Param.Name == colorParameter);
+                if (match.s.Param is null)
+                {
+                    diags.Add(Diagnostic.Create(Diagnostics.FacadeColorThemeBindingFailed, loc, method.Name,
+                        $"ColorParameter='{colorParameter}' does not match any 'long' user parameter"));
+                }
+                else
+                {
+                    picked = match.s;
+                    slots[match.i] = match.s.WithKind(FacadeSlotKind.ThemeColor);
+                }
+            }
+            else if (longSlots.Length == 1)
+            {
+                picked = longSlots[0].s;
+                slots[longSlots[0].i] = longSlots[0].s.WithKind(FacadeSlotKind.ThemeColor);
+            }
+            else if (longSlots.Length == 0)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeColorThemeBindingFailed, loc, method.Name,
+                    "no 'long' user parameter to bind ContainerColor to"));
+            }
+            else
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeColorThemeBindingFailed, loc, method.Name,
+                    $"multiple 'long' user parameters — set ColorParameter to one of: {string.Join(", ", longSlots.Select(t => t.s.Param.Name))}"));
+            }
+            colorSlot = picked;
+        }
+
+        // Phase 7 — sanity check: PainterResource is one-of (validated above).
         if (diags.Count > 0)
             return new GenerationResult(null, null, diags);
 
-        var source = Emit(className, method.Name, scope, composerParam, slots, contentArity);
+        var source = Emit(className, method.Name, scope, composerParam, slots, hasMultiSlot,
+            callerProvidesDefaults, defaultsParam, defaults, defaultsType?.Name, themeColor, colorSlot);
         var hint = $"ComposeNet.Facade.{className}.g.cs";
         return new GenerationResult(source, hint, Array.Empty<Diagnostic>());
     }
 
+    static FacadeSlot? Classify(IParameterSymbol p, Context c, string methodName, Location loc, List<Diagnostic> diags)
+    {
+        // [PainterResource] — annotates the IntPtr bridge param that
+        // takes the resolved Painter handle. The facade exposes a
+        // synthetic `int painterResourceId` ctor arg in its place.
+        if (c.PainterAttr is not null &&
+            p.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.PainterAttr)))
+        {
+            if (p.Type.SpecialType != SpecialType.System_IntPtr)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadePainterMisuse, loc, methodName,
+                    $"[PainterResource] must annotate an 'IntPtr' parameter; '{p.Name}' is '{p.Type.ToDisplayString()}'"));
+                return null;
+            }
+            return new FacadeSlot(p, FacadeSlotKind.PainterResource);
+        }
+
+        // [Callback(typeof(T))]
+        if (c.CallbackAttr is not null)
+        {
+            var cba = p.GetAttributes()
+                .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.CallbackAttr));
+            if (cba is not null)
+            {
+                if (KotlinFunctionArity(p.Type) != 1)
+                {
+                    diags.Add(Diagnostic.Create(Diagnostics.FacadeCallbackUnsupportedType, loc, methodName, p.Name,
+                        $"[Callback] target type must be Kotlin.Jvm.Functions.IFunction1, was '{p.Type.ToDisplayString()}'"));
+                    return null;
+                }
+                var typeArg = cba.ConstructorArguments.Length > 0 ? cba.ConstructorArguments[0].Value as INamedTypeSymbol : null;
+                if (typeArg is null)
+                {
+                    diags.Add(Diagnostic.Create(Diagnostics.FacadeCallbackUnsupportedType, loc, methodName, p.Name, "<missing>"));
+                    return null;
+                }
+                if (typeArg.SpecialType is not (SpecialType.System_Boolean or SpecialType.System_String or SpecialType.System_Single))
+                {
+                    diags.Add(Diagnostic.Create(Diagnostics.FacadeCallbackUnsupportedType, loc, methodName, p.Name,
+                        typeArg.ToDisplayString()));
+                    return null;
+                }
+                return new FacadeSlot(p, FacadeSlotKind.Callback, callbackType: typeArg);
+            }
+        }
+
+        // IModifier?
+        if (IsModifier(p.Type))
+            return new FacadeSlot(p, FacadeSlotKind.Modifier);
+
+        // Kotlin extension receiver — IntPtr with a "Scope"-suffixed name.
+        // Auto-bound to RenderContext.CurrentScope; not a ctor slot, not
+        // tracked in the $default bitmask.
+        if (p.Type.SpecialType == SpecialType.System_IntPtr &&
+            p.Name.EndsWith("Scope", StringComparison.Ordinal))
+            return new FacadeSlot(p, FacadeSlotKind.ScopeReceiver);
+
+        var funcArity = KotlinFunctionArity(p.Type);
+        if (funcArity == 0)
+            return new FacadeSlot(p, FacadeSlotKind.OnClick);
+
+        if (funcArity == 2 || funcArity == 3)
+        {
+            string? slotName = ReadSlotAttribute(p, c.SlotAttr);
+            return new FacadeSlot(p, funcArity == 2 ? FacadeSlotKind.Content2 : FacadeSlotKind.Content3,
+                slotPropertyName: slotName);
+        }
+
+        if (funcArity > 0)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc, methodName, p.Name,
+                $"IFunction{funcArity} (mark with [Callback(typeof(T))] for a typed Action<T> ctor slot)"));
+            return null;
+        }
+
+        if (IsPrimitiveCtorType(p.Type))
+            return new FacadeSlot(p, FacadeSlotKind.Primitive);
+
+        diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc, methodName, p.Name, p.Type.ToDisplayString()));
+        return null;
+    }
+
     static string Emit(string className, string bridgeMethodName, string? scope,
         IParameterSymbol composerParam, IReadOnlyList<FacadeSlot> slots,
-        int contentArity)
+        bool isMultiSlot, bool callerProvidesDefaults, IParameterSymbol? defaultsParam,
+        DefaultsInfo? defaults, string? defaultsEnumName,
+        string? themeColor, FacadeSlot? colorSlot)
     {
-        bool isContainer = contentArity != 0;
+        bool isContainer = !isMultiSlot && slots.Any(s => s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3);
         string baseClass = isContainer ? "global::ComposeNet.ComposableContainer" : "global::ComposeNet.ComposableNode";
 
-        var ctorSlots = slots.Where(s => s.Kind is FacadeSlotKind.OnClick or FacadeSlotKind.Primitive).ToArray();
+        // Ctor slots: every non-modifier, non-named-property slot.
+        var ctorSlots = slots.Where(s => IsCtorSlot(s)).ToArray();
+        // Named-property slots (Phase 3).
+        var namedSlots = slots.Where(s => s.Kind is FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3
+            or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3).ToArray();
 
         var sb = new StringBuilder();
         sb.AppendLine("// <auto-generated/>");
@@ -201,33 +382,42 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         sb.AppendLine("namespace ComposeNet");
         sb.AppendLine("{");
 
-        // No XML <summary> here on purpose: docs live on the sibling
-        // hand-written `partial class <Name>` stub in
-        // src/ComposeNet.Compose/<Name>.cs so users can use real cref
-        // links, code samples, etc. without HTML-escape gymnastics, and
-        // can extend the facade with extra members if needed.
         sb.Append("    public sealed partial class ").Append(className).Append(" : ").AppendLine(baseClass);
         sb.AppendLine("    {");
 
-        // Backing fields for ctor-supplied slots.
+        // Backing fields for ctor slots.
         foreach (var s in ctorSlots)
         {
             var typeRef = CtorFieldType(s);
-            sb.Append("        readonly ").Append(typeRef).Append(" _").Append(s.Param.Name).AppendLine(";");
+            sb.Append("        readonly ").Append(typeRef).Append(" _").Append(CtorIdentifier(s)).AppendLine(";");
         }
 
+        // Phase 6 — ContainerColor property + (no theme fallback here; happens in Render).
+        if (themeColor is not null && colorSlot is not null)
+        {
+            sb.AppendLine("        /// <summary>Optional packed Compose <c>Color</c> (long). Leave <c>0L</c> to inherit the active <c>MaterialTheme.colorScheme</c> fallback.</summary>");
+            sb.AppendLine("        public long ContainerColor { get; set; }");
+        }
+
+        // Phase 3 — named properties.
+        foreach (var s in namedSlots)
+        {
+            sb.Append("        public global::ComposeNet.ComposableNode? ").Append(PropertyName(s)).AppendLine(" { get; set; }");
+        }
+
+        // Constructor.
         if (ctorSlots.Length > 0)
         {
             sb.Append("        public ").Append(className).Append('(');
             for (int i = 0; i < ctorSlots.Length; i++)
             {
                 if (i > 0) sb.Append(", ");
-                sb.Append(CtorFieldType(ctorSlots[i])).Append(' ').Append(EscapeIdent(ctorSlots[i].Param.Name));
+                sb.Append(CtorParamType(ctorSlots[i])).Append(' ').Append(EscapeIdent(CtorIdentifier(ctorSlots[i])));
             }
             sb.AppendLine(")");
             sb.AppendLine("        {");
             foreach (var s in ctorSlots)
-                sb.Append("            _").Append(s.Param.Name).Append(" = ").Append(EscapeIdent(s.Param.Name)).AppendLine(";");
+                sb.Append("            _").Append(CtorIdentifier(s)).Append(" = ").Append(EscapeIdent(CtorIdentifier(s))).AppendLine(";");
             sb.AppendLine("        }");
         }
 
@@ -237,21 +427,66 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
           .Append(composerName).AppendLine(")");
         sb.AppendLine("        {");
 
-        // OnClick wrappers — one line each so per-bridge generated files
-        // give each Wrap*/ComposableLambda* call a unique line (slot-table
-        // keys are derived from CallerLineNumber + CallerFilePath).
+        // Required-named-slot null checks.
+        foreach (var s in namedSlots.Where(s => s.Kind is FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3))
+        {
+            var name = PropertyName(s);
+            sb.Append("            if (").Append(name).AppendLine(" is null)");
+            sb.Append("                throw new global::System.InvalidOperationException(\"")
+              .Append(className).Append('.').Append(name).AppendLine(" is required (the Kotlin parameter has no default).\");");
+        }
+
+        // OnClick wrappers — one per line so slot-table keys stay distinct.
         foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.OnClick))
         {
             sb.Append("            var __").Append(s.Param.Name)
               .Append(" = new global::ComposeNet.ComposableLambda0(_").Append(s.Param.Name).AppendLine(");");
         }
 
-        // Content wrapper.
+        // Callback wrappers (Phase 2).
+        foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.Callback))
+        {
+            EmitCallbackWrapper(sb, s);
+        }
+
+        // Modifier evaluation. Only hoist to a local when needed for
+        // the auto-mask (callerProvidesDefaults). Otherwise the bridge
+        // call uses BuildModifier() inline to keep Phase 1 output stable.
+        var modifierSlot = slots.FirstOrDefault(s => s.Kind == FacadeSlotKind.Modifier);
+        bool hoistModifier = modifierSlot.Param is not null && callerProvidesDefaults;
+        if (hoistModifier)
+        {
+            sb.AppendLine("            var __modifier = BuildModifier();");
+        }
+
+        // Named slot wrappers (Phase 3). One per line.
+        foreach (var s in namedSlots)
+        {
+            var name = PropertyName(s);
+            string wrap = s.Kind is FacadeSlotKind.NamedFunction3 or FacadeSlotKind.RequiredFunction3
+                ? "Wrap3"
+                : "Wrap2";
+            bool nullable = s.Kind is FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3;
+            if (nullable)
+            {
+                sb.Append("            var __").Append(s.Param.Name).Append(" = ").Append(name)
+                  .Append(" is null ? null : global::ComposeNet.ComposableLambdas.").Append(wrap)
+                  .Append('(').Append(composerName).Append(", c => ").Append(name).AppendLine(".Render(c));");
+            }
+            else
+            {
+                sb.Append("            var __").Append(s.Param.Name).Append(" = global::ComposeNet.ComposableLambdas.")
+                  .Append(wrap).Append('(').Append(composerName).Append(", c => ").Append(name).AppendLine("!.Render(c));");
+            }
+        }
+
+        // Content wrapper (Phase 1 only — multi-slot already handled).
         if (isContainer)
         {
             var contentSlot = slots.First(s => s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3);
+            int arity = contentSlot.Kind == FacadeSlotKind.Content3 ? 3 : 2;
             sb.Append("            var __").Append(contentSlot.Param.Name).Append(" = global::ComposeNet.ComposableLambdas.");
-            if (contentArity == 2)
+            if (arity == 2)
             {
                 sb.Append("Wrap2(").Append(composerName).AppendLine(", c => RenderChildren(c));");
             }
@@ -270,32 +505,61 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             }
         }
 
-        // Bridge call — preserve bridge param order. Always use the
-        // bridge method's real name, not the user-chosen facade name
-        // (ClassName attribute may override the latter).
-        sb.Append("            global::ComposeNet.ComposeBridges.").Append(bridgeMethodName).Append('(');
+        // Phase 6 — theme color resolution.
+        if (themeColor is not null && colorSlot is not null)
+        {
+            sb.Append("            long __color = ContainerColor != 0L ? ContainerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(")
+              .Append(composerName).Append(", 0).").Append(Pascal(themeColor)).AppendLine(";");
+        }
+
+        // Phase 7 — PainterResource preamble.
+        var painterIdSlot = slots.FirstOrDefault(s => s.Kind == FacadeSlotKind.PainterResource);
+        bool hasPainter = painterIdSlot.Param is not null;
+        if (hasPainter)
+        {
+            sb.AppendLine("            global::System.IntPtr __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_painterResourceId, "
+                + composerName + ");");
+            sb.AppendLine("            try");
+            sb.AppendLine("            {");
+        }
+
+        string indent = hasPainter ? "                " : "            ";
+
+        // Phase 3 — auto-mask defaults.
+        if (callerProvidesDefaults && defaults is { } d)
+        {
+            EmitDefaultsMask(sb, indent, d, slots, namedSlots, modifierSlot.Param is not null, hasPainter);
+        }
+
+        // Bridge call. Preserve original bridge param order.
+        sb.Append(indent).Append("global::ComposeNet.ComposeBridges.").Append(bridgeMethodName).Append('(');
         bool first = true;
+        // Walk method.Parameters via slots in their original order; the
+        // defaults param (if any) was removed from `slots` so we add it
+        // back here from the local __defaults symbol.
         foreach (var s in slots)
         {
             if (!first) sb.Append(", ");
             first = false;
-            switch (s.Kind)
-            {
-                case FacadeSlotKind.Modifier:
-                    sb.Append("BuildModifier()");
-                    break;
-                case FacadeSlotKind.OnClick:
-                case FacadeSlotKind.Content2:
-                case FacadeSlotKind.Content3:
-                    sb.Append("__").Append(s.Param.Name);
-                    break;
-                case FacadeSlotKind.Primitive:
-                    sb.Append('_').Append(s.Param.Name);
-                    break;
-            }
+            sb.Append(BridgeArgExpr(s, hoistModifier));
+        }
+        if (callerProvidesDefaults)
+        {
+            if (!first) sb.Append(", ");
+            sb.Append("__defaults");
+            first = false;
         }
         if (!first) sb.Append(", ");
         sb.Append(composerName).AppendLine(");");
+
+        if (hasPainter)
+        {
+            sb.AppendLine("            }");
+            sb.AppendLine("            finally");
+            sb.AppendLine("            {");
+            sb.AppendLine("                global::Android.Runtime.JNIEnv.DeleteLocalRef(__painterRef);");
+            sb.AppendLine("            }");
+        }
 
         sb.AppendLine("        }");
         sb.AppendLine("    }");
@@ -303,26 +567,139 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         return sb.ToString();
     }
 
-    static string CtorFieldType(FacadeSlot slot) =>
-        slot.Kind switch
+    static void EmitCallbackWrapper(StringBuilder sb, FacadeSlot s)
+    {
+        var t = s.CallbackType!;
+        string expr = t.SpecialType switch
+        {
+            SpecialType.System_Boolean => "v is global::Java.Lang.Boolean __b && __b.BooleanValue()",
+            SpecialType.System_Single  => "v is global::Java.Lang.Float __f ? __f.FloatValue() : 0f",
+            SpecialType.System_String  => "v?.ToString() ?? string.Empty",
+            _ => "default!",
+        };
+        sb.Append("            var __").Append(s.Param.Name)
+          .Append(" = new global::ComposeNet.ComposableLambda1(v => _")
+          .Append(s.Param.Name).Append('(').Append(expr).AppendLine("));");
+    }
+
+    static void EmitDefaultsMask(StringBuilder sb, string indent, DefaultsInfo d,
+        IReadOnlyList<FacadeSlot> slots, IReadOnlyList<FacadeSlot> namedSlots,
+        bool hasModifier, bool hasPainter)
+    {
+        sb.Append(indent).Append("int __defaults = (int)global::ComposeNet.").Append(d.EnumName).AppendLine(".All;");
+
+        // For each slot the facade DEFINITELY supplies, clear its bit.
+        // - Modifier: clear when __modifier != null.
+        // - Primitive / Callback / OnClick: bit is `!`-suppressed by
+        //   convention (caller-owned); skip silently when absent.
+        // - Named optional slot: clear when property non-null.
+        // - Required slot (Function2/3 / PainterHandle): always cleared.
+
+        foreach (var s in slots)
+        {
+            string? bitMember = MatchEnumMember(d, s);
+            if (bitMember is null) continue;
+            switch (s.Kind)
+            {
+                case FacadeSlotKind.Modifier:
+                    sb.Append(indent).Append("if (__modifier is not null) __defaults &= ~(int)global::ComposeNet.")
+                      .Append(d.EnumName).Append('.').Append(bitMember).AppendLine(";");
+                    break;
+                case FacadeSlotKind.NamedFunction2:
+                case FacadeSlotKind.NamedFunction3:
+                    sb.Append(indent).Append("if (__").Append(s.Param.Name).Append(" is not null) __defaults &= ~(int)global::ComposeNet.")
+                      .Append(d.EnumName).Append('.').Append(bitMember).AppendLine(";");
+                    break;
+                case FacadeSlotKind.RequiredFunction2:
+                case FacadeSlotKind.RequiredFunction3:
+                case FacadeSlotKind.PainterResource:
+                case FacadeSlotKind.Primitive:
+                case FacadeSlotKind.ThemeColor:
+                    sb.Append(indent).Append("__defaults &= ~(int)global::ComposeNet.")
+                      .Append(d.EnumName).Append('.').Append(bitMember).AppendLine(";");
+                    break;
+            }
+        }
+    }
+
+    static string? MatchEnumMember(DefaultsInfo d, FacadeSlot s)
+    {
+        // For named slots: prefer the C# property name (e.g. user
+        // overrode via [Slot]). For everything else: the bridge param
+        // name maps to the Kotlin name 1:1.
+        string lookupName = s.Kind switch
+        {
+            FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3
+                or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3
+                => PropertyName(s),
+            _ => s.Param.Name,
+        };
+        // First try Kotlin name (== bridge param name). Then fall back
+        // to property-name match (case-insensitive).
+        var bk = d.FindByKotlinName(s.Param.Name);
+        if (bk is { } bks && bks.EnumMember is { } em1) return em1;
+        var bp = d.FindByEnumMember(lookupName);
+        if (bp is { } bps && bps.EnumMember is { } em2) return em2;
+        return null;
+    }
+
+    static string BridgeArgExpr(FacadeSlot s, bool hoistModifier) =>
+        s.Kind switch
+        {
+            FacadeSlotKind.Modifier         => hoistModifier ? "__modifier" : "BuildModifier()",
+            FacadeSlotKind.OnClick          => "__" + s.Param.Name,
+            FacadeSlotKind.Content2         => "__" + s.Param.Name,
+            FacadeSlotKind.Content3         => "__" + s.Param.Name,
+            FacadeSlotKind.NamedFunction2   => "__" + s.Param.Name,
+            FacadeSlotKind.NamedFunction3   => "__" + s.Param.Name,
+            FacadeSlotKind.RequiredFunction2 => "__" + s.Param.Name,
+            FacadeSlotKind.RequiredFunction3 => "__" + s.Param.Name,
+            FacadeSlotKind.Callback         => "__" + s.Param.Name,
+            FacadeSlotKind.Primitive        => "_" + s.Param.Name,
+            FacadeSlotKind.PainterResource  => "__painterRef",
+            FacadeSlotKind.ThemeColor       => "__color",
+            FacadeSlotKind.ScopeReceiver    => "global::ComposeNet.RenderContext.CurrentScope",
+            _ => "default",
+        };
+
+    static bool IsCtorSlot(FacadeSlot s) =>
+        s.Kind is FacadeSlotKind.OnClick or FacadeSlotKind.Primitive or FacadeSlotKind.Callback or FacadeSlotKind.PainterResource;
+
+    static string CtorFieldType(FacadeSlot slot) => CtorParamType(slot);
+
+    static string CtorIdentifier(FacadeSlot slot) =>
+        slot.Kind == FacadeSlotKind.PainterResource ? "painterResourceId" : slot.Param.Name;
+
+    static string CtorParamType(FacadeSlot slot)
+    {
+        var format = SymbolDisplayFormat.FullyQualifiedFormat
+            .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes
+                | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers
+                | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+        return slot.Kind switch
         {
             FacadeSlotKind.OnClick   => "global::System.Action",
-            FacadeSlotKind.Primitive => slot.Param.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
-                .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes
-                    | SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers)),
+            FacadeSlotKind.Callback  => "global::System.Action<" + slot.CallbackType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)) + ">",
+            FacadeSlotKind.PainterResource => "int",
+            FacadeSlotKind.Primitive => slot.Param.Type.ToDisplayString(format),
             _ => slot.Param.Type.ToDisplayString(),
         };
+    }
+
+    static string PropertyName(FacadeSlot s) => s.SlotPropertyName ?? Pascal(s.Param.Name);
+
+    static string Pascal(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return s;
+        return char.ToUpperInvariant(s[0]) + s.Substring(1);
+    }
 
     static bool IsModifier(ITypeSymbol type) =>
         type is INamedTypeSymbol n &&
         n.Name == "IModifier" &&
         n.ContainingNamespace?.ToDisplayString() == "AndroidX.Compose.UI";
 
-    /// <summary>
-    /// Returns the arity of a Kotlin <c>IFunction*</c> parameter type
-    /// (<c>0</c> for IFunction0, <c>2</c> for IFunction2, etc.) or
-    /// <c>-1</c> if the type is not a Kotlin function interface.
-    /// </summary>
     static int KotlinFunctionArity(ITypeSymbol type)
     {
         if (type is not INamedTypeSymbol n) return -1;
@@ -341,6 +718,16 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             or SpecialType.System_Single
             or SpecialType.System_Double;
 
+    static bool IsKnownScopeKind(Compilation compilation, string scope)
+    {
+        var enumType = compilation.GetTypeByMetadataName("ComposeNet.ScopeKind");
+        if (enumType is null) return scope is "Row" or "Column";
+        foreach (var m in enumType.GetMembers())
+            if (m.Kind == SymbolKind.Field && m.Name == scope)
+                return true;
+        return false;
+    }
+
     static GenerationResult Fail(DiagnosticDescriptor desc, Location loc, params object?[] args) =>
         new(null, null, new[] { Diagnostic.Create(desc, loc, args) });
 
@@ -351,26 +738,64 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         return null;
     }
 
+    static INamedTypeSymbol? ReadType(AttributeData attr, string name)
+    {
+        foreach (var na in attr.NamedArguments)
+            if (na.Key == name && na.Value.Value is INamedTypeSymbol t) return t;
+        return null;
+    }
+
+    static string? ReadSlotAttribute(IParameterSymbol p, INamedTypeSymbol? slotAttr)
+    {
+        if (slotAttr is null) return null;
+        var a = p.GetAttributes().FirstOrDefault(x => SymbolEqualityComparer.Default.Equals(x.AttributeClass, slotAttr));
+        if (a is null) return null;
+        if (a.ConstructorArguments.Length > 0 && a.ConstructorArguments[0].Value is string s) return s;
+        return null;
+    }
+
     static string EscapeIdent(string name) =>
         SyntaxFacts.GetKeywordKind(name) == SyntaxKind.None ? name : "@" + name;
 
-    enum FacadeSlotKind
+    internal enum FacadeSlotKind
     {
         Modifier,
         OnClick,
         Content2,
         Content3,
         Primitive,
+        Callback,
+        NamedFunction2,
+        NamedFunction3,
+        RequiredFunction2,
+        RequiredFunction3,
+        PainterResource,
+        ThemeColor,
+        ScopeReceiver,
     }
 
-    readonly struct FacadeSlot
+    internal readonly struct FacadeSlot
     {
-        public FacadeSlot(IParameterSymbol param, FacadeSlotKind kind)
+        public FacadeSlot(IParameterSymbol param, FacadeSlotKind kind,
+            ITypeSymbol? callbackType = null, string? slotPropertyName = null)
         {
             Param = param;
             Kind = kind;
+            CallbackType = callbackType;
+            SlotPropertyName = slotPropertyName;
         }
         public IParameterSymbol Param { get; }
         public FacadeSlotKind Kind { get; }
+        public ITypeSymbol? CallbackType { get; }
+        public string? SlotPropertyName { get; }
+        public bool HasSlotAttribute => SlotPropertyName is not null;
+        public bool IsNullableSlot => Param.NullableAnnotation == NullableAnnotation.Annotated
+            && KindIsFnSlot(Kind);
+        static bool KindIsFnSlot(FacadeSlotKind k) =>
+            k is FacadeSlotKind.Content2 or FacadeSlotKind.Content3
+              or FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3
+              or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3;
+        public FacadeSlot WithKind(FacadeSlotKind newKind) =>
+            new(Param, newKind, CallbackType, SlotPropertyName);
     }
 }

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -32,9 +32,10 @@ namespace ComposeNet.SourceGenerators;
 /// <item>Phase 6 — <c>[ComposeFacade(DefaultColorFromTheme="...")]</c>
 /// adds a <c>long ContainerColor</c> property with a
 /// <c>MaterialTheme.colorScheme</c> fallback.</item>
-/// <item>Phase 7 — <c>[PainterResource]</c> on an <c>int</c> param
-/// emits the <c>painterResource()</c> + <c>try</c>/<c>finally</c>
-/// + <c>DeleteLocalRef</c> dance.</item>
+/// <item>Phase 7 — <c>[PainterResource]</c> on an <c>IntPtr</c> param
+/// (the painter handle the bridge forwards) emits a synthetic
+/// <c>int drawableResourceId</c> ctor arg + <c>painterResource()</c>
+/// + <c>try</c>/<c>finally</c> + <c>DeleteLocalRef</c> dance.</item>
 /// </list>
 /// </summary>
 [Generator(LanguageNames.CSharp)]
@@ -268,7 +269,28 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             colorSlot = picked;
         }
 
-        // Phase 7 — sanity check: PainterResource is one-of (validated above).
+        // Phase 7 — at most one [PainterResource] parameter per bridge.
+        int painterCount = 0;
+        foreach (var s in slots)
+            if (s.Kind == FacadeSlotKind.PainterResource) painterCount++;
+        if (painterCount > 1)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeSlotConflict, loc, method.Name,
+                $"[PainterResource] may only be applied to one bridge parameter, found {painterCount}"));
+        }
+
+        // Phase 3 sanity — if the bridge takes a caller-controlled
+        // `int defaults`, we must know its enum (`Defaults = typeof(...)`
+        // + matching `[assembly: ComposeDefaults(...)]`) or the emitted
+        // code will reference an undeclared `__defaults` local.
+        if (callerProvidesDefaults && defaults is null)
+        {
+            string reason = defaultsType is null
+                ? "the bridge has an 'int defaults' parameter but no 'Defaults = typeof(...)' on [ComposeBridge]"
+                : $"no '[assembly: ComposeDefaults(\"{defaultsType.Name}\", ...)]' declaration was found for the bridge's Defaults enum";
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeSlotConflict, loc, method.Name, reason));
+        }
+
         if (diags.Count > 0)
             return new GenerationResult(null, null, diags);
 
@@ -282,7 +304,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     {
         // [PainterResource] — annotates the IntPtr bridge param that
         // takes the resolved Painter handle. The facade exposes a
-        // synthetic `int painterResourceId` ctor arg in its place.
+        // synthetic `int drawableResourceId` ctor arg in its place.
         if (c.PainterAttr is not null &&
             p.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.PainterAttr)))
         {
@@ -304,8 +326,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             {
                 if (KotlinFunctionArity(p.Type) != 1)
                 {
-                    diags.Add(Diagnostic.Create(Diagnostics.FacadeCallbackUnsupportedType, loc, methodName, p.Name,
-                        $"[Callback] target type must be Kotlin.Jvm.Functions.IFunction1, was '{p.Type.ToDisplayString()}'"));
+                    diags.Add(Diagnostic.Create(Diagnostics.FacadeSlotConflict, loc, methodName,
+                        $"[Callback] on parameter '{p.Name}' requires a Kotlin.Jvm.Functions.IFunction1 parameter type; was '{p.Type.ToDisplayString()}'"));
                     return null;
                 }
                 var typeArg = cba.ConstructorArguments.Length > 0 ? cba.ConstructorArguments[0].Value as INamedTypeSymbol : null;
@@ -517,7 +539,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         bool hasPainter = painterIdSlot.Param is not null;
         if (hasPainter)
         {
-            sb.AppendLine("            global::System.IntPtr __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_painterResourceId, "
+            sb.AppendLine("            global::System.IntPtr __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_drawableResourceId, "
                 + composerName + ");");
             sb.AppendLine("            try");
             sb.AppendLine("            {");
@@ -668,7 +690,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     static string CtorFieldType(FacadeSlot slot) => CtorParamType(slot);
 
     static string CtorIdentifier(FacadeSlot slot) =>
-        slot.Kind == FacadeSlotKind.PainterResource ? "painterResourceId" : slot.Param.Name;
+        slot.Kind == FacadeSlotKind.PainterResource ? "drawableResourceId" : slot.Param.Name;
 
     static string CtorParamType(FacadeSlot slot)
     {

--- a/src/ComposeNet.SourceGenerators/DefaultsInfo.cs
+++ b/src/ComposeNet.SourceGenerators/DefaultsInfo.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace ComposeNet.SourceGenerators;
+
+/// <summary>
+/// Parsed view of a declarative <c>[assembly: ComposeDefaults("EnumName",
+/// "p0", "!p1", ...)]</c> attribute. Each slot maps a Kotlin parameter
+/// name to its bit position in the <c>$default</c> bitmask; <c>!</c>-
+/// prefixed names are consumed by the attribute (they occupy a bit) but
+/// are omitted from the generated enum. Shared by
+/// <see cref="ComposeBridgeGenerator"/> and
+/// <see cref="ComposeFacadeGenerator"/>.
+/// </summary>
+internal readonly struct DefaultsInfo
+{
+    public string EnumName { get; }
+    public IReadOnlyList<DefaultsSlot> Slots { get; }
+
+    public DefaultsInfo(string enumName, IReadOnlyList<DefaultsSlot> slots)
+    {
+        EnumName = enumName;
+        Slots = slots;
+    }
+
+    public DefaultsSlot? FindByKotlinName(string kotlinName)
+    {
+        foreach (var s in Slots)
+            if (string.Equals(s.KotlinName, kotlinName, StringComparison.Ordinal))
+                return s;
+        return null;
+    }
+
+    /// <summary>
+    /// Look up a slot whose generated <see cref="DefaultsSlot.EnumMember"/>
+    /// matches <paramref name="propertyName"/> (case-insensitive). Used
+    /// when a facade has renamed a slot via <c>[Slot]</c>: the property
+    /// name is the user-facing name, but the underlying enum member is
+    /// still the Kotlin name PascalCased.
+    /// </summary>
+    public DefaultsSlot? FindByEnumMember(string propertyName)
+    {
+        foreach (var s in Slots)
+            if (s.EnumMember is { } em &&
+                string.Equals(em, propertyName, StringComparison.OrdinalIgnoreCase))
+                return s;
+        return null;
+    }
+
+    public static DefaultsInfo? TryRead(Compilation compilation, INamedTypeSymbol declarativeAttr, string enumName)
+    {
+        var match = compilation.Assembly.GetAttributes()
+            .FirstOrDefault(a =>
+                SymbolEqualityComparer.Default.Equals(a.AttributeClass, declarativeAttr) &&
+                a.ConstructorArguments.Length >= 1 &&
+                a.ConstructorArguments[0].Value is string s &&
+                s == enumName);
+        if (match is null) return null;
+
+        var arr = match.ConstructorArguments[1];
+        var names = arr.Kind == TypedConstantKind.Array
+            ? arr.Values.Select(v => v.Value as string ?? string.Empty).ToArray()
+            : Array.Empty<string>();
+
+        var slots = new List<DefaultsSlot>(names.Length);
+        for (int i = 0; i < names.Length; i++)
+        {
+            var raw = names[i];
+            bool suppressed = raw.StartsWith("!", StringComparison.Ordinal);
+            var kotlin = suppressed ? raw.Substring(1) : raw;
+            slots.Add(new DefaultsSlot(
+                kotlinName: kotlin,
+                bit: i,
+                enumMember: suppressed ? null : Pascal(kotlin)));
+        }
+        return new DefaultsInfo(enumName, slots);
+    }
+
+    static string Pascal(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return s;
+        return char.ToUpperInvariant(s[0]) + s.Substring(1);
+    }
+}
+
+internal readonly struct DefaultsSlot
+{
+    public string KotlinName { get; }
+    public int Bit { get; }
+    /// <summary>Null when the entry was <c>!</c>-suppressed.</summary>
+    public string? EnumMember { get; }
+
+    public DefaultsSlot(string kotlinName, int bit, string? enumMember)
+    {
+        KotlinName = kotlinName;
+        Bit = bit;
+        EnumMember = enumMember;
+    }
+}

--- a/src/ComposeNet.SourceGenerators/Diagnostics.cs
+++ b/src/ComposeNet.SourceGenerators/Diagnostics.cs
@@ -134,7 +134,7 @@ internal static class Diagnostics
 
     public static readonly DiagnosticDescriptor FacadePainterMisuse = new(
         id: "CN3008",
-        title: "[PainterResource] requires a sibling 'IntPtr painter' parameter on the bridge",
+        title: "[PainterResource] must annotate an 'IntPtr' bridge parameter",
         messageFormat: "Facade for bridge '{0}': {1}",
         category: "ComposeNet",
         defaultSeverity: DiagnosticSeverity.Error,

--- a/src/ComposeNet.SourceGenerators/Diagnostics.cs
+++ b/src/ComposeNet.SourceGenerators/Diagnostics.cs
@@ -107,4 +107,36 @@ internal static class Diagnostics
         category: "ComposeNet",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor FacadeCallbackUnsupportedType = new(
+        id: "CN3005",
+        title: "[Callback] unbox type is not supported",
+        messageFormat: "Facade for bridge '{0}': [Callback] on parameter '{1}' uses unsupported value type '{2}'. Supported types: bool, string, float.",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor FacadeSlotConflict = new(
+        id: "CN3006",
+        title: "[ComposeFacade] slot configuration is invalid",
+        messageFormat: "Facade for bridge '{0}': {1}",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor FacadeColorThemeBindingFailed = new(
+        id: "CN3007",
+        title: "[ComposeFacade(DefaultColorFromTheme=...)] could not bind to a bridge parameter",
+        messageFormat: "Facade for bridge '{0}': {1}",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor FacadePainterMisuse = new(
+        id: "CN3008",
+        title: "[PainterResource] requires a sibling 'IntPtr painter' parameter on the bridge",
+        messageFormat: "Facade for bridge '{0}': {1}",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }


### PR DESCRIPTION
Implements #78 — extends `[ComposeFacade]` to cover Phases 2, 3, 6,
and 7 of the issue, so the generator can replace ~24 hand-written
facades with `[ComposeFacade]` annotations + 3-line stubs.

## What the generator now supports

Beyond the existing Phase 1 shape (container + content lambda +
ctor primitives), the generator now handles:

- **Phase 2 — callbacks (`[Callback(typeof(T))]`)**: surface an
  `IFunction1` bridge param as a typed `Action<T>` ctor slot.
  Supported `T`: `bool`, `string`, `float`. Emits the right
  `Java.Lang.Boolean` / `Java.Lang.Float` unbox or `.ToString()`
  adapter inside a `ComposableLambda1`.
- **Phase 3 — multi-slot leafs**: when any `IFunction2`/`IFunction3`
  bridge param is nullable, has `[Slot]`, OR there''s >1 content
  lambda, the facade becomes a leaf with named `ComposableNode?`
  properties (one per slot) instead of the container shape.
  Required content slots throw a clear `InvalidOperationException`
  when left unset; optional slots flip the matching `$default`
  bit when the caller provides them. `[Slot("Foo")]` lets the
  bridge param keep its Kotlin name (so `MatchEnumMember` works)
  while the public-facing property gets a friendlier alias.
- **Phase 6 — theme-color fallback
  (`[ComposeFacade(DefaultColorFromTheme = "secondaryContainer")]`)**:
  reclassifies the matching `long` user param as a `ContainerColor`
  property; the render body falls back to
  `MaterialTheme.Instance.GetColorScheme(composer, 0).<Slot>` when
  the caller leaves it at `0L`. `ColorParameter` disambiguates
  when the bridge has more than one `long`.
- **Phase 7 — `[PainterResource]`**: annotate the `IntPtr` bridge
  param that takes the resolved Painter; the facade exposes a
  synthetic `int painterResourceId` ctor arg in its place, calls
  `ComposeBridges.PainterResource(id, composer)` in a preamble,
  and emits a `try`/`finally` + `JNIEnv.DeleteLocalRef` around the
  bridge call.
- **`IntPtr xxxScope` extension receivers**: classified as a new
  `ScopeReceiver` slot kind. Auto-bound to
  `RenderContext.CurrentScope`; no ctor slot, no `$default` mask
  bit. Needed for `NavigationBarItem`''s `rowScope`.

Phases 4 (state holders — `remember*State` + `Jvm` round-trip)
and 5 (custom scope kinds, scrollable tab rows) are deferred to a
follow-up PR per the design discussion in #78.

## Facades migrated

24 hand-written facades collapsed to 3-line `public sealed partial
class X;` stubs:

- **Phase 2 (6)**: `TextField`, `OutlinedTextField`,
  `IconToggleButton`, `FilledIconToggleButton`,
  `FilledTonalIconToggleButton`, `OutlinedIconToggleButton`.
- **Phase 3 (14)**: `AlertDialog`, `AssistChip`, `ElevatedAssistChip`,
  `FilterChip`, `ElevatedFilterChip`, `InputChip`, `SuggestionChip`,
  `ElevatedSuggestionChip`, `ListItem`, `Snackbar`, `BadgedBox`,
  `Tab`, `LeadingIconTab`, `NavigationBarItem`, `NavigationRailItem`,
  `CenterAlignedTopAppBar`, `MediumTopAppBar`, `LargeTopAppBar`,
  `MediumFlexibleTopAppBar`, `LargeFlexibleTopAppBar`.
- **Phase 6 (3)**: `ModalDrawerSheet`, `DismissibleDrawerSheet`,
  `PermanentDrawerSheet`.
- **Phase 7 (1)**: `Image` (the `int drawableId` overload is preserved
  via a sibling-stub convenience ctor that chains to the generated
  primary ctor).

`TextField`, `OutlinedTextField`, and `Image` keep small convenience
ctors in their sibling stubs (e.g. `Image(int drawableId)` and the
`MutableState<string>` ctor for the text fields). The generator
emits the canonical ctor; the sibling stub chains to it.

## What stays hand-written

- Phase 4 state-holder facades: `DatePicker`, `TimePicker`,
  `SearchBar`/`TopSearchBar`/`ExpandedDockedSearchBar`/
  `ExpandedFullScreenSearchBar`, `SearchBarInputField`,
  `SnackbarHost`, `ModalBottomSheet`, `BottomSheetScaffold`,
  `Tooltip`, `DatePickerDialog`, `TimePickerDialog`.
- Phase 5 scope/scrollable facades: `PrimaryScrollableTabRow`,
  `SecondaryScrollableTabRow`, `SegmentedButton`,
  `SingleChoiceSegmentedButtonRow`,
  `MultiChoiceSegmentedButtonRow`.
- Drawer + drawer-state facades:
  `ModalNavigationDrawer`/`DismissibleNavigationDrawer`/
  `PermanentNavigationDrawer`, `ModalWideNavigationRail`
  (`confirmStateChange` adapter).
- Branching facades: `TopAppBar` (toggles between two bridges
  based on optional `Subtitle`).
- Direct-binding facades (no `[ComposeBridge]` to attach to):
  `WideNavigationRailItem`, `DropdownMenuItem`, `Icon`
  (`ImageVector` overload).
- Hybrid container+slot facades: `BottomAppBar` (required Function3
  + optional Function2 — the multi-slot rule classifies both as
  named properties, breaking the container shape).

## Diagnostics added

| ID      | Meaning                                                            |
|---------|--------------------------------------------------------------------|
| CN3005  | `[Callback(typeof(T))]` target type is unsupported.                |
| CN3006  | `[Slot]` placement conflicts with the facade''s classified shape.  |
| CN3007  | `DefaultColorFromTheme` cannot bind to any `long` user param.      |
| CN3008  | `[PainterResource]` annotates a non-`IntPtr` parameter.            |

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — **58/58
  passing** (8 new tests covering Phases 2/3/6/7 + the new
  `ScopeReceiver` slot kind).
- `dotnet build src/ComposeNet.Compose` — 0 errors, 0 warnings.
- `dotnet build src/ComposeNet.Sample` — 0 errors, 0 warnings.
- `.github/copilot-instructions.md` updated: parameter-type table
  now lists all six recognized shapes, "When to use it" section
  rewritten around Phases 1/2/3/6/7, and the diagnostic table
  picks up CN3005–CN3008.

Closes #78.