### PR TITLE
Phase 8 facade generator: wrapper-passthrough pattern

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -363,7 +363,7 @@ stay distinct per facade.
 ### When to use it
 
 The generator now supports a wide range of facade shapes (Phases 1,
-2, 3, 6, 7 are implemented):
+2, 3, 6, 7, 8 are implemented):
 
 - **Phase 1** — container with content lambda + ctor primitives
   (`Button`, `Card`, `Text`, `Column`, `Row`, `Box`).
@@ -378,6 +378,22 @@ The generator now supports a wide range of facade shapes (Phases 1,
   `ColorScheme` slot when the caller doesn't override.
 - **Phase 7** — `[PainterResource]` resource-id-style facades
   (`Image`, the Painter overload of `Icon`).
+- **Phase 8** — wrapper-passthrough facades for bound bindings the
+  facade generator can otherwise call directly. Stack
+  `[ComposeFacade]` on a `partial` method on `ComposeBridges` that
+  has a hand-written body delegating to a bound `*Kt` method (e.g.
+  `BoxKt.Box`, `CheckboxKt.Checkbox`). The wrapper has a
+  trailing `int defaults` user param that the facade generator
+  fills via the auto-mask and the body passes through to the
+  binding's `_changed:` argument. `[ComposeFacade]` recognizes the
+  `Defaults = typeof(XDefault)` argument and reads the bit names
+  from the matching declarative-form `[assembly: ComposeDefaults(...)]`
+  declaration. There is no `[ComposeBridge]` attribute on these
+  wrappers; the generator pipeline doesn't see the other generator's
+  source-generated enums, so the bit-name map has to come from a
+  declarative `ComposeDefaults` declaration (not the generic form).
+  Used for `Box`, `Column`, `Row`, `Spacer`, `Checkbox`, `Switch`,
+  `RadioButton`, `Slider`.
 
 Facades that still stay hand-written are the ones the generator
 can't model:

--- a/src/ComposeNet.Compose/Box.cs
+++ b/src/ComposeNet.Compose/Box.cs
@@ -1,6 +1,3 @@
-using AndroidX.Compose.Foundation.Layout;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -10,23 +7,4 @@ namespace ComposeNet;
 /// chains. Always uses the 7-param Kotlin overload so children are
 /// rendered through the content slot.
 /// </summary>
-public sealed class Box : ComposableContainer
-{
-    internal override void Render(IComposer composer)
-    {
-        var modifier = BuildModifier();
-        var content  = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
-
-        int defaults = (int)BoxDefault.All;
-        if (modifier is not null) defaults &= ~(int)BoxDefault.Modifier;
-
-        BoxKt.Box(
-            modifier:                 modifier,
-            contentAlignment:         null,
-            propagateMinConstraints:  false,
-            content:                  content,
-            _composer:                composer,
-            p5:                       0,
-            _changed:                 defaults);
-    }
-}
+public sealed partial class Box;

--- a/src/ComposeNet.Compose/Checkbox.cs
+++ b/src/ComposeNet.Compose/Checkbox.cs
@@ -1,6 +1,3 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -9,35 +6,4 @@ namespace ComposeNet;
 /// new Checkbox(@checked: state.Value, onCheckedChange: v => state.Value = v)
 /// </code>
 /// </summary>
-public sealed class Checkbox : ComposableNode
-{
-    readonly bool _checked;
-    readonly System.Action<bool> _onCheckedChange;
-
-    public Checkbox(bool @checked, System.Action<bool> onCheckedChange)
-    {
-        _checked = @checked;
-        _onCheckedChange = onCheckedChange;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onChange = new ComposableLambda1(v =>
-            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
-
-        var modifier = BuildModifier();
-        int defaults = (int)CheckboxDefault.All;
-        if (modifier is not null) defaults &= ~(int)CheckboxDefault.Modifier;
-
-        CheckboxKt.Checkbox(
-            @checked:          _checked,
-            onCheckedChange:   onChange,
-            modifier:          modifier,
-            enabled:           true,
-            colors:            null,
-            interactionSource: null,
-            _composer:         composer,
-            p7:                0,
-            _changed:          defaults);
-    }
-}
+public sealed partial class Checkbox;

--- a/src/ComposeNet.Compose/Column.cs
+++ b/src/ComposeNet.Compose/Column.cs
@@ -1,28 +1,4 @@
-using AndroidX.Compose.Foundation.Layout;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>Foundation <c>Column</c> composable.</summary>
-public sealed class Column : ComposableContainer
-{
-    internal override void Render(IComposer composer)
-    {
-        var modifier = BuildModifier();
-        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
-        {
-            using var _ = RenderContext.PushScope(scope, ScopeKind.Column);
-            RenderChildren(c);
-        });
-        int defaults = (int)ColumnDefault.All;
-        if (modifier is not null) defaults &= ~(int)ColumnDefault.Modifier;
-        ColumnKt.Column(
-            modifier:            modifier,
-            verticalArrangement: null,
-            horizontalAlignment: null,
-            content:             content,
-            _composer:           composer,
-            p5:                  0,
-            _changed:            defaults);
-    }
-}
+public sealed partial class Column;

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1,7 +1,10 @@
 using Android.Runtime;
+using AndroidX.Compose.Foundation.Layout;
 using AndroidX.Compose.Foundation.Lazy.Grid;
+using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI;
+using AndroidX.Compose.UI.State;
 using Kotlin.Jvm.Functions;
 
 namespace ComposeNet;
@@ -655,11 +658,13 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/window/DialogProperties;" +
                     "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(DatePickerDialogDefault))]
+    [ComposeFacade]
     public static partial void DatePickerDialog(
         IFunction0  onDismissRequest,
         IFunction2  confirmButton,
         IModifier?  modifier,
         IFunction2? dismissButton,
+        [Slot("Body")]
         IFunction3  content,
         int         defaults,
         IComposer   composer);
@@ -685,6 +690,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/graphics/Shape;J" +
                     "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(TimePickerDialogDefault))]
+    [ComposeFacade]
     public static partial void TimePickerDialog(
         IFunction0  onDismissRequest,
         IFunction2  confirmButton,
@@ -692,6 +698,7 @@ internal static partial class ComposeBridges
         IModifier?  modifier,
         IFunction2? title,
         IFunction2? modeToggleButton,
+        [Slot("Body")]
         IFunction3  content,
         int         defaults,
         IComposer   composer);
@@ -1846,4 +1853,152 @@ internal static partial class ComposeBridges
         IntPtr     snackbarData,
         IModifier? modifier,
         IComposer  composer);
