### PR TITLE
Expand Modifier fluent surface (#63)

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1404,8 +1404,8 @@ internal static partial class ComposeBridges
 
     // androidx.compose.foundation.BackgroundKt.background-bw27NRU$default —
     // (Modifier, Color, Shape). Color is mangled because it's a
-    // @JvmInline value class (ULong). The C# wrapper supplies color
-    // and lets shape default to RectangleShape.
+    // @JvmInline value class (ULong). The C# wrapper always supplies
+    // color; shape is optional (null → Kotlin default of RectangleShape).
     [ComposeBridge(
         Class     = "androidx/compose/foundation/BackgroundKt",
         JvmName   = "background-bw27NRU$default",
@@ -1413,7 +1413,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)" +
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierBackgroundDefault))]
-    internal static partial IntPtr ModifierBackground(IntPtr modifier, long color);
+    internal static partial IntPtr ModifierBackground(IntPtr modifier, long color, IntPtr? shape);
 
     // androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
     // (Modifier, Dp width, Color, Shape). Both width and color are
@@ -1475,6 +1475,251 @@ internal static partial class ComposeBridges
         Defaults  = typeof(ModifierHorizontalScrollDefault))]
     internal static partial IntPtr ModifierHorizontalScroll(
         IntPtr modifier, IntPtr state, bool enabled, bool reverseScrolling);
+
+    // androidx.compose.foundation.layout.SizeKt — ranged size constraints.
+    // All Dp params are `@JvmInline value class Dp(val value: Float)`
+    // hence the mangled JVM names. Each bridge takes Dp? per parameter so
+    // a `null` value leaves the corresponding $default bit set and Kotlin
+    // substitutes `Dp.Unspecified` (no constraint), letting callers
+    // express one-sided constraints like `Modifier.WidthIn(min: 100)`.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "widthIn-VpY3zN4$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FFILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierWidthInDefault))]
+    internal static partial IntPtr ModifierWidthIn(IntPtr modifier, Dp? min, Dp? max);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "heightIn-VpY3zN4$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FFILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierHeightInDefault))]
+    internal static partial IntPtr ModifierHeightIn(IntPtr modifier, Dp? min, Dp? max);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "sizeIn-qDBjuR0$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FFFFILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierSizeInDefault))]
+    internal static partial IntPtr ModifierSizeIn(IntPtr modifier, Dp? minWidth, Dp? minHeight, Dp? maxWidth, Dp? maxHeight);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "defaultMinSize-VpY3zN4$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FFILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierDefaultMinSizeDefault))]
+    internal static partial IntPtr ModifierDefaultMinSize(IntPtr modifier, Dp? minWidth, Dp? minHeight);
+
+    // androidx.compose.foundation.layout.SizeKt — required size variants.
+    // requiredSize / requiredWidth / requiredHeight bypass parent
+    // constraints (clip-out is permitted). No $default — both args are
+    // mandatory positional. Plain-static shape, no auto-mask.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "requiredSize-3ABfNKs",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierRequiredSizeAll(IntPtr modifier, float dp);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "requiredSize-VpY3zN4",
+        Signature = "(Landroidx/compose/ui/Modifier;FF)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierRequiredSizeWH(IntPtr modifier, float width, float height);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "requiredWidth-3ABfNKs",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierRequiredWidth(IntPtr modifier, float dp);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "requiredHeight-3ABfNKs",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierRequiredHeight(IntPtr modifier, float dp);
+
+    // androidx.compose.foundation.layout.SizeKt — wrapContent variants.
+    // Each takes an Alignment (or Alignment.Horizontal / Vertical) and
+    // an `unbounded` boolean. We always supply the boolean (bit cleared)
+    // and leave alignment to Kotlin's default (Center / CenterHorizontally
+    // / CenterVertically — bit kept set). Names are not mangled (no
+    // inline-class params).
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "wrapContentSize$default",
+        Signature = "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;ZILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierWrapContentSizeDefault))]
+    internal static partial IntPtr ModifierWrapContentSize(IntPtr modifier, bool unbounded);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "wrapContentWidth$default",
+        Signature = "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment$Horizontal;ZILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierWrapContentWidthDefault))]
+    internal static partial IntPtr ModifierWrapContentWidth(IntPtr modifier, bool unbounded);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/SizeKt",
+        JvmName   = "wrapContentHeight$default",
+        Signature = "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment$Vertical;ZILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierWrapContentHeightDefault))]
+    internal static partial IntPtr ModifierWrapContentHeight(IntPtr modifier, bool unbounded);
+
+    // androidx.compose.foundation.layout.AspectRatioKt.aspectRatio$default —
+    // (Modifier, Float ratio, Boolean matchHeightConstraintsFirst). Both
+    // params are non-inline so the JVM name is unmangled. Bit 1 is the
+    // boolean — we leave it to Kotlin's default (false) when the C# caller
+    // doesn't override.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/AspectRatioKt",
+        JvmName   = "aspectRatio$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FZILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierAspectRatioDefault))]
+    internal static partial IntPtr ModifierAspectRatio(IntPtr modifier, float ratio);
+
+    // androidx.compose.foundation.layout.OffsetKt — Dp-Dp offset shifts
+    // a composable's draw position by (x, y) without affecting its parent
+    // layout slot. `offset` is layout-direction-aware (start/end on RTL);
+    // `absoluteOffset` is always absolute (left/right). Both mangled
+    // because of @JvmInline value class Dp.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/OffsetKt",
+        JvmName   = "offset-VpY3zN4$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FFILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierOffsetDefault))]
+    internal static partial IntPtr ModifierOffset(IntPtr modifier, Dp? x, Dp? y);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/OffsetKt",
+        JvmName   = "absoluteOffset-VpY3zN4$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FFILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierAbsoluteOffsetDefault))]
+    internal static partial IntPtr ModifierAbsoluteOffset(IntPtr modifier, Dp? x, Dp? y);
+
+    // androidx.compose.ui.ZIndexModifierKt.zIndex(Modifier, Float) — sets
+    // the draw order within a parent layout (higher z draws later, on
+    // top). No $default. Plain-static, unmangled.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/ZIndexModifierKt",
+        JvmName   = "zIndex",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierZIndex(IntPtr modifier, float z);
+
+    // androidx.compose.ui.draw.AlphaKt.alpha(Modifier, Float) — sets the
+    // composable's alpha (0 = invisible, 1 = opaque). Forces a graphics
+    // layer; cheap to animate.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/draw/AlphaKt",
+        JvmName   = "alpha",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierAlpha(IntPtr modifier, float alpha);
+
+    // androidx.compose.ui.draw.RotateKt.rotate(Modifier, Float) — rotates
+    // around the composable's center by `degrees`.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/draw/RotateKt",
+        JvmName   = "rotate",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierRotate(IntPtr modifier, float degrees);
+
+    // androidx.compose.ui.draw.ScaleKt.scale(Modifier, Float) — uniform
+    // scale around the composable's center.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/draw/ScaleKt",
+        JvmName   = "scale",
+        Signature = "(Landroidx/compose/ui/Modifier;F)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierScaleUniform(IntPtr modifier, float scale);
+
+    // androidx.compose.ui.draw.ScaleKt.scale(Modifier, Float, Float) —
+    // independent X/Y scale. Distinct C# name avoids the partial-method
+    // overload collision; the JVM resolves to the (M,F,F) overload.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/draw/ScaleKt",
+        JvmName   = "scale",
+        Signature = "(Landroidx/compose/ui/Modifier;FF)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierScaleXY(IntPtr modifier, float scaleX, float scaleY);
+
+    // androidx.compose.ui.draw.ShadowKt.shadow-ziNgDLE$default —
+    // (Modifier, Dp elevation, Shape shape, Boolean clip). Mangled because
+    // elevation is @JvmInline value class Dp. The C# wrapper exposes
+    // elevation + shape; Kotlin's default for `clip` is
+    // `elevation > 0.dp` which we honor by leaving that bit set.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/draw/ShadowKt",
+        JvmName   = "shadow-ziNgDLE$default",
+        Signature = "(Landroidx/compose/ui/Modifier;F" +
+                    "Landroidx/compose/ui/graphics/Shape;ZILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierShadowDefault))]
+    internal static partial IntPtr ModifierShadow(IntPtr modifier, float elevation, IntPtr? shape);
+
+    // androidx.compose.foundation.layout.WindowInsetsPadding_androidKt —
+    // additional inset-padding helpers. Same shape as the existing
+    // safeDrawingPadding / systemBarsPadding bridges.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "imePadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierImePadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "navigationBarsPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierNavigationBarsPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "statusBarsPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierStatusBarsPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "displayCutoutPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierDisplayCutoutPadding(IntPtr modifier);
+
+    // androidx.compose.ui.platform.TestTagKt.testTag(Modifier, String) —
+    // attaches a test tag for UI testing frameworks.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/platform/TestTagKt",
+        JvmName   = "testTag",
+        Signature = "(Landroidx/compose/ui/Modifier;Ljava/lang/String;)" +
+                    "Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierTestTag(IntPtr modifier, string tag);
+
+    // Shape factories — additional overloads of RoundedCornerShape /
+    // CutCornerShape beyond the existing Dp variant. The Int (percent)
+    // overloads aren't mangled because Int isn't an inline class. The
+    // Dp variant of CutCornerShape is mangled.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/shape/RoundedCornerShapeKt",
+        JvmName   = "RoundedCornerShape",
+        Signature = "(I)Landroidx/compose/foundation/shape/RoundedCornerShape;")]
+    internal static partial IntPtr RoundedCornerShapePercent(int percent);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/shape/CutCornerShapeKt",
+        JvmName   = "CutCornerShape-0680j_4",
+        Signature = "(F)Landroidx/compose/foundation/shape/CutCornerShape;")]
+    internal static partial IntPtr CutCornerShapeDp(float dp);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/shape/CutCornerShapeKt",
+        JvmName   = "CutCornerShape",
+        Signature = "(I)Landroidx/compose/foundation/shape/CutCornerShape;")]
+    internal static partial IntPtr CutCornerShapePercent(int percent);
 
     // androidx.compose.material3.AppBarKt — TopAppBar / CenterAlignedTopAppBar
     // share the `-GHTll3U` shape (extra `expandedHeight: Dp` vs. the older

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1574,16 +1574,16 @@ internal static partial class ComposeBridges
 
     // androidx.compose.foundation.layout.AspectRatioKt.aspectRatio$default —
     // (Modifier, Float ratio, Boolean matchHeightConstraintsFirst). Both
