### PR TITLE
Add Compose.RememberSaveable for state that survives process death

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -32,6 +32,8 @@
     <PackageReference Update="Xamarin.AndroidX.Compose.Material3Android" Version="1.4.0.3" />
     <PackageReference Update="Xamarin.AndroidX.Compose.Runtime" Version="1.11.2.1" />
     <PackageReference Update="Xamarin.AndroidX.Compose.Runtime.Android" Version="1.11.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Runtime.Saveable" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Runtime.Saveable.Android" Version="1.11.2" />
     <PackageReference Update="Xamarin.AndroidX.Compose.UI" Version="1.11.2" />
     <PackageReference Update="Xamarin.AndroidX.Compose.UI.Android" Version="1.11.2" />
     <PackageReference Update="Xamarin.AndroidX.Compose.UI.Graphics" Version="1.11.2.1" />

--- a/src/ComposeNet.Compose/ComposableLambdas.cs
+++ b/src/ComposeNet.Compose/ComposableLambdas.cs
@@ -60,7 +60,7 @@ internal static class ComposableLambdas
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
         => (IFunction2)ComposableLambdaKt.ComposableLambda(
-            composer, HashCode.Combine(line, file), tracked: true,
+            composer, SourceLocationKey.Compute(line, file), tracked: true,
             block: new ComposableLambda2(body));
 
     /// <summary>
@@ -75,7 +75,7 @@ internal static class ComposableLambdas
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
         => (IFunction3)ComposableLambdaKt.ComposableLambda(
-            composer, HashCode.Combine(line, file), tracked: true,
+            composer, SourceLocationKey.Compute(line, file), tracked: true,
             block: new ComposableLambda3(body));
 
     /// <summary>
@@ -92,7 +92,7 @@ internal static class ComposableLambdas
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
         => (IFunction3)ComposableLambdaKt.ComposableLambda(
-            composer, HashCode.Combine(line, file), tracked: true,
+            composer, SourceLocationKey.Compute(line, file), tracked: true,
             block: new ComposableLambda3(body));
 
     /// <summary>
@@ -118,7 +118,7 @@ internal static class ComposableLambdas
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
         => (IFunction4)ComposableLambdaKt.ComposableLambdaInstance(
-            key: HashCode.Combine(line, file), tracked: true,
+            key: SourceLocationKey.Compute(line, file), tracked: true,
             block: new ComposableLambda4(body));
 
     /// <summary>
@@ -148,6 +148,6 @@ internal static class ComposableLambdas
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
         => (IFunction4)ComposableLambdaKt.ComposableLambda(
-            composer, HashCode.Combine(line, file), tracked: true,
+            composer, SourceLocationKey.Compute(line, file), tracked: true,
             block: new ComposableLambda4(body));
 }

--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -17,12 +17,16 @@ public static class Compose
     /// the first time this call site is reached, then the cached value on
     /// subsequent recompositions.
     ///
-    /// The slot is keyed by <c>HashCode.Combine(line, file)</c> from the
-    /// <see cref="CallerLineNumberAttribute"/> / <see cref="CallerFilePathAttribute"/>
-    /// fill-ins so two call sites in different files (or different lines)
-    /// never share a slot — and so the same call site reached repeatedly
-    /// across recompositions does share its slot, returning the cached
-    /// value.
+    /// The slot is keyed by <see cref="SourceLocationKey"/>'s FNV-1a hash
+    /// of the file path mixed with the line number — a stable identifier
+    /// derived from <see cref="CallerLineNumberAttribute"/> /
+    /// <see cref="CallerFilePathAttribute"/> fill-ins, deterministic
+    /// across process restarts (unlike <see cref="System.HashCode"/>,
+    /// which is per-process randomized) so the saveable-state registry
+    /// can match the recomputed key to its stored value on restore.
+    /// Two call sites in different files (or different lines) never
+    /// share a slot, and the same call site reached repeatedly across
+    /// recompositions does share its slot.
     ///
     /// Wrapped in <c>StartReplaceableGroup</c> / <c>EndReplaceableGroup</c>
     /// so the slot belongs to its own group; sibling positional grouping
@@ -43,7 +47,7 @@ public static class Compose
             ?? throw new System.InvalidOperationException(
                 "Compose.Remember<T> must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
 
-        composer.StartReplaceableGroup(System.HashCode.Combine(line, file));
+        composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
         try
         {
             if (composer.RememberedValue() is RememberHolder existing)
@@ -57,4 +61,133 @@ public static class Compose
             composer.EndReplaceableGroup();
         }
     }