+
+    // Phase 8 — wrapper-passthrough facades. These are [ComposeFacade]-only
+    // partial methods with hand-written bodies that delegate to a bound
+    // binding. They eliminate per-facade boilerplate (ComposableLambda
+    // wrapping, modifier handling, $default mask) by routing through the
+    // ComposeFacadeGenerator. The wrapper itself is just one explicit
+    // call to the binding — no overload resolution magic, every arg
+    // hand-picked.
+
+    [ComposeFacade(Defaults = typeof(BoxDefault))]
+    public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
+
+    public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)
+        => BoxKt.Box(
+            modifier:                modifier,
+            contentAlignment:        null,
+            propagateMinConstraints: false,
+            content:                 content,
+            _composer:               composer,
+            p5:                      0,
+            _changed:                defaults);
+
+    [ComposeFacade(Defaults = typeof(ColumnDefault), Scope = "Column")]
+    public static partial void Column(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
+
+    public static partial void Column(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)
+        => ColumnKt.Column(
+            modifier:            modifier,
+            verticalArrangement: null,
+            horizontalAlignment: null,
+            content:             content,
+            _composer:           composer,
+            p5:                  0,
+            _changed:            defaults);
+
+    [ComposeFacade(Defaults = typeof(RowDefault), Scope = "Row")]
+    public static partial void Row(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
+
+    public static partial void Row(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)
+        => RowKt.Row(
+            modifier:              modifier,
+            horizontalArrangement: null,
+            verticalAlignment:     null,
+            content:               content,
+            _composer:             composer,
+            p5:                    0,
+            _changed:              defaults);
+
+    // Spacer has no Kotlin $default — the modifier param is required.
+    // The wrapper materialises Modifier.Companion when the caller leaves
+    // it null so the binding receives a non-null receiver.
+    [ComposeFacade]
+    public static partial void Spacer(IModifier? modifier, IComposer composer);
+
+    public static partial void Spacer(IModifier? modifier, IComposer composer)
+        => SpacerKt.Spacer(
+            modifier ?? Java.Lang.Object.GetObject<IModifier>(
+                ModifierCompanionInstance(),
+                JniHandleOwnership.TransferLocalRef)!,
+            composer,
+            0);
+
+    [ComposeFacade(Defaults = typeof(CheckboxDefault))]
+    public static partial void Checkbox(
+        bool                       @checked,
+        [Callback(typeof(bool))]
+        IFunction1                 onCheckedChange,
+        IModifier?                 modifier,
+        int                        defaults,
+        IComposer                  composer);
+
+    public static partial void Checkbox(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, int defaults, IComposer composer)
+        => CheckboxKt.Checkbox(
+            @checked:          @checked,
+            onCheckedChange:   onCheckedChange,
+            modifier:          modifier,
+            enabled:           true,
+            colors:            null,
+            interactionSource: null,
+            _composer:         composer,
+            p7:                0,
+            _changed:          defaults);
+
+    [ComposeFacade(Defaults = typeof(SwitchDefault))]
+    public static partial void Switch(
+        bool                       @checked,
+        [Callback(typeof(bool))]
+        IFunction1                 onCheckedChange,
+        IModifier?                 modifier,
+        int                        defaults,
+        IComposer                  composer);
+
+    public static partial void Switch(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, int defaults, IComposer composer)
+        => SwitchKt.Switch(
+            @checked:          @checked,
+            onCheckedChange:   onCheckedChange,
+            modifier:          modifier,
+            thumbContent:      null,
+            enabled:           true,
+            colors:            null,
+            interactionSource: null,
+            _composer:         composer,
+            p8:                0,
+            _changed:          defaults);
+
+    [ComposeFacade(Defaults = typeof(RadioButtonDefault))]
+    public static partial void RadioButton(
+        bool        selected,
+        IFunction0  onClick,
+        IModifier?  modifier,
+        int         defaults,
+        IComposer   composer);
+
+    public static partial void RadioButton(bool selected, IFunction0 onClick, IModifier? modifier, int defaults, IComposer composer)
+        => RadioButtonKt.RadioButton(
+            selected:          selected,
+            onClick:           onClick,
+            modifier:          modifier,
+            enabled:           true,
+            colors:            null,
+            interactionSource: null,
+            _composer:         composer,
+            p7:                0,
+            _changed:          defaults);
+
+    [ComposeFacade(Defaults = typeof(SliderDefault))]
+    public static partial void Slider(
+        float                       value,
+        [Callback(typeof(float))]
+        IFunction1                  onValueChange,
+        IModifier?                  modifier,
+        int                         defaults,
+        IComposer                   composer);
+
+    public static partial void Slider(float value, IFunction1 onValueChange, IModifier? modifier, int defaults, IComposer composer)
+        => SliderKt.Slider(
+            value:                  value,
+            onValueChange:          onValueChange,
+            modifier:               modifier,
+            enabled:                true,
+            valueRange:             null,
+            p5:                     0,
+            onValueChangeFinished:  null,
+            colors:                 null,
+            interactionSource:      null,
+            _composer:              composer,
+            steps:                  0,
+            _changed:               defaults);
 }

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -32,9 +32,14 @@ using AndroidX.Compose.Foundation.Lazy.Grid;
 using AndroidX.Compose.Material3;
 using ComposeNet;
 
-[assembly: ComposeDefaults<ColumnKt>("Column", "ColumnDefault")]
-[assembly: ComposeDefaults<RowKt>("Row", "RowDefault")]
-[assembly: ComposeDefaults<BoxKt>("Box", "BoxDefault")]
+// Hand-rolled declarative form (instead of generic form) so the
+// ComposeFacadeGenerator can see the bit names — generic-form enums
+// are emitted by another source generator in the same pass and aren't
+// visible cross-generator. Bits and names match what the generic form
+// would have produced.
+[assembly: ComposeDefaults("ColumnDefault", "modifier", "verticalArrangement", "horizontalAlignment", "!content")]
+[assembly: ComposeDefaults("RowDefault", "modifier", "horizontalArrangement", "verticalAlignment", "!content")]
+[assembly: ComposeDefaults("BoxDefault", "modifier", "contentAlignment", "propagateMinConstraints", "!content")]
 [assembly: ComposeDefaults<DividerKt>("HorizontalDivider", "HorizontalDividerDefault")]
 [assembly: ComposeDefaults<DividerKt>("VerticalDivider", "VerticalDividerDefault")]
 [assembly: ComposeDefaults<IconKt>("Icon", "IconDefault")]

--- a/src/ComposeNet.Compose/DatePickerDialog.cs
+++ b/src/ComposeNet.Compose/DatePickerDialog.cs
@@ -1,5 +1,3 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -7,49 +5,6 @@ namespace ComposeNet;
 /// builder (<c>rememberDatePickerState-EU0dCGE</c>) is mangled and
 /// stripped from the binding, so we resolve it through JNI inside the
 /// <see cref="DatePicker"/> facade. Place a <see cref="DatePicker"/>
-/// (or any composable) inside <see cref="Body"/>.
+/// (or any composable) inside <c>Body</c>.
 /// </summary>
-public sealed class DatePickerDialog : ComposableNode
-{
-    readonly System.Action _onDismissRequest;
-    public DatePickerDialog(System.Action onDismissRequest) => _onDismissRequest = onDismissRequest;
-
-    /// <summary>Required: the affirmative button (no Kotlin default).</summary>
-    public ComposableNode? ConfirmButton { get; set; }
-
-    /// <summary>Optional: secondary button.</summary>
-    public ComposableNode? DismissButton { get; set; }
-
-    /// <summary>Required: dialog body — typically a <see cref="DatePicker"/>.</summary>
-    public ComposableNode? Body { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (ConfirmButton is null)
-            throw new System.InvalidOperationException(
-                "DatePickerDialog.ConfirmButton is required.");
-        if (Body is null)
-            throw new System.InvalidOperationException(
-                "DatePickerDialog.Body is required (the dialog's content slot).");
-
-        var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var confirm   = ComposableLambdas.Wrap2(composer, c => ConfirmButton.Render(c));
-        var content   = ComposableLambdas.Wrap3(composer, c => Body.Render(c));
-        var dismiss = DismissButton is null ? null
-            : ComposableLambdas.Wrap2(composer, c => DismissButton.Render(c));
-
-        int defaults = (int)DatePickerDialogDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)DatePickerDialogDefault.Modifier;
-        if (dismiss  is not null) defaults &= ~(int)DatePickerDialogDefault.DismissButton;
-
-        ComposeBridges.DatePickerDialog(
-            onDismissRequest: onDismiss,
-            confirmButton:    confirm,
-            modifier:         modifier,
-            dismissButton:    dismiss,
-            content:          content,
-            defaults:         defaults,
-            composer:         composer);
-    }
-}
+public sealed partial class DatePickerDialog;

