### PR TITLE
Type-key sibling slot groups in RenderChildren

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -576,13 +576,22 @@ into a normal hand-written class.
   runs outside composition.
 - **Sibling `Render()` calls inside a loop need per-position slot
   keys.** `ComposableContainer.RenderChildren` already wraps each child
-  in `composer.StartReplaceableGroup(i)` / `EndReplaceableGroup()`. Any
-  custom loop that calls `Children[i].Render(c)` directly — e.g. the
-  segmented-row scope loops in `SingleChoiceSegmentedButtonRow`,
-  `MultiChoiceSegmentedButtonRow`, or `SegmentedButton`'s label slot —
-  must do the same, otherwise same-type siblings collide on a single
-  group key and Compose disambiguates by position only (brittle
-  combined with any identity churn).
+  in `composer.StartReplaceableGroup(HashCode.Combine(i, child.GetType()))`
+  / `EndReplaceableGroup()`. Any custom loop that calls
+  `Children[i].Render(c)` directly — e.g. the segmented-row scope loops
+  in `SingleChoiceSegmentedButtonRow`, `MultiChoiceSegmentedButtonRow`,
+  or `SegmentedButton`'s label slot — must do the same, otherwise same-
+  type siblings collide on a single group key and Compose disambiguates
+  by position only (brittle combined with any identity churn). The
+  type component of the key is what stops a sibling that swaps
+  subclass-at-the-same-position (e.g. tab navigation flipping a
+  `PullToRefreshBox` for a `HorizontalUncontainedCarousel`) from re-
+  entering the prior occupant's group and reading its slot-table
+  entries — that path throws `ClassCastException` from inside
+  Compose's `rememberSaveable` (`SaverKt$Saver$1 cannot be cast to
+  SaveableHolder`). Same-typed siblings at the same position keep
+  their identity and slot state intact — that is intentional Compose
+  positional identity.
 - The single call to `ComposableLambdaKt.ComposableLambdaInstance` in
   `ComposeActivity.SetContent` is the right shape there — it's the
   call-from-anywhere factory for the root content lambda, which runs

--- a/src/ComposeNet.Compose/ComposableContainer.cs
+++ b/src/ComposeNet.Compose/ComposableContainer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using AndroidX.Compose.Runtime;
@@ -37,20 +38,30 @@ public abstract class ComposableContainer : ComposableNode, IEnumerable
 
     /// <summary>
     /// Renders this container's children sequentially into
-    /// <paramref name="composer"/>, wrapping each child in a per-index
-    /// <c>StartReplaceableGroup(i)</c> so sibling renders get distinct
-    /// slot-table group keys. Without this, three sibling
-    /// <c>SegmentedButton</c>s (same C# call site → same group key)
-    /// rely on Compose's positional disambiguation, which combined with
-    /// lambda-identity churn elsewhere can land Reuse/Move ops at the
-    /// wrong tree index.
+    /// <paramref name="composer"/>, wrapping each child in a per-position
+    /// <c>StartReplaceableGroup</c> whose key combines the sibling index
+    /// <em>and</em> the child's runtime <see cref="Type"/>. Without per-
+    /// position groups, three sibling <c>SegmentedButton</c>s (same C#
+    /// call site → same group key) rely on Compose's positional
+    /// disambiguation, which combined with lambda-identity churn
+    /// elsewhere can land Reuse/Move ops at the wrong tree index.
+    /// Without the type component, a sibling that swaps to a different
+    /// <see cref="ComposableNode"/> subclass at the same position
+    /// (e.g. tab navigation flipping a <c>PullToRefreshBox</c> for a
+    /// <c>HorizontalUncontainedCarousel</c>) would re-enter the prior
+    /// occupant's group and read its slot-table entries, throwing
+    /// <c>ClassCastException</c> from inside <c>rememberSaveable</c>
+    /// when the prior slot held an incompatible type. Same-typed
+    /// siblings at the same position keep their identity and slot
+    /// state intact — that is intentional Compose positional identity.
     /// </summary>
     private protected void RenderChildren(IComposer composer)
     {
         for (int i = 0; i < _children.Count; i++)
         {
-            composer.StartReplaceableGroup(i);
-            try { _children[i].Render(composer); }
+            var child = _children[i];
+            composer.StartReplaceableGroup(HashCode.Combine(i, child.GetType()));
+            try { child.Render(composer); }
             finally { composer.EndReplaceableGroup(); }
         }
     }

--- a/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
@@ -1,3 +1,4 @@
+using System;
 using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 
@@ -21,7 +22,7 @@ public sealed class MultiChoiceSegmentedButtonRow : ComposableContainer
             {
                 rows.SetIndex(i);
                 var child = Children[i];
-                c.StartReplaceableGroup(System.HashCode.Combine(i, child.GetType()));
+                c.StartReplaceableGroup(HashCode.Combine(i, child.GetType()));
                 try { child.Render(c); }
                 finally { c.EndReplaceableGroup(); }
             }

--- a/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/MultiChoiceSegmentedButtonRow.cs
@@ -20,8 +20,9 @@ public sealed class MultiChoiceSegmentedButtonRow : ComposableContainer
             for (int i = 0; i < Children.Count; i++)
             {
                 rows.SetIndex(i);
-                c.StartReplaceableGroup(i);
-                try { Children[i].Render(c); }
+                var child = Children[i];
+                c.StartReplaceableGroup(System.HashCode.Combine(i, child.GetType()));
+                try { child.Render(c); }
                 finally { c.EndReplaceableGroup(); }
             }
         });

--- a/src/ComposeNet.Compose/SegmentedButton.cs
+++ b/src/ComposeNet.Compose/SegmentedButton.cs
@@ -1,3 +1,4 @@
+using System;
 using AndroidX.Compose.Runtime;
 
 namespace ComposeNet;
@@ -58,7 +59,7 @@ public sealed class SegmentedButton : ComposableContainer
             for (int i = 0; i < Children.Count; i++)
             {
                 var child = Children[i];
-                c.StartReplaceableGroup(System.HashCode.Combine(i, child.GetType()));
+                c.StartReplaceableGroup(HashCode.Combine(i, child.GetType()));
                 try { child.Render(c); }
                 finally { c.EndReplaceableGroup(); }
             }

--- a/src/ComposeNet.Compose/SegmentedButton.cs
+++ b/src/ComposeNet.Compose/SegmentedButton.cs
@@ -57,8 +57,9 @@ public sealed class SegmentedButton : ComposableContainer
         {
             for (int i = 0; i < Children.Count; i++)
             {
-                c.StartReplaceableGroup(i);
-                try { Children[i].Render(c); }
+                var child = Children[i];
+                c.StartReplaceableGroup(System.HashCode.Combine(i, child.GetType()));
+                try { child.Render(c); }
                 finally { c.EndReplaceableGroup(); }
             }
         });

--- a/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
@@ -29,8 +29,9 @@ public sealed class SingleChoiceSegmentedButtonRow : ComposableContainer
             for (int i = 0; i < Children.Count; i++)
             {
                 rows.SetIndex(i);
-                c.StartReplaceableGroup(i);
-                try { Children[i].Render(c); }
+                var child = Children[i];
+                c.StartReplaceableGroup(System.HashCode.Combine(i, child.GetType()));
+                try { child.Render(c); }
                 finally { c.EndReplaceableGroup(); }
             }
         });

--- a/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
+++ b/src/ComposeNet.Compose/SingleChoiceSegmentedButtonRow.cs
@@ -1,3 +1,4 @@
+using System;
 using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 
@@ -30,7 +31,7 @@ public sealed class SingleChoiceSegmentedButtonRow : ComposableContainer
             {
                 rows.SetIndex(i);
                 var child = Children[i];
-                c.StartReplaceableGroup(System.HashCode.Combine(i, child.GetType()));
+                c.StartReplaceableGroup(HashCode.Combine(i, child.GetType()));
                 try { child.Render(c); }
                 finally { c.EndReplaceableGroup(); }
             }


### PR DESCRIPTION
Fix `ClassCastException: SaverKt$Saver$1 cannot be cast to SaveableHolder` thrown from inside Compose's `rememberSaveable` when tapping the **Carousels** tab right after the **Lazy** tab in the sample app.

## Crash

```
java.lang.ClassCastException: androidx.compose.runtime.saveable.SaverKt$Saver$1
    cannot be cast to androidx.compose.runtime.saveable.SaveableHolder
  at RememberSaveableKt.rememberSaveable(RememberSaveable.kt:93)
  at CarouselStateKt.rememberCarouselState(CarouselState.kt:153)
  at composenet.compose.ComposableLambda3.invoke
  at ColumnKt.Column                              // outer body Column
  at composenet.compose.ComposableLambda3.invoke
  at ColumnKt.Column                              // inner tab-content Column
  at ScaffoldKt$ScaffoldLayout$bodyContent
