### PR TITLE
Bind SecureTextField and OutlinedSecureTextField (issue #5)

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -558,11 +558,17 @@ internal static partial class ComposeBridges
                                                  IModifier? modifier, IComposer composer);
 
     // androidx.compose.material3.SecureTextFieldKt.{SecureTextField,OutlinedSecureTextField}-XvU6IwQ.
-    // Both overloads have identical 23-user-param signatures (TextFieldState
-    // + Modifier + 11 Z/L slots + 7 L slots + Composer + 3 $changed + 1
-    // $default). Hashed JVM names come from the inline-class compiler
-    // mangling on `textObfuscationMode` (TextObfuscationMode is
-    // @JvmInline value class wrapping Int).
+    // Both overloads have identical 23-user-param signatures: the
+    // TextFieldState peer, a Modifier, 19 object slots (TextStyle,
+    // TextFieldLabelPosition, six Function2/3 lambdas, InputTransformation,
+    // KeyboardOptions, KeyboardActionHandler, an onTextLayout Function2,
+    // Shape, TextFieldColors, PaddingValues, MutableInteractionSource),
+    // 2 booleans (enabled, isError), 1 int + 1 char for the inline-class
+    // textObfuscationMode/textObfuscationCharacter pair, then the trailing
+    // Composer + IIII (3 $changed groups + 1 $default int). Hashed JVM
+    // names come from the inline-class compiler mangling on
+    // textObfuscationMode (TextObfuscationMode is @JvmInline value class
+    // wrapping Int).
     const string SecureTextFieldSig =
         "(Landroidx/compose/foundation/text/input/TextFieldState;" +
         "Landroidx/compose/ui/Modifier;Z" +

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -557,6 +557,65 @@ internal static partial class ComposeBridges
     public static partial void OutlinedTextField(string value, [Callback(typeof(string))] IFunction1 onValueChange,
                                                  IModifier? modifier, IComposer composer);
 
+    // androidx.compose.material3.SecureTextFieldKt.{SecureTextField,OutlinedSecureTextField}-XvU6IwQ.
+    // Both overloads have identical 23-user-param signatures (TextFieldState
+    // + Modifier + 11 Z/L slots + 7 L slots + Composer + 3 $changed + 1
+    // $default). Hashed JVM names come from the inline-class compiler
+    // mangling on `textObfuscationMode` (TextObfuscationMode is
+    // @JvmInline value class wrapping Int).
+    const string SecureTextFieldSig =
+        "(Landroidx/compose/foundation/text/input/TextFieldState;" +
+        "Landroidx/compose/ui/Modifier;Z" +
+        "Landroidx/compose/ui/text/TextStyle;" +
+        "Landroidx/compose/material3/TextFieldLabelPosition;" +
+        "Lkotlin/jvm/functions/Function3;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+        "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z" +
+        "Landroidx/compose/foundation/text/input/InputTransformation;IC" +
+        "Landroidx/compose/foundation/text/KeyboardOptions;" +
+        "Landroidx/compose/foundation/text/input/KeyboardActionHandler;" +
+        "Lkotlin/jvm/functions/Function2;" +
+        "Landroidx/compose/ui/graphics/Shape;" +
+        "Landroidx/compose/material3/TextFieldColors;" +
+        "Landroidx/compose/foundation/layout/PaddingValues;" +
+        "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+        "Landroidx/compose/runtime/Composer;IIII)V";
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SecureTextFieldKt",
+        JvmName   = "SecureTextField-XvU6IwQ",
+        Signature = SecureTextFieldSig,
+        Defaults  = typeof(SecureTextFieldDefault))]
+    public static partial void SecureTextField(
+        IntPtr      state,
+        IModifier?  modifier,
+        bool        enabled,
+        IFunction3? label,
+        IFunction2? placeholder,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        IFunction2? supportingText,
+        bool        isError,
+        IComposer   composer);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SecureTextFieldKt",
+        JvmName   = "OutlinedSecureTextField-XvU6IwQ",
+        Signature = SecureTextFieldSig,
+        Defaults  = typeof(OutlinedSecureTextFieldDefault))]
+    public static partial void OutlinedSecureTextField(
+        IntPtr      state,
+        IModifier?  modifier,
+        bool        enabled,
+        IFunction3? label,
+        IFunction2? placeholder,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        IFunction2? supportingText,
+        bool        isError,
+        IComposer   composer);
+
     // androidx.compose.material3.AndroidAlertDialog_androidKt.AlertDialog-Oix01E0
     [ComposeBridge(
         Class     = "androidx/compose/material3/AndroidAlertDialog_androidKt",

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -217,6 +217,30 @@ using ComposeNet;
     "keyboardOptions", "keyboardActions", "singleLine", "maxLines", "minLines",
     "interactionSource", "shape", "colors")]
 
