### PR TITLE
Convert 3 facades to generated; add 2 generator features (#67)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -461,34 +461,64 @@ The generator now supports a wide range of facade shapes (Phases 1,
   source-generated enums, so the bit-name map has to come from a
   declarative `ComposeDefaults` declaration (not the generic form).
   Used for `Box`, `Column`, `Row`, `Spacer`, `Checkbox`, `Switch`,
-  `RadioButton`, `Slider`.
+  `RadioButton`, `Slider`, `WideNavigationRailItem`, `TriStateCheckbox`.
+
+  **Java enum primitives** (issue #67): the primitive-ctor slot detector
+  also accepts any reference type that derives transitively from
+  `Java.Lang.Enum`. The Compose binding generates `@JvmInline`-free
+  Kotlin/Java enums (e.g. `AndroidX.Compose.UI.State.ToggleableState`
+  with `On`, `Off`, `Indeterminate`) as `Java.Lang.Object` subclasses,
+  and these surface as ctor primitives forwarded directly to the
+  bridge — no JNI lowering required (see `TriStateCheckbox`).
+
+  **Hybrid container + named slots** (issue #67): a bridge with
+  exactly one non-nullable `IFunction3` body **plus** one or more
+  nullable `IFunction2?`/`IFunction3?` slots is now allowed when the
+  facade declares `[ComposeFacade(Scope = "...")]`. The non-nullable
+  Function3 stays as the container body (`RenderChildren`), the
+  nullable Function2/3 slots become named `ComposableNode?`
+  properties, and the class still derives from `ComposableContainer`
+  so caller-side collection-init syntax keeps working. Without
+  `Scope`, the bridge still classifies as a multi-slot leaf
+  (existing behavior — preserves `AssistChip`-style facades whose
+  required Function2 is a label, not a content slot). Used for
+  `BottomAppBar`.
 
 Facades that still stay hand-written are the ones the generator
 can't model:
 
+- Facades that call a bound binding method directly (no underlying
+  `[ComposeBridge]` to attach to) — `DropdownMenuItem`, `Icon`
+  (`ImageVector` overload). `WideNavigationRailItem` was migrated
+  to a Phase 8 wrapper-passthrough in issue #67.
+- Facades that branch between two bridges based on an optional
+  slot (`TopAppBar` — Subtitle toggles between `TopAppBar-GHTll3U`
+  and `MediumFlexibleTopAppBar-eXZ4JBQ`).
+- Drawer facades with a `confirmStateChange` adapter — the
+  per-`ComposableNode`-instance `DrawerConfirmStateChange` Java peer
+  has to live in a field on the facade (it's part of
+  `rememberDrawerState`'s cache key), and the Remember call also
+  consumes a user-supplied `initialValue` primitive. That combined
+  shape (per-instance `IFunction1` adapter + Phase 4b parameterised
+  Remember) isn't modelled by the generator yet:
+  `ModalNavigationDrawer`, `DismissibleNavigationDrawer`,
+  `PermanentNavigationDrawer`, `ModalWideNavigationRail`. The
+  permanent drawer doesn't actually need a veto adapter, but it
+  shares the hand-written family for consistency.
 - State-holder facades whose `RememberXxxState` bridge takes user
-  initialisation params (`TimePicker` / `TimeInput` need
-  `initialHour`/`initialMinute`/`is24Hour`; `SearchBar` and
-  `ModalBottomSheet`/`BottomSheetScaffold` similarly). Phase 4
+  parameters (`TimePicker` / `TimeInput` need
+  `initialHour`/`initialMinute`/`is24Hour`; `SearchBar`,
+  `ModalBottomSheet`, `BottomSheetScaffold` similarly). Phase 4
   supports the zero-user-param shape (`DatePicker`,
   `DateRangePicker`); parameterised remembers wait for Phase 4b.
 - Scope facades whose bodies do non-trivial work beyond
   `RenderContext.PushScope` (`SegmentedButton`,
   `SingleChoice`/`MultiChoiceSegmentedButtonRow`, the segmented
   scrollable tab rows).
-- Facades that call a bound binding method directly (no underlying
-  `[ComposeBridge]` to attach to) — `WideNavigationRailItem`,
-  `DropdownMenuItem`, `Icon` (`ImageVector` overload).
-- Facades that branch between two bridges based on an optional
-  slot (`TopAppBar` — Subtitle toggles between `TopAppBar-GHTll3U`
-  and `MediumFlexibleTopAppBar-eXZ4JBQ`).
-- Drawer facades with a `confirmStateChange` adapter
-  (`ModalNavigationDrawer`, `DismissibleNavigationDrawer`,
-  `PermanentNavigationDrawer`, `ModalWideNavigationRail`).
-- Container+slot facades like `BottomAppBar` whose required
-  Function3 is the container's content but also has an optional
-  Function2 slot — the generator's multi-slot rule (any nullable
-  Function2/3 → leaf) doesn't model this hybrid.
+- The `Icon` facade, which exposes two distinct constructors
+  (`ImageVector` vs. resource-id `Painter`) that route to two
+  different bridges. The generator emits one ctor + one `Render`
+  per facade, so the dual-shape control stays hand-written.
 
 Trying to apply `[ComposeFacade]` to an unsupported bridge will
 emit CN3002 (unsupported parameter), CN3003 (scope misuse), CN3005

--- a/src/ComposeNet.Compose/BottomAppBar.cs
+++ b/src/ComposeNet.Compose/BottomAppBar.cs
@@ -1,11 +1,10 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>BottomAppBar</c>. The actions slot is laid out in a
 /// <c>RowScope</c> and filled from this bar's children;
-/// <see cref="FloatingActionButton"/> is an optional trailing slot:
+/// <see cref="ComposeNet.FloatingActionButton"/> is an optional
+/// trailing slot:
 /// <code>
 /// new BottomAppBar
 /// {
@@ -16,21 +15,4 @@ namespace ComposeNet;
 /// }
 /// </code>
 /// </summary>
-public sealed class BottomAppBar : ComposableContainer
-{
-    /// <summary>Optional: trailing slot, typically a <see cref="ComposeNet.FloatingActionButton"/>.</summary>
-    public ComposableNode? FloatingActionButton { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        var actions = ComposableLambdas.Wrap3(composer, (scope, c) =>
-        {
-            using var _ = RenderContext.PushScope(scope, ScopeKind.Row);
-            RenderChildren(c);
-        });
-        var fab = FloatingActionButton is null ? null
-            : ComposableLambdas.Wrap2(composer, c => FloatingActionButton.Render(c));
-
-        ComposeBridges.BottomAppBar(actions, BuildModifier(), fab, composer);
-    }
-}
+public sealed partial class BottomAppBar;

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -2126,6 +2126,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/material3/BottomAppBarScrollBehavior;" +
                     "Landroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(BottomAppBarDefault))]
+    [ComposeFacade(Scope = "Row")]
     public static partial void BottomAppBar(
         IFunction3  actions,
         IModifier?  modifier,
@@ -2385,4 +2386,54 @@ internal static partial class ComposeBridges
             _composer:              composer,
             steps:                  0,
             _changed:               defaults);
+
+    // WideNavigationRailKt.WideNavigationRailItem-pli-t6k. Bound C# wrapper
+    // has misnamed trailing params: `iconPosition` is actually $changed,
+    // `_changed` is actually $default. The mid-list `int p7` is the real
+    // iconPosition slot (not user-exposed).
+    [ComposeFacade(Defaults = typeof(WideNavigationRailItemDefault))]
+    public static partial void WideNavigationRailItem(
+        bool        selected,
+        IFunction0  onClick,
+        IFunction2  icon,
+        IFunction2? label,
+        IModifier?  modifier,
+        int         defaults,
+        IComposer   composer);
+
+    public static partial void WideNavigationRailItem(bool selected, IFunction0 onClick, IFunction2 icon, IFunction2? label, IModifier? modifier, int defaults, IComposer composer)
+        => AndroidX.Compose.Material3.WideNavigationRailKt.WideNavigationRailItem(
+            selected:          selected,
+            onClick:           onClick,
+            icon:              icon,
+            label:             label,
+            railExpanded:      false,
+            modifier:          modifier,
+            enabled:           true,
+            p7:                0,
+            colors:            null,
+            interactionSource: null,
+            _composer:         composer,
+            iconPosition:      0,
+            _changed:          defaults);
+
+    [ComposeFacade(Defaults = typeof(TriStateCheckboxDefault))]
+    public static partial void TriStateCheckbox(
+        AndroidX.Compose.UI.State.ToggleableState state,
+        IFunction0  onClick,
+        IModifier?  modifier,
+        int         defaults,
+        IComposer   composer);
+
+    public static partial void TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState state, IFunction0 onClick, IModifier? modifier, int defaults, IComposer composer)
+        => AndroidX.Compose.Material3.CheckboxKt.TriStateCheckbox(
+            state:             state,
+            onClick:           onClick,
+            modifier:          modifier,
+            enabled:           true,
+            colors:            null,
+            interactionSource: null,
+            _composer:         composer,
+            p7:                0,
+            _changed:          defaults);
 }

--- a/src/ComposeNet.Compose/TriStateCheckbox.cs
+++ b/src/ComposeNet.Compose/TriStateCheckbox.cs
@@ -1,49 +1,15 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-using AndroidX.Compose.UI.State;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>TriStateCheckbox</c> — a checkbox with an
 /// indeterminate state in addition to checked/unchecked. The
-/// <see cref="ToggleableState"/> values are <c>On</c>, <c>Off</c>,
-/// and <c>Indeterminate</c>:
+/// <c>ToggleableState</c> values are <c>On</c>, <c>Off</c>, and
+/// <c>Indeterminate</c>:
 /// <code>
 /// var state = Remember.Of(ToggleableState.Indeterminate);
 /// new TriStateCheckbox(
 ///     state: state.Value,
-///     onClick: () => state.Value = ToggleableState.On)
+///     onClick: () =&gt; state.Value = ToggleableState.On)
 /// </code>
 /// </summary>
-public sealed class TriStateCheckbox : ComposableNode
-{
-    readonly ToggleableState _state;
-    readonly System.Action _onClick;
-
-    public TriStateCheckbox(ToggleableState state, System.Action onClick)
-    {
-        _state = state;
-        _onClick = onClick;
-    }
-
-    internal override void Render(IComposer composer)
-    {
-        var onClick = new ComposableLambda0(_onClick);
-
-        var modifier = BuildModifier();
-        int defaults = (int)TriStateCheckboxDefault.All;
-        if (modifier is not null) defaults &= ~(int)TriStateCheckboxDefault.Modifier;
-
-        CheckboxKt.TriStateCheckbox(
-            state:             _state,
-            onClick:           onClick,
-            modifier:          modifier,
-            enabled:           true,
-            colors:            null,
-            interactionSource: null,
-            _composer:         composer,
-            p7:                0,
-            _changed:          defaults);
-    }
-}
+public sealed partial class TriStateCheckbox;

--- a/src/ComposeNet.Compose/WideNavigationRailItem.cs
+++ b/src/ComposeNet.Compose/WideNavigationRailItem.cs
@@ -1,61 +1,9 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>WideNavigationRailItem</c>. Used inside
 /// <see cref="WideNavigationRail"/>. <see cref="Icon"/> is required;
-/// <see cref="Label"/> is optional.
+/// <see cref="Label"/> is optional (only shown when the rail is
+/// expanded).
 /// </summary>
-public sealed class WideNavigationRailItem : ComposableNode
-{
-    readonly bool _selected;
-    readonly System.Action _onClick;
-
-    public WideNavigationRailItem(bool selected, System.Action onClick)
-    {
-        _selected = selected;
-        _onClick  = onClick;
-    }
-
-    /// <summary>Required: item icon.</summary>
-    public ComposableNode? Icon { get; set; }
-
-    /// <summary>Optional: item label (only shown when the rail is expanded).</summary>
-    public ComposableNode? Label { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Icon is null)
-            throw new System.InvalidOperationException(
-                "WideNavigationRailItem.Icon is required (the Kotlin parameter has no default).");
-
-        var click = new ComposableLambda0(_onClick);
-        var icon  = ComposableLambdas.Wrap2(composer, c => Icon.Render(c));
-        var label = Label is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
-
-        int defaults = (int)WideNavigationRailItemDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)WideNavigationRailItemDefault.Modifier;
-        if (label    is not null) defaults &= ~(int)WideNavigationRailItemDefault.Label;
-
-        // Bound C# wrapper has misnamed trailing params: `iconPosition`
-        // is actually $changed, `_changed` is actually $default. The
-        // mid-list `int p7` is the real iconPosition (we don't expose it).
-        WideNavigationRailKt.WideNavigationRailItem(
-            selected:          _selected,
-            onClick:           click,
-            icon:              icon,
-            label:             label,
-            railExpanded:      false,
-            modifier:          modifier,
-            enabled:           true,
-            p7:                0,
-            colors:            null,
-            interactionSource: null,
-            _composer:         composer,
-            iconPosition:      0,
-            _changed:          defaults);
-    }
-}
+public sealed partial class WideNavigationRailItem;

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -343,6 +343,128 @@ public class FacadeGeneratorTests
     }
 
     [Fact]
