### PR TITLE
Implement issue #58: text styling + TextField config

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -259,11 +259,19 @@ internal static partial class ComposeBridges
     public static partial void Text(
         string text,
         IModifier? modifier,
+        long? color,
         Sp? fontSize,
+        FontStyle? fontStyle,
         FontWeight? fontWeight,
+        FontFamily? fontFamily,
         Sp? letterSpacing,
         TextDecoration? decoration,
+        TextAlign? align,
         Sp? lineHeight,
+        TextOverflow? overflow,
+        bool? softWrap,
+        int? maxLines,
+        int? minLines,
         IComposer composer);
 
     // androidx.compose.material3.ButtonKt.Button
@@ -605,8 +613,24 @@ internal static partial class ComposeBridges
         Signature = TextFieldStringSig,
         Defaults  = typeof(TextFieldDefault))]
     [ComposeFacade]
-    public static partial void TextField(string value, [Callback(typeof(string))] IFunction1 onValueChange,
-                                         IModifier? modifier, IComposer composer);
+    public static partial void TextField(
+        string value,
+        [Callback(typeof(string))] IFunction1 onValueChange,
+        IModifier? modifier,
+        bool? enabled,
+        bool? readOnly,
+        IFunction2? label,
+        IFunction2? placeholder,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        IFunction2? prefix,
+        IFunction2? suffix,
+        IFunction2? supportingText,
+        bool? isError,
+        bool? singleLine,
+        int? maxLines,
+        int? minLines,
+        IComposer composer);
 
     [ComposeBridge(
         Class     = "androidx/compose/material3/OutlinedTextFieldKt",
@@ -614,8 +638,24 @@ internal static partial class ComposeBridges
         Signature = TextFieldStringSig,
         Defaults  = typeof(TextFieldDefault))]
     [ComposeFacade]
-    public static partial void OutlinedTextField(string value, [Callback(typeof(string))] IFunction1 onValueChange,
-                                                 IModifier? modifier, IComposer composer);
+    public static partial void OutlinedTextField(
+        string value,
+        [Callback(typeof(string))] IFunction1 onValueChange,
+        IModifier? modifier,
+        bool? enabled,
+        bool? readOnly,
+        IFunction2? label,
+        IFunction2? placeholder,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        IFunction2? prefix,
+        IFunction2? suffix,
+        IFunction2? supportingText,
+        bool? isError,
+        bool? singleLine,
+        int? maxLines,
+        int? minLines,
+        IComposer composer);
 
     // androidx.compose.material3.SecureTextFieldKt.{SecureTextField,OutlinedSecureTextField}-XvU6IwQ.
     // Both overloads have identical 23-user-param signatures: the

--- a/src/ComposeNet.Compose/FontFamily.cs
+++ b/src/ComposeNet.Compose/FontFamily.cs
@@ -1,0 +1,83 @@
+using Android.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// C# wrapper around <c>androidx.compose.ui.text.font.FontFamily</c>.
+/// Compose's <c>FontFamily</c> is a real Kotlin class, but Compose
+/// 1.11.2.1's <c>ui-text-android</c> package is shipped as a
+/// Java-library-only stub with zero exported types — so the .NET
+/// binding doesn't expose it yet. We subclass <see cref="Java.Lang.Object"/>
+/// directly and resolve the Kotlin <c>Companion</c> instances via JNI;
+/// the bridge generator's reference-type code path
+/// (<c>x is null ? IntPtr.Zero : x.Handle</c>) passes the handle through
+/// to the JNI <c>L</c> slot.
+///
+/// Will swap to bound <c>AndroidX.Compose.UI.Text.Font.FontFamily</c>
+/// once <see href="https://github.com/dotnet/android-libraries/pull/1440"/>
+/// ships and we adopt the next <c>Xamarin.AndroidX.Compose.UI.Text.Android</c>
+/// release.
+/// </summary>
+public sealed class FontFamily : Java.Lang.Object
+{
+    FontFamily(IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer) { }
+
+    // FontFamily.Companion exposes generic-font-family getters:
+    //   FontFamily$Companion.getDefault()    : FontFamily
+    //   FontFamily$Companion.getSansSerif()  : FontFamily
+    //   FontFamily$Companion.getSerif()      : FontFamily
+    //   FontFamily$Companion.getMonospace()  : FontFamily
+    //   FontFamily$Companion.getCursive()    : FontFamily
+    static IntPtr s_companion;
+    static unsafe IntPtr Companion()
+    {
+        if (s_companion == IntPtr.Zero)
+        {
+            IntPtr fontFamilyCls = JNIEnv.FindClass("androidx/compose/ui/text/font/FontFamily");
+            IntPtr fid = JNIEnv.GetStaticFieldID(fontFamilyCls, "Companion", "Landroidx/compose/ui/text/font/FontFamily$Companion;");
+            IntPtr local = JNIEnv.GetStaticObjectField(fontFamilyCls, fid);
+            s_companion = JNIEnv.NewGlobalRef(local);
+            JNIEnv.DeleteLocalRef(local);
+        }
+        return s_companion;
+    }
+
+    static FontFamily Resolve(string getterName, string returnDescriptor)
+    {
+        // FontFamily$Companion getters return concrete subtypes:
+        //   getDefault()    -> SystemFontFamily
+        //   getSansSerif()  -> GenericFontFamily
+        //   getSerif()      -> GenericFontFamily
+        //   getMonospace()  -> GenericFontFamily
+        //   getCursive()    -> GenericFontFamily
+        // All of these extend FontFamily, so we wrap as our base type.
+        IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/font/FontFamily$Companion");
+        IntPtr mid = JNIEnv.GetMethodID(cls, getterName, $"(){returnDescriptor}");
+        IntPtr companion = Companion();
+        IntPtr value = JNIEnv.CallObjectMethod(companion, mid);
+        return new FontFamily(value, JniHandleOwnership.TransferLocalRef);
+    }
+
+    const string SystemFontFamilyDescriptor  = "Landroidx/compose/ui/text/font/SystemFontFamily;";
+    const string GenericFontFamilyDescriptor = "Landroidx/compose/ui/text/font/GenericFontFamily;";
+
+    static FontFamily? s_default, s_sansSerif, s_serif, s_monospace, s_cursive;
+
+    /// <summary>
+    /// <c>FontFamily.Default</c> — the platform's system font family.
+    /// </summary>
+    public static FontFamily Default => s_default ??= Resolve("getDefault", SystemFontFamilyDescriptor);
+
+    /// <summary>Generic sans-serif family (<c>FontFamily.SansSerif</c>).</summary>
+    public static FontFamily SansSerif => s_sansSerif ??= Resolve("getSansSerif", GenericFontFamilyDescriptor);
+
+    /// <summary>Generic serif family (<c>FontFamily.Serif</c>).</summary>
+    public static FontFamily Serif => s_serif ??= Resolve("getSerif", GenericFontFamilyDescriptor);
+
+    /// <summary>Generic monospace family (<c>FontFamily.Monospace</c>).</summary>
+    public static FontFamily Monospace => s_monospace ??= Resolve("getMonospace", GenericFontFamilyDescriptor);
+
+    /// <summary>Generic cursive family (<c>FontFamily.Cursive</c>).</summary>
+    public static FontFamily Cursive => s_cursive ??= Resolve("getCursive", GenericFontFamilyDescriptor);
+}