+// androidx.compose.material3.SecureTextFieldKt.SecureTextField-XvU6IwQ AND
+// OutlinedSecureTextField-XvU6IwQ: 23 user params, bit 0 = state (always
+// provided through the SecureTextFieldState wrapper). Two enums (one per
+// JVM function) so each [ComposeBridge] can disambiguate via its own
+// `Defaults` typeof — the bit layout is identical between filled and
+// outlined variants.
+[assembly: ComposeDefaults("SecureTextFieldDefault",
+    "!state",
+    "modifier", "enabled", "textStyle", "labelPosition",
+    "label", "placeholder", "leadingIcon", "trailingIcon",
+    "prefix", "suffix", "supportingText", "isError",
+    "inputTransformation", "textObfuscationMode", "textObfuscationCharacter",
+    "keyboardOptions", "onKeyboardAction", "onTextLayout",
+    "shape", "colors", "contentPadding", "interactionSource")]
+
+[assembly: ComposeDefaults("OutlinedSecureTextFieldDefault",
+    "!state",
+    "modifier", "enabled", "textStyle", "labelPosition",
+    "label", "placeholder", "leadingIcon", "trailingIcon",
+    "prefix", "suffix", "supportingText", "isError",
+    "inputTransformation", "textObfuscationMode", "textObfuscationCharacter",
+    "keyboardOptions", "onKeyboardAction", "onTextLayout",
+    "shape", "colors", "contentPadding", "interactionSource")]
+
 // androidx.compose.material3.CardKt.Card (non-clickable): 6 user params,
 // bit 5 = content provided. Also reused by OutlinedCard — it takes the
 // same 6 params in the same order.

--- a/src/ComposeNet.Compose/OutlinedSecureTextField.cs
+++ b/src/ComposeNet.Compose/OutlinedSecureTextField.cs
@@ -1,0 +1,95 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>OutlinedSecureTextField</c> — the outlined variant of
+/// <see cref="SecureTextField"/> for password / secure input. Stripped
+/// from the binding for the same reason (<c>@JvmInline value class</c>
+/// parameter, hashed JVM name <c>-XvU6IwQ</c>); reached via
+/// <see cref="ComposeBridges"/>.
+/// </summary>
+/// <remarks>
+/// Same shape as <see cref="SecureTextField"/> — see that type's docs for
+/// the full list of optional slots and which Kotlin defaults are used for
+/// the parameters this facade does not expose.
+///
+/// <code>
+/// var pwd = Remember(() =&gt; new SecureTextFieldState());
+/// new OutlinedSecureTextField(pwd)
+/// {
+///     Label       = new Text("Password"),
+///     LeadingIcon = new Text("🔒"),
+/// }
+/// </code>
+/// </remarks>
+public sealed class OutlinedSecureTextField : ComposableNode
+{
+    readonly SecureTextFieldState _state;
+
+    /// <summary>Creates an outlined secure text field bound to the supplied <see cref="SecureTextFieldState"/>.</summary>
+    public OutlinedSecureTextField(SecureTextFieldState state) => _state = state;
+
+    /// <summary>Whether the field accepts user input. Defaults to <c>true</c>.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Whether to render the field in its error appearance. Defaults to <c>false</c>.</summary>
+    public bool IsError { get; set; }
+
+    /// <summary>Optional label slot (Kotlin <c>label</c>).</summary>
+    public ComposableNode? Label { get; set; }
+
+    /// <summary>Optional placeholder slot drawn when the field is empty (Kotlin <c>placeholder</c>).</summary>
+    public ComposableNode? Placeholder { get; set; }
+
+    /// <summary>Optional leading icon slot (Kotlin <c>leadingIcon</c>).</summary>
+    public ComposableNode? LeadingIcon { get; set; }
+
+    /// <summary>Optional trailing icon slot, typically a "show/hide" toggle (Kotlin <c>trailingIcon</c>).</summary>
+    public ComposableNode? TrailingIcon { get; set; }
+
+    /// <summary>Optional supporting text rendered below the field (Kotlin <c>supportingText</c>).</summary>
+    public ComposableNode? SupportingText { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var statePeer = _state.Resolve(composer);
+
+        var labelNode = Label;
+        var label = labelNode is null
+            ? null
+            : ComposableLambdas.Wrap3(composer, c => labelNode.Render(c));
+
+        var placeholderNode = Placeholder;
+        var placeholder = placeholderNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => placeholderNode.Render(c));
+
+        var leadingIconNode = LeadingIcon;
+        var leadingIcon = leadingIconNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => leadingIconNode.Render(c));
+
+        var trailingIconNode = TrailingIcon;
+        var trailingIcon = trailingIconNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => trailingIconNode.Render(c));
+
+        var supportingTextNode = SupportingText;
+        var supportingText = supportingTextNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => supportingTextNode.Render(c));
+
+        ComposeBridges.OutlinedSecureTextField(
+            state:          statePeer.Handle,
+            modifier:       BuildModifier(),
+            enabled:        Enabled,
+            label:          label,
+            placeholder:    placeholder,
+            leadingIcon:    leadingIcon,
+            trailingIcon:   trailingIcon,
+            supportingText: supportingText,
+            isError:        IsError,
+            composer:       composer);
+    }
+}

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -373,6 +373,22 @@ ComposeNet.OutlinedIconButton
 ComposeNet.OutlinedIconButton.OutlinedIconButton(System.Action! onClick) -> void
 ComposeNet.OutlinedIconToggleButton
 ComposeNet.OutlinedIconToggleButton.OutlinedIconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
