### PR TITLE
Facade generator Phase 4: state-holder facades

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -323,6 +323,7 @@ The generator classifies each user param of the bridge:
 | `IFunction2?` / `IFunction3?` (any nullable, OR `[Slot]`, OR >1 content slot) | Surfaced as a named `ComposableNode?` property — multi-slot leaf shape |
 | `IntPtr` with name ending in `Scope`    | Kotlin extension receiver; auto-bound to `RenderContext.CurrentScope` (no ctor slot) |
 | `IntPtr` + `[PainterResource]`          | Synthetic `int painterResourceId` ctor arg + `PainterResource` resolution + try/finally |
+| `IntPtr` + `[StateHolder(Remember = …, StateType = typeof(…))]` | State-holder shape (Phase 4): the facade exposes the wrapper type as a defaulted ctor slot (`StateType? state = null`), calls the named `RememberXxxState(composer)` bridge on first render, populates the wrapper's `Jvm` field, and forwards the JNI handle to this parameter. |
 | Primitive (`string`, `int`, `long`, `bool`, `float`, `double`)  | Surfaced as a ctor parameter, stored in `_<name>` |
 | Anything else (callbacks, handles, etc.) | Rejected with CN3002                              |
 
@@ -354,6 +355,23 @@ Parameter-level attributes the generator recognizes:
   `int painterResourceId` ctor arg in its place and emits the
   `PainterResource(id, composer)` + try/finally + `DeleteLocalRef`
   preamble around the bridge call.
+- `[StateHolder(Remember = nameof(ComposeBridges.X), StateType = typeof(T))]`
+  — annotate the `IntPtr` user param that carries a Kotlin
+  state-holder handle (e.g. `DatePickerState`,
+  `DateRangePickerState`). The facade gains a defaulted ctor slot
+  `T? state = null` (appended last), calls
+  `ComposeBridges.<Remember>(composer)` at the top of `Render` to
+  obtain the JNI handle, populates `state.Jvm` via
+  `Java.Lang.Object.GetObject<TJvm>(handle, JniHandleOwnership.DoNotTransfer)`
+  the first time it sees a non-null wrapper, and forwards the handle
+  to this parameter. Phase 4 supports only Remember bridges with
+  signature `(IComposer) -> IntPtr` — Remember bridges that take user
+  parameters (e.g. `RememberTimePickerState(int, int, bool, IComposer)`)
+  are blocked on Phase 4b and stay hand-written. The
+  `StateType` must declare an instance, writable, non-readonly,
+  accessible field named `Jvm` whose declared type is the
+  binding-generated state interface (e.g. `IDatePickerState`). Cannot
+  be combined with `[PainterResource]` on the same parameter.
 
 Each facade is emitted to a unique hint name
 (`ComposeNet.Facade.<ClassName>.g.cs`) so the `[CallerFilePath]` +
@@ -363,7 +381,7 @@ stay distinct per facade.
 ### When to use it
 
 The generator now supports a wide range of facade shapes (Phases 1,
-2, 3, 6, 7, 8 are implemented):
+2, 3, 4, 6, 7, 8 are implemented):
 
 - **Phase 1** — container with content lambda + ctor primitives
   (`Button`, `Card`, `Text`, `Column`, `Row`, `Box`).