--- a/src/ComposeNet.Compose/RadioButton.cs
+++ b/src/ComposeNet.Compose/RadioButton.cs
@@ -1,6 +1,3 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -11,34 +8,4 @@ namespace ComposeNet;
 /// new RadioButton(selected: pick.Value == "A", onClick: () => pick.Value = "A")
 /// </code>
 /// </summary>
-public sealed class RadioButton : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public RadioButton(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick = onClick;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onClick = new ComposableLambda0(_onClick);
-
-        var modifier = BuildModifier();
-        int defaults = (int)RadioButtonDefault.All;
-        if (modifier is not null) defaults &= ~(int)RadioButtonDefault.Modifier;
-
-        RadioButtonKt.RadioButton(
-            selected:          _selected,
-            onClick:           onClick,
-            modifier:          modifier,
-            enabled:           true,
-            colors:            null,
-            interactionSource: null,
-            _composer:         composer,
-            p7:                0,
-            _changed:          defaults);
-    }
-}
+public sealed partial class RadioButton;

--- a/src/ComposeNet.Compose/Row.cs
+++ b/src/ComposeNet.Compose/Row.cs
@@ -1,6 +1,3 @@
-using AndroidX.Compose.Foundation.Layout;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -11,27 +8,4 @@ namespace ComposeNet;
 /// new Row { new Text("A"), new Spacer { Modifier = ... }, new Text("B") }
 /// </code>
 /// </summary>