+ComposeNet.OutlinedSecureTextField
+ComposeNet.OutlinedSecureTextField.Enabled.get -> bool
+ComposeNet.OutlinedSecureTextField.Enabled.set -> void
+ComposeNet.OutlinedSecureTextField.IsError.get -> bool
+ComposeNet.OutlinedSecureTextField.IsError.set -> void
+ComposeNet.OutlinedSecureTextField.Label.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedSecureTextField.Label.set -> void
+ComposeNet.OutlinedSecureTextField.LeadingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedSecureTextField.LeadingIcon.set -> void
+ComposeNet.OutlinedSecureTextField.OutlinedSecureTextField(ComposeNet.SecureTextFieldState! state) -> void
+ComposeNet.OutlinedSecureTextField.Placeholder.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedSecureTextField.Placeholder.set -> void
+ComposeNet.OutlinedSecureTextField.SupportingText.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedSecureTextField.SupportingText.set -> void
+ComposeNet.OutlinedSecureTextField.TrailingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedSecureTextField.TrailingIcon.set -> void
 ComposeNet.OutlinedTextField
 ComposeNet.OutlinedTextField.OutlinedTextField(ComposeNet.MutableState<string!>! state) -> void
 ComposeNet.OutlinedTextField.OutlinedTextField(string! value, System.Action<string!>! onValueChange) -> void
@@ -435,6 +451,25 @@ ComposeNet.SecondaryScrollableTabRow
 ComposeNet.SecondaryScrollableTabRow.SecondaryScrollableTabRow(int selectedTabIndex) -> void
 ComposeNet.SecondaryTabRow
 ComposeNet.SecondaryTabRow.SecondaryTabRow(int selectedTabIndex) -> void
+ComposeNet.SecureTextField
+ComposeNet.SecureTextField.Enabled.get -> bool
+ComposeNet.SecureTextField.Enabled.set -> void
+ComposeNet.SecureTextField.IsError.get -> bool
+ComposeNet.SecureTextField.IsError.set -> void
+ComposeNet.SecureTextField.Label.get -> ComposeNet.ComposableNode?
+ComposeNet.SecureTextField.Label.set -> void
+ComposeNet.SecureTextField.LeadingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.SecureTextField.LeadingIcon.set -> void
+ComposeNet.SecureTextField.Placeholder.get -> ComposeNet.ComposableNode?
+ComposeNet.SecureTextField.Placeholder.set -> void
+ComposeNet.SecureTextField.SecureTextField(ComposeNet.SecureTextFieldState! state) -> void
+ComposeNet.SecureTextField.SupportingText.get -> ComposeNet.ComposableNode?
+ComposeNet.SecureTextField.SupportingText.set -> void
+ComposeNet.SecureTextField.TrailingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.SecureTextField.TrailingIcon.set -> void
+ComposeNet.SecureTextFieldState
+ComposeNet.SecureTextFieldState.SecureTextFieldState(string! initialText = "") -> void
+ComposeNet.SecureTextFieldState.Text.get -> string!
 ComposeNet.SegmentedButton
 ComposeNet.SegmentedButton.Icon.get -> ComposeNet.ComposableNode?
 ComposeNet.SegmentedButton.Icon.set -> void

