### PR TITLE
Plumb PaddingValues through ComposableNode (#46)

### DIFF
--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -18,7 +18,7 @@ namespace ComposeNet.Samples.Jetchat;
 ///
 /// Implemented as a static builder rather than a
 /// <see cref="ComposableNode"/> subclass because
-/// <see cref="ComposableNode.Render"/> is internal to the facade
+/// <see cref="ComposableNode.Render(AndroidX.Compose.Runtime.IComposer)"/> is internal to the facade
 /// assembly. Each recomposition calls <see cref="Build"/> to allocate
 /// a fresh tree — that's the Tier 1.5 per-composition cost.
 /// </summary>

--- a/src/ComposeNet.Compose/ComposableNode.cs
+++ b/src/ComposeNet.Compose/ComposableNode.cs
@@ -33,11 +33,13 @@ public abstract class ComposableNode
     Modifier? _prepended;
     Modifier? _appended;
 
-    // Runtime PaddingValues handle stashed by Render(IComposer, IntPtr)
-    // (e.g. a Scaffold body) for the next BuildModifier call to consume.
-    // Per-instance so descendants don't inherit it; save/restored by the
-    // virtual so re-entrant renders nest cleanly. See issue #46.
-    IntPtr _seedPaddingValues;
+    // PaddingValues handle handed to this node by a parent layout
+    // (e.g. Scaffold) via Render(IComposer, IntPtr). The next call
+    // to BuildModifier on this node prepends a Modifier.padding(values)
+    // op for it. Per-instance so descendants don't inherit it;
+    // save/restored by the virtual so re-entrant renders nest cleanly.
+    // See issue #46.
+    IntPtr _contentPadding;
 
     /// <summary>
     /// Set the <see cref="ComposeNet.Modifier"/> to prepend at the
@@ -61,10 +63,11 @@ public abstract class ComposableNode
     /// Replace-semantics keeps the stored modifier bounded to one ref
     /// even when the child never consumes it.
     ///
-    /// Ordering: when both a prepended modifier and a runtime padding
-    /// seed (from <c>Render(IComposer, IntPtr)</c>) are present on the
-    /// same node, the seed runs OUTSIDE the prepended op — i.e.
-    /// <c>seed → prepended → Modifier → appended</c>.
+    /// Ordering: when both a prepended modifier and a runtime
+    /// <c>contentPadding</c> (from <c>Render(IComposer, IntPtr)</c>)
+    /// are present on the same node, the content padding runs OUTSIDE
+    /// the prepended op — i.e.
+    /// <c>contentPadding → prepended → Modifier → appended</c>.
     /// </summary>
     public void PrependModifier(Modifier modifier)
     {
@@ -90,8 +93,8 @@ public abstract class ComposableNode
     /// any pending <see cref="PrependModifier"/> / <see cref="AppendModifier"/>
     /// contributions and clearing them so the next composition starts
     /// fresh. When this node was rendered via the
-    /// <c>Render(IComposer, IntPtr)</c> overload, also seeds the
-    /// chain with a <c>Modifier.padding(paddingValues)</c> op without
+    /// <c>Render(IComposer, IntPtr)</c> overload, also prepends a
+    /// <c>Modifier.padding(contentPadding)</c> op to the chain without
     /// allocating a managed <see cref="Modifier"/> wrapper (issue #46).
     /// Returns <c>null</c> when the combined chain is empty —
     /// callers should leave the Kotlin <c>$default</c> bit set so
@@ -104,11 +107,12 @@ public abstract class ComposableNode
         _prepended = null;
         _appended  = null;
 
-        // Consume any seed stashed by Render(IComposer, IntPtr); the
-        // wrapper restores the prior value in its finally block so
-        // nested renders nest cleanly without leaking.
-        IntPtr seed = _seedPaddingValues;
-        _seedPaddingValues = IntPtr.Zero;
+        // Consume the PaddingValues handle stashed by
+        // Render(IComposer, IntPtr); the wrapper restores the prior
+        // value in its finally block so nested renders nest cleanly
+        // without leaking.
+        IntPtr contentPadding = _contentPadding;
+        _contentPadding = IntPtr.Zero;
 
         Modifier? combined = prepended;
         if (Modifier is not null)
@@ -116,9 +120,9 @@ public abstract class ComposableNode
         if (appended is not null)
             combined = combined is null ? appended : combined.Then(appended);
 
-        if (seed == IntPtr.Zero)
+        if (contentPadding == IntPtr.Zero)
             return combined?.Build();
-        return (combined ?? Modifier.Companion).Build(seed);
+        return (combined ?? Modifier.Companion).Build(contentPadding);
     }
 
     internal abstract void Render(IComposer composer);
@@ -127,12 +131,12 @@ public abstract class ComposableNode
     /// Render this node as the body of a parent layout that supplies a
     /// runtime <c>PaddingValues</c> handle (e.g.
     /// <see cref="Scaffold"/>'s content lambda). The default
-    /// implementation stashes <paramref name="paddingValues"/> in a
+    /// implementation stashes <paramref name="contentPadding"/> in a
     /// per-instance slot and delegates to the regular
     /// <see cref="Render(IComposer)"/>; the next call to
     /// <see cref="BuildModifier"/> on this same node consumes the
-    /// handle and prepends a <c>Modifier.padding(paddingValues)</c> op
-    /// directly via JNI — no per-measure managed
+    /// handle and prepends a <c>Modifier.padding(contentPadding)</c>
+    /// op directly via JNI — no per-measure managed
     /// <see cref="ComposeNet.Modifier"/> allocations.
     ///
     /// Container facades whose Kotlin counterpart accepts a
@@ -141,17 +145,17 @@ public abstract class ComposableNode
     /// forward the handle into the binding instead of materializing a
     /// <c>Modifier.padding(values)</c> chain. See issue #46.
     /// </summary>
-    internal virtual void Render(IComposer composer, IntPtr paddingValues)
+    internal virtual void Render(IComposer composer, IntPtr contentPadding)
     {
-        var prev = _seedPaddingValues;
-        _seedPaddingValues = paddingValues;
+        var prev = _contentPadding;
+        _contentPadding = contentPadding;
         try
         {
             Render(composer);
         }
         finally
         {
-            _seedPaddingValues = prev;
+            _contentPadding = prev;
         }
     }
 }