+
+    /// <summary>
+    /// Compose's <c>rememberSaveable { factory() }</c>: like
+    /// <see cref="Remember{T}(System.Func{T}, int, string)"/>, but the
+    /// cached value also survives <b>process death and activity
+    /// recreation</b> (e.g. rotation when the activity doesn't override
+    /// <c>android:configChanges</c>) via Compose's
+    /// <c>SaveableStateRegistry</c>, which serialises into the
+    /// activity's saved-instance <see cref="Android.OS.Bundle"/>.
+    ///
+    /// Mirrors Kotlin's single <c>rememberSaveable&lt;T&gt;</c> entry
+    /// point — the same call works for scalar values
+    /// (<c>int</c>, <c>long</c>, <c>float</c>, <c>double</c>,
+    /// <c>bool</c>, <c>string</c>, plus any other type
+    /// <see cref="MutableState{T}"/> can box / unbox) and for
+    /// state-holder wrappers (<see cref="MutableState{U}"/>,
+    /// <see cref="MutableNumberState{U}"/>):
+    /// <code>
+    /// var count = RememberSaveable(() =&gt; new MutableNumberState&lt;int&gt;(0));
+    /// var name  = RememberSaveable(() =&gt; new MutableState&lt;string&gt;(""));
+    /// var pi    = RememberSaveable(() =&gt; 3.14159);
+    /// </code>
+    /// Wrappers are routed through Compose's <c>mutableStateSaver</c>
+    /// (only the inner value is persisted); scalars use
+    /// <c>autoSaver</c>.
+    ///
+    /// The slot is keyed by <see cref="SourceLocationKey"/>'s FNV-1a
+    /// hash — deterministic across process restarts so the saveable-
+    /// state registry can match the recomputed key to its stored value
+    /// on restore. The <c>vararg inputs</c> dependency-tracking
+    /// parameter isn't surfaced here — an empty <c>Object[]</c> is
+    /// passed, meaning the cached value is never invalidated on
+    /// dependency change. A future <c>params object?[]</c> overload
+    /// can lift that.
+    /// </summary>
+    public static T RememberSaveable<T>(
+        System.Func<T> factory,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+    {
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.RememberSaveable<T> must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
+
+        composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
+        try
+        {
+            // State-holder branch: T is MutableState<U>, MutableNumberState<U>,
+            // or any future wrapper that implements IMutableStateWrapper.
+            // The `is`-check is type-metadata only — no reflection, no
+            // member lookup, fully trim-safe.
+            if (typeof(IMutableStateWrapper).IsAssignableFrom(typeof(T)))
+                return RememberSaveableWrapper(factory, composer);
+
+            return RememberSaveableScalar(factory, composer);
+        }
+        finally
+        {
+            composer.EndReplaceableGroup();
+        }
+    }
+
+    static T RememberSaveableScalar<T>(System.Func<T> factory, IComposer composer)
+    {
+        var jcw = new ObjectFunction0(() => MutableState<T>.ToJava(factory()));
+        var handle = ComposeBridges.RememberSaveableSimple(
+            ComposeBridges.EmptyObjectArray(),
+            jcw,
+            ((Java.Lang.Object)composer).Handle,
+            changed: 0);
+        try
+        {
+            if (handle == System.IntPtr.Zero)
+                return default!;
+            var boxed = Java.Lang.Object.GetObject<Java.Lang.Object>(
+                handle, Android.Runtime.JniHandleOwnership.DoNotTransfer);
+            return MutableState<T>.FromJava(boxed);
+        }
+        finally
+        {
+            if (handle != System.IntPtr.Zero)
+                Android.Runtime.JNIEnv.DeleteLocalRef(handle);
+            System.GC.KeepAlive(composer);
+        }
+    }
+
+    static T RememberSaveableWrapper<T>(System.Func<T> factory, IComposer composer)
+    {
+        // Cache the C# wrapper across recompositions so we don't
+        // allocate a fresh facade + Kotlin IMutableState on every
+        // render. `Compose.Remember` opens its own nested replaceable
+        // group; nesting is fine — Compose's slot table handles it.
+        var wrapper = Remember(factory)
+            ?? throw new System.InvalidOperationException(
+                $"Compose.RememberSaveable<{typeof(T).Name}>: factory returned null.");
+        var iwrap = (IMutableStateWrapper)wrapper;
+
+        // Hand Compose's `rememberSaveable` the wrapper's underlying
+        // IMutableState. On first composition Compose calls our JCW
+        // and caches whatever we return. On a process-death restore
+        // Compose builds a fresh boxed state via mutableStateSaver
+        // and ignores our JCW; its return value is the restored
+        // state. On every subsequent recomposition Compose returns
+        // the cached state directly. We swap our wrapper's _state
+        // to point at whatever Compose hands back.
+        var jcw = new ObjectFunction0(() => (Java.Lang.Object)iwrap.State);
+        var handle = ComposeBridges.RememberSaveableMutableState(
+            ComposeBridges.EmptyObjectArray(),
+            ComposeBridges.SaverAutoSaver(),
+            jcw,
+            ((Java.Lang.Object)composer).Handle,
+            changed: 0);
+        try
+        {
+            if (handle == System.IntPtr.Zero)
+                throw new System.InvalidOperationException(
+                    $"Compose.RememberSaveable<{typeof(T).Name}>: rememberSaveable returned null.");
+            iwrap.State = Java.Lang.Object.GetObject<IMutableState>(
+                handle, Android.Runtime.JniHandleOwnership.DoNotTransfer)!;
+            return wrapper;
+        }
+        finally
+        {
+            if (handle != System.IntPtr.Zero)
+                Android.Runtime.JNIEnv.DeleteLocalRef(handle);
+            System.GC.KeepAlive(composer);
+        }
+    }
 }