--- a/src/ComposeNet.Compose/SecureTextField.cs
+++ b/src/ComposeNet.Compose/SecureTextField.cs
@@ -1,0 +1,110 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>SecureTextField</c> — a single-line filled text field
+/// designed for password / secure input. Obscures typed characters with
+/// a configurable bullet, disables cut/copy/drag, and pre-configures the
+/// IME for password input. Stripped from the binding because
+/// <c>textObfuscationMode</c> is a <c>@JvmInline value class</c> (hashed
+/// JVM name <c>-XvU6IwQ</c>); reached via <see cref="ComposeBridges"/>.
+/// </summary>
+/// <remarks>
+/// State-based: pass a <see cref="SecureTextFieldState"/> the same way
+/// <see cref="SearchBarInputField"/> takes a
+/// <see cref="SearchBarTextFieldState"/>. Read <c>state.Text</c> to drive
+/// other UI off the typed value (e.g. a "Sign in" button's enabled flag).
+///
+/// <para>The Kotlin signature has 23 parameters; this facade exposes the
+/// most commonly toggled ones (<c>enabled</c>, <c>isError</c>) plus the
+/// optional content slots (<c>label</c>, <c>placeholder</c>,
+/// <c>leadingIcon</c>, <c>trailingIcon</c>, <c>supportingText</c>). All
+/// other Kotlin parameters — <c>textStyle</c>, <c>labelPosition</c>,
+/// <c>prefix</c>, <c>suffix</c>, <c>inputTransformation</c>,
+/// <c>textObfuscationMode</c>, <c>textObfuscationCharacter</c>,
+/// <c>keyboardOptions</c>, <c>onKeyboardAction</c>, <c>onTextLayout</c>,
+/// <c>shape</c>, <c>colors</c>, <c>contentPadding</c>,
+/// <c>interactionSource</c> — fall back to their Compose defaults
+/// (which configure a <c>RevealLastTyped</c> obfuscation mode and a
+/// password-typed IME).</para>
+///
+/// <code>
+/// var pwd = Remember(() =&gt; new SecureTextFieldState());
+/// new SecureTextField(pwd)
+/// {
+///     Label       = new Text("Password"),
+///     LeadingIcon = new Text("🔒"),
+/// }
+/// </code>
+/// </remarks>
+public sealed class SecureTextField : ComposableNode
+{
+    readonly SecureTextFieldState _state;
+
+    /// <summary>Creates a secure text field bound to the supplied <see cref="SecureTextFieldState"/>.</summary>
+    public SecureTextField(SecureTextFieldState state) => _state = state;
+
+    /// <summary>Whether the field accepts user input. Defaults to <c>true</c>.</summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Whether to render the field in its error appearance. Defaults to <c>false</c>.</summary>
+    public bool IsError { get; set; }
+
+    /// <summary>Optional label slot (Kotlin <c>label</c>).</summary>
+    public ComposableNode? Label { get; set; }
+
+    /// <summary>Optional placeholder slot drawn when the field is empty (Kotlin <c>placeholder</c>).</summary>
+    public ComposableNode? Placeholder { get; set; }
+
+    /// <summary>Optional leading icon slot (Kotlin <c>leadingIcon</c>).</summary>
+    public ComposableNode? LeadingIcon { get; set; }
+
+    /// <summary>Optional trailing icon slot, typically a "show/hide" toggle (Kotlin <c>trailingIcon</c>).</summary>
+    public ComposableNode? TrailingIcon { get; set; }
+
+    /// <summary>Optional supporting text rendered below the field (Kotlin <c>supportingText</c>).</summary>
+    public ComposableNode? SupportingText { get; set; }
+
+    internal override void Render(IComposer composer)
+    {
+        var statePeer = _state.Resolve(composer);
+
+        var labelNode = Label;
+        var label = labelNode is null
+            ? null
+            : ComposableLambdas.Wrap3(composer, c => labelNode.Render(c));
+
+        var placeholderNode = Placeholder;
+        var placeholder = placeholderNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => placeholderNode.Render(c));
+
+        var leadingIconNode = LeadingIcon;
+        var leadingIcon = leadingIconNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => leadingIconNode.Render(c));
+
+        var trailingIconNode = TrailingIcon;
+        var trailingIcon = trailingIconNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => trailingIconNode.Render(c));
+
+        var supportingTextNode = SupportingText;
+        var supportingText = supportingTextNode is null
+            ? null
+            : ComposableLambdas.Wrap2(composer, c => supportingTextNode.Render(c));
+
+        ComposeBridges.SecureTextField(
+            state:          statePeer.Handle,
+            modifier:       BuildModifier(),
+            enabled:        Enabled,
+            label:          label,
+            placeholder:    placeholder,
+            leadingIcon:    leadingIcon,
+            trailingIcon:   trailingIcon,
+            supportingText: supportingText,
+            isError:        IsError,
+            composer:       composer);
+    }
+}