--- a/src/ComposeNet.Compose/ComposableNode.cs
+++ b/src/ComposeNet.Compose/ComposableNode.cs
@@ -33,15 +33,11 @@ public abstract class ComposableNode
     Modifier? _prepended;
     Modifier? _appended;
 
-    // Per-render seed for runtime PaddingValues handed to a child node
-    // by a parent layout (e.g. Scaffold) via Render(IComposer, IntPtr).
-    // ThreadStatic because composition is single-threaded (see
-    // RenderContext); owner-checked because BuildModifier is called by
-    // every facade in the tree, not just the seed target — without the
-    // owner check, the first descendant to call BuildModifier would
-    // capture padding meant for the body. See issue #46.
-    [System.ThreadStatic] static ComposableNode? s_seedOwner;
-    [System.ThreadStatic] static IntPtr           s_seedPaddingValues;
+    // Runtime PaddingValues handle stashed by Render(IComposer, IntPtr)
+    // (e.g. a Scaffold body) for the next BuildModifier call to consume.
+    // Per-instance so descendants don't inherit it; save/restored by the
+    // virtual so re-entrant renders nest cleanly. See issue #46.
+    IntPtr _seedPaddingValues;
 
     /// <summary>
     /// Set the <see cref="ComposeNet.Modifier"/> to prepend at the
@@ -108,18 +104,11 @@ public abstract class ComposableNode
         _prepended = null;
         _appended  = null;
 
