### PR TITLE
Bind Small/Large/Extended FloatingActionButton variants

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -474,6 +474,55 @@ internal static partial class ComposeBridges
     public static partial void FloatingActionButton(IFunction0 onClick, IModifier? modifier,
                                                     IFunction2 content, IComposer composer);
 
+    // androidx.compose.material3.FloatingActionButtonKt.SmallFloatingActionButton-X-z6DiA
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/FloatingActionButtonKt",
+        JvmName   = "SmallFloatingActionButton-X-z6DiA",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/ui/graphics/Shape;JJ" +
+                    "Landroidx/compose/material3/FloatingActionButtonElevation;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(SmallFloatingActionButtonDefault))]
+    [ComposeFacade]
+    public static partial void SmallFloatingActionButton(IFunction0 onClick, IModifier? modifier,
+                                                         IFunction2 content, IComposer composer);
+
+    // androidx.compose.material3.FloatingActionButtonKt.LargeFloatingActionButton-X-z6DiA
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/FloatingActionButtonKt",
+        JvmName   = "LargeFloatingActionButton-X-z6DiA",
+        Signature = "(Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/ui/graphics/Shape;JJ" +
+                    "Landroidx/compose/material3/FloatingActionButtonElevation;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(LargeFloatingActionButtonDefault))]
+    [ComposeFacade]
+    public static partial void LargeFloatingActionButton(IFunction0 onClick, IModifier? modifier,
+                                                         IFunction2 content, IComposer composer);
+
+    // androidx.compose.material3.FloatingActionButtonKt.ExtendedFloatingActionButton-ElI5-7k
+    // (icon + text + expanded multi-slot variant — the canonical animated extended FAB)
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/FloatingActionButtonKt",
+        JvmName   = "ExtendedFloatingActionButton-ElI5-7k",
+        Signature = "(Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;" +
+                    "Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/ui/graphics/Shape;JJ" +
+                    "Landroidx/compose/material3/FloatingActionButtonElevation;" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(ExtendedFloatingActionButtonDefault))]
+    [ComposeFacade]
+    public static partial void ExtendedFloatingActionButton(
+        IFunction2 text,
+        IFunction2 icon,
+        IFunction0 onClick,
+        IModifier? modifier,
+        bool       expanded,
+        IComposer  composer);
+
     // androidx.compose.material3.SurfaceKt.Surface-T9BRK9s (non-interactive)
     [ComposeBridge(
         Class     = "androidx/compose/material3/SurfaceKt",

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -141,6 +141,24 @@ using ComposeNet;
     "!onClick", "modifier", "shape", "containerColor", "contentColor",
     "elevation", "interactionSource", "!content")]
 