--- a/src/ComposeNet.Compose/SecureTextField.cs
+++ b/src/ComposeNet.Compose/SecureTextField.cs
@@ -5,8 +5,8 @@ namespace ComposeNet;
 /// <summary>
 /// Material 3 <c>SecureTextField</c> — a single-line filled text field
 /// designed for password / secure input. Obscures typed characters with
-/// a configurable bullet, disables cut/copy/drag, and pre-configures the
-/// IME for password input. Stripped from the binding because
+/// a bullet glyph, disables cut/copy/drag, and pre-configures the IME
+/// for password input. Stripped from the binding because
 /// <c>textObfuscationMode</c> is a <c>@JvmInline value class</c> (hashed
 /// JVM name <c>-XvU6IwQ</c>); reached via <see cref="ComposeBridges"/>.
 /// </summary>

--- a/src/ComposeNet.Compose/SecureTextFieldState.cs
+++ b/src/ComposeNet.Compose/SecureTextFieldState.cs
@@ -1,0 +1,80 @@
+using AndroidX.Compose.Foundation.Text.Input;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Caller-supplied state holder for the text inside a
+/// <see cref="SecureTextField"/> or <see cref="OutlinedSecureTextField"/>.
+/// Mirrors <see cref="SearchBarTextFieldState"/>: the underlying JVM
+/// <c>androidx.compose.foundation.text.input.TextFieldState</c> is created
+/// lazily the first time a <see cref="SecureTextField"/> bound to this
+/// state is rendered, via Compose's <c>rememberTextFieldState</c>.
+/// </summary>
+/// <remarks>
+/// Read <see cref="Text"/> inside composition to drive other UI off the
+/// typed value (e.g. enable a "Sign in" button when the password is
+/// non-empty); reads go through to the live JVM peer's <c>text</c>
+/// property, which is itself a Compose snapshot state, so subscribing
+/// inside composition triggers recomposition.
+///
+/// <para><see cref="SecureTextFieldState"/> only honours the
+/// <c>initialText</c> ctor argument on the first render that resolves
+/// the JVM peer; later mutations to the C# constructor argument are
+/// ignored. Persist your own <see cref="MutableState{T}"/>-backed
+/// mirror if you need to survive process death.</para>
+///
+/// <code>
+/// var pwd = Remember(() =&gt; new SecureTextFieldState());
+/// new Column
+/// {
+///     new SecureTextField(pwd) { Label = new Text("Password") },
+///     new Button(onClick: () =&gt; SignIn(pwd.Text), enabled: pwd.Text.Length &gt;= 8)
+///     {
+///         new Text("Sign in"),
+///     },
+/// }
+/// </code>
+/// </remarks>
+public sealed class SecureTextFieldState
+{
+    readonly string _initialText;
+
+    // Bound peer for the JVM androidx.compose.foundation.text.input.TextFieldState.
+    // Set on first SecureTextField render and reused by every subsequent
+    // recomposition of the same node so the JVM-side text + cursor state
+    // survives across recompositions.
+    internal TextFieldState? Jvm;
+
+    /// <summary>
+    /// Creates a state holder with an optional initial text value
+    /// (defaults to the empty string). The initial value is only used
+    /// the first time a <see cref="SecureTextField"/> bound to this state
+    /// is rendered — once the JVM peer is resolved, mutations to the
+    /// passed-in string are ignored.
+    /// </summary>
+    public SecureTextFieldState(string initialText = "") =>
+        _initialText = initialText;
+
+    /// <summary>
+    /// Current text in the secure input. Reads through to the live
+    /// JVM <c>TextFieldState.text</c> (a Compose snapshot value), so
+    /// reading inside composition subscribes to recomposition. Returns
+    /// the initial value before the first render binds the peer.
+    /// </summary>
+    public string Text => Jvm?.Text ?? _initialText;
+
+    // Lazy-resolve the bound JVM peer. Subsequent SecureTextField renders
+    // sharing this state hit the JNI bridge once on the FIRST render and
+    // reuse the peer for every recomposition.
+    internal TextFieldState Resolve(IComposer composer)
+    {
+        if (Jvm is not null)
+            return Jvm;
+
+        // Bit 1 = default initialSelection (Kotlin places the cursor at
+        // the end of initialText). initialText is provided explicitly.
+        Jvm = TextFieldStateKt.RememberTextFieldState(_initialText, 0L, composer, 0, 2);
+        return Jvm;
+    }
+}