+

--- a/src/ComposeNet.Compose/ComposeActivity.cs
+++ b/src/ComposeNet.Compose/ComposeActivity.cs
@@ -79,6 +79,22 @@ public abstract class ComposeActivity : ComponentActivity
         => Compose.Remember(factory, line, file);
 
     /// <summary>
+    /// Like <see cref="Remember{T}(System.Func{T}, int, string)"/>, but
+    /// the cached value also survives process death / activity
+    /// recreation through Compose's <c>SaveableStateRegistry</c>.
+    /// Mirrors Kotlin's single <c>rememberSaveable&lt;T&gt;</c> entry
+    /// point — works for scalar values and for state-holder wrappers
+    /// (<see cref="MutableState{U}"/> / <see cref="MutableNumberState{U}"/>).
+    /// See <see cref="Compose.RememberSaveable{T}(System.Func{T}, int, string)"/>
+    /// for the full supported-<c>T</c> list.
+    /// </summary>
+    protected T RememberSaveable<T>(
+        System.Func<T> factory,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.RememberSaveable(factory, line, file);
+
+    /// <summary>
     /// Opts the window into edge-to-edge. Call <c>base.OnCreate</c>
     /// first thing in your subclass override — that runs
     /// <see cref="EdgeToEdge.Enable(ComponentActivity)"/> before

--- a/src/ComposeNet.Compose/ComposeNet.Compose.csproj
+++ b/src/ComposeNet.Compose/ComposeNet.Compose.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Xamarin.AndroidX.Activity.Compose" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Runtime" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Android" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Saveable" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Saveable.Android" />
     <PackageReference Include="Xamarin.AndroidX.Compose.UI" />
     <PackageReference Include="Xamarin.AndroidX.Compose.UI.Android" />
     <PackageReference Include="Xamarin.AndroidX.Compose.UI.Graphics" />

--- a/src/ComposeNet.Compose/IMutableStateWrapper.cs
+++ b/src/ComposeNet.Compose/IMutableStateWrapper.cs
@@ -1,0 +1,18 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Non-generic view onto a <see cref="MutableState{T}"/> /
+/// <see cref="MutableNumberState{T}"/> wrapper. Exists so
+/// <see cref="Compose.RememberSaveable{T}(System.Func{T}, int, string)"/>
+/// can detect "<c>T</c> is a state-holder wrapper" with a cheap
+/// <c>is</c>-check (no reflection, trim-safe), and so the dispatcher
+/// can swap the wrapper's underlying <see cref="IMutableState"/>
+/// after Compose's <c>rememberSaveable</c> hands back a (possibly
+/// restored) state on first composition.
+/// </summary>
+internal interface IMutableStateWrapper
+{
+    IMutableState State { get; set; }
+}

--- a/src/ComposeNet.Compose/MutableNumberState.cs
+++ b/src/ComposeNet.Compose/MutableNumberState.cs
@@ -25,49 +25,65 @@ namespace ComposeNet;
 /// (<c>decimal</c>, <c>Half</c>, <c>BigInteger</c>, <c>nint</c>,
 /// <c>nuint</c>) compile but throw at construction.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The primitive-specialized fast path requires the underlying
+/// <see cref="IMutableState"/> to actually be a primitive subtype
+/// (<see cref="IMutableIntState"/>, <see cref="IMutableLongState"/>,
+/// <see cref="IMutableFloatState"/>). That's true when constructed
+/// via <c>new MutableNumberState&lt;int&gt;(0)</c> — <c>CreateState</c>
+/// picks the right Kotlin factory. It's <i>not</i> guaranteed when the
+/// wrapper is built around a state produced elsewhere, such as the
+/// boxed <c>mutableStateOf(restoredValue, policy)</c> that
+/// <see cref="Compose.RememberSaveable{T}"/> returns after a process
+/// death restore. The instance <c>_kind</c> field is probed from the
+/// supplied state once at construction so the <see cref="Value"/>
+/// getter/setter never attempts an invalid cast.
+/// </para>
+/// </remarks>
 public class MutableNumberState<T> : MutableState<T> where T : INumber<T>
 {
     enum Kind { Other, Int, Long, Float }
 
-    // Per-closed-generic constant: each MutableNumberState<int>,
-    // MutableNumberState<long>, MutableNumberState<float>, ... gets its
-    // own s_kind set once at type init. The Value get/set switch on it
-    // collapses to the live branch only on the primitive paths, with no
-    // typeof(T) check per access.
-    static readonly Kind s_kind = ResolveKind();
+    Kind _kind;
 
-    static Kind ResolveKind()
+    public MutableNumberState(T initial) : base(CreateState(initial))
     {
-        if (typeof(T) == typeof(int))   return Kind.Int;
-        if (typeof(T) == typeof(long))  return Kind.Long;
-        if (typeof(T) == typeof(float)) return Kind.Float;
-        return Kind.Other;
+        _kind = ProbeKind(_state);
     }
-
-    public MutableNumberState(T initial) : base(CreateState(initial)) { }
 
     static IMutableState CreateState(T initial)
     {
-        switch (s_kind)
-        {
-            case Kind.Int:
-                return SnapshotIntStateKt.MutableIntStateOf(Unsafe.As<T, int>(ref initial));
-            case Kind.Long:
-                return SnapshotLongStateKt.MutableLongStateOf(Unsafe.As<T, long>(ref initial));
-            case Kind.Float:
-                return PrimitiveSnapshotStateKt.MutableFloatStateOf(Unsafe.As<T, float>(ref initial));
-            default:
-                return SnapshotStateKt.MutableStateOf(
-                    MutableState<T>.ToJava(initial),
-                    SnapshotStateKt.StructuralEqualityPolicy());
-        }
+        if (typeof(T) == typeof(int))
+            return SnapshotIntStateKt.MutableIntStateOf(Unsafe.As<T, int>(ref initial));
+        if (typeof(T) == typeof(long))
+            return SnapshotLongStateKt.MutableLongStateOf(Unsafe.As<T, long>(ref initial));
+        if (typeof(T) == typeof(float))
+            return PrimitiveSnapshotStateKt.MutableFloatStateOf(Unsafe.As<T, float>(ref initial));
+        return SnapshotStateKt.MutableStateOf(
+            MutableState<T>.ToJava(initial),
+            SnapshotStateKt.StructuralEqualityPolicy());
+    }
+
+    static Kind ProbeKind(IMutableState state) => state switch
+    {
+        IMutableIntState   => Kind.Int,
+        IMutableLongState  => Kind.Long,
+        IMutableFloatState => Kind.Float,
+        _                  => Kind.Other,
+    };
+
+    internal override void SetUnderlyingState(IMutableState state)
+    {
+        base.SetUnderlyingState(state);
+        _kind = ProbeKind(state);
     }
 
     public override T Value
     {
         get
         {
-            switch (s_kind)
+            switch (_kind)
             {
                 case Kind.Int:
                     int i = ((IMutableIntState)_state).IntValue;
@@ -84,7 +100,7 @@ public class MutableNumberState<T> : MutableState<T> where T : INumber<T>
         }
         set
         {
-            switch (s_kind)
+            switch (_kind)
             {
                 case Kind.Int:
                     ((IMutableIntState)_state).IntValue = Unsafe.As<T, int>(ref value);

--- a/src/ComposeNet.Compose/MutableState.cs
+++ b/src/ComposeNet.Compose/MutableState.cs
@@ -7,9 +7,9 @@ namespace ComposeNet;
 /// boxed values through the JVM state container so changes are observed
 /// by the Compose runtime and trigger recomposition.
 /// </summary>
-public class MutableState<T>
+public class MutableState<T> : IMutableStateWrapper
 {
-    internal readonly IMutableState _state;
+    internal IMutableState _state;
 
     public MutableState(T initial)
     {
@@ -22,6 +22,22 @@ public class MutableState<T>
     // primitive-specialized IMutableState (MutableIntState etc.) so its
     // overridden Value getter/setter can bypass the boxed slow path.
     internal MutableState(IMutableState state) => _state = state;
+
+    /// <summary>
+    /// Subclass hook for <see cref="IMutableStateWrapper.State"/>'s
+    /// setter. <see cref="MutableNumberState{T}"/> overrides this to
+    /// re-probe its specialized-state <c>_kind</c> when Compose hands
+    /// back a (potentially boxed) restored state after a process-death
+    /// round-trip through
+    /// <see cref="Compose.RememberSaveable{T}(System.Func{T}, int, string)"/>.
+    /// </summary>
+    internal virtual void SetUnderlyingState(IMutableState state) => _state = state;
+
+    IMutableState IMutableStateWrapper.State
+    {
+        get => _state;
+        set => SetUnderlyingState(value);
+    }
 
     public virtual T Value
     {
@@ -57,7 +73,7 @@ public class MutableState<T>
                                     $"MutableState<{typeof(T).Name}>: T must be a Java.Lang.Object subclass, string, bool, char, or a built-in numeric primitive (sbyte/byte/short/ushort/int/uint/long/ulong/float/double). Types like decimal, Half, BigInteger, and IntPtr have no clean Java box and are not supported.")
     };
 
-    static T FromJava(Java.Lang.Object? value)
+    internal static T FromJava(Java.Lang.Object? value)
     {
         if (value is null) return default!;
         if (value is T t) return t;

--- a/src/ComposeNet.Compose/ObjectFunction0.cs
+++ b/src/ComposeNet.Compose/ObjectFunction0.cs
@@ -1,0 +1,26 @@
+using Android.Runtime;
+using Kotlin.Jvm.Functions;
+
+namespace ComposeNet;
+
+/// <summary>
+/// JCW that implements Kotlin's <c>Function0&lt;Object&gt;</c> — a
+/// zero-argument lambda returning a boxed managed object. Unlike
+/// <see cref="ComposableLambda0"/>, which returns <c>Unit.INSTANCE</c>
+/// (void in Kotlin terms), this one returns a typed value Compose /
+/// the binding can consume.
+///
+/// Used wherever a Kotlin API takes a <c>() -&gt; T</c> producer of
+/// a non-<c>Unit</c> value, e.g. <see cref="Compose.RememberSaveable{T}"/>
+/// for the value the saveable registry should cache.
+/// </summary>
+[Register("composenet/compose/ObjectFunction0")]
+internal sealed class ObjectFunction0 : Java.Lang.Object, IFunction0
+{
+    readonly System.Func<Java.Lang.Object?> _factory;
+
+    public ObjectFunction0(System.Func<Java.Lang.Object?> factory) =>
+        _factory = factory;
+
+    public Java.Lang.Object Invoke() => _factory()!;
+}

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -84,6 +84,7 @@ ComposeNet.Compose
 ComposeNet.ComposeActivity
 ComposeNet.ComposeActivity.ComposeActivity() -> void
 ComposeNet.ComposeActivity.Remember<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.RememberSaveable<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
 ComposeNet.ComposeActivity.SetContent(System.Func<ComposeNet.ComposableNode!>! content) -> void
 ComposeNet.CustomTab
 ComposeNet.CustomTab.CustomTab(bool selected, System.Action! onClick) -> void
@@ -714,6 +715,7 @@ static ComposeNet.Arrangement.SpaceEvenly.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Start.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Top.get -> ComposeNet.Arrangement!
 static ComposeNet.Compose.Remember<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(float value) -> ComposeNet.Dp
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(int value) -> ComposeNet.Dp
 static ComposeNet.Dp.operator !=(ComposeNet.Dp left, ComposeNet.Dp right) -> bool

--- a/src/ComposeNet.Compose/SaveableBridges.cs
+++ b/src/ComposeNet.Compose/SaveableBridges.cs
@@ -1,0 +1,179 @@
+using Android.Runtime;
+
+namespace ComposeNet;
+
+// Hand-written raw-JNI bridges for the
+// `androidx.compose.runtime.saveable` package. The Xamarin
+// NuGet (`Xamarin.AndroidX.Compose.Runtime.Saveable.Android`) ships
+// the Java library but does not generate C# bindings, so every
+// Saveable entry point we use here goes through `JNIEnv.*` calls.
+// Same model as `SuspendBridges.cs`.
+//
+// When/if `dotnet/android-libraries` adds bindings for this package,
+// these methods can be replaced with direct binding calls and this
+// file can shrink to whatever is still mangled or unbound.
+internal static partial class ComposeBridges
+{
+    static System.IntPtr s_autoSaver_class;
+    static System.IntPtr s_autoSaver_method;
+    static System.IntPtr s_autoSaver_handle;
+
+    static System.IntPtr s_rememberSaveableSimple_class;
+    static System.IntPtr s_rememberSaveableSimple_method;
+
+    static System.IntPtr s_rememberSaveableState_class;
+    static System.IntPtr s_rememberSaveableState_method;
+
+    static System.IntPtr s_emptyObjectArray;
+
+    // androidx.compose.runtime.saveable.SaverKt.autoSaver(): Saver<T, Object>
+    //
+    // The default `Saver` Compose uses for any `Bundle`-saveable value
+    // (primitives, strings, parcelables, …). Cached as a global ref —
+    // returns the same singleton on every call from Kotlin, and we
+    // need it as the `stateSaver` argument for the MutableState-overload
+    // of `rememberSaveable`.
+    internal static System.IntPtr SaverAutoSaver()
+    {
+        if (s_autoSaver_handle != System.IntPtr.Zero)
+            return s_autoSaver_handle;
+
+        if (s_autoSaver_method == System.IntPtr.Zero)
+        {
+            s_autoSaver_class = JNIEnv.FindClass("androidx/compose/runtime/saveable/SaverKt");
+            s_autoSaver_method = JNIEnv.GetStaticMethodID(
+                s_autoSaver_class,
+                "autoSaver",
+                "()Landroidx/compose/runtime/saveable/Saver;");
+        }
+
+        var local = JNIEnv.CallStaticObjectMethod(s_autoSaver_class, s_autoSaver_method);
+        try
+        {
+            s_autoSaver_handle = JNIEnv.NewGlobalRef(local);
+        }
+        finally
+        {
+            JNIEnv.DeleteLocalRef(local);
+        }
+        return s_autoSaver_handle;
+    }
+
+    // Lazily-cached empty `Object[]` for the `vararg inputs` parameter
+    // of `rememberSaveable`. Compose treats inputs as "dependency
+    // tracking" — if any element changes, the cached factory result
+    // is discarded. We always pass an empty array (= "never invalidate
+    // on input change"); future overloads with `params object?[]`
+    // can build the array on demand.
+    internal static System.IntPtr EmptyObjectArray()
+    {
+        if (s_emptyObjectArray != System.IntPtr.Zero)
+            return s_emptyObjectArray;
+
+        var objectClass = Java.Lang.Class.FromType(typeof(Java.Lang.Object));
+        var local = JNIEnv.NewObjectArray(0, objectClass.Handle, System.IntPtr.Zero);
+        try
+        {
+            s_emptyObjectArray = JNIEnv.NewGlobalRef(local);
+        }
+        finally
+        {
+            JNIEnv.DeleteLocalRef(local);
+        }
+        return s_emptyObjectArray;
+    }
+
+    // androidx.compose.runtime.saveable.RememberSaveableKt.rememberSaveable(
+    //     Object[] inputs,
+    //     Function0<? extends T> init,
+    //     Composer composer,
+    //     int $changed): Object
+    //
+    // The no-saver overload — Compose internally uses `autoSaver()`,
+    // which handles every Bundle-saveable value (primitives, strings,
+    // parcelables). Returns a JNI local ref to the boxed result.
+    internal static unsafe System.IntPtr RememberSaveableSimple(
+        System.IntPtr inputs,
+        ObjectFunction0 init,
+        System.IntPtr composer,
+        int changed)
+    {
+        if (s_rememberSaveableSimple_method == System.IntPtr.Zero)
+        {
+            s_rememberSaveableSimple_class = JNIEnv.FindClass(
+                "androidx/compose/runtime/saveable/RememberSaveableKt");
+            s_rememberSaveableSimple_method = JNIEnv.GetStaticMethodID(
+                s_rememberSaveableSimple_class,
+                "rememberSaveable",
+                "([Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;");
+        }
+
+        try
+        {
+            JValue* args = stackalloc JValue[4];
+            args[0] = new JValue(inputs);
+            args[1] = new JValue(init.Handle);
+            args[2] = new JValue(composer);
+            args[3] = new JValue(changed);
+            return JNIEnv.CallStaticObjectMethod(
+                s_rememberSaveableSimple_class,
+                s_rememberSaveableSimple_method,
+                args);
+        }
+        finally
+        {
+            System.GC.KeepAlive(init);
+        }
+    }
+
+    // androidx.compose.runtime.saveable.RememberSaveableKt.rememberSaveable(
+    //     Object[] inputs,
+    //     Saver<T, ?> stateSaver,
+    //     Function0<? extends MutableState<T>> init,
+    //     Composer composer,
+    //     int $changed): MutableState<T>
+    //
+    // The MutableState overload — Compose internally wraps
+    // `stateSaver` with `mutableStateSaver(stateSaver)` and persists
+    // only the inner value. On restore Compose calls
+    // `mutableStateOf(restoredValue, policy)` to rebuild the state
+    // wrapper, so the returned `IMutableState` is *not* guaranteed
+    // to be a primitive-specialized `IMutableIntState`/etc. — it's
+    // the boxed default unless the caller supplied a custom saver
+    // that re-creates the specialized type.
+    internal static unsafe System.IntPtr RememberSaveableMutableState(
+        System.IntPtr inputs,
+        System.IntPtr stateSaver,
+        ObjectFunction0 init,
+        System.IntPtr composer,
+        int changed)
+    {
+        if (s_rememberSaveableState_method == System.IntPtr.Zero)
+        {
+            s_rememberSaveableState_class = JNIEnv.FindClass(
+                "androidx/compose/runtime/saveable/RememberSaveableKt");
+            s_rememberSaveableState_method = JNIEnv.GetStaticMethodID(
+                s_rememberSaveableState_class,
+                "rememberSaveable",
+                "([Ljava/lang/Object;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/MutableState;");
+        }
+
+        try
+        {
+            JValue* args = stackalloc JValue[5];
+            args[0] = new JValue(inputs);
+            args[1] = new JValue(stateSaver);
+            args[2] = new JValue(init.Handle);
+            args[3] = new JValue(composer);
+            args[4] = new JValue(changed);
+            return JNIEnv.CallStaticObjectMethod(
+                s_rememberSaveableState_class,
+                s_rememberSaveableState_method,
+                args);
+        }
+        finally
+        {
+            System.GC.KeepAlive(init);
+        }
+    }
+}

--- a/src/ComposeNet.Compose/SourceLocationKey.cs
+++ b/src/ComposeNet.Compose/SourceLocationKey.cs
@@ -1,0 +1,46 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Deterministic slot-table key derived from a <c>[CallerLineNumber]</c>
+/// / <c>[CallerFilePath]</c> pair. Used by every group/lambda key the
+/// facade hands to Compose so the same call site produces the same
+/// <c>int</c> in every process — a hard requirement for
+/// <see cref="Compose.RememberSaveable{T}(System.Func{T}, int, string)"/>,
+/// whose <c>SaveableStateRegistry</c> key is built from the full chain
+/// of ancestor group keys leading to the call.
+/// </summary>
+/// <remarks>
+/// <see cref="System.HashCode.Combine{T1,T2}(T1,T2)"/> and
+/// <see cref="string.GetHashCode()"/> are randomized per process on
+/// modern .NET, so they can't be used here — the saved key embedded
+/// in <c>onSaveInstanceState</c> would never match the key recomputed
+/// after the activity is recreated, and every <c>rememberSaveable</c>
+/// slot would silently reinitialise on restore. This helper uses
+/// FNV-1a 32-bit over the UTF-16 code units of the path, then mixes
+/// in the line number, giving a stable identifier with the same
+/// collision footprint as a regular hash.
+/// </remarks>
+internal static class SourceLocationKey
+{
+    const uint FnvOffset = 2166136261u;
+    const uint FnvPrime  = 16777619u;
+
+    public static int Compute(int line, string file)
+    {
+        uint hash = FnvOffset;
+        if (file is not null)
+        {
+            for (int i = 0; i < file.Length; i++)
+            {
+                hash ^= file[i];
+                hash *= FnvPrime;
+            }
+        }
+        // Mix the line number in by XORing the full 32-bit value and
+        // running one more FNV step, so distinct lines in the same
+        // file land in distinct buckets.
+        hash ^= (uint)line;
+        hash *= FnvPrime;
+        return unchecked((int)hash);
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -28,10 +28,13 @@ public class MainActivity : ComposeActivity
         base.OnCreate(savedInstanceState);
         SetContent(() =>
         {
-            var count       = Remember(() => new MutableNumberState<int>(0));
-            var name        = Remember(() => new MutableState<string>(""));
-            var liked       = Remember(() => new MutableState<bool>(false));
-            var tab         = Remember(() => new MutableNumberState<int>(0));
+            // These four use RememberSaveable so their values survive
+            // process death / activity recreation (e.g. rotation when
+            // the activity doesn't override android:configChanges).
+            var count       = RememberSaveable(() => new MutableNumberState<int>(0));
+            var name        = RememberSaveable(() => new MutableState<string>(""));
+            var liked       = RememberSaveable(() => new MutableState<bool>(false));
+            var tab         = RememberSaveable(() => new MutableNumberState<int>(0));
             var sub         = Remember(() => new MutableNumberState<int>(0));
             var showAlert   = Remember(() => new MutableState<bool>(false));
             var showSheet   = Remember(() => new MutableState<bool>(false));


### PR DESCRIPTION
Implements Phase 3 of #66 (bind `androidx.compose.runtime.saveable.RememberSaveable`) — closes #101.

## Public API

Three new entry points on `Compose` (and matching `protected` helpers on `ComposeActivity`):

```csharp
// Scalar value (int, long, float, double, bool, string, …)
var count = Compose.RememberSaveable(() => 0);

// MutableState<U>
var name = Compose.RememberSaveableState(() => "");

// MutableNumberState<U>
var tab = Compose.RememberSaveableNumberState(() => 0);
```

Cached values survive **process death and activity recreation** (e.g. rotation when the activity doesn't override `android:configChanges`) via Compose's `SaveableStateRegistry`, which serialises into the activity's saved-instance `Bundle`.

## How it works

`Xamarin.AndroidX.Compose.Runtime.Saveable[.Android]` ships only the Java library — no C# bindings — so the implementation goes through raw JNI, same model as `SuspendBridges.cs`:

- `SaveableBridges.cs` caches class refs / method IDs for `RememberSaveableKt.rememberSaveable` (no-saver + stateSaver overloads) and `SaverKt.autoSaver()`, plus a global-ref empty `Object[]` used as the always-empty `vararg inputs`.
- `RememberSaveableFactory` is a `[Register]`-d JCW that implements `Function0<Object>` — unlike `ComposableLambda0` (which always returns `Unit.INSTANCE`), this lambda hands back the typed boxed value Compose needs to cache.

The three public methods are split (rather than one dispatcher with runtime `typeof(T)` reflection) so each path calls the right internal `MutableState<U>` ctor directly, with no trimming/AOT hazards.

## Deterministic slot keys (`SourceLocationKey`)

Compose's `SaveableStateRegistry` derives its keys from `currentCompositeKeyHash`, which is built from the chain of ancestor group keys leading to a `rememberSaveable` call. Every `[CallerLineNumber]` / `[CallerFilePath]`-based key we passed to `StartReplaceableGroup` / `ComposableLambda` was previously computed via `HashCode.Combine(line, file)` — but `string.GetHashCode()` and `System.HashCode` are **randomized per process** on modern .NET, so the key embedded in `onSaveInstanceState` would never match the one recomputed after the activity is recreated, and every `rememberSaveable` slot would silently reinitialise on restore.

`SourceLocationKey.Compute(line, file)` replaces those with a stable FNV-1a 32-bit hash of the file path mixed with the line number, used by `Compose.Remember`, `Compose.RememberSaveable*`, and every helper in `ComposableLambdas` (`Wrap2`, `Wrap3`, `Wrap4`, `Instantiate4`).

## `MutableNumberState` instance `_kind` field

After process death, Compose's `mutableStateSaver` rebuilds the state via `mutableStateOf(restoredValue, policy)` — producing a plain `IMutableState`, never an `IMutableIntState` / `IMutableLongState` / `IMutableFloatState`. The previous static-`s_kind` approach on `MutableNumberState<T>` would have failed the cast in `Value`'s getter/setter after restore. Switched to an instance `_kind` field probed from `_state` at construction, with a new internal `MutableNumberState(IMutableState state)` ctor for the restore path to wrap the boxed state Compose hands back. Fresh sessions still get the primitive-specialized fast path through `CreateState`.

## Sample

`MainActivity.cs` migrates `count` / `name` / `liked` / `tab` to the new RememberSaveable* helpers to demonstrate rotation-stable state. The other ~25 `Remember(...)` call sites are intentionally left alone so both paths get exercised side by side.

## Test plan

- [x] `dotnet build src/ComposeNet.Compose` — clean (0 warnings, 0 errors)
- [x] `dotnet build src/ComposeNet.Sample` — clean
- [x] `dotnet test src/ComposeNet.SourceGenerators.Tests` — 69/69 passed
- [x] Deployed to a physical Pixel device, app launches without crashes, survives portrait↔landscape rotation cleanly
- [ ] Manual verification on a real device: increment counter on Counter tab → rotate → counter value persists (vs `sub` which resets — same tab, side by side)
- [ ] Same end-to-end test with `adb shell am kill` + relaunch (true process-death restore)