```

The `as SaveableHolder` cast inside `RememberSaveable.kt:93` fired because the slot-table cell already held a `SaverKt$Saver$1` singleton from a previous occupant's `rememberSaveable` call.

## Root cause

`ComposableContainer.RenderChildren` keyed each child's `StartReplaceableGroup` purely **positionally**:

```csharp
composer.StartReplaceableGroup(i);
```

When `tabContent` flips from a Lazy `Column` to a Carousels `Column`, both bodies are `Column` so the body re-enters the same outer group. Inside, sibling-index 1 was previously `PullToRefreshBox` (whose `rememberPullToRefreshState` populated the slot table with a `Saver`) and is now `HorizontalUncontainedCarousel` (whose internal `rememberCarouselState` issues a fresh `rememberSaveable`). Same positional key, different child types → Compose advances into the prior occupant's group, the carousel's `remember { SaveableHolder(...) }` reads the stale `Saver` slot, the cast throws.

This is a latent positional-slot-collision bug, not introduced by PR #75. The pre-PR-#75 `Dictionary<int, object>` `Remember` masked it for some setups (state lived on the activity, not in slot table), but the structural collision in `RenderChildren` was already there.

## Fix

Include the child's runtime `Type` in the sibling slot key so a swap to a different `ComposableNode` subclass at the same index gets a fresh group:

```csharp
composer.StartReplaceableGroup(HashCode.Combine(i, child.GetType()));
```

Same change applied to the three hand-written sibling-render loops that mirror `RenderChildren`'s pattern:

- `SingleChoiceSegmentedButtonRow.Render`
- `MultiChoiceSegmentedButtonRow.Render`
- `SegmentedButton.Render` (label slot)

## What this catches / doesn't

- ✅ **Different types at same position** (the bug: `PullToRefreshBox` → `HorizontalUncontainedCarousel` at sibling-index 1) — different type hash, fresh group, slots discarded cleanly.
- ✅ **Same type at same position** keeps the same key — slots preserved. This is intentional Compose positional identity (not a regression).
- ❌ **Same-type-different-instance branch identity collapse** (e.g. two tabs each rendering their own `LazyColumn<int>` at the same outer position — Compose treats them as one identity, scroll state shared). Out of scope for this fix; would need an explicit `Key`/`MovableContent` API. The carousel crash doesn't hit this case.

Singleton slot renders (`Scaffold.Body`, `TopBar`, `SnackbarHost`, `DropdownMenuItem.LeadingIcon`, etc.) already get unique slot identity via `ComposableLambdas.Wrap*`'s `[CallerLineNumber]+[CallerFilePath]` keys, so this fix is scoped to the loop sites only.

## Verification

On device (Pixel `0A041FDD400327`, on top of `main` HEAD `550f23a`):

- **Repro fixed:** Lazy → Carousels — no crash, all three carousel facades (`HorizontalUncontainedCarousel`, `HorizontalMultiBrowseCarousel`, `HorizontalCenteredHeroCarousel`) render.
- **Reverse:** Carousels → Lazy — no crash, `LazyColumn` / `LazyRow` / `LazyVerticalGrid` render correctly.
- **Full tab cycle** (Basics → Buttons → Cards → Drawer → Misc → App bars → Pickers → Bars → Lazy → Carousels) — no `FATAL` / `ClassCastException` / `monodroid-error` entries in logcat.

Build:

- `dotnet test src/ComposeNet.SourceGenerators.Tests` → **69/69 pass**.
- `dotnet build src/ComposeNet.Sample` → 0 warnings, 0 errors.
- `dotnet build samples/Jetchat` → 0 warnings, 0 errors.

Also updates the `Sibling Render() calls inside a loop need per-position slot keys` convention note in `.github/copilot-instructions.md` so the new key shape is discoverable.