--- a/src/ComposeNet.Compose/SecureTextFieldState.cs
+++ b/src/ComposeNet.Compose/SecureTextFieldState.cs
@@ -18,11 +18,12 @@ namespace ComposeNet;
 /// property, which is itself a Compose snapshot state, so subscribing
 /// inside composition triggers recomposition.
 ///
-/// <para><see cref="SecureTextFieldState"/> only honours the
-/// <c>initialText</c> ctor argument on the first render that resolves
-/// the JVM peer; later mutations to the C# constructor argument are
-/// ignored. Persist your own <see cref="MutableState{T}"/>-backed
-/// mirror if you need to survive process death.</para>
+/// <para>The <c>initialText</c> constructor argument only seeds the
+/// JVM peer the first time a <see cref="SecureTextField"/> bound to
+/// this state is rendered. Once the peer exists, the seed value is no
+/// longer consulted — to clear or reset the text, mutate the live JVM
+/// state via the typed UI or persist your own <see cref="MutableState{T}"/>-backed
+/// mirror.</para>
 ///
 /// <code>
 /// var pwd = Remember(() =&gt; new SecureTextFieldState());

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -46,6 +46,15 @@ public class MainActivity : ComposeActivity
             var iconToggle3 = Remember(() => new MutableState<bool>(false));
             var iconToggle4 = Remember(() => new MutableState<bool>(true));
 
+            var pwd        = Remember(() => new SecureTextFieldState());
+            var pwdConfirm = Remember(() => new SecureTextFieldState());
+            // SecureTextFieldState.Text isn't snapshot-tracked when
+            // read from C# build code (same constraint as
+            // SearchBarTextFieldState — see Pickers tab note). Mirror
+            // the lengths into a MutableState on Sign-in tap so the
+            // status line updates reactively.
+            var signInStatus = Remember(() => new MutableState<string>(""));
+
             var menuOpen      = Remember(() => new MutableState<bool>(false));
             var menuSelection = Remember(() => new MutableState<string>("(none)"));
             var searchState   = Remember(() => new SearchBarState());
@@ -111,7 +120,35 @@ public class MainActivity : ComposeActivity
                                     .Clickable(() => count++)
                                     .Padding(horizontalDp: 16, verticalDp: 8),
                             },