-public sealed class Row : ComposableContainer
-{
-    internal override void Render(IComposer composer)
-    {
-        var modifier = BuildModifier();
-        var content  = ComposableLambdas.Wrap3(composer, (scope, c) =>
-        {
-            using var _ = RenderContext.PushScope(scope, ScopeKind.Row);
-            RenderChildren(c);
-        });
-
-        int defaults = (int)RowDefault.All;
-        if (modifier is not null) defaults &= ~(int)RowDefault.Modifier;
-
-        RowKt.Row(
-            modifier:              modifier,
-            horizontalArrangement: null,
-            verticalAlignment:     null,
-            content:               content,
-            _composer:             composer,
-            p5:                    0,
-            _changed:              defaults);
-    }
-}
+public sealed partial class Row;

--- a/src/ComposeNet.Compose/Slider.cs
+++ b/src/ComposeNet.Compose/Slider.cs
@@ -1,6 +1,3 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -12,38 +9,4 @@ namespace ComposeNet;
 /// richer overloads (with custom <c>thumb</c> / <c>track</c> slots, or
 /// a <c>SliderState</c> first param) aren't exposed in this facade.
 /// </summary>
-public sealed class Slider : ComposableNode
-{
-    readonly float _value;
-    readonly System.Action<float> _onValueChange;
-
-    public Slider(float value, System.Action<float> onValueChange)
-    {
-        _value = value;
-        _onValueChange = onValueChange;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onChange = new ComposableLambda1(v =>
-            _onValueChange(v is Java.Lang.Float f ? f.FloatValue() : 0f));
-
-        var modifier = BuildModifier();
-        int defaults = (int)SliderDefault.All;
-        if (modifier is not null) defaults &= ~(int)SliderDefault.Modifier;
-
-        SliderKt.Slider(
-            value:                  _value,
-            onValueChange:          onChange,
-            modifier:               modifier,
-            enabled:                true,
-            valueRange:             null,
-            p5:                     0,
-            onValueChangeFinished:  null,
-            colors:                 null,
-            interactionSource:      null,
-            _composer:              composer,
-            steps:                  0,
-            _changed:               defaults);
-    }
-}
+public sealed partial class Slider;

--- a/src/ComposeNet.Compose/Spacer.cs
+++ b/src/ComposeNet.Compose/Spacer.cs
@@ -1,9 +1,3 @@
-using Android.Runtime;
-using AndroidX.Compose.Foundation.Layout;
-using AndroidX.Compose.Runtime;
-using AndroidX.Compose.UI;
-using Java.Interop;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -19,21 +13,11 @@ namespace ComposeNet;
 /// <c>Modifier.Companion</c> (the empty modifier) when the caller
 /// doesn't supply a chain so the binding receives a non-null value.
 /// </remarks>
-public sealed class Spacer : ComposableNode
+public sealed partial class Spacer
 {
     /// <summary>Empty Spacer (zero-sized). Apply a sizing modifier to give it presence.</summary>
     public Spacer() { }
 
     /// <summary>Convenience overload that sets <see cref="ComposableNode.Modifier"/>.</summary>
     public Spacer(Modifier modifier) => Modifier = modifier;
-
-    internal override void Render(IComposer composer)
-    {
-        var modifier = BuildModifier()
-            ?? Java.Lang.Object.GetObject<IModifier>(
-                ComposeBridges.ModifierCompanionInstance(),
-                JniHandleOwnership.TransferLocalRef)!;
-
-        SpacerKt.Spacer(modifier, composer, 0);
-    }
 }