-        // Only consume the seed if it was scoped to this node. The
-        // owner check prevents leaking padding into descendants when a
-        // pass-through container (e.g. MaterialTheme) doesn't call
-        // BuildModifier itself; in that case padding is silently dropped,
-        // matching the long-standing PrependModifier caveat above.
-        IntPtr seed = IntPtr.Zero;
-        if (ReferenceEquals(s_seedOwner, this))
-        {
-            seed = s_seedPaddingValues;
-            s_seedOwner         = null;
-            s_seedPaddingValues = IntPtr.Zero;
-        }
+        // Consume any seed stashed by Render(IComposer, IntPtr); the
+        // wrapper restores the prior value in its finally block so
+        // nested renders nest cleanly without leaking.
+        IntPtr seed = _seedPaddingValues;
+        _seedPaddingValues = IntPtr.Zero;
 
         Modifier? combined = prepended;
         if (Modifier is not null)
@@ -139,8 +128,8 @@ public abstract class ComposableNode
     /// runtime <c>PaddingValues</c> handle (e.g.
     /// <see cref="Scaffold"/>'s content lambda). The default
     /// implementation stashes <paramref name="paddingValues"/> in a
-    /// thread-static slot keyed on this node and delegates to the
-    /// regular <see cref="Render(IComposer)"/>; the next call to
+    /// per-instance slot and delegates to the regular
+    /// <see cref="Render(IComposer)"/>; the next call to
     /// <see cref="BuildModifier"/> on this same node consumes the
     /// handle and prepends a <c>Modifier.padding(paddingValues)</c> op
     /// directly via JNI — no per-measure managed
@@ -154,18 +143,15 @@ public abstract class ComposableNode
     /// </summary>
     internal virtual void Render(IComposer composer, IntPtr paddingValues)
     {
-        var prevOwner = s_seedOwner;
-        var prevSeed  = s_seedPaddingValues;
-        s_seedOwner         = this;
-        s_seedPaddingValues = paddingValues;
+        var prev = _seedPaddingValues;
+        _seedPaddingValues = paddingValues;
         try
         {
             Render(composer);
         }
         finally
         {
-            s_seedOwner         = prevOwner;
-            s_seedPaddingValues = prevSeed;
+            _seedPaddingValues = prev;
         }
     }
 }

--- a/src/ComposeNet.Compose/ComposableNode.cs
+++ b/src/ComposeNet.Compose/ComposableNode.cs
@@ -8,9 +8,9 @@ namespace ComposeNet;
 ///
 /// A <see cref="ComposableNode"/> is a passive AST node: building it
 /// (<c>new Text("Hi")</c>, <c>new Column { ... }</c>) does NOT call into
-/// Compose. The activity walks the tree and calls <see cref="Render"/>
-/// during composition, threading the <see cref="IComposer"/> through
-/// container nodes to their children.
+/// Compose. The activity walks the tree and calls
+/// <see cref="Render(IComposer)"/> during composition, threading the
+/// <see cref="IComposer"/> through container nodes to their children.
 ///
 /// This is the C# moral equivalent of Kotlin Compose's IR transform —
 /// the composer is explicit at the implementation layer (honest mirror
@@ -33,6 +33,16 @@ public abstract class ComposableNode
     Modifier? _prepended;
     Modifier? _appended;
 
+    // Per-render seed for runtime PaddingValues handed to a child node
+    // by a parent layout (e.g. Scaffold) via Render(IComposer, IntPtr).
+    // ThreadStatic because composition is single-threaded (see
+    // RenderContext); owner-checked because BuildModifier is called by
+    // every facade in the tree, not just the seed target — without the
+    // owner check, the first descendant to call BuildModifier would
+    // capture padding meant for the body. See issue #46.
+    [System.ThreadStatic] static ComposableNode? s_seedOwner;
+    [System.ThreadStatic] static IntPtr           s_seedPaddingValues;
+
     /// <summary>
     /// Set the <see cref="ComposeNet.Modifier"/> to prepend at the
     /// START of this node's modifier chain on the next call to
@@ -41,12 +51,12 @@ public abstract class ComposableNode
     /// at the call site to combine multiple ops into one.
     ///
     /// Intended use: a parent layout that needs to pass a runtime