-                        },
+                                // Secure text inputs — exercise both
+                                // SecureTextField (filled) and
+                                // OutlinedSecureTextField. The two state
+                                // holders are independent; tapping "Sign in"
+                                // snapshots both lengths into signInStatus.
+                                new Text("Secure inputs:"),
+                                new SecureTextField(pwd)
+                                {
+                                    Label          = new Text("Password"),
+                                    LeadingIcon    = new Text("🔒"),
+                                    SupportingText = new Text("Filled"),
+                                },
+                                new OutlinedSecureTextField(pwdConfirm)
+                                {
+                                    Label          = new Text("Confirm password"),
+                                    LeadingIcon    = new Text("🔒"),
+                                    SupportingText = new Text("Outlined"),
+                                },
+                                new Button(onClick: () =>
+                                    signInStatus.Value =
+                                        $"len={pwd.Text.Length}/{pwdConfirm.Text.Length}, " +
+                                        $"match={(pwd.Text == pwdConfirm.Text)}")
+                                {
+                                    new Text("Sign in"),
+                                },
+                                new Text(string.IsNullOrEmpty(signInStatus.Value)
+                                    ? "Tap Sign in to compare"
+                                    : signInStatus.Value),
+                            },
                         1 => new Column
                         {
                             new Text($"Count: {count}"),


### PR DESCRIPTION
Closes the last remaining gap in #5 by binding the two `SecureTextField` composables stripped from `Xamarin.AndroidX.Compose.Material3Android` 1.4.0.3. Both have hashed JVM names — `-XvU6IwQ` — because `textObfuscationMode` is a `@JvmInline value class` wrapping `Int`, which mangles the JVM name.

Per the issue's triage update, this is the only remaining missing item — `WideNavigationRail`, `ModalWideNavigationRail`, `SegmentedButton`, `LinearProgressIndicator`, and `CircularProgressIndicator` are all already bound in earlier PRs. The `TextFieldState` blocker is unblocked: `SearchBarTextFieldState` already established that pattern, so this PR mirrors it.

## What's added

- **`ComposeBridges.cs`** — two `[ComposeBridge]` partial methods for `SecureTextField-XvU6IwQ` and `OutlinedSecureTextField-XvU6IwQ`, sharing a single 23-user-param JNI signature constant. The trailing `IIII` decodes to 3 `$changed` ints + 1 `$default` int (since `ceil(23 / 10) = 3`). Source-generated `try`/`finally` wraps the call.
- **`ComposeDefaults.cs`** — two `[assembly: ComposeDefaults]` declarations describing the 23-bit Kotlin parameter layout (one each so each bridge gets its own `typeof(...)` reference, even though the layouts are identical). Bit 0 (`!state`) is consumed but suppressed since the state holder always provides the peer.
- **`SecureTextFieldState.cs`** — new public state holder, mirrors `SearchBarTextFieldState`. Lazily resolves a JVM `androidx.compose.foundation.text.input.TextFieldState` via `rememberTextFieldState` on first render, then reuses the peer for every recomposition. `Text` reads through to the live snapshot, so subscribing inside composition triggers recomposition.
- **`SecureTextField.cs` and `OutlinedSecureTextField.cs`** — hand-written leaf facades (couldn't use `[ComposeFacade]` because `IntPtr state` isn't one of the supported facade slot types in the param table). Each exposes `Enabled`, `IsError`, `Label`, `Placeholder`, `LeadingIcon`, `TrailingIcon`, `SupportingText`. All other Kotlin parameters (`textStyle`, `labelPosition`, `prefix`, `suffix`, `inputTransformation`, `textObfuscationMode`, `textObfuscationCharacter`, `keyboardOptions`, `onKeyboardAction`, `onTextLayout`, `shape`, `colors`, `contentPadding`, `interactionSource`) fall back to their Compose defaults — which configure a sensible password-typed IME and `RevealLastTyped` obfuscation mode.
- **`PublicAPI.Unshipped.txt`** — entries for the three new public types.

## Trade-off documented

For non-nullable `bool` user params, the bridge generator unconditionally clears the corresponding `$default` bit (always passes the value). That means C# owns `enabled` and `isError` defaults — Kotlin's defaults for those two are no longer reachable. This is consistent with how every other `bool` user-param bridge in the repo behaves.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 61/61 passing
- `dotnet build src/ComposeNet.Compose` — clean (0 warnings, 0 errors)
- `dotnet build src/ComposeNet.Sample` — clean (0 warnings, 0 errors), full Android wiring

## Usage

```csharp
var pwd = Remember(() => new SecureTextFieldState());
new Column
{
    new SecureTextField(pwd) { Label = new Text("Password") },
    new Button(onClick: () => SignIn(pwd.Text), enabled: pwd.Text.Length >= 8)
    {
        new Text("Sign in"),
    },
}
```

Closes #5.