--- a/src/ComposeNet.Compose/Switch.cs
+++ b/src/ComposeNet.Compose/Switch.cs
@@ -1,6 +1,3 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
@@ -9,36 +6,4 @@ namespace ComposeNet;
 /// new Switch(@checked: state.Value, onCheckedChange: v => state.Value = v)
 /// </code>
 /// </summary>
-public sealed class Switch : ComposableNode
-{
-    readonly bool _checked;
-    readonly System.Action<bool> _onCheckedChange;
-
-    public Switch(bool @checked, System.Action<bool> onCheckedChange)
-    {
-        _checked = @checked;
-        _onCheckedChange = onCheckedChange;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onChange = new ComposableLambda1(v =>
-            _onCheckedChange(v is Java.Lang.Boolean b && b.BooleanValue()));
-
-        var modifier = BuildModifier();
-        int defaults = (int)SwitchDefault.All;
-        if (modifier is not null) defaults &= ~(int)SwitchDefault.Modifier;
-
-        SwitchKt.Switch(
-            @checked:          _checked,
-            onCheckedChange:   onChange,
-            modifier:          modifier,
-            thumbContent:      null,
-            enabled:           true,
-            colors:            null,
-            interactionSource: null,
-            _composer:         composer,
-            p8:                0,
-            _changed:          defaults);
-    }
-}
+public sealed partial class Switch;

--- a/src/ComposeNet.Compose/TimePickerDialog.cs
+++ b/src/ComposeNet.Compose/TimePickerDialog.cs
@@ -1,58 +1,9 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>TimePickerDialog</c>. Both <c>ConfirmButton</c> and
-/// <c>DismissButton</c> are required by Compose; <see cref="Title"/>
-/// and <see cref="ModeToggleButton"/> are optional. Place a
-/// <see cref="TimePicker"/> in the body.
+/// <c>DismissButton</c> are required by Compose; <c>Title</c> and
+/// <c>ModeToggleButton</c> are optional. Place a
+/// <see cref="TimePicker"/> in <c>Body</c>.
 /// </summary>
-public sealed class TimePickerDialog : ComposableNode
-{
-    readonly System.Action _onDismissRequest;
-    public TimePickerDialog(System.Action onDismissRequest) => _onDismissRequest = onDismissRequest;
-
-    public ComposableNode? ConfirmButton    { get; set; }
-    public ComposableNode? DismissButton    { get; set; }
-    public ComposableNode? Title            { get; set; }
-    public ComposableNode? ModeToggleButton { get; set; }
-    /// <summary>Required: dialog body — typically a <see cref="TimePicker"/>.</summary>
-    public ComposableNode? Body             { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (ConfirmButton is null || DismissButton is null)
-            throw new System.InvalidOperationException(
-                "TimePickerDialog.ConfirmButton and DismissButton are both required.");
-        if (Body is null)
-            throw new System.InvalidOperationException(
-                "TimePickerDialog.Body is required (the dialog's content slot).");
-
-        var onDismiss = new ComposableLambda0(_onDismissRequest);
-        var confirm   = ComposableLambdas.Wrap2(composer, c => ConfirmButton.Render(c));
-        var dismiss   = ComposableLambdas.Wrap2(composer, c => DismissButton.Render(c));
-        var content   = ComposableLambdas.Wrap3(composer, c => Body.Render(c));
-        var title = Title is null ? null
-            : ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var toggle = ModeToggleButton is null ? null
-            : ComposableLambdas.Wrap2(composer, c => ModeToggleButton.Render(c));
-
-        int defaults = (int)TimePickerDialogDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)TimePickerDialogDefault.Modifier;
-        if (title    is not null) defaults &= ~(int)TimePickerDialogDefault.Title;
-        if (toggle   is not null) defaults &= ~(int)TimePickerDialogDefault.ModeToggleButton;
-
-        ComposeBridges.TimePickerDialog(
-            onDismissRequest: onDismiss,
-            confirmButton:    confirm,
-            dismissButton:    dismiss,
-            modifier:         modifier,
-            title:            title,
-            modeToggleButton: toggle,
-            content:          content,
-            defaults:         defaults,
-            composer:         composer);
-    }
-}
+public sealed partial class TimePickerDialog;

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -1002,4 +1002,112 @@ public class FacadeGeneratorTests
         var (_, diags, _) = Run(code, "Foo");
         Assert.Contains(diags, d => d.Id == "CN3006" && d.GetMessage().Contains("int defaults"));
     }