--- a/src/ComposeNet.Compose/FontStyle.cs
+++ b/src/ComposeNet.Compose/FontStyle.cs
@@ -1,0 +1,75 @@
+using Android.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// C# wrapper around <c>androidx.compose.ui.text.font.FontStyle</c>.
+/// In Kotlin source, <c>FontStyle</c> is a <c>@JvmInline value class</c>
+/// wrapping an <c>Int</c>, but every <c>@Composable</c> function in
+/// Material 3 declares it as <em>nullable</em> (<c>fontStyle: FontStyle?
+/// = null</c>) — so at the JNI boundary it travels as a boxed
+/// <c>androidx/compose/ui/text/font/FontStyle;</c> reference, not a
+/// packed <c>int</c>. The bridge generator's reference-type path
+/// passes the handle through to the JNI <c>L</c> slot.
+///
+/// Same trick as <see cref="TextAlign"/>: call the mangled
+/// <c>Companion.getNormal-_-LCdwA()I</c> for the packed int, then
+/// route through static <c>FontStyle.box-impl(I)LFontStyle;</c>.
+///
+/// Will swap to bound <c>AndroidX.Compose.UI.Text.Font.FontStyle</c>
+/// once <see href="https://github.com/dotnet/android-libraries/pull/1440"/>
+/// ships.
+/// </summary>
+public sealed class FontStyle : Java.Lang.Object
+{
+    FontStyle(IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer) { }
+
+    static IntPtr s_companion;
+    static IntPtr s_box;
+
+    static unsafe IntPtr Companion()
+    {
+        if (s_companion == IntPtr.Zero)
+        {
+            IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/font/FontStyle");
+            IntPtr fid = JNIEnv.GetStaticFieldID(cls, "Companion", "Landroidx/compose/ui/text/font/FontStyle$Companion;");
+            IntPtr local = JNIEnv.GetStaticObjectField(cls, fid);
+            s_companion = JNIEnv.NewGlobalRef(local);
+            JNIEnv.DeleteLocalRef(local);
+        }
+        return s_companion;
+    }
+
+    static IntPtr BoxMethod()
+    {
+        if (s_box == IntPtr.Zero)
+        {
+            IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/font/FontStyle");
+            s_box = JNIEnv.GetStaticMethodID(cls, "box-impl", "(I)Landroidx/compose/ui/text/font/FontStyle;");
+        }
+        return s_box;
+    }
+
+    static unsafe FontStyle Resolve(string mangledGetter)
+    {
+        IntPtr companionCls = JNIEnv.FindClass("androidx/compose/ui/text/font/FontStyle$Companion");
+        IntPtr getter = JNIEnv.GetMethodID(companionCls, mangledGetter, "()I");
+        int packed = JNIEnv.CallIntMethod(Companion(), getter);
+
+        IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/font/FontStyle");
+        JValue* args = stackalloc JValue[1];
+        args[0] = new JValue(packed);
+        IntPtr boxed = JNIEnv.CallStaticObjectMethod(cls, BoxMethod(), args);
+        return new FontStyle(boxed, JniHandleOwnership.TransferLocalRef);
+    }
+
+    static FontStyle? s_normal, s_italic;
+
+    /// <summary>Upright glyphs (the default).</summary>
+    public static FontStyle Normal => s_normal ??= Resolve("getNormal-_-LCdwA");
+
+    /// <summary>Italic / slanted glyphs.</summary>
+    public static FontStyle Italic => s_italic ??= Resolve("getItalic-_-LCdwA");
+}
+

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 
-~override ComposeNet.TextAlign.Equals(object obj) -> bool
-~override ComposeNet.TextAlign.ToString() -> string
+~override ComposeNet.TextOverflow.Equals(object obj) -> bool
+~override ComposeNet.TextOverflow.ToString() -> string
 ComposeNet.AlertDialog
 ComposeNet.AlertDialog.AlertDialog(System.Action! onDismissRequest) -> void
 ComposeNet.AlertDialog.ConfirmButton.get -> ComposeNet.ComposableNode?
@@ -221,6 +221,8 @@ ComposeNet.FlexibleBottomAppBar
 ComposeNet.FlexibleBottomAppBar.FlexibleBottomAppBar() -> void
 ComposeNet.FloatingActionButton
 ComposeNet.FloatingActionButton.FloatingActionButton(System.Action! onClick) -> void
+ComposeNet.FontFamily
+ComposeNet.FontStyle
 ComposeNet.FontWeight
 ComposeNet.GridCells
 ComposeNet.HorizontalCenteredHeroCarousel<T>
@@ -463,8 +465,34 @@ ComposeNet.OutlinedSecureTextField.SupportingText.set -> void
 ComposeNet.OutlinedSecureTextField.TrailingIcon.get -> ComposeNet.ComposableNode?
 ComposeNet.OutlinedSecureTextField.TrailingIcon.set -> void
 ComposeNet.OutlinedTextField
+ComposeNet.OutlinedTextField.Enabled.get -> bool?
+ComposeNet.OutlinedTextField.Enabled.set -> void
+ComposeNet.OutlinedTextField.IsError.get -> bool?
+ComposeNet.OutlinedTextField.IsError.set -> void
+ComposeNet.OutlinedTextField.Label.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedTextField.Label.set -> void
+ComposeNet.OutlinedTextField.LeadingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedTextField.LeadingIcon.set -> void
+ComposeNet.OutlinedTextField.MaxLines.get -> int?
+ComposeNet.OutlinedTextField.MaxLines.set -> void
+ComposeNet.OutlinedTextField.MinLines.get -> int?
+ComposeNet.OutlinedTextField.MinLines.set -> void
 ComposeNet.OutlinedTextField.OutlinedTextField(ComposeNet.MutableState<string!>! state) -> void
 ComposeNet.OutlinedTextField.OutlinedTextField(string! value, System.Action<string!>! onValueChange) -> void
+ComposeNet.OutlinedTextField.Placeholder.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedTextField.Placeholder.set -> void
+ComposeNet.OutlinedTextField.Prefix.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedTextField.Prefix.set -> void
+ComposeNet.OutlinedTextField.ReadOnly.get -> bool?
+ComposeNet.OutlinedTextField.ReadOnly.set -> void
+ComposeNet.OutlinedTextField.SingleLine.get -> bool?
+ComposeNet.OutlinedTextField.SingleLine.set -> void
+ComposeNet.OutlinedTextField.Suffix.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedTextField.Suffix.set -> void
+ComposeNet.OutlinedTextField.SupportingText.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedTextField.SupportingText.set -> void
+ComposeNet.OutlinedTextField.TrailingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.OutlinedTextField.TrailingIcon.set -> void
 ComposeNet.PermanentDrawerSheet
 ComposeNet.PermanentDrawerSheet.ContainerColor.get -> long
 ComposeNet.PermanentDrawerSheet.ContainerColor.set -> void
@@ -612,30 +640,73 @@ ComposeNet.Tab.Text.set -> void
 ComposeNet.TabRow
 ComposeNet.TabRow.TabRow(int selectedTabIndex) -> void
 ComposeNet.Text
+ComposeNet.Text.Align.get -> ComposeNet.TextAlign?
+ComposeNet.Text.Align.set -> void
+ComposeNet.Text.Color.get -> long?
+ComposeNet.Text.Color.set -> void
 ComposeNet.Text.Decoration.get -> ComposeNet.TextDecoration?
 ComposeNet.Text.Decoration.set -> void
+ComposeNet.Text.FontFamily.get -> ComposeNet.FontFamily?
+ComposeNet.Text.FontFamily.set -> void
 ComposeNet.Text.FontSize.get -> ComposeNet.Sp?
 ComposeNet.Text.FontSize.set -> void
+ComposeNet.Text.FontStyle.get -> ComposeNet.FontStyle?
+ComposeNet.Text.FontStyle.set -> void
 ComposeNet.Text.FontWeight.get -> ComposeNet.FontWeight?
 ComposeNet.Text.FontWeight.set -> void
 ComposeNet.Text.LetterSpacing.get -> ComposeNet.Sp?
 ComposeNet.Text.LetterSpacing.set -> void
 ComposeNet.Text.LineHeight.get -> ComposeNet.Sp?
 ComposeNet.Text.LineHeight.set -> void