+    public void HybridContainer_RequiredFn3PlusNullableFn2_EmitsContainerWithNamedSlot()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BottomAppBarDefault",
+                "!actions", "modifier", "floatingActionButton", "containerColor",
+                "contentColor", "tonalElevation", "contentPadding", "windowInsets",
+                "scrollBehavior")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/AppBarKt", JvmName="BottomAppBar-qhFBPw4",
+                                   Signature="(Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;JJFLandroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/WindowInsets;Landroidx/compose/material3/BottomAppBarScrollBehavior;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BottomAppBarDefault))]
+                    [ComposeFacade(Scope = "Row")]
+                    public static partial void BottomAppBar(IFunction3 actions, IModifier? modifier, IFunction2? floatingActionButton, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "BottomAppBar");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // Derives from ComposableContainer (container body), not ComposableNode.
+        Assert.Contains(": global::ComposeNet.ComposableContainer", emitted);
+        // Required Fn3 stays as container body: RenderChildren + PushScope(Row).
+        Assert.Contains("Wrap3(composer, (__scope, c) =>", emitted);
+        Assert.Contains("global::ComposeNet.RenderContext.PushScope(__scope, global::ComposeNet.ScopeKind.Row);", emitted);
+        Assert.Contains("RenderChildren(c);", emitted);
+        // Nullable Fn2 surfaces as a named property.
+        Assert.Contains("public global::ComposeNet.ComposableNode? FloatingActionButton { get; set; }", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void HybridContainer_WithoutScope_StillBehavesAsLeaf()
+    {
+        // Same shape as BottomAppBar but without [ComposeFacade(Scope=...)] —
+        // the generator must NOT treat as hybrid; both Fn slots become
+        // named properties (no RenderChildren, no ComposableContainer).
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("FooBarDefault",
+                "!actions", "modifier", "floatingActionButton")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/Z", JvmName="FooBar",
+                                   Signature="(Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(FooBarDefault))]
+                    [ComposeFacade]
+                    public static partial void FooBar(IFunction3 actions, IModifier? modifier, IFunction2? floatingActionButton, IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "FooBar");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // No Scope → leaf shape: ComposableNode base, no RenderChildren.
+        Assert.Contains(": global::ComposeNet.ComposableNode", emitted);
+        Assert.DoesNotContain("RenderChildren", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Actions { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? FloatingActionButton { get; set; }", emitted);
+    }
+
+    [Fact]
+    public void JavaEnumPrimitive_SurfacedAsCtorParam()
+    {
+        // Simulates ToggleableState — a class derived from Java.Lang.Enum.
+        // The generator must accept it as a primitive-like ctor slot.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("TriStateCheckboxDefault",
+                "!state", "!onClick", "modifier", "enabled", "colors", "interactionSource")]
+
+            namespace ComposeNet.Demo
+            {
+                public class FakeToggleableState : global::Java.Lang.Enum { }
+            }
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/Z", JvmName="TriStateCheckbox",
+                                   Signature="(Landroidx/compose/ui/state/ToggleableState;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/material3/CheckboxColors;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(TriStateCheckboxDefault))]
+                    [ComposeFacade]
+                    public static partial void TriStateCheckbox(global::ComposeNet.Demo.FakeToggleableState state, IFunction0 onClick, IModifier? modifier, IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "TriStateCheckbox");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // Java enum surfaces as a ctor field + ctor param + bridge arg pass-through.
+        Assert.Contains("readonly global::ComposeNet.Demo.FakeToggleableState _state;", emitted);
+        Assert.Contains("global::ComposeNet.Demo.FakeToggleableState state", emitted);
+        Assert.Contains("ComposeBridges.TriStateCheckbox(_state,", emitted);
+    }
+
+    [Fact]
     public void ScopePublishingContainer_EmitsPushScope()
     {
         var code = """

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -50,6 +50,7 @@ public class FacadeGeneratorTests
             }
             public sealed class Boolean : Object { public bool BooleanValue() => false; }
             public sealed class Float : Object { public float FloatValue() => 0f; }
+            public abstract class Enum : Object { }
         }
         namespace AndroidX.Compose.Runtime { public interface IComposer { } }
         namespace AndroidX.Compose.UI { public interface IModifier { } }
@@ -455,13 +456,20 @@ public class FacadeGeneratorTests
             }
             """;
 
-        var (_, diags, emitted) = Run(code, "TriStateCheckbox");
+        var (output, diags, emitted) = Run(code, "TriStateCheckbox");
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
         // Java enum surfaces as a ctor field + ctor param + bridge arg pass-through.
         Assert.Contains("readonly global::ComposeNet.Demo.FakeToggleableState _state;", emitted);
         Assert.Contains("global::ComposeNet.Demo.FakeToggleableState state", emitted);
         Assert.Contains("ComposeBridges.TriStateCheckbox(_state,", emitted);
+
+        // Sanity-check: the synthetic compilation must actually compile —
+        // otherwise the generator could be matching against an
+        // IErrorTypeSymbol's syntactic Name/Namespace rather than truly
+        // exercising IsJavaEnum's inheritance walk.
+        var compileErrors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(compileErrors);
     }
 
     [Fact]

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -215,27 +215,55 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         // an explicit [Slot], OR there's >1 Fn2/3 slot, treat the facade
         // as a multi-slot LEAF (named properties). Otherwise stick with
         // the Phase 1 "container with children" shape.
+        // Hybrid container exception: exactly 1 non-nullable Fn3 (+ no
+        // [Slot]) PLUS 1+ nullable Fn2/3 slots AND `[ComposeFacade(Scope = "...")]`
+        // explicitly set — the non-nullable Fn3 stays as the container
+        // body (RenderChildren) and the nullable slots become named
+        // properties. The Scope opt-in disambiguates from leafs that
+        // happen to have a required Fn2 label slot (e.g. AssistChip).
         bool hasMultiSlot = slots.Any(s => s.IsNullableSlot || s.HasSlotAttribute) || fnContentCount > 1;
+        bool isHybridContainer = false;
+        if (hasMultiSlot && !string.IsNullOrEmpty(scope))
+        {
+            var nonNullableFn3 = slots.Where(s =>
+                s.Kind == FacadeSlotKind.Content3 &&
+                s.Param.NullableAnnotation != NullableAnnotation.Annotated &&
+                !s.HasSlotAttribute).ToArray();
+            var nullableContent = slots.Where(s =>
+                s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3 &&
+                s.Param.NullableAnnotation == NullableAnnotation.Annotated).ToArray();
+            isHybridContainer =
+                nonNullableFn3.Length == 1 &&
+                nullableContent.Length >= 1 &&
+                !slots.Any(s => s.HasSlotAttribute);
+        }
         if (hasMultiSlot)
         {
             // Re-classify the Fn2/Fn3 slots into property slots (the
             // generator picks one shape per bridge; mixing is invalid).
+            // Hybrid container: leave the sole non-nullable Fn3 as
+            // Content3 so it renders the container body.
             for (int i = 0; i < slots.Count; i++)
             {
                 var s = slots[i];
-                if (s.Kind is FacadeSlotKind.Content2)
+                bool isContainerBody = isHybridContainer
+                    && s.Kind == FacadeSlotKind.Content3
+                    && s.Param.NullableAnnotation != NullableAnnotation.Annotated
+                    && !s.HasSlotAttribute;
+                if (s.Kind is FacadeSlotKind.Content2 && !isContainerBody)
                     slots[i] = s.WithKind(s.Param.NullableAnnotation == NullableAnnotation.Annotated
                         ? FacadeSlotKind.NamedFunction2 : FacadeSlotKind.RequiredFunction2);
-                else if (s.Kind is FacadeSlotKind.Content3)
+                else if (s.Kind is FacadeSlotKind.Content3 && !isContainerBody)
                     slots[i] = s.WithKind(s.Param.NullableAnnotation == NullableAnnotation.Annotated
                         ? FacadeSlotKind.NamedFunction3 : FacadeSlotKind.RequiredFunction3);
             }
         }
 
-        // Scope only makes sense with a Phase 1 Content3 (container shape).
+        // Scope only makes sense with a Content3 (container shape — Phase 1
+        // pure container, or the new hybrid container with named slots).
         if (!string.IsNullOrEmpty(scope))
         {
-            if (hasMultiSlot || !slots.Any(s => s.Kind == FacadeSlotKind.Content3))
+            if ((hasMultiSlot && !isHybridContainer) || !slots.Any(s => s.Kind == FacadeSlotKind.Content3))
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeScopeMisuse, loc, method.Name, scope ?? "?"));
             }