+
+    [Fact]
+    public void WrapperFacade_WithBodyAndDefaults_GeneratesFacade()
+    {
+        // Direct-binding "wrapper" facade: a partial method with a
+        // hand-written body and no [ComposeBridge]. The wrapper takes
+        // an `int defaults` (user-controlled mask) so the facade emits
+        // the auto-mask logic and the wrapper just passes it through.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BoxDefault", "modifier", "contentAlignment", "propagateMinConstraints", "!content")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeFacade(Defaults = typeof(BoxDefault))]
+                    public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
+
+                    public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)
+                    {
+                        // Pretend this calls BoxKt.Box — body irrelevant to the facade generator.
+                    }
+                }
+            }
+            """;
+        var (_, diags, emitted) = Run(code, "Box");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("public sealed partial class Box : global::ComposeNet.ComposableContainer", emitted);
+        Assert.Contains("global::ComposeNet.ComposeBridges.Box(", emitted);
+        // Auto-mask emits because the wrapper takes `int defaults`.
+        Assert.Contains("(int)global::ComposeNet.BoxDefault.All", emitted);
+        Assert.Contains("if (__modifier is not null) __defaults &= ~(int)global::ComposeNet.BoxDefault.Modifier", emitted);
+    }
+
+    [Fact]
+    public void WrapperFacade_NoDefaultsAttribute_GeneratesFacadeWithoutMask()
+    {
+        // Spacer-style wrapper: no $default in the bytecode, so no
+        // Defaults enum either. Facade generator should still emit a
+        // working facade — just without the auto-mask code.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeFacade]
+                    public static partial void Spacer(IModifier? modifier, IComposer composer);
+
+                    public static partial void Spacer(IModifier? modifier, IComposer composer) { }
+                }
+            }
+            """;
+        var (_, diags, emitted) = Run(code, "Spacer");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("public sealed partial class Spacer : global::ComposeNet.ComposableNode", emitted);
+        Assert.Contains("global::ComposeNet.ComposeBridges.Spacer(", emitted);
+        Assert.DoesNotContain("__defaults", emitted);
+    }
+
+    [Fact]
+    public void Facade_EnumCtorParameter_IsAcceptedAsPrimitive()
+    {
+        // TriStateCheckbox-style facade: the ctor takes an enum value
+        // (ToggleableState) plus an Action onClick. Enums should be
+        // classified as ctor primitives (TypeKind.Enum).
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            namespace MyApp { public enum MyState { On, Off, Mixed } }
+
+            [assembly: ComposeDefaults("TriDefault", "!state", "!onClick", "modifier")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeFacade(Defaults = typeof(TriDefault))]
+                    public static partial void TriStateCheckbox(
+                        MyApp.MyState state, IFunction0 onClick, IModifier? modifier, IComposer composer);
+
+                    public static partial void TriStateCheckbox(
+                        MyApp.MyState state, IFunction0 onClick, IModifier? modifier, IComposer composer) { }
+                }
+            }
+            """;
+        var (_, diags, emitted) = Run(code, "TriStateCheckbox");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("public sealed partial class TriStateCheckbox : global::ComposeNet.ComposableNode", emitted);
+        // Enum becomes a positional ctor primitive.
+        Assert.Contains("readonly global::MyApp.MyState _state", emitted);
+        Assert.Contains("global::MyApp.MyState state", emitted);
+    }
 }

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -1110,4 +1110,52 @@ public class FacadeGeneratorTests
         Assert.Contains("readonly global::MyApp.MyState _state", emitted);
         Assert.Contains("global::MyApp.MyState state", emitted);
     }
+
+    [Fact]
+    public void WrapperFacade_TryReadFromEnum_HandlesBit31()
+    {
+        // Regression: bit 31 of an int $default mask is negative when
+        // read as `int`. TryReadFromEnum must still decode it correctly.
+        // Verified by placing Modifier at bit 31 so the IModifier?
+        // auto-mask emits "& ~(int)WideDefault.Modifier" — without the
+        // fix, TryReadFromEnum drops the Modifier slot (v <= 0 filter)
+        // and the auto-mask clear is silently omitted.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            namespace MyApp
+            {
+                [Flags]
+                public enum WideDefault
+                {
+                    Other      = 1 << 0,
+                    Modifier   = unchecked((int)0x80000000), // bit 31
+                    All        = Other | Modifier,
+                }
+            }
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeFacade(Defaults = typeof(MyApp.WideDefault))]
+                    public static partial void Wide(int other, IModifier? modifier, int defaults, IComposer composer);
+
+                    public static partial void Wide(int other, IModifier? modifier, int defaults, IComposer composer) { }
+                }
+            }
+            """;
+        var (_, diags, emitted) = Run(code, "Wide");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // The auto-mask clear for the IModifier? slot proves bit 31 was
+        // decoded — without it, this clear would be missing.
+        Assert.True(
+            emitted!.Contains("WideDefault.Modifier"),
+            "Expected emitted facade to reference WideDefault.Modifier (bit 31 slot). Emitted:\n" + emitted);
+    }
 }

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -172,6 +172,20 @@ internal static class Attributes
                 /// ambiguity.
                 /// </summary>
                 public string? ColorParameter { get; set; }
+
+                /// <summary>
+                /// Phase 8 — fallback for the <c>$default</c> enum when
+                /// the facade method has no paired
+                /// <see cref="ComposeBridgeAttribute"/>. Used by tiny
+                /// pass-through "wrapper" bridges (extended partial methods
+                /// with hand-written bodies that delegate straight to a
+                /// bound binding instead of doing JNI). Set this to
+                /// <c>typeof(XxxDefault)</c> to drive the auto-mask logic
+                /// for direct-binding facades. Bridge-mode facades read
+                /// <c>Defaults</c> from their <c>[ComposeBridge]</c>
+                /// instead — this property is ignored in that case.
+                /// </summary>
+                public global::System.Type? Defaults { get; set; }
             }
 
             /// <summary>

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -126,13 +126,17 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             return Fail(Diagnostics.FacadeWrongContainingType, loc, method.Name, container.ToDisplayString());
         }
 