+ComposeNet.Text.MaxLines.get -> int?
+ComposeNet.Text.MaxLines.set -> void
+ComposeNet.Text.MinLines.get -> int?
+ComposeNet.Text.MinLines.set -> void
+ComposeNet.Text.Overflow.get -> ComposeNet.TextOverflow?
+ComposeNet.Text.Overflow.set -> void
+ComposeNet.Text.SoftWrap.get -> bool?
+ComposeNet.Text.SoftWrap.set -> void
 ComposeNet.Text.Text(string! text) -> void
 ComposeNet.TextAlign
-ComposeNet.TextAlign.Deconstruct(out int Value) -> void
-ComposeNet.TextAlign.Equals(ComposeNet.TextAlign other) -> bool
-ComposeNet.TextAlign.TextAlign() -> void
-ComposeNet.TextAlign.TextAlign(int Value) -> void
-ComposeNet.TextAlign.Value.get -> int
-ComposeNet.TextAlign.Value.init -> void
 ComposeNet.TextButton
 ComposeNet.TextButton.TextButton(System.Action! onClick) -> void
 ComposeNet.TextDecoration
 ComposeNet.TextField
+ComposeNet.TextField.Enabled.get -> bool?
+ComposeNet.TextField.Enabled.set -> void
+ComposeNet.TextField.IsError.get -> bool?
+ComposeNet.TextField.IsError.set -> void
+ComposeNet.TextField.Label.get -> ComposeNet.ComposableNode?
+ComposeNet.TextField.Label.set -> void
+ComposeNet.TextField.LeadingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.TextField.LeadingIcon.set -> void
+ComposeNet.TextField.MaxLines.get -> int?
+ComposeNet.TextField.MaxLines.set -> void
+ComposeNet.TextField.MinLines.get -> int?
+ComposeNet.TextField.MinLines.set -> void
+ComposeNet.TextField.Placeholder.get -> ComposeNet.ComposableNode?
+ComposeNet.TextField.Placeholder.set -> void
+ComposeNet.TextField.Prefix.get -> ComposeNet.ComposableNode?
+ComposeNet.TextField.Prefix.set -> void
+ComposeNet.TextField.ReadOnly.get -> bool?
+ComposeNet.TextField.ReadOnly.set -> void
+ComposeNet.TextField.SingleLine.get -> bool?
+ComposeNet.TextField.SingleLine.set -> void
+ComposeNet.TextField.Suffix.get -> ComposeNet.ComposableNode?
+ComposeNet.TextField.Suffix.set -> void
+ComposeNet.TextField.SupportingText.get -> ComposeNet.ComposableNode?
+ComposeNet.TextField.SupportingText.set -> void
 ComposeNet.TextField.TextField(ComposeNet.MutableState<string!>! state) -> void
 ComposeNet.TextField.TextField(string! value, System.Action<string!>! onValueChange) -> void
+ComposeNet.TextField.TrailingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.TextField.TrailingIcon.set -> void
+ComposeNet.TextOverflow
+ComposeNet.TextOverflow.Deconstruct(out int Value) -> void
+ComposeNet.TextOverflow.Equals(ComposeNet.TextOverflow other) -> bool
+ComposeNet.TextOverflow.TextOverflow() -> void
+ComposeNet.TextOverflow.TextOverflow(int Value) -> void
+ComposeNet.TextOverflow.Value.get -> int
+ComposeNet.TextOverflow.Value.init -> void
 ComposeNet.TimePicker
 ComposeNet.TimePicker.TimePicker(ComposeNet.TimePickerState? state = null) -> void
 ComposeNet.TimePickerDialog
@@ -703,7 +774,7 @@ override ComposeNet.MutableState<T>.ToString() -> string!
 override ComposeNet.Sp.Equals(object? obj) -> bool
 override ComposeNet.Sp.GetHashCode() -> int
 override ComposeNet.Sp.ToString() -> string!
-override ComposeNet.TextAlign.GetHashCode() -> int
+override ComposeNet.TextOverflow.GetHashCode() -> int
 static ComposeNet.Arrangement.Bottom.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Center.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.End.get -> ComposeNet.Arrangement!
@@ -720,6 +791,13 @@ static ComposeNet.Dp.operator !=(ComposeNet.Dp left, ComposeNet.Dp right) -> boo
 static ComposeNet.Dp.operator ==(ComposeNet.Dp left, ComposeNet.Dp right) -> bool
 static ComposeNet.Dp.Pack(ComposeNet.Dp? value) -> float
 static ComposeNet.Dp.Zero.get -> ComposeNet.Dp
+static ComposeNet.FontFamily.Cursive.get -> ComposeNet.FontFamily!
+static ComposeNet.FontFamily.Default.get -> ComposeNet.FontFamily!
+static ComposeNet.FontFamily.Monospace.get -> ComposeNet.FontFamily!
+static ComposeNet.FontFamily.SansSerif.get -> ComposeNet.FontFamily!
+static ComposeNet.FontFamily.Serif.get -> ComposeNet.FontFamily!
+static ComposeNet.FontStyle.Italic.get -> ComposeNet.FontStyle!
+static ComposeNet.FontStyle.Normal.get -> ComposeNet.FontStyle!
 static ComposeNet.FontWeight.Black.get -> ComposeNet.FontWeight!
 static ComposeNet.FontWeight.Bold.get -> ComposeNet.FontWeight!
 static ComposeNet.FontWeight.ExtraBold.get -> ComposeNet.FontWeight!
@@ -740,18 +818,23 @@ static ComposeNet.Sp.operator !=(ComposeNet.Sp left, ComposeNet.Sp right) -> boo
 static ComposeNet.Sp.operator ==(ComposeNet.Sp left, ComposeNet.Sp right) -> bool
 static ComposeNet.Sp.Pack(ComposeNet.Sp? value) -> long
 static ComposeNet.Sp.Zero.get -> ComposeNet.Sp
-static ComposeNet.TextAlign.Center.get -> ComposeNet.TextAlign
-static ComposeNet.TextAlign.End.get -> ComposeNet.TextAlign
-static ComposeNet.TextAlign.Justify.get -> ComposeNet.TextAlign
-static ComposeNet.TextAlign.Left.get -> ComposeNet.TextAlign
-static ComposeNet.TextAlign.operator !=(ComposeNet.TextAlign left, ComposeNet.TextAlign right) -> bool
-static ComposeNet.TextAlign.operator ==(ComposeNet.TextAlign left, ComposeNet.TextAlign right) -> bool
-static ComposeNet.TextAlign.Pack(ComposeNet.TextAlign? value) -> int
-static ComposeNet.TextAlign.Right.get -> ComposeNet.TextAlign
-static ComposeNet.TextAlign.Start.get -> ComposeNet.TextAlign
-static ComposeNet.TextAlign.Unspecified.get -> ComposeNet.TextAlign
+static ComposeNet.TextAlign.Center.get -> ComposeNet.TextAlign!
+static ComposeNet.TextAlign.End.get -> ComposeNet.TextAlign!
+static ComposeNet.TextAlign.Justify.get -> ComposeNet.TextAlign!
+static ComposeNet.TextAlign.Left.get -> ComposeNet.TextAlign!
+static ComposeNet.TextAlign.Right.get -> ComposeNet.TextAlign!
+static ComposeNet.TextAlign.Start.get -> ComposeNet.TextAlign!
+static ComposeNet.TextAlign.Unspecified.get -> ComposeNet.TextAlign!
 static ComposeNet.TextDecoration.LineThrough.get -> ComposeNet.TextDecoration!
 static ComposeNet.TextDecoration.None.get -> ComposeNet.TextDecoration!
 static ComposeNet.TextDecoration.Underline.get -> ComposeNet.TextDecoration!
