### PR TITLE
Bind PullToRefreshBox (Material 3 pull-to-refresh)

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -874,6 +874,38 @@ internal static partial class ComposeBridges
         InstanceField = "INSTANCE")]
     public static partial IntPtr RememberPlainTooltipPositionProvider(IComposer composer);
 
+    // androidx.compose.material3.pulltorefresh.PullToRefreshKt.PullToRefreshBox
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/pulltorefresh/PullToRefreshKt",
+        JvmName   = "PullToRefreshBox",
+        Signature = "(ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/material3/pulltorefresh/PullToRefreshState;" +
+                    "Landroidx/compose/ui/Alignment;Lkotlin/jvm/functions/Function3;" +
+                    "Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(PullToRefreshBoxDefault))]
+    [ComposeFacade]
+    public static partial void PullToRefreshBox(
+        bool        isRefreshing,
+        IFunction0  onRefresh,
+        [StateHolder(Remember  = nameof(RememberPullToRefreshState),
+                     StateType = typeof(PullToRefreshState))]
+        IntPtr      state,
+        IModifier?  modifier,
+        IFunction3  content,
+        int         defaults,
+        IComposer   composer);
+
+    // androidx.compose.material3.pulltorefresh.PullToRefreshKt.rememberPullToRefreshState
+    // No-arg @Composable; signature has only the trailing _changed I slot
+    // (no $default), so omit Defaults entirely per the bridge generator
+    // contract (see CN2005).
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/pulltorefresh/PullToRefreshKt",
+        JvmName   = "rememberPullToRefreshState",
+        Signature = "(Landroidx/compose/runtime/Composer;I)" +
+                    "Landroidx/compose/material3/pulltorefresh/PullToRefreshState;")]
+    public static partial IntPtr RememberPullToRefreshState(IComposer composer);
+
     // androidx.compose.material3.CardKt.Card (non-clickable)
     const string CardSig =
         "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;" +

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -717,11 +717,13 @@ using ComposeNet;
 // isRefreshing / onRefresh (bits 0/1) and a state holder for bit 3 (via
 // the [StateHolder] attribute on the bridge), so those three bits are
 // suppressed ("!" prefix — consume the bit position, emit no enum
-// member). Bits 4/5 (contentAlignment / indicator) are not exposed at
-// all by the bridge — JNI sees null for those slots and Kotlin
-// substitutes the defaults; suppressing them prevents bogus enum
-// members no caller can use. Bit 6 (content) is the container content
-// slot, always provided by RenderChildren.
+// member). Bits 4/5 (contentAlignment / indicator) are not exposed by
+// the bridge — JNI passes null for those slots and the bits MUST be
+// set in $default so Kotlin substitutes its defaults instead of
+// invoking a null Function3 (NPE). Keeping them as enum members lets
+// `All` include those bits; nothing surfaced to callers ever clears
+// them. Bit 6 (content) is the container content slot, always
+// provided by RenderChildren.
 [assembly: ComposeDefaults("PullToRefreshBoxDefault",
-    "!isRefreshing", "!onRefresh", "modifier", "!state", "!contentAlignment",
-    "!indicator", "!content")]
+    "!isRefreshing", "!onRefresh", "modifier", "!state", "contentAlignment",
+    "indicator", "!content")]

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -711,3 +711,17 @@ using ComposeNet;
     "!snackbarData", "modifier", "actionOnNewLine", "shape", "containerColor",
     "contentColor", "actionColor", "actionContentColor",
     "dismissActionContentColor")]
+
+// androidx.compose.material3.pulltorefresh.PullToRefreshKt.PullToRefreshBox:
+// 7 user params. The [ComposeFacade] generator surfaces ctor params for
+// isRefreshing / onRefresh (bits 0/1) and a state holder for bit 3 (via
+// the [StateHolder] attribute on the bridge), so those three bits are
+// suppressed ("!" prefix — consume the bit position, emit no enum
+// member). Bits 4/5 (contentAlignment / indicator) are not exposed at
+// all by the bridge — JNI sees null for those slots and Kotlin
+// substitutes the defaults; suppressing them prevents bogus enum
+// members no caller can use. Bit 6 (content) is the container content
+// slot, always provided by RenderChildren.
+[assembly: ComposeDefaults("PullToRefreshBoxDefault",
+    "!isRefreshing", "!onRefresh", "modifier", "!state", "!contentAlignment",
+    "!indicator", "!content")]

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -445,6 +445,12 @@ ComposeNet.PrimaryScrollableTabRow
 ComposeNet.PrimaryScrollableTabRow.PrimaryScrollableTabRow(int selectedTabIndex) -> void
 ComposeNet.PrimaryTabRow
 ComposeNet.PrimaryTabRow.PrimaryTabRow(int selectedTabIndex) -> void