-    // params are non-inline so the JVM name is unmangled. Bit 1 is the
-    // boolean — we leave it to Kotlin's default (false) when the C# caller
-    // doesn't override.
+    // params are non-inline so the JVM name is unmangled. Both bits are
+    // cleared when the caller supplies values (the auto-mask treats
+    // non-nullable primitives as unconditional clears).
     [ComposeBridge(
         Class     = "androidx/compose/foundation/layout/AspectRatioKt",
         JvmName   = "aspectRatio$default",
         Signature = "(Landroidx/compose/ui/Modifier;FZILjava/lang/Object;)" +
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierAspectRatioDefault))]
-    internal static partial IntPtr ModifierAspectRatio(IntPtr modifier, float ratio);
+    internal static partial IntPtr ModifierAspectRatio(IntPtr modifier, float ratio, bool matchHeightConstraintsFirst);
 
     // androidx.compose.foundation.layout.OffsetKt — Dp-Dp offset shifts
     // a composable's draw position by (x, y) without affecting its parent

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -380,6 +380,53 @@ using ComposeNet;
 [assembly: ComposeDefaults("ModifierWeightDefault",
     "!modifier", "!weight", "fill")]
 
+// androidx.compose.foundation.layout.SizeKt — ranged size constraints.
+// Each bit corresponds to one Dp parameter. C# bridges declare each
+// param as `Dp?`, so the auto-mask clears the bit only when the user
+// supplies a non-null value (otherwise Kotlin substitutes
+// `Dp.Unspecified` — no constraint on that side).
+[assembly: ComposeDefaults("ModifierWidthInDefault", "min", "max")]
+[assembly: ComposeDefaults("ModifierHeightInDefault", "min", "max")]
+[assembly: ComposeDefaults("ModifierSizeInDefault",
+    "minWidth", "minHeight", "maxWidth", "maxHeight")]
+[assembly: ComposeDefaults("ModifierDefaultMinSizeDefault",
+    "minWidth", "minHeight")]
+
+// androidx.compose.foundation.layout.SizeKt — wrapContent variants.
+// Bit 0 = align (left to Kotlin's default — Center, etc.; the
+// param has no C# slot, generator emits IntPtr.Zero into the JNI
+// arg and the bit stays set). Bit 1 = unbounded — always supplied
+// by the C# wrapper, so the auto-mask must clear the bit; do NOT
+// prefix with `!` (that would skip auto-mask clearing and Kotlin
+// would always use its `false` default).
+[assembly: ComposeDefaults("ModifierWrapContentSizeDefault",
+    "align", "unbounded")]
+[assembly: ComposeDefaults("ModifierWrapContentWidthDefault",
+    "align", "unbounded")]
+[assembly: ComposeDefaults("ModifierWrapContentHeightDefault",
+    "align", "unbounded")]
+
+// androidx.compose.foundation.layout.AspectRatioKt.aspectRatio$default —
+// (Modifier, Float ratio, Boolean matchHeightConstraintsFirst). Bit 0
+// = ratio (always supplied), bit 1 = matchHeightConstraintsFirst (we
+// leave it at Kotlin's default of false).
+[assembly: ComposeDefaults("ModifierAspectRatioDefault",
+    "!ratio", "matchHeightConstraintsFirst")]
+
+// androidx.compose.foundation.layout.OffsetKt.offset / absoluteOffset —
+// (Modifier, Dp x, Dp y). Both Dp params are nullable in the C#
+// wrapper; null leaves Kotlin's default of 0.dp on that axis.
+[assembly: ComposeDefaults("ModifierOffsetDefault", "x", "y")]
+[assembly: ComposeDefaults("ModifierAbsoluteOffsetDefault", "x", "y")]
+
+// androidx.compose.ui.draw.ShadowKt.shadow-ziNgDLE$default —
+// (Modifier, Dp elevation, Shape shape, Boolean clip). Bit 0 =
+// elevation (always supplied), bit 1 = shape (auto-mask honors
+// null), bit 2 = clip (left to Kotlin's default of
+// `elevation > 0.dp`).
+[assembly: ComposeDefaults("ModifierShadowDefault",
+    "!elevation", "shape", "clip")]
+
 // androidx.compose.material3.NavigationRailKt.NavigationRail-qi6gXK8:
 // 6 user params, bit 5 = content provided.
 [assembly: ComposeDefaults("NavigationRailDefault",

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -408,8 +408,8 @@ using ComposeNet;
 
 // androidx.compose.foundation.layout.AspectRatioKt.aspectRatio$default —
 // (Modifier, Float ratio, Boolean matchHeightConstraintsFirst). Bit 0
-// = ratio (always supplied), bit 1 = matchHeightConstraintsFirst (we
-// leave it at Kotlin's default of false).
+// = ratio (always supplied), bit 1 = matchHeightConstraintsFirst (cleared
+// when the C# caller supplies a value; default false matches Kotlin).
 [assembly: ComposeDefaults("ModifierAspectRatioDefault",
     "!ratio", "matchHeightConstraintsFirst")]
 

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -43,8 +43,8 @@ namespace ComposeNet;
 /// Phase 1 ships <see cref="Padding(ComposeNet.Dp)"/>, the horizontal/vertical
 /// + per-edge overloads, and <see cref="FillMaxWidth"/> /
 /// <see cref="FillMaxHeight"/> / <see cref="FillMaxSize"/>. Phase 2
-/// adds <see cref="Background"/>, <see cref="Border"/>,
-/// <see cref="Clip"/>, and <see cref="Clickable"/>. Gesture and
+/// adds <see cref="Background(long)"/>, <see cref="Border(ComposeNet.Dp, long)"/>,
+/// <see cref="Clip(ComposeNet.Dp)"/>, and <see cref="Clickable"/>. Gesture and
 /// size-constraint modifiers land in later phases (issue #21).
 /// </summary>
 public sealed class Modifier
@@ -225,21 +225,45 @@ public sealed class Modifier
     /// <c>int</c> overload.
     /// </summary>
     public Modifier Background(long color) =>
-        Append(curr => ComposeBridges.ModifierBackground(curr, color));
+        Append(curr => ComposeBridges.ModifierBackground(curr, color, null));
 
     /// <summary>
-    /// <c>Modifier.border(width, color, shape)</c> — draws a stroke
+    /// <c>Modifier.background(color, shape)</c> — paints a flat fill
+    /// behind the composable, clipped to <paramref name="shape"/>. Pass
+    /// <c>null</c> for the default <c>RectangleShape</c>; otherwise build
+    /// a shape via <see cref="ComposeNet.Shape.RoundedCorners(Dp)"/>,
+    /// <see cref="ComposeNet.Shape.Circle"/>,
+    /// <see cref="ComposeNet.Shape.CutCorners(Dp)"/>, etc. The shape is
+    /// captured by the closure so its Java peer stays alive across
+    /// recompositions.
+    /// </summary>
+    public Modifier Background(long color, Shape? shape) =>
+        Append(curr => ComposeBridges.ModifierBackground(curr, color, shape?.Handle));
+
+    /// <summary>
+    /// <c>Modifier.border(width, color)</c> — draws a rectangular stroke
     /// around the composable. <paramref name="width"/> is the stroke
     /// width in density-independent pixels. <paramref name="color"/> is a
     /// packed Compose <c>Color</c> long (see
-    /// <see cref="Background(long)"/> for how to build one).
-    /// <paramref name="cornerRadius"/> defaults to <c>0</c> for a
-    /// rectangular stroke; pass a positive value to match a
-    /// <see cref="Clip(Dp)"/> earlier in the chain so the corners
-    /// align (otherwise the rectangular stroke gets sliced by a rounded
-    /// clip and you see jagged corner stubs).
+    /// <see cref="Background(long)"/> for how to build one). For rounded
+    /// corners use <see cref="Border(Dp, long, Dp)"/>; for arbitrary
+    /// shapes use <see cref="Border(Dp, long, Shape?)"/>.
     /// </summary>
-    public Modifier Border(Dp width, long color, Dp cornerRadius = default)
+    public Modifier Border(Dp width, long color)
+    {
+        var w = width.Value;
+        return Append(curr => ComposeBridges.ModifierBorder(curr, w, color, null));
+    }
+
+    /// <summary>
+    /// <c>Modifier.border(width, color, RoundedCornerShape(cornerRadius))</c> —
+    /// draws a stroke with rounded corners. Match
+    /// <paramref name="cornerRadius"/> to a <see cref="Clip(Dp)"/>
+    /// earlier in the chain so the corners align (otherwise the
+    /// rectangular stroke gets sliced by a rounded clip and you see
+    /// jagged corner stubs).
+    /// </summary>
+    public Modifier Border(Dp width, long color, Dp cornerRadius)
     {
         var w = width.Value;
         var r = cornerRadius.Value;
@@ -262,6 +286,19 @@ public sealed class Modifier
     }
 
     /// <summary>
+    /// <c>Modifier.border(width, color, shape)</c> — overload taking an
+    /// explicit <see cref="ComposeNet.Shape"/> for non-rounded geometry
+    /// (cut corners, custom shape factories, etc.). Pass <c>null</c> for
+    /// <c>RectangleShape</c>. The shape is captured by the closure so its
+    /// Java peer stays alive across recompositions.
+    /// </summary>
+    public Modifier Border(Dp width, long color, Shape? shape)
+    {
+        var w = width.Value;
+        return Append(curr => ComposeBridges.ModifierBorder(curr, w, color, shape?.Handle));
+    }
+
+    /// <summary>
     /// <c>Modifier.clip(RoundedCornerShape(<paramref name="cornerRadius"/>))</c> —
     /// rounds the four corners by the same radius and clips drawing to the
     /// resulting shape. Pass <c>0</c> for no rounding (rectangle clip).
@@ -270,6 +307,20 @@ public sealed class Modifier
     {
         var dp = cornerRadius.Value;
         return Append(curr => ComposeBridges.ModifierClipRoundedCorners(curr, dp));
+    }
+
+    /// <summary>
+    /// <c>Modifier.clip(shape)</c> — clips drawing (and pointer hits)
+    /// to the supplied <paramref name="shape"/>. Use with
+    /// <see cref="ComposeNet.Shape.Circle"/> for circular clips,
+    /// <see cref="ComposeNet.Shape.CutCorners(Dp)"/> for chamfered
+    /// corners, or any other shape factory. The shape is captured by
+    /// the closure so its Java peer stays alive across recompositions.
+    /// </summary>
+    public Modifier Clip(Shape shape)
+    {
+        System.ArgumentNullException.ThrowIfNull(shape);
+        return Append(curr => ComposeBridges.ModifierClip(curr, shape.Handle));
     }
 
     /// <summary>
@@ -373,6 +424,233 @@ public sealed class Modifier
                     $"Current scope kind: {kind}.")
             };
         });