-    /// modifier into a child without inserting a wrapper layout node —
-    /// e.g. <see cref="Scaffold"/> threading
-    /// <c>Modifier.padding(paddingValues)</c> into its body so the
-    /// body's own modifier chain composes naturally with the inset
-    /// padding, mirroring the Kotlin idiom
-    /// <c>Column(Modifier.padding(paddingValues)) { ... }</c>.
+    /// modifier into a child without inserting a wrapper layout node.
+    /// For the specific case of forwarding a <c>PaddingValues</c>
+    /// handle from <see cref="Scaffold"/> to its body, prefer the
+    /// internal <c>Render(IComposer, IntPtr)</c> overload — it skips
+    /// the managed <see cref="ComposeNet.Modifier"/> wrapper altogether
+    /// (see issue #46).
     ///
     /// Caveat: the injected modifier is silently dropped if the child's
     /// <c>Render</c> never calls <see cref="BuildModifier"/> (i.e.
@@ -54,6 +64,11 @@ public abstract class ComposableNode
     /// parameter — <see cref="MaterialTheme"/>, the drawer sheets).
     /// Replace-semantics keeps the stored modifier bounded to one ref
     /// even when the child never consumes it.
+    ///
+    /// Ordering: when both a prepended modifier and a runtime padding
+    /// seed (from <c>Render(IComposer, IntPtr)</c>) are present on the
+    /// same node, the seed runs OUTSIDE the prepended op — i.e.
+    /// <c>seed → prepended → Modifier → appended</c>.
     /// </summary>
     public void PrependModifier(Modifier modifier)
     {
@@ -78,16 +93,33 @@ public abstract class ComposableNode
     /// Materialize <see cref="Modifier"/> for the JNI call, folding in
     /// any pending <see cref="PrependModifier"/> / <see cref="AppendModifier"/>
     /// contributions and clearing them so the next composition starts
-    /// fresh. Returns <c>null</c> when the combined chain is empty —
+    /// fresh. When this node was rendered via the
+    /// <c>Render(IComposer, IntPtr)</c> overload, also seeds the
+    /// chain with a <c>Modifier.padding(paddingValues)</c> op without
+    /// allocating a managed <see cref="Modifier"/> wrapper (issue #46).
+    /// Returns <c>null</c> when the combined chain is empty —
     /// callers should leave the Kotlin <c>$default</c> bit set so
     /// Compose substitutes its real default.
     /// </summary>
     internal IModifier? BuildModifier()
     {
         var prepended = _prepended;
-        var appended = _appended;
+        var appended  = _appended;
         _prepended = null;
-        _appended = null;
+        _appended  = null;
+
+        // Only consume the seed if it was scoped to this node. The
+        // owner check prevents leaking padding into descendants when a
+        // pass-through container (e.g. MaterialTheme) doesn't call
+        // BuildModifier itself; in that case padding is silently dropped,
+        // matching the long-standing PrependModifier caveat above.
+        IntPtr seed = IntPtr.Zero;
+        if (ReferenceEquals(s_seedOwner, this))
+        {
+            seed = s_seedPaddingValues;
+            s_seedOwner         = null;
+            s_seedPaddingValues = IntPtr.Zero;
+        }
 
         Modifier? combined = prepended;
         if (Modifier is not null)
@@ -95,8 +127,45 @@ public abstract class ComposableNode
         if (appended is not null)
             combined = combined is null ? appended : combined.Then(appended);
 
-        return combined?.Build();
+        if (seed == IntPtr.Zero)
+            return combined?.Build();
+        return (combined ?? Modifier.Companion).Build(seed);
     }
 
     internal abstract void Render(IComposer composer);
+
+    /// <summary>
+    /// Render this node as the body of a parent layout that supplies a
+    /// runtime <c>PaddingValues</c> handle (e.g.
+    /// <see cref="Scaffold"/>'s content lambda). The default
+    /// implementation stashes <paramref name="paddingValues"/> in a
+    /// thread-static slot keyed on this node and delegates to the
+    /// regular <see cref="Render(IComposer)"/>; the next call to
+    /// <see cref="BuildModifier"/> on this same node consumes the
+    /// handle and prepends a <c>Modifier.padding(paddingValues)</c> op
+    /// directly via JNI — no per-measure managed
+    /// <see cref="ComposeNet.Modifier"/> allocations.
+    ///
+    /// Container facades whose Kotlin counterpart accepts a
+    /// <c>contentPadding</c> parameter directly (<see cref="LazyColumn{T}"/>,
+    /// <see cref="LazyRow{T}"/>, the lazy grids) can override this to
+    /// forward the handle into the binding instead of materializing a
+    /// <c>Modifier.padding(values)</c> chain. See issue #46.
+    /// </summary>
+    internal virtual void Render(IComposer composer, IntPtr paddingValues)
+    {
+        var prevOwner = s_seedOwner;
+        var prevSeed  = s_seedPaddingValues;
+        s_seedOwner         = this;
+        s_seedPaddingValues = paddingValues;
+        try
+        {
+            Render(composer);
+        }
+        finally
+        {
+            s_seedOwner         = prevOwner;
+            s_seedPaddingValues = prevSeed;
+        }
+    }
 }

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -385,28 +385,35 @@ public sealed class Modifier
 
     /// <summary>
     /// Materialize the chain into a managed <c>IModifier</c> wrapper,