-        // CN3004 — paired with [ComposeBridge].
+        // CN3004 — paired with [ComposeBridge]. Relaxed for "wrapper"
+        // facades: a partial method with a hand-written body and no
+        // [ComposeBridge] is a tiny pass-through to a bound binding
+        // (e.g. BoxKt.Box) — its $default enum is read from
+        // [ComposeFacade].Defaults instead.
         AttributeData? bridge = null;
         if (c.BridgeAttr is not null)
         {
             bridge = method.GetAttributes()
                 .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.BridgeAttr));
-            if (bridge is null)
+            if (bridge is null && !HasMethodBody(method))
             {
                 return Fail(Diagnostics.FacadeMissingBridge, loc, method.Name);
             }
@@ -155,12 +159,21 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         var userParams = csParams.Take(csParams.Length - 1).ToArray();
 
         // Look up the bridge's Defaults enum so Phase 3 can emit the
-        // matching auto-mask code.
+        // matching auto-mask code. Bridge-mode reads it from
+        // [ComposeBridge].Defaults; wrapper-mode (no bridge) falls
+        // back to [ComposeFacade].Defaults.
         DefaultsInfo? defaults = null;
-        INamedTypeSymbol? defaultsType = bridge is null ? null : ReadType(bridge, "Defaults");
-        if (defaultsType is not null && c.DeclarativeAttr is not null)
+        INamedTypeSymbol? defaultsType = bridge is not null ? ReadType(bridge, "Defaults") : null;
+        defaultsType ??= ReadType(attr, "Defaults");
+        if (defaultsType is not null)
         {
-            defaults = DefaultsInfo.TryRead(c.Compilation, c.DeclarativeAttr, defaultsType.Name);
+            // Try declarative form first; fall back to walking the enum
+            // directly (covers generic-form-generated enums).
+            if (c.DeclarativeAttr is not null)
+            {
+                defaults = DefaultsInfo.TryRead(c.Compilation, c.DeclarativeAttr, defaultsType.Name);
+            }
+            defaults ??= DefaultsInfo.TryReadFromEnum(defaultsType);
         }
 
         // Look up a sibling "defaults: int" param the caller manages. If
@@ -733,6 +746,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     }
 
     static bool IsPrimitiveCtorType(ITypeSymbol type) =>
+        type.TypeKind == TypeKind.Enum ||
         type.SpecialType is SpecialType.System_String
             or SpecialType.System_Int32
             or SpecialType.System_Int64
@@ -778,6 +792,27 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
     static string EscapeIdent(string name) =>
         SyntaxFacts.GetKeywordKind(name) == SyntaxKind.None ? name : "@" + name;