+static ComposeNet.TextOverflow.Clip.get -> ComposeNet.TextOverflow
+static ComposeNet.TextOverflow.Ellipsis.get -> ComposeNet.TextOverflow
+static ComposeNet.TextOverflow.MiddleEllipsis.get -> ComposeNet.TextOverflow
+static ComposeNet.TextOverflow.operator !=(ComposeNet.TextOverflow left, ComposeNet.TextOverflow right) -> bool
+static ComposeNet.TextOverflow.operator ==(ComposeNet.TextOverflow left, ComposeNet.TextOverflow right) -> bool
+static ComposeNet.TextOverflow.Pack(ComposeNet.TextOverflow? value) -> int
+static ComposeNet.TextOverflow.StartEllipsis.get -> ComposeNet.TextOverflow
+static ComposeNet.TextOverflow.Visible.get -> ComposeNet.TextOverflow
 virtual ComposeNet.MutableState<T>.Value.get -> T
 virtual ComposeNet.MutableState<T>.Value.set -> void

--- a/src/ComposeNet.Compose/TextAlign.cs
+++ b/src/ComposeNet.Compose/TextAlign.cs
@@ -1,49 +1,94 @@
+using Android.Runtime;
+
 namespace ComposeNet;
 
 /// <summary>
-/// C# mirror of Kotlin's <c>androidx.compose.ui.text.style.TextAlign</c>
-/// — a <c>@JvmInline value class</c> wrapping an <c>Int</c>. The bridge
-/// generator lowers <c>TextAlign?</c> to the underlying <c>int</c> JNI
-/// slot.
+/// C# wrapper around <c>androidx.compose.ui.text.style.TextAlign</c>.
+/// In Kotlin source, <c>TextAlign</c> is a <c>@JvmInline value class</c>
+/// wrapping an <c>Int</c>, but every <c>@Composable</c> function in
+/// Material 3 declares it as <em>nullable</em> (<c>textAlign: TextAlign?
+/// = null</c>) — so at the JNI boundary it travels as a boxed
+/// <c>androidx/compose/ui/text/style/TextAlign;</c> reference, not a
+/// packed <c>int</c>. The bridge generator's reference-type path
+/// passes the handle through to the JNI <c>L</c> slot.
 ///
-/// Values mirror the Kotlin <c>TextAlign.Companion</c> constants:
-/// <list type="bullet">
-///   <item><see cref="Left"/> = 1</item>
-///   <item><see cref="Right"/> = 2</item>
-///   <item><see cref="Center"/> = 3</item>
-///   <item><see cref="Justify"/> = 4</item>
-///   <item><see cref="Start"/> = 5</item>
-///   <item><see cref="End"/> = 6</item>
-/// </list>
+/// To produce that boxed reference the constants here call the
+/// inline-class's mangled <c>Companion.getCenter-e0LSkKk()I</c>
+/// (and friends) for the packed int, then route it through the
+/// synthesized static <c>TextAlign.box-impl(I)LTextAlign;</c> to wrap.
+///
+/// Will swap to bound <c>AndroidX.Compose.UI.Text.Style.TextAlign</c>
+/// once <see href="https://github.com/dotnet/android-libraries/pull/1440"/>
+/// ships and we adopt the next <c>Xamarin.AndroidX.Compose.UI.Text.Android</c>
+/// release.
 /// </summary>
-public readonly record struct TextAlign(int Value)
+public sealed class TextAlign : Java.Lang.Object
 {
+    TextAlign(IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer) { }
+
+    static IntPtr s_companion;
+    static IntPtr s_box;
+
+    static unsafe IntPtr Companion()
+    {
+        if (s_companion == IntPtr.Zero)
+        {
+            IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/style/TextAlign");
+            IntPtr fid = JNIEnv.GetStaticFieldID(cls, "Companion", "Landroidx/compose/ui/text/style/TextAlign$Companion;");
+            IntPtr local = JNIEnv.GetStaticObjectField(cls, fid);
+            s_companion = JNIEnv.NewGlobalRef(local);
+            JNIEnv.DeleteLocalRef(local);
+        }
+        return s_companion;
+    }
+
+    static IntPtr BoxMethod()
+    {
+        if (s_box == IntPtr.Zero)
+        {
+            IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/style/TextAlign");
+            s_box = JNIEnv.GetStaticMethodID(cls, "box-impl", "(I)Landroidx/compose/ui/text/style/TextAlign;");
+        }
+        return s_box;
+    }
+
+    static unsafe TextAlign Resolve(string mangledGetter)
+    {
+        // 1. Companion.<getter>()I returns the packed int.
+        IntPtr companionCls = JNIEnv.FindClass("androidx/compose/ui/text/style/TextAlign$Companion");
+        IntPtr getter = JNIEnv.GetMethodID(companionCls, mangledGetter, "()I");
+        int packed = JNIEnv.CallIntMethod(Companion(), getter);
+
+        // 2. TextAlign.box-impl(int) -> Landroidx/.../TextAlign;
+        IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/style/TextAlign");
+        JValue* args = stackalloc JValue[1];
+        args[0] = new JValue(packed);
+        IntPtr boxed = JNIEnv.CallStaticObjectMethod(cls, BoxMethod(), args);
+        return new TextAlign(boxed, JniHandleOwnership.TransferLocalRef);
+    }
+
+    static TextAlign? s_left, s_right, s_center, s_justify, s_start, s_end, s_unspecified;
+
     /// <summary>Align text to the left edge of the container.</summary>
-    public static TextAlign Left => new(1);
+    public static TextAlign Left => s_left ??= Resolve("getLeft-e0LSkKk");
 
     /// <summary>Align text to the right edge of the container.</summary>
-    public static TextAlign Right => new(2);
+    public static TextAlign Right => s_right ??= Resolve("getRight-e0LSkKk");
 
     /// <summary>Center text within the container.</summary>
-    public static TextAlign Center => new(3);
+    public static TextAlign Center => s_center ??= Resolve("getCenter-e0LSkKk");
 
     /// <summary>Stretch lines to fill the container width.</summary>
-    public static TextAlign Justify => new(4);
+    public static TextAlign Justify => s_justify ??= Resolve("getJustify-e0LSkKk");
 
     /// <summary>Align text to the layout-direction start edge.</summary>
-    public static TextAlign Start => new(5);
+    public static TextAlign Start => s_start ??= Resolve("getStart-e0LSkKk");
 
     /// <summary>Align text to the layout-direction end edge.</summary>
-    public static TextAlign End => new(6);
+    public static TextAlign End => s_end ??= Resolve("getEnd-e0LSkKk");
 
-    /// <summary>Kotlin's <c>TextAlign.Unspecified</c> sentinel.</summary>
-    public static TextAlign Unspecified => new(int.MinValue);
-
-    /// <summary>
-    /// Pack a nullable <see cref="TextAlign"/> into the raw <c>int</c>
-    /// the JNI slot expects. <c>null</c> → <c>0</c>; the auto-mask
-    /// leaves the <c>$default</c> bit set so Kotlin's real default
-    /// applies.
-    /// </summary>
-    public static int Pack(TextAlign? value) => value?.Value ?? 0;
+    /// <summary>The unspecified-alignment sentinel value (Kotlin's default for nullable slots).</summary>
+    public static TextAlign Unspecified => s_unspecified ??= Resolve("getUnspecified-e0LSkKk");
 }
+