-    /// optionally seeding it with a <c>Modifier.padding(paddingValues)</c>
-    /// op against the supplied <see cref="IntPtr"/> handle. The seed op
-    /// runs FIRST, before any user ops — semantically equivalent to
-    /// <c>Modifier.padding(paddingValues).then(this)</c> but without
+    /// optionally prepending a <c>Modifier.padding(contentPadding)</c>
+    /// op against the supplied <see cref="IntPtr"/> handle. The padding
+    /// op runs FIRST, before any user ops — semantically equivalent to
+    /// <c>Modifier.padding(contentPadding).then(this)</c> but without
     /// allocating a managed <see cref="Modifier"/> wrapper. Used by
     /// <see cref="ComposableNode.BuildModifier"/> to apply the
     /// <see cref="Scaffold"/>-supplied <c>PaddingValues</c> to the body
     /// node on every measure pass without per-pass allocations
     /// (issue #46).
     /// </summary>
-    internal IModifier? Build(IntPtr seedPaddingValues)
+    internal IModifier? Build(IntPtr contentPadding)
     {
-        bool hasSeed = seedPaddingValues != IntPtr.Zero;
-        if (_ops.Length == 0 && !hasSeed)
+        bool hasContentPadding = contentPadding != IntPtr.Zero;
+        if (_ops.Length == 0 && !hasContentPadding)
             return null;
 
-        IntPtr current = ComposeBridges.ModifierCompanionInstance();
+        // `current` always holds the latest live local ref. On the
+        // happy path we zero it out after handing ownership to
+        // GetObject; the finally then no-ops. On any exception path
+        // — JNI op throwing, GetObject throwing, anything in between
+        // — the finally deletes whichever local ref is still live so
+        // we never leak.
+        IntPtr current = IntPtr.Zero;
         try
         {
-            if (hasSeed)
+            current = ComposeBridges.ModifierCompanionInstance();
+            if (hasContentPadding)
             {
-                IntPtr next = ComposeBridges.ModifierPaddingValues(current, seedPaddingValues);
+                IntPtr next = ComposeBridges.ModifierPaddingValues(current, contentPadding);
                 JNIEnv.DeleteLocalRef(current);
                 current = next;
             }
@@ -416,14 +423,15 @@ public sealed class Modifier
                 JNIEnv.DeleteLocalRef(current);
                 current = next;
             }
+
+            var result = Java.Lang.Object.GetObject<IModifier>(current, JniHandleOwnership.TransferLocalRef)!;
+            current = IntPtr.Zero;
+            return result;
         }
-        catch
+        finally
         {
             if (current != IntPtr.Zero)
                 JNIEnv.DeleteLocalRef(current);
-            throw;
         }