+
+    static bool HasMethodBody(IMethodSymbol method)
+    {
+        if (HasBodyInRefs(method)) return true;
+        if (method.PartialImplementationPart is { } impl && HasBodyInRefs(impl)) return true;
+        if (method.PartialDefinitionPart is { } defn && HasBodyInRefs(defn)) return true;
+        return false;
+    }
+
+    static bool HasBodyInRefs(IMethodSymbol m)
+    {
+        foreach (var sr in m.DeclaringSyntaxReferences)
+        {
+            if (sr.GetSyntax() is MethodDeclarationSyntax mds &&
+                (mds.Body is not null || mds.ExpressionBody is not null))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 
     internal enum FacadeSlotKind
     {

--- a/src/ComposeNet.SourceGenerators/DefaultsInfo.cs
+++ b/src/ComposeNet.SourceGenerators/DefaultsInfo.cs
@@ -97,12 +97,15 @@ internal readonly struct DefaultsInfo
         {
             if (!member.IsConst) continue;
             if (member.Name == "All") continue;
-            if (member.ConstantValue is not int v || v <= 0) continue;
-            // Single-bit masks only — the All sentinel is filtered above
-            // and any future composite values are skipped.
+            if (member.ConstantValue is not int raw || raw == 0) continue;
+            // Treat the value as an unsigned bitmask so bit 31 (which is
+            // negative when read as `int`) is decoded correctly. Single-bit
+            // masks only — the All sentinel is filtered above and any
+            // composite values are skipped.
+            uint v = unchecked((uint)raw);
             if ((v & (v - 1)) != 0) continue;
             int bit = 0;
-            for (int x = v; x > 1; x >>= 1) bit++;
+            for (uint x = v; x > 1; x >>= 1) bit++;
             var kotlin = char.ToLowerInvariant(member.Name[0]) + member.Name.Substring(1);
             slots.Add(new DefaultsSlot(kotlin, bit, member.Name));
         }

--- a/src/ComposeNet.SourceGenerators/DefaultsInfo.cs
+++ b/src/ComposeNet.SourceGenerators/DefaultsInfo.cs
@@ -78,6 +78,39 @@ internal readonly struct DefaultsInfo
         return new DefaultsInfo(enumName, slots);
     }
 
+    /// <summary>
+    /// Read slot info directly from the generated enum's members. Used as
+    /// a fallback when the enum was declared via the generic form
+    /// (<c>[assembly: ComposeDefaults&lt;T&gt;("Method", "EnumName")]</c>),
+    /// which doesn't leave a declarative attribute behind for
+    /// <see cref="TryRead"/> to parse. Each non-<c>All</c> enum member's
+    /// constant value is treated as a single-bit mask and decoded via
+    /// log2; the member name (PascalCased) maps back to a camelCase
+    /// Kotlin parameter name.
+    /// </summary>
+    public static DefaultsInfo? TryReadFromEnum(INamedTypeSymbol enumType)
+    {
+        if (enumType.TypeKind != TypeKind.Enum) return null;
+
+        var slots = new List<DefaultsSlot>();
+        foreach (var member in enumType.GetMembers().OfType<IFieldSymbol>())
+        {
+            if (!member.IsConst) continue;
+            if (member.Name == "All") continue;
+            if (member.ConstantValue is not int v || v <= 0) continue;
+            // Single-bit masks only — the All sentinel is filtered above
+            // and any future composite values are skipped.
+            if ((v & (v - 1)) != 0) continue;
+            int bit = 0;
+            for (int x = v; x > 1; x >>= 1) bit++;
+            var kotlin = char.ToLowerInvariant(member.Name[0]) + member.Name.Substring(1);
+            slots.Add(new DefaultsSlot(kotlin, bit, member.Name));
+        }
+        if (slots.Count == 0) return null;
+        slots.Sort((a, b) => a.Bit.CompareTo(b.Bit));
+        return new DefaultsInfo(enumType.Name, slots);
+    }
+
     static string Pascal(string s)
     {
         if (string.IsNullOrEmpty(s)) return s;


### PR DESCRIPTION
Towards #67.

Adds a **wrapper-passthrough** facade mode: a `[ComposeFacade]`-only
partial method on `ComposeBridges` with a tiny hand-written body that
delegates to a bound binding (e.g. `BoxKt.Box`, `CheckboxKt.Checkbox`).
The facade generator emits the full `ComposableNode` / `ComposableContainer`
subclass — base class, ctor, `Render()` body, `$default` mask, lambda
wrapping — so each hand-written facade drops from ~30 lines to ~10.

## Converted in this PR (11 facades)

Wrapper-passthrough bridges added in `ComposeBridges.cs`:

- `Box`, `Column`, `Row`, `Spacer`
- `Checkbox`, `Switch`, `RadioButton`, `Slider`

`[ComposeFacade]` + `[Slot("Body")]` added to existing bridges:

- `DatePickerDialog`, `TimePickerDialog`

Total `[ComposeFacade]` usages: **56 → 67**.

The generated output is byte-identical to what the hand-written
`Render()` bodies were emitting; `PublicAPI.Unshipped.txt` is unchanged.

## Generator changes

- `ComposeFacadeAttribute.Defaults` (new) — lets a wrapper supply its
  `$default` enum directly without needing a sibling `[ComposeBridge]`.
- `ComposeFacadeGenerator` — relaxed the "must have `[ComposeBridge]`"
  rule for partials with a body and a `Defaults` argument.
  `IsPrimitiveCtorType` now accepts `TypeKind.Enum`. `HasMethodBody`
  walks both partial halves so the body check works regardless of
  which partial declaration the symbol API surfaces.
- `DefaultsInfo.TryReadFromEnum` — best-effort fallback that walks an
  enum's `[Flags]` members directly. In practice Box/Column/Row use
  declarative-form `[assembly: ComposeDefaults]` because source
  generators can't see each other's outputs in a single compilation
  pass (the generic form would resolve to `ErrorTypeSymbol` when the
  facade generator runs). Converted those three to declarative form.
- 3 new generator tests: wrapper mode w/ defaults, wrapper mode w/o
  defaults, enum ctor param.

## Docs

- `.github/copilot-instructions.md` — added Phase 8 entry to the
  facade-generator section, including the cross-generator caveat
  about `[ComposeDefaults]` form.

## Validation

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — all 64 tests pass
- `dotnet build src/ComposeNet.Compose` — clean
- `dotnet build src/ComposeNet.Sample` — clean

## What's still hand-written

Issue #67 originally targeted ~85 hand-written facades; ~35 remain
after this PR. The leftovers are the ones the generator can't model
without additional shapes:

- State-holder facades that need `remember*State` resolution
  (Phase 4 work — `DatePicker`, `TimePicker`, `SearchBar`,
  `SnackbarHost`, `ModalBottomSheet`).
- Drawer facades with `confirmStateChange` JNI adapters.
- Scope facades with non-trivial bodies (`SegmentedButton`,
  `SingleChoice`/`MultiChoiceSegmentedButtonRow`).
- `TopAppBar` (branches between two bridges based on optional slot).
- `BottomAppBar` (required content + optional Function2 slot — hybrid).
- `TriStateCheckbox` (`ToggleableState` is a Java enum wrapper class,
  not a C# enum; would need Java-enum class detection).