+    }
+
+    /// <summary>
+    /// <c>Modifier.widthIn(min, max)</c> — adds a min and/or max width
+    /// constraint. Pass <c>null</c> for either bound to leave it
+    /// unconstrained (Kotlin's <c>Dp.Unspecified</c> default), so
+    /// <c>WidthIn(min: 100)</c> caps only the lower bound.
+    /// </summary>
+    public Modifier WidthIn(Dp? min = null, Dp? max = null) =>
+        Append(curr => ComposeBridges.ModifierWidthIn(curr, min, max));
+
+    /// <summary>
+    /// <c>Modifier.heightIn(min, max)</c> — adds a min and/or max height
+    /// constraint. Pass <c>null</c> for either bound to leave it
+    /// unconstrained.
+    /// </summary>
+    public Modifier HeightIn(Dp? min = null, Dp? max = null) =>
+        Append(curr => ComposeBridges.ModifierHeightIn(curr, min, max));
+
+    /// <summary>
+    /// <c>Modifier.sizeIn(minWidth, minHeight, maxWidth, maxHeight)</c> —
+    /// constrains both axes. Pass <c>null</c> for any bound to leave it
+    /// unconstrained.
+    /// </summary>
+    public Modifier SizeIn(Dp? minWidth = null, Dp? minHeight = null, Dp? maxWidth = null, Dp? maxHeight = null) =>
+        Append(curr => ComposeBridges.ModifierSizeIn(curr, minWidth, minHeight, maxWidth, maxHeight));
+
+    /// <summary>
+    /// <c>Modifier.requiredSize(size)</c> — declares an exact size that
+    /// bypasses the parent's constraints (the composable is allowed to
+    /// be drawn outside the parent if needed). Use sparingly; prefer
+    /// <see cref="Size(Dp)"/> for normal layout.
+    /// </summary>
+    public Modifier RequiredSize(Dp size)
+    {
+        var dp = size.Value;
+        return Append(curr => ComposeBridges.ModifierRequiredSizeAll(curr, dp));
+    }
+
+    /// <summary>
+    /// <c>Modifier.requiredSize(width, height)</c> — overload taking
+    /// independent width and height (each bypassing parent constraints).
+    /// </summary>
+    public Modifier RequiredSize(Dp width, Dp height)
+    {
+        var w = width.Value;
+        var h = height.Value;
+        return Append(curr => ComposeBridges.ModifierRequiredSizeWH(curr, w, h));
+    }
+
+    /// <summary>
+    /// <c>Modifier.requiredWidth(width)</c> — declares an exact width
+    /// that bypasses the parent's constraints.
+    /// </summary>
+    public Modifier RequiredWidth(Dp width)
+    {
+        var w = width.Value;
+        return Append(curr => ComposeBridges.ModifierRequiredWidth(curr, w));
+    }
+
+    /// <summary>
+    /// <c>Modifier.requiredHeight(height)</c> — declares an exact height
+    /// that bypasses the parent's constraints.
+    /// </summary>
+    public Modifier RequiredHeight(Dp height)
+    {
+        var h = height.Value;
+        return Append(curr => ComposeBridges.ModifierRequiredHeight(curr, h));
+    }
+
+    /// <summary>
+    /// <c>Modifier.defaultMinSize(minWidth, minHeight)</c> — supplies a
+    /// minimum size that's only used when the parent doesn't already
+    /// constrain that dimension. Useful for default-sized buttons /
+    /// chips that should grow with content but never shrink below a
+    /// hit-target floor. Pass <c>null</c> for either bound to leave it
+    /// unspecified.
+    /// </summary>
+    public Modifier DefaultMinSize(Dp? minWidth = null, Dp? minHeight = null) =>
+        Append(curr => ComposeBridges.ModifierDefaultMinSize(curr, minWidth, minHeight));
+
+    /// <summary>
+    /// <c>Modifier.wrapContentSize(unbounded)</c> — measures content
+    /// without imposing the parent's constraints, then centers the
+    /// result inside the parent's available space. Set
+    /// <paramref name="unbounded"/> to <c>true</c> to let content
+    /// overflow the parent.
+    /// </summary>
+    public Modifier WrapContentSize(bool unbounded = false) =>
+        Append(curr => ComposeBridges.ModifierWrapContentSize(curr, unbounded));
+
+    /// <summary>
+    /// <c>Modifier.wrapContentWidth(unbounded)</c> — same as
+    /// <see cref="WrapContentSize(bool)"/> but only relaxes the width
+    /// axis.
+    /// </summary>
+    public Modifier WrapContentWidth(bool unbounded = false) =>
+        Append(curr => ComposeBridges.ModifierWrapContentWidth(curr, unbounded));
+
+    /// <summary>
+    /// <c>Modifier.wrapContentHeight(unbounded)</c> — same as
+    /// <see cref="WrapContentSize(bool)"/> but only relaxes the height
+    /// axis.
+    /// </summary>
+    public Modifier WrapContentHeight(bool unbounded = false) =>
+        Append(curr => ComposeBridges.ModifierWrapContentHeight(curr, unbounded));
+
+    /// <summary>
+    /// <c>Modifier.aspectRatio(ratio)</c> — forces the composable's
+    /// width-to-height ratio. <paramref name="ratio"/> is
+    /// <c>width / height</c>: <c>16f / 9f</c> for a wide video frame,
+    /// <c>1f</c> for a square.
+    /// </summary>
+    public Modifier AspectRatio(float ratio) =>
+        Append(curr => ComposeBridges.ModifierAspectRatio(curr, ratio));
+
+    /// <summary>
+    /// <c>Modifier.offset(x, y)</c> — shifts the composable's draw
+    /// position by (x, y) without affecting the layout slot the parent
+    /// allocates for it. Layout-direction-aware (start/end on RTL).
+    /// Pass <c>null</c> for either axis to leave it at <c>0.dp</c>.
+    /// </summary>
+    public Modifier Offset(Dp? x = null, Dp? y = null) =>
+        Append(curr => ComposeBridges.ModifierOffset(curr, x, y));
+
+    /// <summary>
+    /// <c>Modifier.absoluteOffset(x, y)</c> — like <see cref="Offset"/>
+    /// but always uses absolute (left/right) axes, ignoring layout
+    /// direction.
+    /// </summary>
+    public Modifier AbsoluteOffset(Dp? x = null, Dp? y = null) =>
+        Append(curr => ComposeBridges.ModifierAbsoluteOffset(curr, x, y));
+
+    /// <summary>
+    /// <c>Modifier.zIndex(z)</c> — sets the draw order within a parent
+    /// layout. Children with higher <paramref name="z"/> draw on top of
+    /// siblings with lower values. Defaults to <c>0f</c>.
+    /// </summary>
+    public Modifier ZIndex(float z) =>
+        Append(curr => ComposeBridges.ModifierZIndex(curr, z));
+
+    /// <summary>
+    /// <c>Modifier.alpha(alpha)</c> — applies an alpha multiplier to
+    /// the composable's draw output. <c>0f</c> is fully transparent;
+    /// <c>1f</c> is fully opaque. Cheap to animate (forces a graphics
+    /// layer).
+    /// </summary>
+    public Modifier Alpha(float alpha) =>
+        Append(curr => ComposeBridges.ModifierAlpha(curr, alpha));
+
+    /// <summary>
+    /// <c>Modifier.rotate(degrees)</c> — rotates the composable around
+    /// its center by <paramref name="degrees"/>. Negative values rotate
+    /// counter-clockwise.
+    /// </summary>
+    public Modifier Rotate(float degrees) =>
+        Append(curr => ComposeBridges.ModifierRotate(curr, degrees));
+
+    /// <summary>
+    /// <c>Modifier.scale(scale)</c> — uniform scale around the
+    /// composable's center.
+    /// </summary>
+    public Modifier Scale(float scale) =>
+        Append(curr => ComposeBridges.ModifierScaleUniform(curr, scale));
+
+    /// <summary>
+    /// <c>Modifier.scale(scaleX, scaleY)</c> — independent X / Y scale
+    /// around the composable's center.
+    /// </summary>
+    public Modifier Scale(float scaleX, float scaleY) =>
+        Append(curr => ComposeBridges.ModifierScaleXY(curr, scaleX, scaleY));
+
+    /// <summary>
+    /// <c>Modifier.shadow(elevation, shape)</c> — draws a soft drop
+    /// shadow under the composable. <paramref name="elevation"/> is the
+    /// shadow's apparent depth in dp. Pass a non-null
+    /// <paramref name="shape"/> to clip the shadow to a custom outline;
+    /// otherwise it follows Kotlin's default <c>RectangleShape</c>. The
+    /// shape is captured by the closure so its Java peer stays alive
+    /// across recompositions. Kotlin's default for the underlying
+    /// <c>clip</c> parameter (<c>elevation &gt; 0.dp</c>) is honored.
+    /// </summary>
+    public Modifier Shadow(Dp elevation, Shape? shape = null)
+    {
+        var e = elevation.Value;
+        return Append(curr => ComposeBridges.ModifierShadow(curr, e, shape?.Handle));
+    }
+
+    /// <summary>
+    /// <c>Modifier.imePadding()</c> — pads the composable so it sits
+    /// above the soft keyboard (IME) when it's visible. Use under
+    /// edge-to-edge to keep input controls visible.
+    /// </summary>
+    public Modifier ImePadding() =>
+        Append(curr => ComposeBridges.ModifierImePadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.navigationBarsPadding()</c> — pads for the system
+    /// navigation bar inset only.
+    /// </summary>
+    public Modifier NavigationBarsPadding() =>
+        Append(curr => ComposeBridges.ModifierNavigationBarsPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.statusBarsPadding()</c> — pads for the status bar
+    /// inset only.
+    /// </summary>
+    public Modifier StatusBarsPadding() =>
+        Append(curr => ComposeBridges.ModifierStatusBarsPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.displayCutoutPadding()</c> — pads for display cutouts
+    /// (notches, hole-punch cameras) so content doesn't get clipped by
+    /// hardware features.
+    /// </summary>
+    public Modifier DisplayCutoutPadding() =>
+        Append(curr => ComposeBridges.ModifierDisplayCutoutPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.testTag(tag)</c> — attaches a stable identifier for
+    /// UI testing frameworks (Compose UI Test, Espresso). Has no visual
+    /// effect; only affects the semantics tree.
+    /// </summary>
+    public Modifier TestTag(string tag)
+    {
+        System.ArgumentNullException.ThrowIfNull(tag);
+        return Append(curr => ComposeBridges.ModifierTestTag(curr, tag));
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -532,13 +532,16 @@ public sealed class Modifier
         Append(curr => ComposeBridges.ModifierWrapContentHeight(curr, unbounded));
 
     /// <summary>
-    /// <c>Modifier.aspectRatio(ratio)</c> — forces the composable's
-    /// width-to-height ratio. <paramref name="ratio"/> is
-    /// <c>width / height</c>: <c>16f / 9f</c> for a wide video frame,
-    /// <c>1f</c> for a square.
+    /// <c>Modifier.aspectRatio(ratio, matchHeightConstraintsFirst)</c> —
+    /// forces the composable's width-to-height ratio.
+    /// <paramref name="ratio"/> is <c>width / height</c>: <c>16f / 9f</c>
+    /// for a wide video frame, <c>1f</c> for a square. When
+    /// <paramref name="matchHeightConstraintsFirst"/> is <c>true</c>, the
+    /// height constraint is preferred when both width and height are
+    /// bounded; otherwise width wins (Kotlin's default).
     /// </summary>
-    public Modifier AspectRatio(float ratio) =>
-        Append(curr => ComposeBridges.ModifierAspectRatio(curr, ratio));
+    public Modifier AspectRatio(float ratio, bool matchHeightConstraintsFirst = false) =>
+        Append(curr => ComposeBridges.ModifierAspectRatio(curr, ratio, matchHeightConstraintsFirst));
 
     /// <summary>
     /// <c>Modifier.offset(x, y)</c> — shifts the composable's draw

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -380,26 +380,55 @@ ComposeNet.ModalWideNavigationRail.Header.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalWideNavigationRail.Header.set -> void
 ComposeNet.ModalWideNavigationRail.ModalWideNavigationRail() -> void
 ComposeNet.Modifier
+ComposeNet.Modifier.AbsoluteOffset(ComposeNet.Dp? x = null, ComposeNet.Dp? y = null) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Alpha(float alpha) -> ComposeNet.Modifier!
+ComposeNet.Modifier.AspectRatio(float ratio) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Background(long color) -> ComposeNet.Modifier!
-ComposeNet.Modifier.Border(ComposeNet.Dp width, long color, ComposeNet.Dp cornerRadius = default(ComposeNet.Dp)) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Background(long color, ComposeNet.Shape? shape) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Border(ComposeNet.Dp width, long color) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Border(ComposeNet.Dp width, long color, ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Border(ComposeNet.Dp width, long color, ComposeNet.Shape? shape) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clickable(System.Action! onClick) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Clip(ComposeNet.Shape! shape) -> ComposeNet.Modifier!
+ComposeNet.Modifier.DefaultMinSize(ComposeNet.Dp? minWidth = null, ComposeNet.Dp? minHeight = null) -> ComposeNet.Modifier!
+ComposeNet.Modifier.DisplayCutoutPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxHeight(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxSize(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxWidth(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Height(ComposeNet.Dp height) -> ComposeNet.Modifier!
+ComposeNet.Modifier.HeightIn(ComposeNet.Dp? min = null, ComposeNet.Dp? max = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.HorizontalScroll(ComposeNet.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> ComposeNet.Modifier!
+ComposeNet.Modifier.ImePadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.NavigationBarsPadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.Offset(ComposeNet.Dp? x = null, ComposeNet.Dp? y = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Padding(ComposeNet.Dp all) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Padding(ComposeNet.Dp horizontal, ComposeNet.Dp vertical) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Padding(ComposeNet.Dp start, ComposeNet.Dp top, ComposeNet.Dp end, ComposeNet.Dp bottom) -> ComposeNet.Modifier!
+ComposeNet.Modifier.RequiredHeight(ComposeNet.Dp height) -> ComposeNet.Modifier!
+ComposeNet.Modifier.RequiredSize(ComposeNet.Dp size) -> ComposeNet.Modifier!
+ComposeNet.Modifier.RequiredSize(ComposeNet.Dp width, ComposeNet.Dp height) -> ComposeNet.Modifier!
+ComposeNet.Modifier.RequiredWidth(ComposeNet.Dp width) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Rotate(float degrees) -> ComposeNet.Modifier!
 ComposeNet.Modifier.SafeDrawingPadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.Scale(float scale) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Scale(float scaleX, float scaleY) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Shadow(ComposeNet.Dp elevation, ComposeNet.Shape? shape = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp size) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp width, ComposeNet.Dp height) -> ComposeNet.Modifier!
+ComposeNet.Modifier.SizeIn(ComposeNet.Dp? minWidth = null, ComposeNet.Dp? minHeight = null, ComposeNet.Dp? maxWidth = null, ComposeNet.Dp? maxHeight = null) -> ComposeNet.Modifier!
+ComposeNet.Modifier.StatusBarsPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.SystemBarsPadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.TestTag(string! tag) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Then(ComposeNet.Modifier! other) -> ComposeNet.Modifier!
 ComposeNet.Modifier.VerticalScroll(ComposeNet.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Weight(float weight, bool fill = true) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Width(ComposeNet.Dp width) -> ComposeNet.Modifier!
+ComposeNet.Modifier.WidthIn(ComposeNet.Dp? min = null, ComposeNet.Dp? max = null) -> ComposeNet.Modifier!
+ComposeNet.Modifier.WrapContentHeight(bool unbounded = false) -> ComposeNet.Modifier!
+ComposeNet.Modifier.WrapContentSize(bool unbounded = false) -> ComposeNet.Modifier!
+ComposeNet.Modifier.WrapContentWidth(bool unbounded = false) -> ComposeNet.Modifier!
+ComposeNet.Modifier.ZIndex(float z) -> ComposeNet.Modifier!
 ComposeNet.MultiChoiceSegmentedButtonRow
 ComposeNet.MultiChoiceSegmentedButtonRow.MultiChoiceSegmentedButtonRow() -> void
 ComposeNet.MutableNumberState<T>
@@ -734,7 +763,11 @@ static ComposeNet.GridCells.Fixed(int count) -> AndroidX.Compose.Foundation.Lazy
 static ComposeNet.Modifier.Companion.get -> ComposeNet.Modifier!
 static ComposeNet.MutableNumberState<T>.operator --(ComposeNet.MutableNumberState<T>! s) -> ComposeNet.MutableNumberState<T>!
 static ComposeNet.MutableNumberState<T>.operator ++(ComposeNet.MutableNumberState<T>! s) -> ComposeNet.MutableNumberState<T>!
+static ComposeNet.Shape.Circle() -> ComposeNet.Shape!
+static ComposeNet.Shape.CutCorners(ComposeNet.Dp cornerSize) -> ComposeNet.Shape!
+static ComposeNet.Shape.CutCornersPercent(int percent) -> ComposeNet.Shape!
 static ComposeNet.Shape.RoundedCorners(ComposeNet.Dp cornerRadius) -> ComposeNet.Shape!
+static ComposeNet.Shape.RoundedPercent(int percent) -> ComposeNet.Shape!
 static ComposeNet.Sp.implicit operator ComposeNet.Sp(int value) -> ComposeNet.Sp
 static ComposeNet.Sp.operator !=(ComposeNet.Sp left, ComposeNet.Sp right) -> bool
 static ComposeNet.Sp.operator ==(ComposeNet.Sp left, ComposeNet.Sp right) -> bool

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -382,7 +382,7 @@ ComposeNet.ModalWideNavigationRail.ModalWideNavigationRail() -> void
 ComposeNet.Modifier
 ComposeNet.Modifier.AbsoluteOffset(ComposeNet.Dp? x = null, ComposeNet.Dp? y = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Alpha(float alpha) -> ComposeNet.Modifier!
-ComposeNet.Modifier.AspectRatio(float ratio) -> ComposeNet.Modifier!
+ComposeNet.Modifier.AspectRatio(float ratio, bool matchHeightConstraintsFirst = false) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Background(long color) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Background(long color, ComposeNet.Shape? shape) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Border(ComposeNet.Dp width, long color) -> ComposeNet.Modifier!

--- a/src/ComposeNet.Compose/Shape.cs
+++ b/src/ComposeNet.Compose/Shape.cs
@@ -30,4 +30,44 @@ public sealed class Shape : Java.Lang.Object
         IntPtr handle = ComposeBridges.RoundedCornerShape(cornerRadius.Value);
         return new Shape(handle, JniHandleOwnership.TransferLocalRef);
     }
+
+    /// <summary>
+    /// <c>androidx.compose.foundation.shape.RoundedCornerShape(percent: Int)</c>
+    /// — equal radius on all four corners, expressed as a percentage of
+    /// the smaller dimension. <c>0</c> = rectangle, <c>50</c> = pill /
+    /// circle (use <see cref="Circle"/> for the canonical name).
+    /// </summary>
+    public static Shape RoundedPercent(int percent)
+    {
+        IntPtr handle = ComposeBridges.RoundedCornerShapePercent(percent);
+        return new Shape(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// <c>RoundedCornerShape(50)</c> — fully rounded, producing a
+    /// circle (when the bounds are square) or a pill (when they're
+    /// rectangular).
+    /// </summary>
+    public static Shape Circle() => RoundedPercent(50);
+
+    /// <summary>
+    /// <c>androidx.compose.foundation.shape.CutCornerShape(size: Dp)</c>
+    /// — chamfered (straight-line) corners on all four sides.
+    /// </summary>
+    public static Shape CutCorners(Dp cornerSize)
+    {
+        IntPtr handle = ComposeBridges.CutCornerShapeDp(cornerSize.Value);
+        return new Shape(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// <c>androidx.compose.foundation.shape.CutCornerShape(percent: Int)</c>
+    /// — chamfered corners expressed as a percentage of the smaller
+    /// dimension.
+    /// </summary>
+    public static Shape CutCornersPercent(int percent)
+    {
+        IntPtr handle = ComposeBridges.CutCornerShapePercent(percent);
+        return new Shape(handle, JniHandleOwnership.TransferLocalRef);
+    }
 }

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -386,6 +386,98 @@ public class MainActivity : ComposeActivity
                         new Text("OutlinedCard (border)"),
                         new Text($"Counter snapshot: {count}"),
                     },
+
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text("Modifier showcase — shapes, shadow, transforms"),
+
+                    // Background(long, Shape) + Shape.Circle / RoundedPercent /
+                    // CutCorners. Each tile is a 56dp Box wrapping a label.
+                    new Row
+                    {
+                        new Box
+                        {
+                            Modifier.Companion
+                                .Size(56)
+                                .Background(ColorKt.Color(red: 0xD0, green: 0xBC, blue: 0xFF, alpha: 0xFF), Shape.Circle()),
+                            new Text("●") { Modifier = Modifier.Companion.Padding(16) },
+                        },
+                        new Spacer { Modifier = Modifier.Companion.WidthIn(8, null) },
+                        new Box
+                        {
+                            Modifier.Companion
+                                .Size(56)
+                                .Background(ColorKt.Color(red: 0xB3, green: 0xE5, blue: 0xFC, alpha: 0xFF), Shape.RoundedPercent(25)),
+                            new Text("◼") { Modifier = Modifier.Companion.Padding(16) },
+                        },
+                        new Spacer { Modifier = Modifier.Companion.WidthIn(8, null) },
+                        new Box
+                        {
+                            Modifier.Companion
+                                .Size(56)
+                                .Background(ColorKt.Color(red: 0xC8, green: 0xE6, blue: 0xC9, alpha: 0xFF), Shape.CutCorners(10)),
+                            new Text("◆") { Modifier = Modifier.Companion.Padding(16) },
+                        },
+                    },
+
+                    // Shadow(elevation, shape) + Border(width, color, shape).
+                    new Box
+                    {
+                        Modifier.Companion
+                            .Padding(8)
+                            .Shadow(8, Shape.RoundedCorners(16))
+                            .Background(ColorKt.Color(red: 0xFF, green: 0xE0, blue: 0xB2, alpha: 0xFF), Shape.RoundedCorners(16))
+                            .Border(2, ColorKt.Color(red: 0xEF, green: 0x6C, blue: 0x00, alpha: 0xFF), Shape.RoundedCorners(16))
+                            .Padding(16),
+                        new Text("Shadow + Border + Background, all on a shared Shape"),
+                    },
+
+                    // AspectRatio(16f/9f, matchHeightConstraintsFirst:true) — when
+                    // both width and height are bounded, prefer the height
+                    // constraint and let width follow.
+                    new Box
+                    {
+                        Modifier.Companion
+                            .FillMaxWidth()
+                            .Height(80)
+                            .AspectRatio(16f / 9f, matchHeightConstraintsFirst: true)
+                            .Background(ColorKt.Color(red: 0xCC, green: 0xC2, blue: 0xDC, alpha: 0xFF)),
+                        new Text("16:9 (height-first)") { Modifier = Modifier.Companion.Padding(8) },
+                    },
+
+                    // Rotate / Scale / Alpha tiles, each tagged so UI tests can
+                    // match by semantic id.
+                    new Row
+                    {
+                        new Box
+                        {
+                            Modifier.Companion
+                                .TestTag("rotate-tile")
+                                .Size(48)
+                                .Rotate(15f)
+                                .Background(ColorKt.Color(red: 0xEF, green: 0xB8, blue: 0xC8, alpha: 0xFF)),
+                            new Text("⟲") { Modifier = Modifier.Companion.Padding(12) },
+                        },
+                        new Spacer { Modifier = Modifier.Companion.WidthIn(8, null) },
+                        new Box
+                        {
+                            Modifier.Companion
+                                .TestTag("scale-tile")
+                                .Size(48)
+                                .Scale(0.85f, 1.15f)
+                                .Background(ColorKt.Color(red: 0xFF, green: 0xCD, blue: 0xD2, alpha: 0xFF)),
+                            new Text("↕") { Modifier = Modifier.Companion.Padding(12) },
+                        },
+                        new Spacer { Modifier = Modifier.Companion.WidthIn(8, null) },
+                        new Box
+                        {
+                            Modifier.Companion
+                                .TestTag("alpha-tile")
+                                .Size(48)
+                                .Alpha(0.4f)
+                                .Background(ColorKt.Color(red: 0xD7, green: 0xCC, blue: 0xC8, alpha: 0xFF)),
+                            new Text("◐") { Modifier = Modifier.Companion.Padding(12) },
+                        },
+                    },
                 },
                 3 => new Column
                 {


### PR DESCRIPTION
Closes a slice of #63 by adding non-`@Composable` Modifier extensions that fit the existing `[ComposeBridge]` plain-static / `$default` shapes. No new generator features were needed; everything lowers through the existing pipeline.

## New surface

### Shape overloads on already-bridged modifiers
- `Modifier.Background(long color, Shape shape)` — existing color-only kept.
- `Modifier.Border(Dp width, long color, Shape shape)` — existing radius variant kept.
- `Modifier.Clip(Shape shape)` — overload alongside the existing `Dp` corner-radius variant.

### Size (`foundation.layout.SizeKt`)
- `Modifier.WidthIn(Dp? min, Dp? max)` / `HeightIn` / `SizeIn` — `Dp?` so callers can express one-sided constraints (Kotlin's defaults are `Dp.Unspecified`, not 0).
- `Modifier.DefaultMinSize(Dp? minWidth, Dp? minHeight)`.
- `Modifier.RequiredSize(Dp)` / `RequiredSize(Dp width, Dp height)` / `RequiredWidth` / `RequiredHeight`.
- `Modifier.WrapContentSize(bool unbounded = false)` / `WrapContentWidth` / `WrapContentHeight`.

### Geometry / transform
- `Modifier.AspectRatio(float ratio, bool matchHeightConstraintsFirst = false)`.
- `Modifier.Offset(Dp x, Dp y)` and `Modifier.AbsoluteOffset(Dp x, Dp y)`.
- `Modifier.ZIndex(float)`, `Modifier.Alpha(float)`, `Modifier.Rotate(float)`.
- `Modifier.Scale(float)` and `Modifier.Scale(float scaleX, float scaleY)`.
- `Modifier.Shadow(Dp elevation, Shape? shape = null)` — `clip` param intentionally omitted so Kotlin's `clip = elevation > 0.dp` default applies.

### Window insets (`foundation.layout.WindowInsetsPadding_androidKt`)
- `Modifier.ImePadding`, `Modifier.NavigationBarsPadding`, `Modifier.StatusBarsPadding`, `Modifier.DisplayCutoutPadding`.

### A11y / testing
- `Modifier.TestTag(string tag)`.

### Shape factories
- `Shape.Circle()` (`RoundedCornerShape(50)`), `Shape.RoundedPercent(int)`.
- `Shape.CutCorners(Dp)`, `Shape.CutCornersPercent(int)`.

## Border refactor (no behavioral change)

The previous `Modifier.Border(Dp width, long color, Dp cornerRadius = default)` overload with an optional default parameter tripped `RS0027` once a `Shape` overload was added. It's been split into three explicit non-defaulted overloads: `Border(Dp, long)`, `Border(Dp, long, Dp)`, `Border(Dp, long, Shape)`. Existing call sites compile unchanged.

## Out of scope

Issue #63 deliberately stays open after this lands — the following still need follow-ups and are tracked there:

- Scope modifiers (`BoxScope.Align`, row/column `Align`, `MatchParentSize`) — need new generator support for `BoxScope`/`RowScope`/`ColumnScope` interface dispatch.
- Gestures (`Selectable`, `Toggleable`, `CombinedClickable`).
- Focus (`Focusable`, `OnFocusChanged`, `FocusRequester`).
- `Semantics { ... }` / `ClearAndSetSemantics { ... }` DSL.
- `GraphicsLayer { ... }` unified block.
- The generic `WindowInsetsPadding(insets)` form.

## Validation

- `dotnet build src/ComposeNet.Compose` — clean, no warnings.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 80/80 pass.
- `dotnet build src/ComposeNet.Sample` — Android build succeeds.
- Inspected emitted `.g.cs` for `WidthIn`, `Shadow`, `WrapContentSize`, `ScaleXY` to confirm the auto-mask handles `Dp?` / `Shape?` / `bool` / overloaded JVM names correctly.

Refs #63.