--- a/src/ComposeNet.Compose/TextOverflow.cs
+++ b/src/ComposeNet.Compose/TextOverflow.cs
@@ -1,0 +1,42 @@
+namespace ComposeNet;
+
+/// <summary>
+/// C# mirror of Kotlin's <c>androidx.compose.ui.text.style.TextOverflow</c>
+/// — a <c>@JvmInline value class</c> wrapping an <c>Int</c>. The bridge
+/// generator lowers <c>TextOverflow?</c> to the underlying <c>int</c>
+/// JNI slot.
+///
+/// Values mirror the Kotlin <c>TextOverflow.Companion</c> constants:
+/// <list type="bullet">
+///   <item><see cref="Clip"/> = 1 — truncate at the container edge.</item>
+///   <item><see cref="Ellipsis"/> = 2 — replace overflow with <c>"…"</c>.</item>
+///   <item><see cref="Visible"/> = 3 — render past the container bounds.</item>
+///   <item><see cref="StartEllipsis"/> = 4 — leading ellipsis.</item>
+///   <item><see cref="MiddleEllipsis"/> = 5 — middle ellipsis.</item>
+/// </list>
+/// </summary>
+public readonly record struct TextOverflow(int Value)
+{
+    /// <summary>Truncate the text at the edge of the container.</summary>
+    public static TextOverflow Clip => new(1);
+
+    /// <summary>Replace the overflowing text with an ellipsis (default for single-line).</summary>
+    public static TextOverflow Ellipsis => new(2);
+
+    /// <summary>Render the text outside the container bounds (no clipping).</summary>
+    public static TextOverflow Visible => new(3);
+
+    /// <summary>Place the ellipsis at the start of the text.</summary>
+    public static TextOverflow StartEllipsis => new(4);
+
+    /// <summary>Place the ellipsis in the middle of the text.</summary>
+    public static TextOverflow MiddleEllipsis => new(5);
+
+    /// <summary>
+    /// Pack a nullable <see cref="TextOverflow"/> into the raw
+    /// <c>int</c> the JNI slot expects. <c>null</c> → <c>0</c>; the
+    /// auto-mask leaves the <c>$default</c> bit set so Kotlin's real
+    /// default applies.
+    /// </summary>
+    public static int Pack(TextOverflow? value) => value?.Value ?? 0;
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -180,6 +180,60 @@ public class MainActivity : ComposeActivity
                                 LineHeight = 22,
                                 Modifier = Modifier.Companion.Padding(8),
                             },
+                            // Issue #58: text styling additions — color, italic /
+                            // family, alignment, overflow, line clamping. Each
+                            // property surfaces through the [ComposeFacade] /
+                            // [ComposeBridge] nullable-primitive generator path.
+                            new Text("Issue #58 text styling:")
+                            {
+                                Modifier = Modifier.Companion.Padding(top: 8, bottom: 4, start: 0, end: 0),
+                                FontWeight = ComposeNet.FontWeight.Bold,
+                            },
+                            new Text("Italic serif red, centered")
+                            {
+                                Color = ColorKt.Color(red: 0xC6, green: 0x28, blue: 0x28, alpha: 0xFF),
+                                FontStyle = ComposeNet.FontStyle.Italic,
+                                FontFamily = ComposeNet.FontFamily.Serif,
+                                Align = ComposeNet.TextAlign.Center,
+                                Modifier = Modifier.Companion.FillMaxWidth(),
+                            },
+                            new Text("Monospace, end-aligned")
+                            {
+                                FontFamily = ComposeNet.FontFamily.Monospace,
+                                Align = ComposeNet.TextAlign.End,
+                                Modifier = Modifier.Companion.FillMaxWidth(),
+                            },
+                            new Text("This long line should clip with an ellipsis because we cap it at MaxLines=1 and force overflow.")
+                            {
+                                MaxLines = 1,
+                                Overflow = ComposeNet.TextOverflow.Ellipsis,
+                                SoftWrap = false,
+                            },
+                            new Text("This paragraph wraps to at most two lines and uses a non-default minLines so the slot reserves vertical space even when the content is shorter than the maximum allowed.")
+                            {
+                                MaxLines = 2,
+                                MinLines = 2,
+                                Overflow = ComposeNet.TextOverflow.Ellipsis,
+                            },
+                            // TextField with new slots: leading/trailing icons,
+                            // label, supporting text, prefix, suffix.
+                            new TextField(name)
+                            {
+                                Label          = new Text("Your name"),
+                                Placeholder    = new Text("Type something…"),
+                                LeadingIcon    = new Text("👤"),
+                                TrailingIcon   = new Text("✎"),
+                                SupportingText = new Text("Powered by issue #58 slots"),
+                                SingleLine     = true,
+                            },
+                            new OutlinedTextField(name)
+                            {
+                                Label          = new Text("Outlined variant"),
+                                Prefix         = new Text("@"),
+                                Suffix         = new Text(".dev"),
+                                SupportingText = new Text($"len={name.Value.Length}"),
+                                SingleLine     = true,
+                            },
                             // Phase 2 modifier demo — clickable rounded chip painted with
                             // Background + Border + Clip; tapping it increments the counter.
                             new Text($"Phase 2 modifiers (tap me): {count}")

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -182,8 +182,12 @@ public class MainActivity : ComposeActivity
                             },
                             // Issue #58: text styling additions — color, italic /
                             // family, alignment, overflow, line clamping. Each
-                            // property surfaces through the [ComposeFacade] /
-                            // [ComposeBridge] nullable-primitive generator path.
+                            // property flows through the [ComposeFacade] /
+                            // [ComposeBridge] generators: Color/MaxLines/MinLines/
+                            // SoftWrap use the new nullable-primitive path,
+                            // FontStyle/FontFamily/TextAlign use the nullable
+                            // reference-wrapper path, and TextOverflow uses the
+                            // packed @JvmInline value-class path.
                             new Text("Issue #58 text styling:")
                             {
                                 Modifier = Modifier.Companion.Padding(top: 8, bottom: 4, start: 0, end: 0),

--- a/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -78,13 +78,16 @@ public class BridgeGeneratorTests
             {
                 public static long Pack(Em? value) => default;
             }
-            public readonly record struct TextAlign(int Value)
-            {
-                public static int Pack(TextAlign? value) => value?.Value ?? 0;
-            }
             public sealed class Shape : Java.Lang.Object { }
             public sealed class FontWeight : Java.Lang.Object { }
+            public sealed class FontStyle : Java.Lang.Object { }
+            public sealed class FontFamily : Java.Lang.Object { }
+            public sealed class TextAlign : Java.Lang.Object { }
             public sealed class TextDecoration : Java.Lang.Object { }
+            public readonly record struct TextOverflow(int Value)
+            {
+                public static int Pack(TextOverflow? value) => value?.Value ?? 0;
+            }
         }
         """;
 
@@ -1132,15 +1135,19 @@ public class BridgeGeneratorTests
     }
 
     [Fact]
-    public void ValueType_SpTextAlign_LowerCorrectly()
+    public void ValueType_SpTextOverflow_LowerCorrectly()
     {
-        // @Composable bridge: (Sp fontSize, TextAlign align, Composer).
+        // @Composable bridge: (Sp fontSize, TextOverflow overflow, Composer).
         // JNI: 2 user slots (J/I) + Composer (L) + 1 $changed (I) + 1 $default (I).
+        // Sp lowers to packed long; TextOverflow lowers to packed int —
+        // both are non-nullable in their real-world Compose @Composable
+        // declarations, so they travel as primitives rather than boxed
+        // references.
         var code = """
             using ComposeNet;
             using AndroidX.Compose.Runtime;
 
-            [assembly: ComposeDefaults("FontDefault", "fontSize", "align")]
+            [assembly: ComposeDefaults("FontDefault", "fontSize", "overflow")]
 
             namespace ComposeNet
             {
@@ -1151,7 +1158,7 @@ public class BridgeGeneratorTests
                         JvmName = "f",
                         Signature = "(JILandroidx/compose/runtime/Composer;II)V",
                         Defaults = typeof(FontDefault))]