+ComposeNet.PullToRefreshBox
+ComposeNet.PullToRefreshBox.PullToRefreshBox(bool isRefreshing, System.Action! onRefresh, ComposeNet.PullToRefreshState? state = null) -> void
+ComposeNet.PullToRefreshState
+ComposeNet.PullToRefreshState.DistanceFraction.get -> float
+ComposeNet.PullToRefreshState.IsAnimating.get -> bool
+ComposeNet.PullToRefreshState.PullToRefreshState() -> void
 ComposeNet.RadioButton
 ComposeNet.RadioButton.RadioButton(bool selected, System.Action! onClick) -> void
 ComposeNet.RangeSlider

--- a/src/ComposeNet.Compose/PullToRefreshBox.cs
+++ b/src/ComposeNet.Compose/PullToRefreshBox.cs
@@ -1,0 +1,43 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>PullToRefreshBox</c>. A container that wraps scrollable
+/// content (typically a <see cref="LazyColumn{T}"/>) with the Material
+/// pull-to-refresh gesture: the user drags past the threshold and
+/// Compose invokes <c>onRefresh</c>. The caller owns the busy flag
+/// (<c>isRefreshing</c>) and clears it when the async reload finishes.
+/// </summary>
+/// <remarks>
+/// Pass an explicit <see cref="ComposeNet.PullToRefreshState"/> to
+/// observe pull progress (<see cref="PullToRefreshState.DistanceFraction"/> /
+/// <see cref="PullToRefreshState.IsAnimating"/>) for a custom indicator
+/// or analytics; omit it and Compose creates one internally via
+/// <c>rememberPullToRefreshState()</c>. The stock Material 3 spinner is
+/// always used — indicator customization is not yet exposed (the
+/// underlying container + optional <c>Function3</c> slot is the same
+/// hybrid shape the facade generator can't model for <c>BottomAppBar</c>;
+/// see <c>.github/copilot-instructions.md</c>).
+///
+/// <code>
+/// var refreshing = Remember(() =&gt; new MutableState&lt;bool&gt;(false));
+///
+/// new PullToRefreshBox(
+///     isRefreshing: refreshing.Value,
+///     onRefresh:    () =&gt; StartReload(refreshing))
+/// {
+///     new LazyColumn&lt;int&gt;(items: rows, itemContent: i =&gt; new Text($"Row {i}"))
+///     {
+///         Modifier = Modifier.Companion.FillMaxSize(),
+///     },
+/// }
+/// </code>
+///
+/// The generated <c>Render()</c> calls
+/// <c>ComposeBridges.RememberPullToRefreshState</c> to obtain the JVM
+/// state handle, populates the wrapper's <c>Jvm</c> field on first
+/// render (so subsequent property reads on the wrapper hit the live
+/// state), and forwards the handle into the
+/// <c>androidx.compose.material3.pulltorefresh.PullToRefreshKt.PullToRefreshBox</c>
+/// composable.
+/// </remarks>
+public sealed partial class PullToRefreshBox;