+// androidx.compose.material3.FloatingActionButtonKt.SmallFloatingActionButton-X-z6DiA:
+// same shape as FloatingActionButton.
+[assembly: ComposeDefaults("SmallFloatingActionButtonDefault",
+    "!onClick", "modifier", "shape", "containerColor", "contentColor",
+    "elevation", "interactionSource", "!content")]
+
+// androidx.compose.material3.FloatingActionButtonKt.LargeFloatingActionButton-X-z6DiA:
+// same shape as FloatingActionButton.
+[assembly: ComposeDefaults("LargeFloatingActionButtonDefault",
+    "!onClick", "modifier", "shape", "containerColor", "contentColor",
+    "elevation", "interactionSource", "!content")]
+
+// androidx.compose.material3.FloatingActionButtonKt.ExtendedFloatingActionButton-ElI5-7k:
+// 10 user params; text/icon/onClick/expanded always provided by the caller.
+[assembly: ComposeDefaults("ExtendedFloatingActionButtonDefault",
+    "!text", "!icon", "!onClick", "modifier", "!expanded", "shape",
+    "containerColor", "contentColor", "elevation", "interactionSource")]
+
 // androidx.compose.material3.SurfaceKt.Surface-T9BRK9s (non-interactive):
 // 8 user params, only bit 7 = content provided.
 [assembly: ComposeDefaults("SurfaceDefault",

--- a/src/ComposeNet.Compose/ExtendedFloatingActionButton.cs
+++ b/src/ComposeNet.Compose/ExtendedFloatingActionButton.cs
@@ -7,11 +7,10 @@ namespace ComposeNet;
 /// icon&#x202F;+&#x202F;text states.
 ///
 /// <code>
-/// new ExtendedFloatingActionButton(onClick: () => /* ... */)
+/// new ExtendedFloatingActionButton(onClick: () => count.Value++, expanded: true)
 /// {
-///     Icon     = new Text("+"),
-///     Text     = new Text("Add"),
-///     Expanded = true,
+///     Icon = new Text("+"),
+///     Text = new Text("Add"),
 /// }
 /// </code>
 ///

--- a/src/ComposeNet.Compose/ExtendedFloatingActionButton.cs
+++ b/src/ComposeNet.Compose/ExtendedFloatingActionButton.cs
@@ -1,0 +1,23 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>ExtendedFloatingActionButton</c> — the animated
+/// extended FAB with separate <c>Icon</c> and <c>Text</c> slots and an
+/// <c>Expanded</c> flag that animates between the icon-only and
+/// icon&#x202F;+&#x202F;text states.
+///
+/// <code>
+/// new ExtendedFloatingActionButton(onClick: () => /* ... */)
+/// {
+///     Icon     = new Text("+"),
+///     Text     = new Text("Add"),
+///     Expanded = true,
+/// }
+/// </code>
+///
+/// Both <see cref="Icon"/> and <see cref="Text"/> are required — the
+/// underlying Kotlin parameters have no default. Setting either to
+/// <c>null</c> throws <see cref="System.InvalidOperationException"/> at
+/// render time.
+/// </summary>
+public sealed partial class ExtendedFloatingActionButton;

--- a/src/ComposeNet.Compose/LargeFloatingActionButton.cs
+++ b/src/ComposeNet.Compose/LargeFloatingActionButton.cs
@@ -1,0 +1,16 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>LargeFloatingActionButton</c>. Identical shape to
+/// <see cref="FloatingActionButton"/> — just the larger (96&#x202F;dp)
+/// container. Use the collection-initializer form for a single icon
+/// child:
+///
+/// <code>
+/// new LargeFloatingActionButton(onClick: () => /* ... */)
+/// {
+///     new Text("+"),
+/// }
+/// </code>
+/// </summary>
+public sealed partial class LargeFloatingActionButton;

--- a/src/ComposeNet.Compose/LargeFloatingActionButton.cs
+++ b/src/ComposeNet.Compose/LargeFloatingActionButton.cs
@@ -7,7 +7,7 @@ namespace ComposeNet;
 /// child:
 ///
 /// <code>
-/// new LargeFloatingActionButton(onClick: () => /* ... */)
+/// new LargeFloatingActionButton(onClick: () => count.Value++)
 /// {
 ///     new Text("+"),
 /// }

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -193,6 +193,12 @@ ComposeNet.ExposedDropdownMenu
 ComposeNet.ExposedDropdownMenu.ExposedDropdownMenu(bool expanded, System.Action! onDismissRequest) -> void
 ComposeNet.ExposedDropdownMenuBox
 ComposeNet.ExposedDropdownMenuBox.ExposedDropdownMenuBox(bool expanded, System.Action<bool>! onExpandedChange) -> void
+ComposeNet.ExtendedFloatingActionButton
+ComposeNet.ExtendedFloatingActionButton.ExtendedFloatingActionButton(System.Action! onClick, bool expanded) -> void
+ComposeNet.ExtendedFloatingActionButton.Icon.get -> ComposeNet.ComposableNode?
+ComposeNet.ExtendedFloatingActionButton.Icon.set -> void
+ComposeNet.ExtendedFloatingActionButton.Text.get -> ComposeNet.ComposableNode?
+ComposeNet.ExtendedFloatingActionButton.Text.set -> void
 ComposeNet.FilledIconButton
 ComposeNet.FilledIconButton.FilledIconButton(System.Action! onClick) -> void
 ComposeNet.FilledIconToggleButton
@@ -280,6 +286,8 @@ ComposeNet.LargeFlexibleTopAppBar.Subtitle.get -> ComposeNet.ComposableNode?
 ComposeNet.LargeFlexibleTopAppBar.Subtitle.set -> void
 ComposeNet.LargeFlexibleTopAppBar.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.LargeFlexibleTopAppBar.Title.set -> void
+ComposeNet.LargeFloatingActionButton
+ComposeNet.LargeFloatingActionButton.LargeFloatingActionButton(System.Action! onClick) -> void
 ComposeNet.LargeTopAppBar
 ComposeNet.LargeTopAppBar.Actions.get -> ComposeNet.ComposableNode?
 ComposeNet.LargeTopAppBar.Actions.set -> void
@@ -562,6 +570,8 @@ ComposeNet.SingleChoiceSegmentedButtonRow
 ComposeNet.SingleChoiceSegmentedButtonRow.SingleChoiceSegmentedButtonRow() -> void
 ComposeNet.Slider
 ComposeNet.Slider.Slider(float value, System.Action<float>! onValueChange) -> void
+ComposeNet.SmallFloatingActionButton
+ComposeNet.SmallFloatingActionButton.SmallFloatingActionButton(System.Action! onClick) -> void
 ComposeNet.Snackbar
 ComposeNet.Snackbar.Action.get -> ComposeNet.ComposableNode?
 ComposeNet.Snackbar.Action.set -> void

--- a/src/ComposeNet.Compose/SmallFloatingActionButton.cs
+++ b/src/ComposeNet.Compose/SmallFloatingActionButton.cs
@@ -7,7 +7,7 @@ namespace ComposeNet;
 /// child:
 ///
 /// <code>
-/// new SmallFloatingActionButton(onClick: () => /* ... */)
+/// new SmallFloatingActionButton(onClick: () => count.Value++)
 /// {
 ///     new Text("+"),
 /// }

--- a/src/ComposeNet.Compose/SmallFloatingActionButton.cs
+++ b/src/ComposeNet.Compose/SmallFloatingActionButton.cs
@@ -1,0 +1,16 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>SmallFloatingActionButton</c>. Identical shape to
+/// <see cref="FloatingActionButton"/> — just the smaller (40&#x202F;dp)
+/// container. Use the collection-initializer form for a single icon
+/// child:
+///
+/// <code>
+/// new SmallFloatingActionButton(onClick: () => /* ... */)
+/// {
+///     new Text("+"),
+/// }
+/// </code>
+/// </summary>
+public sealed partial class SmallFloatingActionButton;

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -307,6 +307,16 @@ public class MainActivity : ComposeActivity
                     {
                         new Text("✕"),
                     },
+                    new Row
+                    {
+                        new SmallFloatingActionButton(onClick: () => count++) { new Text("+") },
+                        new LargeFloatingActionButton(onClick: () => count++) { new Text("+") },
+                    },
+                    new ExtendedFloatingActionButton(onClick: () => count++, expanded: true)
+                    {
+                        Icon = new Text("✓"),
+                        Text = new Text("Increment"),
+                    },
                     new Button(onClick: () => showSnack.Value = true)
                     {
                         new Text("Show snackbar"),


### PR DESCRIPTION
Adds `[ComposeBridge]` partials + declarative `[ComposeDefaults]` enums for the three Material 3 1.4-bindable FAB variants:

- `SmallFloatingActionButton` (40&nbsp;dp) — same shape as `FloatingActionButton`
- `LargeFloatingActionButton` (96&nbsp;dp) — same shape
- `ExtendedFloatingActionButton` — multi-slot icon+text variant with `Expanded:bool`, modeled on `AlertDialog`. `Icon` and `Text` are required `ComposableNode?` slots (runtime-validated, since the Kotlin parameters have no default).

All four overloads are hash-mangled (`-X-z6DiA`, `-ElI5-7k`) because of inline `Color` / `Dp` parameters, so they need `[ComposeBridge]` until [dotnet/java-interop#1440](https://github.com/dotnet/java-interop/pull/1440) lands.

The M3 Expressive variants (`MediumFloatingActionButton`, `FloatingActionButtonMenu`, `ToggleFloatingActionButton`) are split into #103 — they're not in `Xamarin.AndroidX.Compose.Material3` 1.4.0.3 and need a newer NuGet.

Sample app exercises all three (Small + Large in a `Row`, Extended with `Expanded = true`).

Closes #52.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 69 passed
- `dotnet build src/ComposeNet.Compose` — clean
- `dotnet build src/ComposeNet.Sample` — clean