-                    public static partial void F(Sp? fontSize, TextAlign? align, IComposer composer);
+                    public static partial void F(Sp? fontSize, TextOverflow? overflow, IComposer composer);
                 }
             }
             """;
@@ -1160,7 +1167,7 @@ public class BridgeGeneratorTests
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
         Assert.Contains("global::ComposeNet.Sp.Pack(fontSize)", emitted);
-        Assert.Contains("global::ComposeNet.TextAlign.Pack(align)", emitted);
+        Assert.Contains("global::ComposeNet.TextOverflow.Pack(overflow)", emitted);
     }
 
     [Fact]
@@ -1252,5 +1259,76 @@ public class BridgeGeneratorTests
         Assert.NotNull(emitted);
         Assert.Contains("weight is null ? global::System.IntPtr.Zero : ((global::Java.Lang.Object)weight).Handle", emitted);
         Assert.Contains("if (weight is not null) defaults &= ~(int)global::ComposeNet.WeightedDefault.Weight", emitted);
+    }
+
+    [Fact]
+    public void NullablePrimitive_BoolIntLong_LowerToZeroDefaults()
+    {
+        // bool? / int? / long? params surface as nullable so the caller
+        // can leave the Kotlin default in place (auto-mask bit stays
+        // set). When the caller supplies a value, the mask bit clears
+        // and the value is passed through to the JNI primitive slot.
+        var code = """
+            using ComposeNet;
+            using AndroidX.Compose.Runtime;
+
+            [assembly: ComposeDefaults("PrimDefault",
+                "softWrap", "maxLines", "color")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "x/Y",
+                        JvmName = "f",
+                        Signature = "(ZIJLandroidx/compose/runtime/Composer;II)V",
+                        Defaults = typeof(PrimDefault))]
+                    public static partial void F(bool? softWrap, int? maxLines, long? color, IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // Lowering: pass underlying primitive with null → zero literal.
+        Assert.Contains("(softWrap ?? false)", emitted);
+        Assert.Contains("(maxLines ?? 0)", emitted);
+        Assert.Contains("(color ?? 0L)", emitted);
+        // Auto-mask: clear the bit only when a value was supplied.
+        Assert.Contains("if (softWrap is not null) defaults &= ~(int)global::ComposeNet.PrimDefault.SoftWrap", emitted);
+        Assert.Contains("if (maxLines is not null) defaults &= ~(int)global::ComposeNet.PrimDefault.MaxLines", emitted);
+        Assert.Contains("if (color is not null) defaults &= ~(int)global::ComposeNet.PrimDefault.Color", emitted);
+    }
+
+    [Fact]
+    public void NullablePrimitive_FloatDouble_LowerCorrectly()
+    {
+        var code = """
+            using ComposeNet;
+            using AndroidX.Compose.Runtime;
+
+            [assembly: ComposeDefaults("FloatDefault", "ratio", "scale")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "x/Y",
+                        JvmName = "f",
+                        Signature = "(FDLandroidx/compose/runtime/Composer;II)V",
+                        Defaults = typeof(FloatDefault))]
+                    public static partial void F(float? ratio, double? scale, IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("(ratio ?? 0f)", emitted);
+        Assert.Contains("(scale ?? 0d)", emitted);
     }
 }

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -104,13 +104,16 @@ public class FacadeGeneratorTests
                 public float Value { get; }
                 public static long Pack(Em? e) => 0L;
             }
-            public readonly struct TextAlign
+            public readonly struct TextOverflow
             {
-                public TextAlign(int v) { Value = v; }
+                public TextOverflow(int v) { Value = v; }
                 public int Value { get; }
-                public static int Pack(TextAlign? a) => 0;
+                public static int Pack(TextOverflow? a) => 0;
             }
             public class FontWeight : Java.Lang.Object { }
+            public class FontStyle : Java.Lang.Object { }
+            public class FontFamily : Java.Lang.Object { }
+            public class TextAlign : Java.Lang.Object { }
             public class TextDecoration : Java.Lang.Object { }
             public class Shape : Java.Lang.Object { }
             public abstract class ComposableNode
@@ -1562,8 +1565,11 @@ public class FacadeGeneratorTests
     }
 
     [Fact]
-    public void OptionalValue_TextAlignAndDpAreClassifiedAsValueTypes()
+    public void OptionalValue_TextOverflowAndDpAreClassifiedAsValueTypes()
     {
+        // TextOverflow is a non-nullable @JvmInline value class in
+        // Compose source — it travels as packed `I`. Dp is also packed
+        // (`F`). Both surface as nullable auto-properties.
         var code = """
             using AndroidX.Compose.Runtime;
             using AndroidX.Compose.UI;
@@ -1571,7 +1577,7 @@ public class FacadeGeneratorTests
             using Kotlin.Jvm.Functions;
 
             [assembly: ComposeDefaults("FooDefault",
-                "!a", "align", "size")]
+                "!a", "overflow", "size")]
 
             namespace ComposeNet
             {
@@ -1581,7 +1587,7 @@ public class FacadeGeneratorTests
                                    Signature="(Ljava/lang/String;IFLandroidx/compose/runtime/Composer;II)V",
                                    Defaults=typeof(FooDefault))]
                     [ComposeFacade]