@@ -373,6 +391,13 @@ The generator now supports a wide range of facade shapes (Phases 1,
 - **Phase 3** — multi-slot leafs with named `ComposableNode?`
   properties (`AlertDialog`, `AssistChip`, `ListItem`, `Snackbar`,
   `BadgedBox`, `Tab`, `NavigationBarItem`, the top-app-bar family).
+- **Phase 4** — `[StateHolder(...)]` state-holder facades that need
+  a `RememberXxxState(composer)` round-trip and a `.Jvm` population
+  for the caller-supplied wrapper (`DatePicker`, `DateRangePicker`).
+  Limited to Remember bridges with signature `(IComposer) -> IntPtr`;
+  parameterised remembers (`TimePicker`, `TimeInput`, `SearchBar`,
+  `SnackbarHost`, `ModalBottomSheet`, `BottomSheetScaffold`) stay
+  hand-written until Phase 4b.
 - **Phase 6** — `[ComposeFacade(DefaultColorFromTheme = "...")]`
   for drawer sheets and similar containers that fall back to a
   `ColorScheme` slot when the caller doesn't override.
@@ -398,9 +423,12 @@ The generator now supports a wide range of facade shapes (Phases 1,
 Facades that still stay hand-written are the ones the generator
 can't model:
 
-- State-holder facades that need `remember*State` resolution and a
-  `Jvm` round-trip (`DatePicker`, `TimePicker`, `SearchBar`,
-  `SnackbarHost`, `ModalBottomSheet`). These are Phase 4 work.
+- State-holder facades whose `RememberXxxState` bridge takes user
+  initialisation params (`TimePicker` / `TimeInput` need
+  `initialHour`/`initialMinute`/`is24Hour`; `SearchBar` and
+  `ModalBottomSheet`/`BottomSheetScaffold` similarly). Phase 4
+  supports the zero-user-param shape (`DatePicker`,
+  `DateRangePicker`); parameterised remembers wait for Phase 4b.
 - Scope facades whose bodies do non-trivial work beyond
   `RenderContext.PushScope` (`SegmentedButton`,
   `SingleChoice`/`MultiChoiceSegmentedButtonRow`, the segmented
@@ -422,7 +450,8 @@ can't model:
 Trying to apply `[ComposeFacade]` to an unsupported bridge will
 emit CN3002 (unsupported parameter), CN3003 (scope misuse), CN3005
 (invalid callback type), CN3006 (slot conflict), CN3007 (color
-theme binding failed), or CN3008 (painter misuse) at build time —
+theme binding failed), CN3008 (painter misuse), or CN3009
+(state-holder misuse) at build time —
 back out the attribute and write the facade by hand.
 
 ### Adding a new generated facade
@@ -453,7 +482,7 @@ end-to-end recipe is:
    the stub** — without it the generated class has no XML docs.
 4. **Build the sample** (`dotnet build src/ComposeNet.Sample`) to
    verify the bridge + facade compile together. The supported
-   shapes are validated at build time; CN3001-CN3008 will fire if
+   shapes are validated at build time; CN3001-CN3009 will fire if
    the generator can't accept the bridge.
 5. **If CN3002 fires**, the bridge has a parameter outside the
    table above — either an unmarked `IFunction1` callback, a
@@ -478,6 +507,7 @@ end-to-end recipe is:
 | CN3006  | `[Slot]` placement conflicts with the facade's classified shape, `[Callback]` placed on a non-`IFunction1` param, multiple `[PainterResource]` params on one bridge, or `int defaults` declared without a resolvable `Defaults` enum. |
 | CN3007  | `DefaultColorFromTheme` cannot bind to any `long` user param (or `ColorParameter` is ambiguous / missing). |
 | CN3008  | `[PainterResource]` annotates a non-`IntPtr` parameter.            |
+| CN3009  | `[StateHolder]` is invalid: applied to a non-`IntPtr` param, combined with `[PainterResource]`, missing or unidentifier-valued `Remember` / `StateType`, the named `Remember` method is not a static `(IComposer) -> IntPtr` on `ComposeBridges`, or `StateType` has no accessible writable instance field named `Jvm`. |
 
 ### Migration rule
 

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -798,8 +798,14 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/focus/FocusRequester;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(DatePickerDefault))]
-    public static partial void DatePicker(IntPtr state, IModifier? modifier,
-                                          int defaults, IComposer composer);
+    [ComposeFacade]
+    public static partial void DatePicker(
+        [StateHolder(Remember = nameof(RememberDatePickerState),
+                     StateType = typeof(DatePickerState))]
+        IntPtr      state,
+        IModifier?  modifier,
+        int         defaults,
+        IComposer   composer);
 
     // androidx.compose.material3.DatePickerKt.rememberDatePickerState-EU0dCGE
     [ComposeBridge(
@@ -810,6 +816,36 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/DatePickerState;",
         Defaults  = typeof(RememberDatePickerStateDefault))]
     public static partial IntPtr RememberDatePickerState(IComposer composer);
+
+    // androidx.compose.material3.DateRangePickerKt.DateRangePicker
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/DateRangePickerKt",
+        JvmName   = "DateRangePicker",
+        Signature = "(Landroidx/compose/material3/DateRangePickerState;Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/material3/DatePickerFormatter;" +
+                    "Landroidx/compose/material3/DatePickerColors;" +
+                    "Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Z" +
+                    "Landroidx/compose/ui/focus/FocusRequester;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(DateRangePickerDefault))]
+    [ComposeFacade]
+    public static partial void DateRangePicker(
+        [StateHolder(Remember = nameof(RememberDateRangePickerState),
+                     StateType = typeof(DateRangePickerState))]
+        IntPtr      state,
+        IModifier?  modifier,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.DateRangePickerKt.rememberDateRangePickerState-IlFM19s
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/DateRangePickerKt",
+        JvmName   = "rememberDateRangePickerState-IlFM19s",
+        Signature = "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lkotlin/ranges/IntRange;I" +
+                    "Landroidx/compose/material3/SelectableDates;" +
+                    "Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/DateRangePickerState;",
+        Defaults  = typeof(RememberDateRangePickerStateDefault))]
+    public static partial IntPtr RememberDateRangePickerState(IComposer composer);
 
     // androidx.compose.material3.TimePickerKt.rememberTimePickerState
     [ComposeBridge(

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -193,6 +193,12 @@ using ComposeNet;
     "!state", "modifier", "dateFormatter", "colors", "title",
     "headline", "showModeToggle", "requestFocus")]
 