-
-        return Java.Lang.Object.GetObject<IModifier>(current, JniHandleOwnership.TransferLocalRef)!;
     }
 }

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -381,14 +381,35 @@ public sealed class Modifier
     /// callers can keep the Kotlin <c>$default</c> bit set and let
     /// Compose substitute the real default.
     /// </summary>
-    internal IModifier? Build()
+    internal IModifier? Build() => Build(IntPtr.Zero);
+
+    /// <summary>
+    /// Materialize the chain into a managed <c>IModifier</c> wrapper,
+    /// optionally seeding it with a <c>Modifier.padding(paddingValues)</c>
+    /// op against the supplied <see cref="IntPtr"/> handle. The seed op
+    /// runs FIRST, before any user ops — semantically equivalent to
+    /// <c>Modifier.padding(paddingValues).then(this)</c> but without
+    /// allocating a managed <see cref="Modifier"/> wrapper. Used by
+    /// <see cref="ComposableNode.BuildModifier"/> to apply the
+    /// <see cref="Scaffold"/>-supplied <c>PaddingValues</c> to the body
+    /// node on every measure pass without per-pass allocations
+    /// (issue #46).
+    /// </summary>
+    internal IModifier? Build(IntPtr seedPaddingValues)
     {
-        if (_ops.Length == 0)
+        bool hasSeed = seedPaddingValues != IntPtr.Zero;
+        if (_ops.Length == 0 && !hasSeed)
             return null;
 
         IntPtr current = ComposeBridges.ModifierCompanionInstance();
         try
         {
+            if (hasSeed)
+            {
+                IntPtr next = ComposeBridges.ModifierPaddingValues(current, seedPaddingValues);
+                JNIEnv.DeleteLocalRef(current);
+                current = next;
+            }
             for (int i = 0; i < _ops.Length; i++)
             {
                 IntPtr next = _ops[i](current);

--- a/src/ComposeNet.Compose/Scaffold.cs
+++ b/src/ComposeNet.Compose/Scaffold.cs
@@ -49,36 +49,16 @@ public sealed class Scaffold : ComposableNode
 
         // Material 3's Scaffold passes PaddingValues as the first arg of
         // its content lambda — body must apply it to avoid rendering
-        // behind the top/bottom bars. Compose a runtime
-        // `Modifier.padding(values)` onto Body's existing chain so the
-        // padding and Body's own modifiers compose on the same layout
-        // node, mirroring Kotlin's
-        // `Column(Modifier.padding(paddingValues)) { ... }`.
-        //
-        // ScaffoldLayout is a SubcomposeLayout, so this content callback
-        // runs once per measure pass (and again on remeasure), not once
-        // per composition. We snapshot-and-restore `body.Modifier`
-        // locally inside the lambda instead of using `PrependModifier`,
-        // which would leave mutated state on the user-supplied Body
-        // node between measure passes (see #42 H5). `Modifier` is a
-        // plain auto-property with no side effects, and composition
-        // is single-threaded, so the temporary mutation is invisible
-        // outside this synchronous block.
+        // behind the top/bottom bars. Forward the raw handle directly
+        // through ComposableNode.Render(IComposer, IntPtr) so body's
+        // BuildModifier can prepend a `Modifier.padding(values)` op via
+        // JNI without allocating a managed Modifier wrapper per measure
+        // pass (issue #46). ScaffoldLayout is a SubcomposeLayout — this
+        // lambda runs on every measure pass, so the saved allocation
+        // adds up quickly during scrolls, rotations, and IME animations.
         var body = Body;
         var content = ComposableLambdas.Wrap3(composer, (paddingHandle, c) =>
-        {
-            var saved = body.Modifier;
-            var padding = Modifier.Companion.Padding(paddingHandle);
-            body.Modifier = saved is null ? padding : padding.Then(saved);
-            try
-            {
-                body.Render(c);
-            }
-            finally
-            {
-                body.Modifier = saved;
-            }
-        });
+            body.Render(c, paddingHandle));
 
         // Always pass non-null slot lambdas. Toggling between Compose's
         // default `{}` (a synthetic Java SAM lambda) and our IFunction2


### PR DESCRIPTION
Closes #46.

`Scaffold.Render`'s content lambda runs on every measure pass of M3's `ScaffoldLayout` (a `SubcomposeLayout`). PR #45 fixed the correctness problem — mutating `body.Modifier` outside the synchronous render call — but left two managed `Modifier` allocations per measure pass behind:

1. `Modifier.Companion.Padding(paddingHandle)` — a fresh `Modifier` wrapping a single padding-values op.
2. `padding.Then(saved)` — a second `Modifier` merging the padding wrapper with the body's existing chain.

## Fix — Option 3 from the issue

Plumb the raw `PaddingValues` handle through `ComposableNode` directly so the body can apply it without ever materializing a managed `Modifier` wrapper:

- **New `internal virtual void Render(IComposer, IntPtr contentPadding)`** on `ComposableNode`. The default stashes the handle in a per-instance `IntPtr _contentPadding` field and delegates to the regular `Render(IComposer)`; on the next `BuildModifier` call, the field is consumed and turned into a `Modifier.padding(values)` JNI op prepended to the existing chain. Per-instance (not `[ThreadStatic]`) because the handle targets exactly one node — descendants have their own field defaulting to `IntPtr.Zero` and cannot accidentally consume the body's padding.
- **New `Modifier.Build(IntPtr contentPadding)` overload** performs the JNI op directly: `companion → ModifierPaddingValues(contentPadding) → user ops`. Same JNI cost as today's path, zero managed wrapper allocations. While in here, the local-ref cleanup also moved from a `catch`+rethrow to a `try`/`finally` so a throw from `GetObject<IModifier>` no longer leaks the final local ref.
- **`Scaffold.Render`'s content lambda** collapses from a save/restore dance over `body.Modifier` to a one-liner:
  ```csharp
  body.Render(c, paddingHandle)
  ```

## Honest take on the win

The raw allocation savings (~150 bytes per measure pass) are too small to show up in a frame-time graph on their own. The real value of this PR is as an **enabler**:

- `LazyColumn` / `LazyRow` / lazy grids can now override `Render(IComposer, IntPtr)` to forward the handle into their Kotlin `contentPadding` parameter. That's both a real perf improvement (no per-item modifier op) and a real UX improvement (items can scroll edge-to-edge under the top bar instead of being clipped by an outer padding). **Left as a follow-up.**
- `Scaffold.cs`'s content lambda drops from 15 lines of save/restore commentary to a one-liner.
- Future Scaffold-shaped composables (e.g. `BottomSheetScaffold`'s content slot) get a clean primitive instead of needing to copy PR #45's mutation dance.

Without the lazy-container follow-up this PR is a "nice cleanup" rather than a measurable perf win. With it, the combined change is a defensible improvement for edge-to-edge UX.

## Notes

- The new field, parameter, and virtual all use the name `contentPadding` to match Kotlin's parameter name on `LazyColumn` / `LazyRow` / lazy grids — instantly recognizable to anyone who has used Compose.
- `PrependModifier`/`AppendModifier` (declared but unused, unshipped) retain their semantics; the new content-padding op runs OUTSIDE prepended ops — `contentPadding → prepended → Modifier → appended`. PR #45's de-facto ordering was `prepended → padding → Modifier → appended`, but no caller relied on it (zero call sites in the repo).
- The new virtual is `internal`, so no `PublicAPI.Unshipped.txt` churn.

## Validation

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 69/69 pass.
- `dotnet build src/ComposeNet.Compose` — clean, no `RS0016/RS0017`.
- `dotnet build src/ComposeNet.Sample` — clean.

## Cross-links

- #42 (parent investigation)
- #45 (H5 fix — adds the snapshot/restore this issue obsoletes)
- #37 (closed — `PrependModifier`/`AppendModifier`, partially superseded by this change)