-                    public static partial void Foo(string a, TextAlign? align, Dp? size, IComposer composer);
+                    public static partial void Foo(string a, TextOverflow? overflow, Dp? size, IComposer composer);
                 }
             }
             """;
@@ -1589,7 +1595,7 @@ public class FacadeGeneratorTests
         var (output, diags, emitted) = Run(code, "Foo");
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
-        Assert.Contains("public global::ComposeNet.TextAlign? Align { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.TextOverflow? Overflow { get; set; }", emitted);
         Assert.Contains("public global::ComposeNet.Dp? Size { get; set; }", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
@@ -1636,6 +1642,56 @@ public class FacadeGeneratorTests
         Assert.Contains(
             "if (FontWeight is not null) __defaults &= ~(int)global::ComposeNet.BarDefault.FontWeight;",
             emitted);
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void OptionalValue_NullablePrimitivesEmitNullableAutoProperties()
+    {
+        // bool? / int? / long? params surface as Optional auto-properties
+        // — null leaves the Kotlin default in place via the auto-mask
+        // bit, a value clears the bit and lowers to the JNI primitive
+        // slot.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("PrimDefault",
+                "!text", "modifier", "softWrap", "maxLines", "color")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Y", JvmName="F",
+                                   Signature="(Ljava/lang/String;Landroidx/compose/ui/Modifier;ZIJLandroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(PrimDefault))]
+                    [ComposeFacade]
+                    public static partial void F(
+                        string text, IModifier? modifier,
+                        bool? softWrap, int? maxLines, long? color,
+                        IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "F");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // Each nullable primitive surfaces as an auto-property.
+        Assert.Contains("public bool? SoftWrap { get; set; }", emitted);
+        Assert.Contains("public int? MaxLines { get; set; }", emitted);
+        Assert.Contains("public long? Color { get; set; }", emitted);
+        // The bridge call passes the property names through.
+        Assert.Contains("global::ComposeNet.ComposeBridges.F(_text, BuildModifier(), SoftWrap, MaxLines, Color, composer);", emitted);
+        // Not surfaced as ctor parameters.
+        Assert.DoesNotContain("bool? softWrap", emitted);
+        Assert.DoesNotContain("int? maxLines", emitted);
+        Assert.DoesNotContain("long? color", emitted);
+
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
     }

--- a/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
@@ -768,7 +768,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             return false;
         if (IsNullableIntPtr(p.Type)) return false;
         if (IsNullablePrimitive(p.Type)) return false;
-        // Recognized Compose value types (Color/Dp/Sp/Em/TextAlign) lower
+        // Recognized Compose value types (Dp/Sp/Em/TextOverflow) lower
         // to JNI primitives — no managed handle to keep alive.
         if (ComposeValueTypes.TryGet(p.Type, out _, out _)) return false;
         return true;

--- a/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeBridgeGenerator.cs
@@ -532,7 +532,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
 
                 var member = PascalCase(p.Name);
                 bool nullableValueType = ComposeValueTypes.TryGet(p.Type, out _, out _);
-                if (p.NullableAnnotation == NullableAnnotation.Annotated || p.Type.IsReferenceType || nullableValueType || IsNullableIntPtr(p.Type))
+                if (p.NullableAnnotation == NullableAnnotation.Annotated || p.Type.IsReferenceType || nullableValueType || IsNullableIntPtr(p.Type) || IsNullablePrimitive(p.Type))
                 {
                     sb.Append("        if (").Append(EscapeIdent(p.Name)).Append(" is not null) defaults &= ~(int)global::ComposeNet.")
                       .Append(enumName).Append('.').Append(member).AppendLine(";");
@@ -710,6 +710,16 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             sb.Append('(').Append(p.Name).Append(" ?? global::System.IntPtr.Zero)");
             return;
         }
+        if (IsNullablePrimitive(p.Type))
+        {
+            // `bool? / int? / long? / float? / double?` → null means
+            // "let the Kotlin default kick in"; pass the zero literal
+            // in that slot. The auto-mask logic clears the matching
+            // `$default` bit only when the caller supplied a value.
+            var defaultLit = NullablePrimitiveZeroLiteral(p.Type);
+            sb.Append('(').Append(EscapeIdent(p.Name)).Append(" ?? ").Append(defaultLit).Append(')');
+            return;
+        }
         if (ComposeValueTypes.TryGet(p.Type, out _, out var info))
         {
             // Recognized Compose @JvmInline value class. The lowering
@@ -757,6 +767,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             or SpecialType.System_String)
             return false;
         if (IsNullableIntPtr(p.Type)) return false;
+        if (IsNullablePrimitive(p.Type)) return false;
         // Recognized Compose value types (Color/Dp/Sp/Em/TextAlign) lower
         // to JNI primitives — no managed handle to keep alive.
         if (ComposeValueTypes.TryGet(p.Type, out _, out _)) return false;
@@ -768,6 +779,48 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         n.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
         n.TypeArguments.Length == 1 &&
         n.TypeArguments[0].SpecialType == SpecialType.System_IntPtr;
+
+    /// <summary>
+    /// True for parameters typed as <c>Nullable&lt;T&gt;</c> where
+    /// <c>T</c> is one of the primitive JNI-friendly value types
+    /// (<c>bool</c>, <c>int</c>, <c>long</c>, <c>float</c>,
+    /// <c>double</c>). These let a bridge expose an "optional" Compose
+    /// param: <c>null</c> leaves the <c>$default</c> bit set so Kotlin's
+    /// real default applies; a value clears the bit and is passed
+    /// through to the JNI primitive slot.
+    /// </summary>
+    static bool IsNullablePrimitive(ITypeSymbol t)
+    {
+        if (t is not INamedTypeSymbol n) return false;
+        if (n.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T) return false;
+        if (n.TypeArguments.Length != 1) return false;
+        return n.TypeArguments[0].SpecialType is
+            SpecialType.System_Boolean
+            or SpecialType.System_Int32
+            or SpecialType.System_Int64
+            or SpecialType.System_Single
+            or SpecialType.System_Double;
+    }
+
+    /// <summary>
+    /// Zero-literal expression for the underlying primitive of a
+    /// <see cref="IsNullablePrimitive"/> type. Used as the
+    /// <c>?? default</c> fallback in <see cref="EmitUserArgValue"/>
+    /// when the caller passes <c>null</c>.
+    /// </summary>
+    static string NullablePrimitiveZeroLiteral(ITypeSymbol t)
+    {
+        var inner = ((INamedTypeSymbol)t).TypeArguments[0].SpecialType;
+        return inner switch
+        {
+            SpecialType.System_Boolean => "false",
+            SpecialType.System_Int32   => "0",
+            SpecialType.System_Int64   => "0L",
+            SpecialType.System_Single  => "0f",
+            SpecialType.System_Double  => "0d",
+            _ => "default",
+        };
+    }
 
     static bool IsModifierType(ITypeSymbol t)
     {

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -934,8 +934,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     /// <summary>
     /// True for parameters typed as <c>Nullable&lt;T&gt;</c> where <c>T</c>
     /// is a recognized Compose <c>@JvmInline value class</c> (Dp/Sp/Em/
-    /// TextAlign), or for <em>nullable</em> reference-typed wrappers in
-    /// <see cref="ComposeReferenceTypes"/>. Both shapes surface as
+    /// TextAlign), for <em>nullable</em> reference-typed wrappers in
+    /// <see cref="ComposeReferenceTypes"/>, or for <c>Nullable&lt;T&gt;</c>
+    /// where <c>T</c> is a JNI-friendly primitive (<c>bool</c>,
+    /// <c>int</c>, <c>long</c>, <c>float</c>, <c>double</c>) — the
+    /// "optional Compose primitive" shape: <c>null</c> → leave the
+    /// <c>$default</c> bit set; a value clears the bit and lowers to
+    /// the primitive JNI slot. All three shapes surface as
     /// <see cref="FacadeSlotKind.OptionalValue"/> auto-properties on
     /// the generated facade. Non-nullable reference wrappers do not
     /// qualify — emitting a nullable auto-property for them would
@@ -944,6 +949,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     static bool IsOptionalValueType(ITypeSymbol type, NullableAnnotation annotation)
     {
         if (ComposeValueTypes.TryGet(type, out _, out _)) return true;
+        // Nullable<primitive>: bool?, int?, long?, float?, double?.
+        if (IsNullablePrimitive(type)) return true;
         // Nullable reference-type wrapper: T? where T is recognized.
         // The C# nullable-annotation flow gives us the underlying type
         // directly (no Nullable<T> wrapping) for reference types, so
@@ -953,6 +960,26 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             && ComposeReferenceTypes.IsRecognized(type))
             return true;
         return false;
+    }
+
+    /// <summary>
+    /// Mirror of <c>ComposeBridgeGenerator.IsNullablePrimitive</c> —
+    /// see that helper for the rationale. Kept private here because
+    /// the bridge generator's copy lives in a separate translation
+    /// unit and the registry of "primitive Nullable types" is small
+    /// and stable.
+    /// </summary>
+    static bool IsNullablePrimitive(ITypeSymbol t)
+    {
+        if (t is not INamedTypeSymbol n) return false;
+        if (n.OriginalDefinition.SpecialType != SpecialType.System_Nullable_T) return false;
+        if (n.TypeArguments.Length != 1) return false;
+        return n.TypeArguments[0].SpecialType is
+            SpecialType.System_Boolean
+            or SpecialType.System_Int32
+            or SpecialType.System_Int64
+            or SpecialType.System_Single
+            or SpecialType.System_Double;
     }
 
     static bool IsKnownScopeKind(Compilation compilation, string scope)

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -934,17 +934,18 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     /// <summary>
     /// True for parameters typed as <c>Nullable&lt;T&gt;</c> where <c>T</c>
     /// is a recognized Compose <c>@JvmInline value class</c> (Dp/Sp/Em/
-    /// TextAlign), for <em>nullable</em> reference-typed wrappers in
-    /// <see cref="ComposeReferenceTypes"/>, or for <c>Nullable&lt;T&gt;</c>
-    /// where <c>T</c> is a JNI-friendly primitive (<c>bool</c>,
-    /// <c>int</c>, <c>long</c>, <c>float</c>, <c>double</c>) — the
-    /// "optional Compose primitive" shape: <c>null</c> → leave the
-    /// <c>$default</c> bit set; a value clears the bit and lowers to
-    /// the primitive JNI slot. All three shapes surface as
-    /// <see cref="FacadeSlotKind.OptionalValue"/> auto-properties on
-    /// the generated facade. Non-nullable reference wrappers do not
-    /// qualify — emitting a nullable auto-property for them would
-    /// pass <c>null</c> to a non-nullable bridge parameter.
+    /// TextOverflow), for <em>nullable</em> reference-typed wrappers in
+    /// <see cref="ComposeReferenceTypes"/> (FontWeight/FontStyle/
+    /// FontFamily/TextAlign/TextDecoration/Shape), or for
+    /// <c>Nullable&lt;T&gt;</c> where <c>T</c> is a JNI-friendly
+    /// primitive (<c>bool</c>, <c>int</c>, <c>long</c>, <c>float</c>,
+    /// <c>double</c>) — the "optional Compose primitive" shape:
+    /// <c>null</c> → leave the <c>$default</c> bit set; a value clears
+    /// the bit and lowers to the primitive JNI slot. All three shapes
+    /// surface as <see cref="FacadeSlotKind.OptionalValue"/>
+    /// auto-properties on the generated facade. Non-nullable reference
+    /// wrappers do not qualify — emitting a nullable auto-property for
+    /// them would pass <c>null</c> to a non-nullable bridge parameter.
     /// </summary>
     static bool IsOptionalValueType(ITypeSymbol type, NullableAnnotation annotation)
     {

--- a/src/ComposeNet.SourceGenerators/ComposeReferenceTypes.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeReferenceTypes.cs
@@ -31,6 +31,9 @@ internal static class ComposeReferenceTypes
     public static readonly IReadOnlyCollection<string> Recognized = new HashSet<string>
     {
         "ComposeNet.FontWeight",
+        "ComposeNet.FontFamily",
+        "ComposeNet.FontStyle",
+        "ComposeNet.TextAlign",
         "ComposeNet.TextDecoration",
         "ComposeNet.Shape",
     };

--- a/src/ComposeNet.SourceGenerators/ComposeValueTypes.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeValueTypes.cs
@@ -41,9 +41,13 @@ internal static class ComposeValueTypes
             ["ComposeNet.Sp"] =
                 ('J', "global::ComposeNet.Sp.Pack({0})"),
 
-            // androidx.compose.ui.text.style.TextAlign → JNI int.
-            ["ComposeNet.TextAlign"] =
-                ('I', "global::ComposeNet.TextAlign.Pack({0})"),
+            // androidx.compose.ui.text.style.TextOverflow → JNI int.
+            // (Compose declares TextOverflow as non-nullable in
+            // @Composable signatures, so it lowers as packed `I` rather
+            // than the boxed `L` reference seen for nullable inline
+            // classes like TextAlign / FontStyle.)
+            ["ComposeNet.TextOverflow"] =
+                ('I', "global::ComposeNet.TextOverflow.Pack({0})"),
 
             // androidx.compose.ui.graphics.Color is bound by
             // Xamarin.AndroidX.Compose.UI.Graphics 1.11.2.1, but Kotlin's


### PR DESCRIPTION
Closes #58 (the bulk of it — see _Deferred_ at the bottom for the remainder).

## What ships

### New `Text` properties
`Color`, `FontStyle`, `FontFamily`, `Align`, `Overflow`, `SoftWrap`, `MaxLines`, `MinLines`.

```csharp
new Text("Italic serif red, centered")
{
    Color      = ColorKt.Color(0xC6, 0x28, 0x28, 0xFF),
    FontStyle  = FontStyle.Italic,
    FontFamily = FontFamily.Serif,
    Align      = TextAlign.Center,
    Modifier   = Modifier.Companion.FillMaxWidth(),
}

new Text("This long line clips with an ellipsis…")
{
    MaxLines = 1,
    Overflow = TextOverflow.Ellipsis,
    SoftWrap = false,
}
```

### New `TextField` / `OutlinedTextField` slots
`Enabled`, `ReadOnly`, `Label`, `Placeholder`, `LeadingIcon`, `TrailingIcon`, `Prefix`, `Suffix`, `SupportingText`, `IsError`, `SingleLine`, `MaxLines`, `MinLines`.

```csharp
new TextField(name)
{
    Label          = new Text("Your name"),
    Placeholder    = new Text("Type something…"),
    LeadingIcon    = new Text("👤"),
    TrailingIcon   = new Text("✎"),
    SupportingText = new Text("Powered by issue #58 slots"),
    SingleLine     = true,
}
```

## Generator changes

`ComposeBridgeGenerator` and `ComposeFacadeGenerator` now recognize **nullable primitives** (`bool?`, `int?`, `long?`, `float?`, `double?`). At the bridge level these lower to `(name ?? defaultLiteral)` so a `null` clears the corresponding `$default` bit and Kotlin's default runs; at the facade level they surface as nullable auto-properties — parity with existing nullable Compose value types like `Dp?` / `Sp?`. Three tests cover the new behaviour (one bridge, one facade, one mixed).

## New wrapper types

| Type | Lowering | Why |
|------|----------|-----|
| `FontStyle` | reference (slot `L`) | `@JvmInline value class` but Compose declares `fontStyle:` nullable, which boxes |
| `FontFamily` | reference (slot `L`) | regular Kotlin class, just not bound yet |
| `TextOverflow` | packed `int` (slot `I`) | `@JvmInline value class`, declared **non-nullable** in Compose |
| `TextAlign` | reference (slot `L`) — **breaking change**, was a value struct | same boxing reason as `FontStyle` |

`FontStyle` and `TextAlign` reach Compose's companion via the mangled inline-class accessors (`getCenter-e0LSkKk()I`, `getNormal-_-LCdwA()I`) and box through the synthesized `box-impl(I)L<Type>;` static. `FontFamily`'s companion getters return concrete subtypes (`SystemFontFamily` / `GenericFontFamily`) so each call uses its exact descriptor. All names verified against `ui-text-android` 1.11.2.1 bytecode.

## Sample

The Greeting tab in `MainActivity.cs` now demos the new styling — color + italic serif center-aligned text, monospace end-aligned text, ellipsis clipping with `MaxLines = 1`, two-line clamp with reserved height, plus a `TextField` and `OutlinedTextField` exercising the new slots.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — **83/83 passing**
- `dotnet build src/ComposeNet.Compose` — clean (`PublicAPI.Unshipped.txt` updated)
- `dotnet build src/ComposeNet.Sample` — clean

## Deferred (blocked or out of scope)

- **`KeyboardOptions` / `KeyboardActions`** — `KeyboardOptions` ctor is stripped from the binding (inline-class params: `KeyboardType`, `ImeAction`, `KeyboardCapitalization`); needs a `[ComposeBridge(JvmName="<init>")]` follow-up.
- **`VisualTransformation`, `AnnotatedString`, `TextStyle`, `LinkAnnotation`** — all in `androidx.compose.ui.text.input` / `androidx.compose.ui.text`, still 0 exported types until the next Compose package release post [dotnet/android-libraries#1440](https://github.com/dotnet/android-libraries/pull/1440) (merged but not yet shipped).
- **`BasicText` / `BasicTextField` / `LocalTextStyle` / `FocusRequester`** — separate facades; out of scope here.

## Breaking change

`TextAlign` is no longer a `record struct`. Callers that previously used the `Pack` static, `Equals`/`Deconstruct`, or accessed `Value` directly will need to migrate; the `TextAlign.Left/Right/Center/Justify/Start/End/Unspecified` accessors are unchanged in name and still typed `TextAlign`.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;