--- a/src/ComposeNet.Compose/PullToRefreshState.cs
+++ b/src/ComposeNet.Compose/PullToRefreshState.cs
@@ -1,0 +1,61 @@
+using AndroidX.Compose.Material3.PullToRefresh;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Caller-supplied state holder for <see cref="PullToRefreshBox"/>. The
+/// underlying JVM
+/// <c>androidx.compose.material3.pulltorefresh.PullToRefreshState</c>
+/// is created lazily the first time a <see cref="PullToRefreshBox"/>
+/// bound to this state is rendered; reads of <see cref="DistanceFraction"/>
+/// or <see cref="IsAnimating"/> before that point return safe defaults
+/// (<c>0f</c> / <c>false</c>).
+/// </summary>
+/// <remarks>
+/// Same shape as <see cref="DateRangePickerState"/>: a thin wrapper
+/// whose <c>Jvm</c> field is populated by the generator-emitted state-
+/// holder facade on first render. Typical usage is to <c>Remember</c>
+/// an instance, pass it as the <c>state</c> ctor arg of a
+/// <see cref="PullToRefreshBox"/>, and (optionally) drive UI off the
+/// progress properties — e.g. a custom indicator that fades in as
+/// <see cref="DistanceFraction"/> approaches <c>1</c>.
+///
+/// <code>
+/// var refreshing = Remember(() =&gt; new MutableState&lt;bool&gt;(false));
+/// var ptrState   = Remember(() =&gt; new PullToRefreshState());
+///
+/// new PullToRefreshBox(
+///     isRefreshing: refreshing.Value,
+///     onRefresh:    () =&gt; StartReload(refreshing),
+///     state:        ptrState)
+/// {
+///     new LazyColumn&lt;int&gt;(items: rows, itemContent: i =&gt; new Text($"Row {i}"))
+///     {
+///         Modifier = Modifier.Companion.FillMaxSize(),
+///     },
+/// }
+/// </code>
+/// </remarks>
+public sealed class PullToRefreshState
+{
+    internal IPullToRefreshState? Jvm;
+
+    /// <summary>
+    /// Current pull progress, in the range <c>[0f, 1f+]</c>. <c>0f</c>
+    /// at rest; reaches <c>1f</c> at the refresh threshold; can exceed
+    /// <c>1f</c> on over-pull. Returns <c>0f</c> until the first
+    /// <see cref="PullToRefreshBox"/> render binds this state to the
+    /// JVM picker. Read inside a composable to drive a custom
+    /// indicator's visual feedback.
+    /// </summary>
+    public float DistanceFraction => Jvm?.DistanceFraction ?? 0f;
+
+    /// <summary>
+    /// <c>true</c> while the indicator is animating into / out of its
+    /// rest position (typically right after the user releases past the
+    /// threshold, before <c>onRefresh</c> fires, and while the indicator
+    /// retracts after the caller clears the busy flag). Returns
+    /// <c>false</c> until the state is bound.
+    /// </summary>
+    public bool IsAnimating => Jvm?.IsAnimating ?? false;
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -84,11 +84,13 @@ public class MainActivity : ComposeActivity
             // filter without binding InputTransformation.
             var searchQuery   = Remember(() => new MutableState<string>(""));
 
-            // Scroll state for the (long) Buttons tab — `Modifier.VerticalScroll`
-            // turns its outer Column into a scrollable viewport, the standard
-            // Compose pattern for non-Lazy content that simply might overflow
-            // on small screens.
-            var buttonsScroll = Remember(() => new ScrollState());
+            // Lazy tab: pull-to-refresh demo state. `refreshing` drives the
+            // PullToRefreshBox indicator; `refreshTick` bumps once per
+            // completed refresh so the rows visibly change. The reload
+            // is faked with a 1.2s Handler.PostDelayed callback so the
+            // spinner is observable without any real async work.
+            var refreshing  = Remember(() => new MutableState<bool>(false));
+            var refreshTick = Remember(() => new MutableNumberState<int>(0));
 
             string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy", "Carousels" };
 
@@ -221,7 +223,6 @@ public class MainActivity : ComposeActivity
                 },
                 1 => new Column
                 {
-                    Modifier.Companion.Weight(1f).VerticalScroll(buttonsScroll),
                     new Text("Button fill styles"),
                     new Button(onClick: () => count++) { new Text("Filled") },
                     new ElevatedButton(onClick: () => count++) { new Text("Elevated") },
@@ -649,12 +650,31 @@ public class MainActivity : ComposeActivity
                     // list + a per-item callback. Compose lazily composes
                     // only the visible window, so 1000 rows costs about
                     // the same as 20.
-                    new Text("LazyColumn (1000 rows)"),
-                    new LazyColumn<int>(
-                        items:       System.Linq.Enumerable.Range(0, 1000).ToList(),
-                        itemContent: i => new Text($"Row {i:D4}"))
+                    new Text($"LazyColumn (1000 rows) — pull to refresh, rev {refreshTick}"),
+                    // PullToRefreshBox wraps a scrollable child and surfaces
+                    // the Material 3 pull gesture. The Box stretches to fill
+                    // the available height so the indicator animates over
+                    // the list rather than overflowing below it.
+                    new PullToRefreshBox(
+                        isRefreshing: refreshing.Value,
+                        onRefresh:    () =>
+                        {
+                            refreshing.Value = true;
+                            new Handler(Looper.MainLooper!).PostDelayed(() =>
+                            {
+                                refreshTick.Value++;
+                                refreshing.Value = false;
+                            }, 1200);
+                        })
                     {
-                        Modifier = Modifier.Companion.FillMaxWidth().Height(220),
+                        Modifier.Companion.FillMaxWidth().Height(220),
+
+                        new LazyColumn<int>(
+                            items:       System.Linq.Enumerable.Range(0, 1000).ToList(),
+                            itemContent: i => new Text($"Row {i:D4} (rev {refreshTick})"))
+                        {
+                            Modifier = Modifier.Companion.FillMaxSize(),
+                        },
                     },
                     new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
                     new Text("LazyRow (carousel)"),
@@ -816,7 +836,7 @@ public class MainActivity : ComposeActivity
                             : null,
                         Body = new Column
                         {
-                            Modifier.Companion.FillMaxSize().Padding(16),
+                            Modifier.Companion.Padding(16),
                             // ScrollableTabRow handles many tabs better than NavigationBar
                             // (which is spec'd for 3-5 items) — the row scrolls horizontally
                             // so every tab stays reachable as we add more demos.


### PR DESCRIPTION
Closes #53. Built on top of the Phase 4 `[StateHolder]` facility from #92.

## Surface

```csharp
// Simplest case — defer to the default rememberPullToRefreshState():
new PullToRefreshBox(
    isRefreshing: refreshing.Value,
    onRefresh:    () => StartReload(refreshing))
{
    new LazyColumn<int>(
        items:       rows,
        itemContent: i => new Text($"Row {i}"))
    {
        Modifier = Modifier.Companion.FillMaxSize(),
    },
}

// With state observation:
var ptrState = Remember(() => new PullToRefreshState());
new PullToRefreshBox(refreshing.Value, () => Reload(), state: ptrState)
{
    new Text($"pull {ptrState.DistanceFraction:P0}"),
}
```

- `ComposableContainer` shape — children fill the scrollable Box.
- Required `bool isRefreshing` + `System.Action onRefresh` ctor args.
- Optional `PullToRefreshState? state = null` ctor arg surfacing the
  Kotlin state holder. Exposes `DistanceFraction` (pull progress) and
  `IsAnimating` for custom indicators / analytics.
- Indicator slot deferred — always renders the stock M3 spinner. The
  underlying container + optional `Function3` indicator is the same
  hybrid shape the facade generator can't model for `BottomAppBar`
  (see `.github/copilot-instructions.md`); will need either Phase X
  support or a hand-written escape hatch.

## Implementation

Uses the **Phase 4 `[ComposeFacade]` + `[StateHolder]` generator
shape** introduced in #92 (`DatePicker` / `DateRangePicker` are the
existing consumers):

```csharp
// In ComposeBridges.cs
[ComposeBridge(/* JNI sig for PullToRefreshBox */,
               Defaults = typeof(PullToRefreshBoxDefault))]
[ComposeFacade]
public static partial void PullToRefreshBox(
    bool        isRefreshing,
    IFunction0  onRefresh,
    [StateHolder(Remember  = nameof(RememberPullToRefreshState),
                 StateType = typeof(PullToRefreshState))]
    IntPtr      state,
    IModifier?  modifier,
    IFunction3  content,
    int         defaults,
    IComposer   composer);

[ComposeBridge(/* (IComposer;I) -> PullToRefreshState */)]
public static partial IntPtr RememberPullToRefreshState(IComposer composer);
```

- `PullToRefreshBox.cs` collapses to a 3-line `partial class` stub.
- `PullToRefreshState.cs` wrapper holds an `internal IPullToRefreshState? Jvm`
  field that the generator populates on first render, and surfaces
  `DistanceFraction` / `IsAnimating` properties that safely fall back
  when unbound.
- `ComposeDefaults` entries for the box and the remember bridge mark
  every `$default` bit `!`-suppressed (the generator provides them).

## Sample

The Lazy tab in `ComposeNet.Sample` wraps its 1000-row `LazyColumn` in
a `PullToRefreshBox`. Pulling triggers a 1.2s `Handler.PostDelayed`
that bumps a `MutableNumberState<int>` revision counter; the row
labels include the revision so a successful refresh is visible.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 69 passed.
- `dotnet build src/ComposeNet.Compose` — clean (no `RS0016`).
- `dotnet build src/ComposeNet.Sample` — clean.
- Device run: **not verified** — would appreciate a run on the Lazy
  tab to confirm the M3 spinner appears on pull and the `rev N` label
  in each row increments after ~1.2s.
