### PR TITLE
Surface Arrangement on Row / Column

### DIFF
--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -218,14 +218,15 @@ public static class Conversation
     }
 
     // Author + timestamp on one line, separated by a small spacer.
-    // alignEnd pushes the row's content to the right via
-    // Arrangement.End — matches what "me" message rows want.
+    // When alignEnd is true (me messages), this row sizes to its
+    // content rather than FillMaxWidth so the enclosing Column
+    // collapses too and the OUTER Row's Arrangement.End can push the
+    // whole "me" stack (header + bubble) to the right edge.
     static Row BuildAuthorAndTimestamp(Message m, bool alignEnd)
     {
-        var row = new Row(alignEnd ? Arrangement.End : null)
-        {
-            Modifier.Companion.FillMaxWidth(),
-        };
+        var row = alignEnd
+            ? new Row()
+            : new Row { Modifier.Companion.FillMaxWidth() };
         row.Add(new Text(m.Author));
         row.Add(new Spacer(Modifier.Companion.Width(8)));
         row.Add(new Text(m.Timestamp));

--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -153,18 +153,14 @@ public static class Conversation
             : BuildOtherMessageRow(m, isStreak);
     }
 
-    // "me" messages: right-aligned via a leading Spacer().Weight(1f),
+    // "me" messages: right-aligned via Arrangement.End on the Row,
     // no avatar tile, blueish bubble. Upstream uses a primary-color
-    // bubble with no avatar on the "me" side — same idea, different
-    // exact color since we don't have MaterialTheme.colorScheme reads
-    // (issue #61).
+    // bubble — same idea, different exact color since we don't have
+    // MaterialTheme.colorScheme reads (issue #61).
     static Row BuildMyMessageRow(Message m) =>