@@ -513,7 +541,14 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         DefaultsInfo? defaults, string? defaultsEnumName,
         string? themeColor, FacadeSlot? colorSlot)
     {
-        bool isContainer = !isMultiSlot && slots.Any(s => s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3);
+        // After classification, only the container's body survives as
+        // Content2/3 (multi-slot leafs re-classified to Named/Required).
+        // For the hybrid "container + named slots" shape (e.g.
+        // BottomAppBar's required `actions` Function3 + nullable
+        // `floatingActionButton` Function2 slot), the Content2/3 body
+        // and the Named slots coexist — the class still derives from
+        // ComposableContainer and the body wraps RenderChildren.
+        bool isContainer = slots.Any(s => s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3);
         string baseClass = isContainer ? "global::ComposeNet.ComposableContainer" : "global::ComposeNet.ComposableNode";
 
         // Ctor slots: every non-modifier, non-named-property slot.
@@ -924,12 +959,33 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
     static bool IsPrimitiveCtorType(ITypeSymbol type) =>
         type.TypeKind == TypeKind.Enum ||
+        IsJavaEnum(type) ||
         type.SpecialType is SpecialType.System_String
             or SpecialType.System_Int32
             or SpecialType.System_Int64
             or SpecialType.System_Boolean
             or SpecialType.System_Single
             or SpecialType.System_Double;
+
+    /// <summary>
+    /// True when <paramref name="type"/> derives (transitively) from
+    /// <c>Java.Lang.Enum</c> — i.e. it's a Kotlin/Java enum class
+    /// generated by the Xamarin.Android binding (e.g. Compose's
+    /// <c>ToggleableState</c>: <c>On</c>, <c>Off</c>,
+    /// <c>Indeterminate</c>). Recognized as a primitive-like ctor
+    /// slot: surfaced as a positional ctor parameter and forwarded
+    /// to the bridge unchanged.
+    /// </summary>
+    static bool IsJavaEnum(ITypeSymbol type)
+    {
+        for (var t = type.BaseType; t is not null; t = t.BaseType)
+        {
+            if (t.Name == "Enum" &&
+                t.ContainingNamespace?.ToDisplayString() == "Java.Lang")
+                return true;
+        }
+        return false;
+    }
 
     /// <summary>
     /// True for parameters typed as <c>Nullable&lt;T&gt;</c> where <c>T</c>


### PR DESCRIPTION
## Summary

This PR partially advances #67 by converting three mechanical hand-written facades to generator-emitted Phase 8 wrapper-passthroughs, and ships two new `ComposeFacadeGenerator` features that enabled them.

### New generator features

1. **Java enum primitives** — the primitive-ctor-slot detector now accepts reference types that derive (transitively) from `Java.Lang.Enum`. Compose Java enums like `AndroidX.Compose.UI.State.ToggleableState` (`On` / `Off` / `Indeterminate`) surface as ctor primitives forwarded directly to the bridge — no JNI lowering required.

2. **Hybrid container + named slots (Scope-gated)** — a bridge with one non-nullable `IFunction3` content slot **plus** one or more nullable `IFunction2?` / `IFunction3?` slots now keeps the non-nullable body as the container (`RenderChildren`) and surfaces the nullable slots as named `ComposableNode?` properties — but only when the facade explicitly opts in via `[ComposeFacade(Scope = "...")]`. Without `Scope`, the bridge still classifies as a multi-slot leaf, preserving `AssistChip`-style facades whose required `IFunction2` is a label, not a content slot.

### Facades converted

- `WideNavigationRailItem` → Phase 8 wrapper around `WideNavigationRailKt.WideNavigationRailItem`.
- `TriStateCheckbox` → Phase 8 wrapper around `CheckboxKt.TriStateCheckbox`, using the new Java-enum support.
- `BottomAppBar` → Phase 8 wrapper using the new hybrid container shape (required `actions` Function3 + optional `FloatingActionButton` slot).

### Tests

Three new generator unit tests (`HybridContainer_RequiredFn3PlusNullableFn2_EmitsContainerWithNamedSlot`, `HybridContainer_WithoutScope_StillBehavesAsLeaf`, `JavaEnumPrimitive_SurfacedAsCtorParam`). 83/83 tests pass; sample build clean.

### Out of scope (kept hand-written, documented)

The remaining hand-written facades stay as-is with explicit reasons in `copilot-instructions.md`:

- **Drawer family** (`ModalNavigationDrawer`, `DismissibleNavigationDrawer`, `PermanentNavigationDrawer`, `ModalWideNavigationRail`) — per-instance `DrawerConfirmStateChange` Java peer plus a Phase 4b parameterised `RememberDrawerState` call that needs a user-supplied `initialValue`.
- **Parameterised state-holder facades** (`TimePicker`, `TimeInput`, `SearchBar`, `ModalBottomSheet`, `BottomSheetScaffold`) — Phase 4 supports zero-user-param remembers only; these need Phase 4b.
- **`Icon`** — two distinct constructors (`ImageVector` vs resource-id `Painter`) route to two bridges; one ctor + one `Render` per generated facade can't model this.
- **`TopAppBar`** — branches between two bridges based on an optional `Subtitle` slot.
- **Scope facades with non-trivial bodies** (`SegmentedButton`, `SingleChoice`/`MultiChoiceSegmentedButtonRow`, segmented scrollable tab rows).
- **`DropdownMenuItem`** — backwards compat with the existing `Enabled` ctor primitive API.

Each remaining facade is concise, type-correct, and has clear semantics that don't benefit from one-off generator features.