+// androidx.compose.material3.DateRangePickerKt.DateRangePicker:
+// 8 user params; bit 0 (state) always provided.
+[assembly: ComposeDefaults("DateRangePickerDefault",
+    "!state", "modifier", "dateFormatter", "colors", "title",
+    "headline", "showModeToggle", "requestFocus")]
+
 // androidx.compose.material3.TimePickerKt.TimePicker-mT9BvqQ:
 // 4 user params; bit 0 (state) always provided.
 [assembly: ComposeDefaults("TimePickerDefault",
@@ -359,6 +365,13 @@ using ComposeNet;
 // 5 user params, all defaulted by the wrapper (which exposes none).
 [assembly: ComposeDefaults("RememberDatePickerStateDefault",
     "initialSelectedDateMillis", "initialDisplayedMonthMillis", "yearRange",
+    "initialDisplayMode", "selectableDates")]
+
+// androidx.compose.material3.DateRangePickerKt.rememberDateRangePickerState-IlFM19s:
+// 6 user params, all defaulted by the wrapper (which exposes none).
+[assembly: ComposeDefaults("RememberDateRangePickerStateDefault",
+    "initialSelectedStartDateMillis", "initialSelectedEndDateMillis",
+    "initialDisplayedMonthMillis", "yearRange",
     "initialDisplayMode", "selectableDates")]
 
 // androidx.compose.material3.TimePickerKt.rememberTimePickerState:

--- a/src/ComposeNet.Compose/DatePicker.cs
+++ b/src/ComposeNet.Compose/DatePicker.cs
@@ -1,32 +1,17 @@
-using Android.Runtime;
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>DatePicker</c>. The Kotlin <c>DatePickerKt.DatePicker</c>
-/// composable IS exposed by the binding, but its <c>$default</c> bitmask
-/// param isn't user-visible (the binding drops the trailing
-/// <c>$default</c> parameter on @Composable functions), so we go through
-/// raw JNI to set it. Place inside <see cref="DatePickerDialog"/>'s body.
-/// Pass an explicit <see cref="ComposeNet.DatePickerState"/> to read the
-/// selection from a button callback; if none is supplied a fresh state
-/// is created internally and the selection is unobservable.
+/// Material 3 <c>DatePicker</c>. Place inside <see cref="DatePickerDialog"/>'s
+/// body. Pass an explicit <see cref="ComposeNet.DatePickerState"/> to
+/// read the selection from a button callback; if none is supplied a
+/// fresh state is created internally and the selection is unobservable.
 /// </summary>
-public sealed class DatePicker : ComposableNode
-{
-    readonly DatePickerState? _state;
-    public DatePicker(DatePickerState? state = null) => _state = state;
-
-    internal override void Render(IComposer composer)
-    {
-        var stateHandle = ComposeBridges.RememberDatePickerState(composer);
-        if (_state is not null && _state.Jvm is null)
-            _state.Jvm = Java.Lang.Object.GetObject<IDatePickerState>(stateHandle, JniHandleOwnership.DoNotTransfer)!;
-        var modifier = BuildModifier();
-        int defaults = (int)DatePickerDefault.All;
-        if (modifier is not null) defaults &= ~(int)DatePickerDefault.Modifier;
-        ComposeBridges.DatePicker(stateHandle, modifier, defaults, composer);
-    }
-}
+/// <remarks>
+/// The generated <c>Render()</c> calls
+/// <c>ComposeBridges.RememberDatePickerState</c> to obtain the JVM
+/// state handle, populates the wrapper's <c>Jvm</c> field on first
+/// render (so subsequent property reads on the wrapper hit the live
+/// state), and forwards the handle into the
+/// <c>androidx.compose.material3.DatePickerKt.DatePicker</c> composable.
+/// </remarks>
+public sealed partial class DatePicker;

--- a/src/ComposeNet.Compose/DateRangePicker.cs
+++ b/src/ComposeNet.Compose/DateRangePicker.cs
@@ -1,0 +1,20 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>DateRangePicker</c>. Place inside
+/// <see cref="DatePickerDialog"/>'s body. Pass an explicit
+/// <see cref="ComposeNet.DateRangePickerState"/> to read the picked
+/// range from a button callback; if none is supplied a fresh state is
+/// created internally and the selection is unobservable. Same shape as
+/// <see cref="DatePicker"/> — see that facade for the broader pattern.
+/// </summary>
+/// <remarks>
+/// The generated <c>Render()</c> calls
+/// <c>ComposeBridges.RememberDateRangePickerState</c> to obtain the JVM
+/// state handle, populates the wrapper's <c>Jvm</c> field on first
+/// render (so subsequent property reads on the wrapper hit the live
+/// state), and forwards the handle into the
+/// <c>androidx.compose.material3.DateRangePickerKt.DateRangePicker</c>
+/// composable.
+/// </remarks>
+public sealed partial class DateRangePicker;

--- a/src/ComposeNet.Compose/DateRangePickerState.cs
+++ b/src/ComposeNet.Compose/DateRangePickerState.cs
@@ -1,0 +1,89 @@
+using AndroidX.Compose.Material3;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Caller-supplied state holder for <see cref="DateRangePicker"/>. The
+/// underlying JVM <c>androidx.compose.material3.DateRangePickerState</c>
+/// is created lazily the first time a <see cref="DateRangePicker"/>
+/// bound to this state is rendered; reads/writes to
+/// <see cref="SelectedStartDateMillis"/> /
+/// <see cref="SelectedEndDateMillis"/> before that point are
+/// no-ops/fallbacks.
+/// </summary>
+/// <remarks>
+/// Typical usage — <c>Remember</c> a state instance, pass it to a
+/// <see cref="DateRangePicker"/>, and read the picked range from the
+/// dialog's <c>ConfirmButton.OnClick</c>:
+/// <code>
+/// var rangeState = Remember(() =&gt; new DateRangePickerState());
+///
+/// new DatePickerDialog(onDismissRequest: ...)
+/// {
+///     ConfirmButton = new Button(onClick: () =&gt;
+///     {
+///         var start = rangeState.SelectedStartDateMillis;
+///         var end   = rangeState.SelectedEndDateMillis;
+///         // start/end are Unix epoch milliseconds (UTC), nullable.
+///     })
+///     { new Text("OK") },
+///     Body          = new DateRangePicker(rangeState),
+/// }
+/// </code>
+/// </remarks>
+public sealed class DateRangePickerState
+{
+    internal IDateRangePickerState? Jvm;
+
+    /// <summary>
+    /// The start of the currently selected range as Unix epoch
+    /// milliseconds (UTC), or <c>null</c> if no start date is selected.
+    /// Mirrors Kotlin's <c>DateRangePickerState.selectedStartDateMillis: Long?</c>.
+    /// Returns <c>null</c> until the first <see cref="DateRangePicker"/>
+    /// render binds this state to the JVM picker. Setting either end of
+    /// the range goes through the JVM <c>setSelection</c> helper to keep
+    /// the start/end pair consistent.
+    /// </summary>
+    public long? SelectedStartDateMillis
+    {
+        get => Jvm?.SelectedStartDateMillis?.LongValue();
+        set => SetSelection(value, SelectedEndDateMillis);
+    }
+
+    /// <summary>
+    /// The end of the currently selected range as Unix epoch
+    /// milliseconds (UTC), or <c>null</c> if no end date is selected.
+    /// Mirrors Kotlin's <c>DateRangePickerState.selectedEndDateMillis: Long?</c>.
+    /// Returns <c>null</c> until the state is bound.
+    /// </summary>
+    public long? SelectedEndDateMillis
+    {
+        get => Jvm?.SelectedEndDateMillis?.LongValue();
+        set => SetSelection(SelectedStartDateMillis, value);
+    }
+
+    /// <summary>
+    /// First-of-month milliseconds for the month currently shown by the
+    /// picker. Mirrors Kotlin's <c>DateRangePickerState.displayedMonthMillis</c>.
+    /// Returns <c>0</c> until the state is bound.
+    /// </summary>
+    public long DisplayedMonthMillis
+    {
+        get => Jvm?.DisplayedMonthMillis ?? 0L;
+        set { if (Jvm is not null) Jvm.DisplayedMonthMillis = value; }
+    }
+
+    /// <summary>
+    /// Sets both ends of the selected range in a single JVM round-trip.
+    /// Use this when both endpoints change at once to avoid the
+    /// intermediate "start without end" / "end without start" state the
+    /// individual property setters would otherwise produce.
+    /// </summary>
+    public void SetSelection(long? startDateMillis, long? endDateMillis)
+    {
+        if (Jvm is null) return;
+        var start = startDateMillis is long s ? Java.Lang.Long.ValueOf(s) : null;
+        var end   = endDateMillis   is long e ? Java.Lang.Long.ValueOf(e) : null;
+        Jvm.SetSelection(start, end);
+    }
+}

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -97,6 +97,17 @@ ComposeNet.DatePickerState.DisplayedMonthMillis.get -> long
 ComposeNet.DatePickerState.DisplayedMonthMillis.set -> void
 ComposeNet.DatePickerState.SelectedDateMillis.get -> long?
 ComposeNet.DatePickerState.SelectedDateMillis.set -> void
+ComposeNet.DateRangePicker
+ComposeNet.DateRangePicker.DateRangePicker(ComposeNet.DateRangePickerState? state = null) -> void
+ComposeNet.DateRangePickerState
+ComposeNet.DateRangePickerState.DateRangePickerState() -> void
+ComposeNet.DateRangePickerState.DisplayedMonthMillis.get -> long
+ComposeNet.DateRangePickerState.DisplayedMonthMillis.set -> void
+ComposeNet.DateRangePickerState.SelectedEndDateMillis.get -> long?
+ComposeNet.DateRangePickerState.SelectedEndDateMillis.set -> void
+ComposeNet.DateRangePickerState.SelectedStartDateMillis.get -> long?
+ComposeNet.DateRangePickerState.SelectedStartDateMillis.set -> void
+ComposeNet.DateRangePickerState.SetSelection(long? startDateMillis, long? endDateMillis) -> void
 ComposeNet.DismissibleDrawerSheet
 ComposeNet.DismissibleDrawerSheet.ContainerColor.get -> long
 ComposeNet.DismissibleDrawerSheet.ContainerColor.set -> void

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -34,7 +34,7 @@ public class FacadeGeneratorTests
                 public static unsafe System.IntPtr CallObjectMethod(System.IntPtr inst, System.IntPtr m, Android.Runtime.JValue* args) => default;
                 public static unsafe System.IntPtr NewObject(System.IntPtr cls, System.IntPtr m, Android.Runtime.JValue* args) => default;
             }
-            public enum JniHandleOwnership { TransferLocalRef = 0 }
+            public enum JniHandleOwnership { TransferLocalRef = 0, DoNotTransfer = 1 }
             public readonly struct JValue
             {
                 public JValue(System.IntPtr v) { } public JValue(bool v) { } public JValue(int v) { }
@@ -1157,5 +1157,220 @@ public class FacadeGeneratorTests
         Assert.True(
             emitted!.Contains("WideDefault.Modifier"),
             "Expected emitted facade to reference WideDefault.Modifier (bit 31 slot). Emitted:\n" + emitted);
+    }
+
+    // ─── Phase 4 — [StateHolder] state-holder facades ─────────────────
+
+    /// <summary>Shared snippet stubbing a DatePicker-style state class.</summary>
+    const string DatePickerStateStubs = """
+        namespace AndroidX.Compose.Material3
+        {
+            public interface IDatePickerState { }
+        }
+        namespace ComposeNet
+        {
+            public sealed class DatePickerState
+            {
+                internal AndroidX.Compose.Material3.IDatePickerState? Jvm;
+            }
+        }
+        """;
+
+    const string DatePickerSig =
+        "(Landroidx/compose/material3/DatePickerState;Landroidx/compose/ui/Modifier;Landroidx/compose/material3/DatePickerFormatter;Landroidx/compose/material3/DatePickerColors;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLandroidx/compose/runtime/Composer;II)V";
+
+    [Fact]
+    public void DatePicker_StateHolder_GeneratesRememberRoundTrip()
+    {
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DatePickerDefault",
+                "!state", "modifier", "dateFormatter", "colors", "title", "headline", "showModeToggle")]
+
+            {{DatePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/DatePickerKt",
+                                   JvmName="DatePicker",
+                                   Signature="{{DatePickerSig}}",
+                                   Defaults=typeof(DatePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void DatePicker(
+                        [StateHolder(Remember = nameof(RememberDatePickerState),
+                                     StateType = typeof(DatePickerState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDatePickerState(IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "DatePicker");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Ctor: state slot LAST, with default = null.
+        Assert.Contains("readonly global::ComposeNet.DatePickerState? _state;", emitted);
+        Assert.Contains("public DatePicker(global::ComposeNet.DatePickerState? state = null)", emitted);
+
+        // Render: Remember + .Jvm population.
+        Assert.Contains(
+            "var __state = global::ComposeNet.ComposeBridges.RememberDatePickerState(composer);",
+            emitted);
+        Assert.Contains("if (_state is not null && _state.Jvm is null)", emitted);
+        Assert.Contains(
+            "_state.Jvm = global::Java.Lang.Object.GetObject<global::AndroidX.Compose.Material3.IDatePickerState>(__state, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;",
+            emitted);
+
+        // Bridge call uses __state in the IntPtr slot.
+        Assert.Contains(
+            "global::ComposeNet.ComposeBridges.DatePicker(__state, __modifier, __defaults, composer);",
+            emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void StateHolder_OnNonIntPtr_FailsCN3009()
+    {
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("DatePickerDefault",
+                "!state", "modifier", "dateFormatter", "colors", "title", "headline", "showModeToggle")]
+
+            {{DatePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/DatePickerKt", JvmName="DatePicker",
+                                   Signature="{{DatePickerSig}}",
+                                   Defaults=typeof(DatePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void DatePicker(
+                        [StateHolder(Remember = nameof(RememberDatePickerState),
+                                     StateType = typeof(DatePickerState))]
+                        int state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static System.IntPtr RememberDatePickerState(IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "DatePicker");
+        Assert.Null(emitted);
+        Assert.Contains(diags, d => d.Id == "CN3009"
+            && d.GetMessage().Contains("must annotate an 'IntPtr' parameter"));
+    }
+
+    [Fact]
+    public void StateHolder_MissingJvmField_FailsCN3009()
+    {
+        // Wrapper class with NO Jvm field — generator must reject.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DatePickerDefault",
+                "!state", "modifier", "dateFormatter", "colors", "title", "headline", "showModeToggle")]
+
+            namespace AndroidX.Compose.Material3 { public interface IDatePickerState { } }
+            namespace ComposeNet { public sealed class BadState { } }
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/DatePickerKt", JvmName="DatePicker",
+                                   Signature="{{DatePickerSig}}",
+                                   Defaults=typeof(DatePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void DatePicker(
+                        [StateHolder(Remember = nameof(RememberDatePickerState),
+                                     StateType = typeof(BadState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDatePickerState(IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "DatePicker");
+        Assert.Null(emitted);
+        Assert.Contains(diags, d => d.Id == "CN3009"
+            && d.GetMessage().Contains("no instance field named 'Jvm'"));
+    }
+
+    [Fact]
+    public void StateHolder_NonSuppressedStateBit_ClearedByMask()
+    {
+        // If a future declaration forgets the "!" prefix and exposes
+        // the state bit as an enum member, the StateHolder belt+suspenders
+        // mask path MUST still clear it so the bridge sees "supplied".
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DatePickerDefault",
+                "state", "modifier", "dateFormatter", "colors", "title", "headline", "showModeToggle")]
+
+            {{DatePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/DatePickerKt", JvmName="DatePicker",
+                                   Signature="{{DatePickerSig}}",
+                                   Defaults=typeof(DatePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void DatePicker(
+                        [StateHolder(Remember = nameof(RememberDatePickerState),
+                                     StateType = typeof(DatePickerState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDatePickerState(IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "DatePicker");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains(
+            "__defaults &= ~(int)global::ComposeNet.DatePickerDefault.State;",
+            emitted);
     }
 }

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -236,6 +236,43 @@ internal static class Attributes
             {
                 public PainterResourceAttribute() { }
             }
+
+            /// <summary>
+            /// Phase 4 — apply to the <c>IntPtr</c> bridge parameter that
+            /// carries a Kotlin state-holder handle (e.g.
+            /// <c>DatePickerState</c>, <c>DateRangePickerState</c>). The
+            /// facade calls the named <c>Remember*State</c> bridge on
+            /// <c>ComposeBridges</c> to resolve the handle, optionally
+            /// binds it to a caller-supplied wrapper of type
+            /// <see cref="StateType"/>, and forwards the handle to this
+            /// parameter. The wrapper is exposed as a defaulted ctor
+            /// argument (<c>StateType? state = null</c>).
+            /// </summary>
+            /// <remarks>
+            /// <para><b>Remember</b>: the <c>nameof(ComposeBridges.X)</c>
+            /// of a static partial bridge on <c>ComposeBridges</c> with
+            /// signature <c>(IComposer composer) -&gt; IntPtr</c>. Phase
+            /// 4 supports only zero-user-param remembers; bridges that
+            /// take initialization values (e.g.
+            /// <c>RememberTimePickerState(int, int, bool, composer)</c>)
+            /// stay hand-written until Phase 4b.</para>
+            /// <para><b>StateType</b>: the C# wrapper class that exposes
+            /// the state-holder's properties. It must declare an
+            /// instance, writable, non-readonly field named <c>Jvm</c>
+            /// whose declared type is the binding-generated interface
+            /// (e.g. <c>IDatePickerState</c>) — the generator emits
+            /// <c>state.Jvm = Java.Lang.Object.GetObject&lt;IXxxState&gt;
+            /// (handle, JniHandleOwnership.DoNotTransfer)!</c> the first
+            /// time <c>Render</c> sees a non-null wrapper.</para>
+            /// </remarks>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class StateHolderAttribute : global::System.Attribute
+            {
+                public StateHolderAttribute() { }
+                public string Remember { get; set; } = "";
+                public global::System.Type StateType { get; set; } = null!;
+            }
         }
         """;
 }

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -47,6 +47,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     const string SlotAttributeMetadataName = "ComposeNet.SlotAttribute";
     const string CallbackAttributeMetadataName = "ComposeNet.CallbackAttribute";
     const string PainterResourceAttributeMetadataName = "ComposeNet.PainterResourceAttribute";
+    const string StateHolderAttributeMetadataName = "ComposeNet.StateHolderAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -70,6 +71,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             var slotAttr = compilation.GetTypeByMetadataName(SlotAttributeMetadataName);
             var callbackAttr = compilation.GetTypeByMetadataName(CallbackAttributeMetadataName);
             var painterAttr = compilation.GetTypeByMetadataName(PainterResourceAttributeMetadataName);
+            var stateHolderAttr = compilation.GetTypeByMetadataName(StateHolderAttributeMetadataName);
             if (facadeAttr is null) return;
 
             var method = (IMethodSymbol)ctx.SemanticModel.GetDeclaredSymbol((MethodDeclarationSyntax)ctx.Node)!;
@@ -77,7 +79,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, facadeAttr));
             if (attr is null) return;
 
-            var ctxObj = new Context(method, attr, bridgeAttr, declarativeAttr, slotAttr, callbackAttr, painterAttr, compilation);
+            var ctxObj = new Context(method, attr, bridgeAttr, declarativeAttr, slotAttr, callbackAttr, painterAttr, stateHolderAttr, compilation);
             var result = Build(ctxObj);
             foreach (var diag in result.Diagnostics)
                 spc.ReportDiagnostic(diag);
@@ -95,11 +97,12 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         public INamedTypeSymbol? SlotAttr { get; }
         public INamedTypeSymbol? CallbackAttr { get; }
         public INamedTypeSymbol? PainterAttr { get; }
+        public INamedTypeSymbol? StateHolderAttr { get; }
         public Compilation Compilation { get; }
 
         public Context(IMethodSymbol method, AttributeData attr, INamedTypeSymbol? bridgeAttr,
             INamedTypeSymbol? declarativeAttr, INamedTypeSymbol? slotAttr, INamedTypeSymbol? callbackAttr,
-            INamedTypeSymbol? painterAttr, Compilation compilation)
+            INamedTypeSymbol? painterAttr, INamedTypeSymbol? stateHolderAttr, Compilation compilation)
         {
             Method = method;
             Attr = attr;
@@ -108,6 +111,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             SlotAttr = slotAttr;
             CallbackAttr = callbackAttr;
             PainterAttr = painterAttr;
+            StateHolderAttr = stateHolderAttr;
             Compilation = compilation;
         }
     }
@@ -315,6 +319,107 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
     static FacadeSlot? Classify(IParameterSymbol p, Context c, string methodName, Location loc, List<Diagnostic> diags)
     {
+        // [StateHolder] — annotates the IntPtr bridge param carrying a
+        // Kotlin state-holder handle. The facade emits a RememberXxxState
+        // round-trip and an optional `.Jvm` population for a wrapper.
+        AttributeData? stateAttr = null;
+        if (c.StateHolderAttr is not null)
+        {
+            stateAttr = p.GetAttributes()
+                .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.StateHolderAttr));
+        }
+        if (stateAttr is not null)
+        {
+            // Mutex with [PainterResource].
+            if (c.PainterAttr is not null &&
+                p.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.PainterAttr)))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"parameter '{p.Name}' has both [StateHolder] and [PainterResource]; pick one"));
+                return null;
+            }
+            if (p.Type.SpecialType != SpecialType.System_IntPtr)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] must annotate an 'IntPtr' parameter; '{p.Name}' is '{p.Type.ToDisplayString()}'"));
+                return null;
+            }
+            string? remember = ReadString(stateAttr, "Remember");
+            INamedTypeSymbol? stateType = ReadType(stateAttr, "StateType");
+            if (string.IsNullOrEmpty(remember))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}' is missing required property 'Remember'"));
+                return null;
+            }
+            if (stateType is null)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}' is missing required property 'StateType'"));
+                return null;
+            }
+            if (!SyntaxFacts.IsValidIdentifier(remember!))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': Remember value '{remember}' is not a valid C# identifier"));
+                return null;
+            }
+
+            // Validate the Remember bridge resolves to a static
+            // `(IComposer) -> IntPtr` method on ComposeNet.ComposeBridges.
+            var bridgesType = c.Compilation.GetTypeByMetadataName("ComposeNet.ComposeBridges");
+            if (bridgesType is null)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': cannot resolve type 'ComposeNet.ComposeBridges'"));
+                return null;
+            }
+            var rememberMethods = bridgesType.GetMembers(remember!).OfType<IMethodSymbol>().ToArray();
+            if (rememberMethods.Length == 0)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': no static method 'ComposeBridges.{remember}' found"));
+                return null;
+            }
+            var rememberFit = rememberMethods.FirstOrDefault(m =>
+                m.IsStatic &&
+                m.Parameters.Length == 1 &&
+                ComposeDefaultsGenerator.IsComposer(m.Parameters[0].Type) &&
+                m.ReturnType.SpecialType == SpecialType.System_IntPtr);
+            if (rememberFit is null)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': 'ComposeBridges.{remember}' must be a static method with signature '(IComposer) -> IntPtr' (Phase 4 supports only zero-user-param remembers)"));
+                return null;
+            }
+
+            // Validate StateType has a writable instance Jvm field.
+            var jvmMember = stateType.GetMembers("Jvm").OfType<IFieldSymbol>().FirstOrDefault();
+            if (jvmMember is null)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': StateType '{stateType.ToDisplayString()}' has no instance field named 'Jvm'"));
+                return null;
+            }
+            if (jvmMember.IsStatic || jvmMember.IsConst || jvmMember.IsReadOnly)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': StateType '{stateType.ToDisplayString()}'.Jvm must be a non-static, non-const, non-readonly field"));
+                return null;
+            }
+            if (jvmMember.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal or Accessibility.ProtectedOrInternal))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': StateType '{stateType.ToDisplayString()}'.Jvm must be accessible (public or internal)"));
+                return null;
+            }
+
+            return new FacadeSlot(p, FacadeSlotKind.StateHolder,
+                rememberMethodName: remember,
+                stateWrapperType: stateType,
+                stateJvmType: jvmMember.Type);
+        }
+
         // [PainterResource] — annotates the IntPtr bridge param that
         // takes the resolved Painter handle. The facade exposes a
         // synthetic `int drawableResourceId` ctor arg in its place.
@@ -405,7 +510,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         string baseClass = isContainer ? "global::ComposeNet.ComposableContainer" : "global::ComposeNet.ComposableNode";
 
         // Ctor slots: every non-modifier, non-named-property slot.
-        var ctorSlots = slots.Where(s => IsCtorSlot(s)).ToArray();
+        // StateHolder slots go LAST (they have default = null) so all
+        // required slots come first and stay positional.
+        var ctorSlotsAll = slots.Where(s => IsCtorSlot(s)).ToArray();
+        var ctorSlots = ctorSlotsAll
+            .Where(s => s.Kind != FacadeSlotKind.StateHolder)
+            .Concat(ctorSlotsAll.Where(s => s.Kind == FacadeSlotKind.StateHolder))
+            .ToArray();
         // Named-property slots (Phase 3).
         var namedSlots = slots.Where(s => s.Kind is FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3
             or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3).ToArray();
@@ -448,6 +559,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             {
                 if (i > 0) sb.Append(", ");
                 sb.Append(CtorParamType(ctorSlots[i])).Append(' ').Append(EscapeIdent(CtorIdentifier(ctorSlots[i])));
+                if (ctorSlots[i].Kind == FacadeSlotKind.StateHolder)
+                    sb.Append(" = null");
             }
             sb.AppendLine(")");
             sb.AppendLine("        {");
@@ -469,6 +582,22 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             sb.Append("            if (").Append(name).AppendLine(" is null)");
             sb.Append("                throw new global::System.InvalidOperationException(\"")
               .Append(className).Append('.').Append(name).AppendLine(" is required (the Kotlin parameter has no default).\");");
+        }
+
+        // StateHolder preamble — call RememberXxxState and (optionally)
+        // populate the caller-supplied wrapper's Jvm field.
+        foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.StateHolder))
+        {
+            var id = CtorIdentifier(s);
+            var jvmFqn = s.StateJvmType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+            sb.Append("            var __").Append(s.Param.Name)
+              .Append(" = global::ComposeNet.ComposeBridges.").Append(s.RememberMethodName)
+              .Append('(').Append(composerName).AppendLine(");");
+            sb.Append("            if (_").Append(id).Append(" is not null && _").Append(id).AppendLine(".Jvm is null)");
+            sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+              .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+              .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
         }
 
         // OnClick wrappers — one per line so slot-table keys stay distinct.
@@ -650,6 +779,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 case FacadeSlotKind.PainterResource:
                 case FacadeSlotKind.Primitive:
                 case FacadeSlotKind.ThemeColor:
+                case FacadeSlotKind.StateHolder:
                     sb.Append(indent).Append("__defaults &= ~(int)global::ComposeNet.")
                       .Append(d.EnumName).Append('.').Append(bitMember).AppendLine(";");
                     break;
@@ -694,11 +824,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             FacadeSlotKind.PainterResource  => "__painterRef",
             FacadeSlotKind.ThemeColor       => "__color",
             FacadeSlotKind.ScopeReceiver    => "global::ComposeNet.RenderContext.CurrentScope",
+            FacadeSlotKind.StateHolder      => "__" + s.Param.Name,
             _ => "default",
         };
 
     static bool IsCtorSlot(FacadeSlot s) =>
-        s.Kind is FacadeSlotKind.OnClick or FacadeSlotKind.Primitive or FacadeSlotKind.Callback or FacadeSlotKind.PainterResource;
+        s.Kind is FacadeSlotKind.OnClick or FacadeSlotKind.Primitive or FacadeSlotKind.Callback
+            or FacadeSlotKind.PainterResource or FacadeSlotKind.StateHolder;
 
     static string CtorFieldType(FacadeSlot slot) => CtorParamType(slot);
 
@@ -717,6 +849,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             FacadeSlotKind.Callback  => "global::System.Action<" + slot.CallbackType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                 .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)) + ">",
             FacadeSlotKind.PainterResource => "int",
+            FacadeSlotKind.StateHolder => slot.StateWrapperType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes)) + "?",
             FacadeSlotKind.Primitive => slot.Param.Type.ToDisplayString(format),
             _ => slot.Param.Type.ToDisplayString(),
         };
@@ -829,22 +963,31 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         PainterResource,
         ThemeColor,
         ScopeReceiver,
+        StateHolder,
     }
 
     internal readonly struct FacadeSlot
     {
         public FacadeSlot(IParameterSymbol param, FacadeSlotKind kind,
-            ITypeSymbol? callbackType = null, string? slotPropertyName = null)
+            ITypeSymbol? callbackType = null, string? slotPropertyName = null,
+            string? rememberMethodName = null, INamedTypeSymbol? stateWrapperType = null,
+            ITypeSymbol? stateJvmType = null)
         {
             Param = param;
             Kind = kind;
             CallbackType = callbackType;
             SlotPropertyName = slotPropertyName;
+            RememberMethodName = rememberMethodName;
+            StateWrapperType = stateWrapperType;
+            StateJvmType = stateJvmType;
         }
         public IParameterSymbol Param { get; }
         public FacadeSlotKind Kind { get; }
         public ITypeSymbol? CallbackType { get; }
         public string? SlotPropertyName { get; }
+        public string? RememberMethodName { get; }
+        public INamedTypeSymbol? StateWrapperType { get; }
+        public ITypeSymbol? StateJvmType { get; }
         public bool HasSlotAttribute => SlotPropertyName is not null;
         public bool IsNullableSlot => Param.NullableAnnotation == NullableAnnotation.Annotated
             && KindIsFnSlot(Kind);
@@ -853,6 +996,6 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
               or FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3
               or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3;
         public FacadeSlot WithKind(FacadeSlotKind newKind) =>
-            new(Param, newKind, CallbackType, SlotPropertyName);
+            new(Param, newKind, CallbackType, SlotPropertyName, RememberMethodName, StateWrapperType, StateJvmType);
     }
 }

--- a/src/ComposeNet.SourceGenerators/Diagnostics.cs
+++ b/src/ComposeNet.SourceGenerators/Diagnostics.cs
@@ -139,4 +139,12 @@ internal static class Diagnostics
         category: "ComposeNet",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor FacadeStateHolderInvalid = new(
+        id: "CN3009",
+        title: "[StateHolder] configuration is invalid",
+        messageFormat: "Facade for bridge '{0}': {1}",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }


### PR DESCRIPTION
Lands **Phase 4** of the facade generator from #67: state-holder
facades. The generator now emits the `RememberXxxState(composer)` JNI
round-trip + idempotent `.Jvm` field population for state-holder
facades that previously had to be hand-written.

## What changed

### New `[StateHolder]` parameter-level attribute

```csharp
[ComposeBridge(... Defaults = typeof(DatePickerDefault))]
[ComposeFacade]
public static partial void DatePicker(
    [StateHolder(Remember  = nameof(ComposeBridges.RememberDatePickerState),
                 StateType = typeof(DatePickerState))]
    IntPtr     state,
    IModifier? modifier,
    int        defaults,
    IComposer  composer);
```

Annotate the `IntPtr` user param that carries the state-holder
handle. The generator then:

* surfaces the C# wrapper as a defaulted ctor slot
  (`DatePickerState? state = null`), appended last;
* emits `var __state = ComposeBridges.RememberDatePickerState(composer);`
  at the top of `Render`;
* populates the wrapper''s `.Jvm` field once (idempotent) via
  `Java.Lang.Object.GetObject<IDatePickerState>(handle, JniHandleOwnership.DoNotTransfer)`;
* forwards the JNI handle to the bridge in place of the IntPtr user
  param.

Phase 4 is scoped to Remember bridges with signature
`(IComposer) -> IntPtr`. Parameterised remembers (`TimePicker`,
`TimeInput`, `SearchBar`, `ModalBottomSheet`, `BottomSheetScaffold`,
`SnackbarHost`) still stay hand-written until Phase 4b.

### Consumers converted

* `DatePicker` collapses from a ~32-line hand-written facade to a
  3-line `partial class` stub.
* `DateRangePicker` ships brand-new as a Phase 4 facade, including
  a new `DateRangePickerState` wrapper, a
  `RememberDateRangePickerState` bridge, a `DateRangePicker`
  Material 3 bridge, and matching `DateRangePickerDefault` /
  `RememberDateRangePickerStateDefault` declarative-form
  `[ComposeDefaults]`.

### New diagnostic — `CN3009`

Covers all `[StateHolder]` validation failures:

* non-`IntPtr` target;
* combined with `[PainterResource]` on the same param;
* missing or non-identifier-valued `Remember`;
* missing `StateType`;
* `Remember` doesn''t resolve to a static `(IComposer) -> IntPtr` on
  `ComposeNet.ComposeBridges`;
* `StateType` has no accessible, writable, instance field named `Jvm`.

### Validation

* `dotnet test src/ComposeNet.SourceGenerators.Tests` — **69/69 pass**
  (65 existing + 4 new: happy path, non-IntPtr CN3009, missing-Jvm
  CN3009, non-suppressed-state-bit auto-mask clear).
* `dotnet build src/ComposeNet.Compose` — **clean** (0 warnings, 0
  errors).
* `dotnet build src/ComposeNet.Sample` — **clean**; the converted
  `DatePicker` round-trips through the binding, and the new
  `DateRangePicker` / `IDateRangePickerState` resolves against
  `Xamarin.AndroidX.Compose.Material3`.

### Docs

`.github/copilot-instructions.md` updated with:

* new `[StateHolder]` row in the parameter-type table;
* new `[StateHolder]` entry in the parameter-attributes section;
* Phase 4 added to the supported-shapes list;
* CN3009 entry in the facade-generator diagnostics table;
* state-holder facades reclassified under "still hand-written until
  Phase 4b" (with the note that the blocker is parameterised
  remembers).

### PublicAPI

`PublicAPI.Unshipped.txt` adds 11 new entries for `DateRangePicker`
and `DateRangePickerState`. `DatePicker`''s public surface is
unchanged.

## Out of scope (deferred)

* Drawer `confirmStateChange` adapter (separate generator feature).
* Scope facades with per-child loops.
* `TopAppBar` bridge-branching.
* `BottomAppBar`-style container+slot hybrids.
* `TriStateCheckbox` / Java-enum detection.
* Parameterised `Remember*State` bridges (Phase 4b — relax the
  Remember-signature check and map ctor / property-on-wrapper →
  Remember-arg positionally).

Closes none — partial work toward #67.