-        new()
+        new(Arrangement.End)
         {
             Modifier.Companion.FillMaxWidth().Padding(horizontalDp: 8, verticalDp: 4),
-            // Push everything to the right edge. Workaround for missing
-            // Row(horizontalArrangement=Arrangement.End) — issue #70.
-            new Spacer(Modifier.Companion.Weight(1f)),
             new Column
             {
                 BuildAuthorAndTimestamp(m, alignEnd: true),
@@ -222,17 +218,14 @@ public static class Conversation
     }
 
     // Author + timestamp on one line, separated by a small spacer.
-    // alignEnd uses a leading Spacer-weight trick to push the row's
-    // content to the right (workaround for missing
-    // Row(horizontalArrangement=Arrangement.End) — issue #70).
+    // alignEnd pushes the row's content to the right via
+    // Arrangement.End — matches what "me" message rows want.
     static Row BuildAuthorAndTimestamp(Message m, bool alignEnd)
     {
-        var row = new Row
+        var row = new Row(alignEnd ? Arrangement.End : null)
         {
             Modifier.Companion.FillMaxWidth(),
         };
-        if (alignEnd)
-            row.Add(new Spacer(Modifier.Companion.Weight(1f)));
         row.Add(new Text(m.Author));
         row.Add(new Spacer(Modifier.Companion.Width(8)));
         row.Add(new Text(m.Timestamp));

--- a/src/ComposeNet.Compose/Arrangement.cs
+++ b/src/ComposeNet.Compose/Arrangement.cs
@@ -1,0 +1,110 @@
+using BindingArrangement = AndroidX.Compose.Foundation.Layout.Arrangement;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Compose's <c>Arrangement</c> — how a <see cref="Row"/> or
+/// <see cref="Column"/> distributes its children along its main axis.
+/// Pass one of the static factories to
+/// <see cref="Row(Arrangement?)"/>'s <c>horizontalArrangement</c> or
+/// <see cref="Column(Arrangement?)"/>'s <c>verticalArrangement</c>:
+///
+/// <code>
+/// new Row(horizontalArrangement: Arrangement.SpaceBetween) { /* … */ }
+/// new Column(verticalArrangement:  Arrangement.SpacedBy(8)) { /* … */ }
+/// </code>
+///
+/// Each factory wraps the corresponding member of the bound
+/// <c>androidx.compose.foundation.layout.Arrangement</c> Kotlin singleton:
+/// <list type="bullet">
+/// <item><description><see cref="Start"/> / <see cref="End"/> — horizontal-only.</description></item>
+/// <item><description><see cref="Top"/> / <see cref="Bottom"/> — vertical-only.</description></item>
+/// <item><description><see cref="Center"/>, <see cref="SpaceBetween"/>,
+/// <see cref="SpaceAround"/>, <see cref="SpaceEvenly"/>, <see cref="SpacedBy(int)"/>
+/// — usable in either orientation.</description></item>
+/// </list>
+/// Passing a horizontal-only arrangement to <see cref="Column"/> (or
+/// vice-versa) throws <see cref="System.ArgumentException"/> at the
+/// container's constructor — the orientation check is fail-fast so
+/// mistakes surface at the call site, not during composition.
+/// </summary>
+public sealed class Arrangement
+{
+    static readonly System.Lazy<Arrangement> _start =
+        new(() => new Arrangement(BindingArrangement.Instance.Start));
+    static readonly System.Lazy<Arrangement> _end =
+        new(() => new Arrangement(BindingArrangement.Instance.End));
+    static readonly System.Lazy<Arrangement> _top =
+        new(() => new Arrangement(BindingArrangement.Instance.Top));
+    static readonly System.Lazy<Arrangement> _bottom =
+        new(() => new Arrangement(BindingArrangement.Instance.Bottom));
+    static readonly System.Lazy<Arrangement> _center =
+        new(() => new Arrangement(BindingArrangement.Instance.Center));
+    static readonly System.Lazy<Arrangement> _spaceBetween =
+        new(() => new Arrangement(BindingArrangement.Instance.SpaceBetween));
+    static readonly System.Lazy<Arrangement> _spaceAround =
+        new(() => new Arrangement(BindingArrangement.Instance.SpaceAround));
+    static readonly System.Lazy<Arrangement> _spaceEvenly =
+        new(() => new Arrangement(BindingArrangement.Instance.SpaceEvenly));
+
+    /// <summary>Pack children toward the start of the main axis. Horizontal only.</summary>
+    public static Arrangement Start => _start.Value;
+
+    /// <summary>Pack children toward the end of the main axis. Horizontal only.</summary>
+    public static Arrangement End => _end.Value;
+
+    /// <summary>Pack children toward the top of the main axis. Vertical only.</summary>
+    public static Arrangement Top => _top.Value;
+
+    /// <summary>Pack children toward the bottom of the main axis. Vertical only.</summary>
+    public static Arrangement Bottom => _bottom.Value;
+
+    /// <summary>Center the children along the main axis. Either orientation.</summary>
+    public static Arrangement Center => _center.Value;
+
+    /// <summary>
+    /// Place children so the first sits at the start, the last at the
+    /// end, and the rest are evenly spaced between them. Either orientation.
+    /// </summary>
+    public static Arrangement SpaceBetween => _spaceBetween.Value;
+
+    /// <summary>
+    /// Place children with equal space surrounding each one — including a
+    /// half-space at the start and end. Either orientation.
+    /// </summary>
+    public static Arrangement SpaceAround => _spaceAround.Value;
+
+    /// <summary>
+    /// Place children with equal space between them — including full
+    /// equal-sized gaps at the start and end. Either orientation.
+    /// </summary>
+    public static Arrangement SpaceEvenly => _spaceEvenly.Value;
+
+    /// <summary>
+    /// Place children with <paramref name="dp"/> density-independent
+    /// pixels of space between consecutive items. Either orientation.
+    /// Replaces the common <c>Spacer().Width(dp)</c> /
+    /// <c>Spacer().Height(dp)</c> idiom between every pair of children.
+    /// </summary>
+    public static Arrangement SpacedBy(int dp) =>
+        new(BindingArrangement.Instance.SpacedBy((float)dp));
+
+    internal BindingArrangement.IHorizontal? Horizontal { get; }
+    internal BindingArrangement.IVertical? Vertical { get; }
+
+    Arrangement(BindingArrangement.IHorizontal horizontal)
+    {
+        Horizontal = horizontal;
+    }
+
+    Arrangement(BindingArrangement.IVertical vertical)
+    {
+        Vertical = vertical;
+    }
+
+    Arrangement(BindingArrangement.IHorizontalOrVertical both)
+    {
+        Horizontal = both;
+        Vertical = both;
+    }
+}

--- a/src/ComposeNet.Compose/Column.cs
+++ b/src/ComposeNet.Compose/Column.cs
@@ -1,4 +1,75 @@
+using AndroidX.Compose.Runtime;
+
 namespace ComposeNet;
 
-/// <summary>Foundation <c>Column</c> composable.</summary>
-public sealed partial class Column;
+/// <summary>
+/// Foundation <c>Column</c> composable — lays its children out
+/// vertically. Mirror of <see cref="Row"/>; same collection-init shape:
+/// <code>
+/// new Column { new Text("A"), new Text("B") }
+/// </code>
+/// Pass an optional <see cref="Arrangement"/> to control how children
+/// are distributed along the vertical axis:
+/// <code>
+/// new Column(verticalArrangement: Arrangement.SpacedBy(8)) { /* … */ }
+/// </code>
+/// </summary>
+public sealed class Column : ComposableContainer
+{
+    readonly Arrangement? _verticalArrangement;
+
+    /// <summary>
+    /// Lay out children top-to-bottom with Compose's default
+    /// vertical arrangement (<c>Arrangement.Top</c>).
+    /// </summary>
+    public Column() : this(null) { }
+
+    /// <summary>
+    /// Lay out children top-to-bottom using
+    /// <paramref name="verticalArrangement"/> to distribute them along
+    /// the vertical axis. Pass <see langword="null"/> (or use the
+    /// parameterless ctor) for Compose's default.
+    /// </summary>
+    /// <param name="verticalArrangement">
+    /// One of the <see cref="Arrangement"/> static factories. Must wrap
+    /// a vertical-capable Kotlin arrangement
+    /// (<see cref="Arrangement.Top"/>, <see cref="Arrangement.Bottom"/>,
+    /// <see cref="Arrangement.Center"/>, <see cref="Arrangement.SpaceBetween"/>,
+    /// <see cref="Arrangement.SpaceAround"/>, <see cref="Arrangement.SpaceEvenly"/>,
+    /// or <see cref="Arrangement.SpacedBy(int)"/>). Passing a
+    /// horizontal-only arrangement (<see cref="Arrangement.Start"/>,
+    /// <see cref="Arrangement.End"/>) throws
+    /// <see cref="System.ArgumentException"/>.
+    /// </param>
+    public Column(Arrangement? verticalArrangement)
+    {
+        if (verticalArrangement is not null && verticalArrangement.Vertical is null)
+        {
+            throw new System.ArgumentException(
+                $"{nameof(verticalArrangement)} must wrap a vertical " +
+                $"or horizontal-or-vertical Compose Arrangement; got a " +
+                $"horizontal-only value (e.g. Arrangement.Start / Arrangement.End).",
+                nameof(verticalArrangement));
+        }
+
+        _verticalArrangement = verticalArrangement;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        var vertical = _verticalArrangement?.Vertical;
+        var modifier = BuildModifier();
+
+        int defaults = (int)ColumnDefault.All;
+        if (modifier is not null) defaults &= ~(int)ColumnDefault.Modifier;
+        if (vertical is not null) defaults &= ~(int)ColumnDefault.VerticalArrangement;
+
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
+        {
+            using var __scopeFrame = RenderContext.PushScope(scope, ScopeKind.Column);
+            RenderChildren(c);
+        });
+
+        ComposeBridges.Column(modifier, vertical, content, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -2040,26 +2040,37 @@ internal static partial class ComposeBridges
             p5:                      0,
             _changed:                defaults);
 
-    [ComposeFacade(Defaults = typeof(ColumnDefault), Scope = "Column")]
-    public static partial void Column(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
-
-    public static partial void Column(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)
+    // Internal forwarder for Column. The public-facing facade
+    // (Column.cs) is hand-written because the [ComposeFacade] generator
+    // can't surface a typed Arrangement? ctor parameter; it owns the
+    // $default mask and forwards the chosen verticalArrangement here.
+    internal static void Column(
+        IModifier? modifier,
+        AndroidX.Compose.Foundation.Layout.Arrangement.IVertical? verticalArrangement,
+        IFunction3 content,
+        int defaults,
+        IComposer composer)
         => ColumnKt.Column(
             modifier:            modifier,
-            verticalArrangement: null,
+            verticalArrangement: verticalArrangement,
             horizontalAlignment: null,
             content:             content,
             _composer:           composer,
             p5:                  0,
             _changed:            defaults);
 
-    [ComposeFacade(Defaults = typeof(RowDefault), Scope = "Row")]
-    public static partial void Row(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
-
-    public static partial void Row(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)
+    // Internal forwarder for Row — see the Column helper above for why
+    // this isn't an auto-generated facade. Row.cs supplies the typed
+    // horizontalArrangement and matching $default mask.
+    internal static void Row(
+        IModifier? modifier,
+        AndroidX.Compose.Foundation.Layout.Arrangement.IHorizontal? horizontalArrangement,
+        IFunction3 content,
+        int defaults,
+        IComposer composer)
         => RowKt.Row(
             modifier:              modifier,
-            horizontalArrangement: null,
+            horizontalArrangement: horizontalArrangement,
             verticalAlignment:     null,
             content:               content,
             _composer:             composer,

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -11,6 +11,16 @@ ComposeNet.AlertDialog.Text.get -> ComposeNet.ComposableNode?
 ComposeNet.AlertDialog.Text.set -> void
 ComposeNet.AlertDialog.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.AlertDialog.Title.set -> void
+ComposeNet.Arrangement
+static ComposeNet.Arrangement.Bottom.get -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.Center.get -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.End.get -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.SpaceAround.get -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.SpaceBetween.get -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.SpaceEvenly.get -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.SpacedBy(int dp) -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.Start.get -> ComposeNet.Arrangement!
+static ComposeNet.Arrangement.Top.get -> ComposeNet.Arrangement!
 ComposeNet.AssistChip
 ComposeNet.AssistChip.AssistChip(System.Action! onClick) -> void
 ComposeNet.AssistChip.Label.get -> ComposeNet.ComposableNode?
@@ -65,6 +75,7 @@ ComposeNet.CircularProgressIndicator.TrackColorArgb.get -> long?
 ComposeNet.CircularProgressIndicator.TrackColorArgb.set -> void
 ComposeNet.Column
 ComposeNet.Column.Column() -> void
+ComposeNet.Column.Column(ComposeNet.Arrangement? verticalArrangement) -> void
 ComposeNet.ComposableContainer
 ComposeNet.ComposableContainer.Add(ComposeNet.ComposableNode? child) -> void
 ComposeNet.ComposableContainer.Add(ComposeNet.Modifier! modifier) -> void
@@ -459,6 +470,7 @@ ComposeNet.Resource
 ComposeNet.Resource.Resource() -> void
 ComposeNet.Row
 ComposeNet.Row.Row() -> void
+ComposeNet.Row.Row(ComposeNet.Arrangement? horizontalArrangement) -> void
 ComposeNet.Scaffold
 ComposeNet.Scaffold.Body.get -> ComposeNet.ComposableNode?
 ComposeNet.Scaffold.Body.set -> void

--- a/src/ComposeNet.Compose/Row.cs
+++ b/src/ComposeNet.Compose/Row.cs
@@ -1,3 +1,5 @@
+using AndroidX.Compose.Runtime;
+
 namespace ComposeNet;
 
 /// <summary>
@@ -7,5 +9,68 @@ namespace ComposeNet;
 /// <code>
 /// new Row { new Text("A"), new Spacer { Modifier = ... }, new Text("B") }
 /// </code>
+/// Pass an optional <see cref="Arrangement"/> to control how children
+/// are distributed along the horizontal axis:
+/// <code>
+/// new Row(horizontalArrangement: Arrangement.SpaceBetween) { /* … */ }
+/// </code>
 /// </summary>
-public sealed partial class Row;
+public sealed class Row : ComposableContainer
+{
+    readonly Arrangement? _horizontalArrangement;
+
+    /// <summary>
+    /// Lay out children left-to-right with Compose's default
+    /// horizontal arrangement (<c>Arrangement.Start</c>).
+    /// </summary>
+    public Row() : this(null) { }
+
+    /// <summary>
+    /// Lay out children left-to-right using
+    /// <paramref name="horizontalArrangement"/> to distribute them along
+    /// the horizontal axis. Pass <see langword="null"/> (or use the
+    /// parameterless ctor) for Compose's default.
+    /// </summary>
+    /// <param name="horizontalArrangement">
+    /// One of the <see cref="Arrangement"/> static factories. Must wrap
+    /// a horizontal-capable Kotlin arrangement
+    /// (<see cref="Arrangement.Start"/>, <see cref="Arrangement.End"/>,
+    /// <see cref="Arrangement.Center"/>, <see cref="Arrangement.SpaceBetween"/>,
+    /// <see cref="Arrangement.SpaceAround"/>, <see cref="Arrangement.SpaceEvenly"/>,
+    /// or <see cref="Arrangement.SpacedBy(int)"/>). Passing a
+    /// vertical-only arrangement (<see cref="Arrangement.Top"/>,
+    /// <see cref="Arrangement.Bottom"/>) throws
+    /// <see cref="System.ArgumentException"/>.
+    /// </param>
+    public Row(Arrangement? horizontalArrangement)
+    {
+        if (horizontalArrangement is not null && horizontalArrangement.Horizontal is null)
+        {
+            throw new System.ArgumentException(
+                $"{nameof(horizontalArrangement)} must wrap a horizontal " +
+                $"or horizontal-or-vertical Compose Arrangement; got a " +
+                $"vertical-only value (e.g. Arrangement.Top / Arrangement.Bottom).",
+                nameof(horizontalArrangement));
+        }
+
+        _horizontalArrangement = horizontalArrangement;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        var horizontal = _horizontalArrangement?.Horizontal;
+        var modifier = BuildModifier();
+
+        int defaults = (int)RowDefault.All;
+        if (modifier is not null)   defaults &= ~(int)RowDefault.Modifier;
+        if (horizontal is not null) defaults &= ~(int)RowDefault.HorizontalArrangement;
+
+        var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
+        {
+            using var __scopeFrame = RenderContext.PushScope(scope, ScopeKind.Row);
+            RenderChildren(c);
+        });
+
+        ComposeBridges.Row(modifier, horizontal, content, defaults, composer);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -386,18 +386,14 @@ public class MainActivity : ComposeActivity
                 4 => (ComposableNode)new Column
                 {
                     new Text("Selection controls"),
-                    new Row
+                    new Row(Arrangement.SpacedBy(12))
                     {
                         new Checkbox(@checked: checkbox.Value, onCheckedChange: v => checkbox.Value = v),
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
                         new Switch(@checked: switchOn.Value, onCheckedChange: v => switchOn.Value = v),
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
                         new RadioButton(selected: radioPick.Value == 0, onClick: () => radioPick.Value = 0),
                         new Text("A"),
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.03f) },
                         new RadioButton(selected: radioPick.Value == 1, onClick: () => radioPick.Value = 1),
                         new Text("B"),
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.03f) },
                         new RadioButton(selected: radioPick.Value == 2, onClick: () => radioPick.Value = 2),
                         new Text("C"),
                     },
@@ -417,12 +413,10 @@ public class MainActivity : ComposeActivity
                 5 => new Column
                 {
                     new Text("Dialogs and sheets"),
-                    new Row
+                    new Row(Arrangement.SpacedBy(8))
                     {
                         new Button(onClick: () => showSheet.Value = true) { new Text("Sheet") },
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.03f) },
                         new Button(onClick: () => showDate.Value  = true) { new Text("Date") },
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.03f) },
                         new Button(onClick: () => showTime.Value  = true) { new Text("Time") },
                     },
                     new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
@@ -433,10 +427,9 @@ public class MainActivity : ComposeActivity
                 {
                     new Text("Misc Material 3"),
                     new Text("Progress indicators (indeterminate):"),
-                    new Row
+                    new Row(Arrangement.SpacedBy(12))
                     {
                         new CircularProgressIndicator(),
-                        new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
                         new Column
                         {
                             new Text("Linear ↓"),


### PR DESCRIPTION
Closes #70.

Compose's `Row.horizontalArrangement` / `Column.verticalArrangement` were not reachable from C# — callers had to fake `Arrangement.End` with a leading `Spacer(Weight(1f))` and `SpacedBy(...)` with `FillMaxWidth(0.0x)` spacers between every sibling. Both the Jetchat port and the kitchen-sink sample carried explicit `// Workaround for issue #70` comments.

## Approach

Adds a public `ComposeNet.Arrangement` helper that wraps the already-bound `AndroidX.Compose.Foundation.Layout.Arrangement` singleton:

- `Start` / `End` (horizontal-only)
- `Top` / `Bottom` (vertical-only)
- `Center`, `SpaceBetween`, `SpaceAround`, `SpaceEvenly`, `SpacedBy(int dp)` (either orientation)

Singletons are lazily cached for stable identity. `SpacedBy(int)` returns a fresh wrapper each call (Compose diffs non-lambda params by equality, so identity stability is unnecessary).

`Row` and `Column` are no longer `[ComposeFacade]`-generated stubs. The facade generator only accepts a fixed set of ctor-slot types (IModifier, IFunctionN, Action, primitives, ...) and can't surface a custom `Arrangement?`. They are now hand-written `ComposableContainer` subclasses with two constructors each: a parameterless one (back-compat: Compose default) and `Row(Arrangement?)` / `Column(Arrangement?)`. Each parameterized ctor validates orientation up front and throws `ArgumentException` if you hand `Row` a vertical-only arrangement (or `Column` a horizontal-only one) — fail-fast at the call site beats a silent NRE during composition.

`ComposeBridges.Row` / `ComposeBridges.Column` stay as the single-source-of-truth binding shim; they now take a typed `IHorizontal?` / `IVertical?` and forward to `RowKt.Row` / `ColumnKt.Column` instead of hard-coding `null`. No JNI bridges needed — the binding already exposes everything we want.

## Sample updates

- `ComposeNet.Sample` (kitchen sink): three rows converted to `Arrangement.SpacedBy(...)`, dropping eight `Spacer { FillMaxWidth(0.0x) }` lines (Selection controls, Dialogs/Sheets, Progress indicators).
- `samples/Jetchat`: the two sites with explicit `// Workaround ... issue #70` markers in `Conversation.cs` now use `Arrangement.End`. No other Jetchat rows touched — upstream Kotlin Jetchat uses default arrangements for them, so changing those would diverge from upstream parity.

## Verification

- `dotnet build src/ComposeNet.Compose` clean
- `dotnet build src/ComposeNet.Sample` clean
- `dotnet build samples/Jetchat` clean
- `dotnet test src/ComposeNet.SourceGenerators.Tests` 69/69 passing