### PR TITLE
Phase 4b: parameterised state-holder facades via [StateHolder]

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -401,20 +401,44 @@ Parameter-level attributes the generator recognizes:
 - `[StateHolder(Remember = nameof(ComposeBridges.X), StateType = typeof(T))]`
   — annotate the `IntPtr` user param that carries a Kotlin
   state-holder handle (e.g. `DatePickerState`,
-  `DateRangePickerState`). The facade gains a defaulted ctor slot
-  `T? state = null` (appended last), calls
-  `ComposeBridges.<Remember>(composer)` at the top of `Render` to
-  obtain the JNI handle, populates `state.Jvm` via
-  `Java.Lang.Object.GetObject<TJvm>(handle, JniHandleOwnership.DoNotTransfer)`
-  the first time it sees a non-null wrapper, and forwards the handle
-  to this parameter. Phase 4 supports only Remember bridges with
-  signature `(IComposer) -> IntPtr` — Remember bridges that take user
-  parameters (e.g. `RememberTimePickerState(int, int, bool, IComposer)`)
-  are blocked on Phase 4b and stay hand-written. The
+  `DateRangePickerState`, `TimePickerState`). The facade gains a
+  defaulted ctor slot `T? state = null` (appended last), calls the
+  named `Remember` bridge at the top of `Render` to obtain the JNI
+  handle, populates `state.Jvm` via
+  `Java.Lang.Object.GetObject<TJvm>(handle, JniHandleOwnership.DoNotTransfer)`,
+  and forwards the handle to this parameter.
+
+  Two shapes are supported:
+
+  - **Phase 4** — zero-user-param Remember
+    (`(IComposer) -> IntPtr`, e.g. `RememberDatePickerState`,
+    `RememberDateRangePickerState`). `_state` stays nullable; `Jvm`
+    is only populated when the caller supplies a non-null wrapper
+    (`if (_state is not null && _state.Jvm is null) …`).
+  - **Phase 4b** — parameterised Remember
+    (`(arg1, arg2, …, IComposer) -> IntPtr`, e.g.
+    `RememberTimePickerState(int initialHour, int initialMinute,
+    bool is24Hour, IComposer)`). Each Remember user param is
+    resolved to a readable instance member (property or field) on
+    `StateType` by PascalCase match first
+    (`initialHour` → `InitialHour`), then `Initial<PascalCase>`
+    fallback (`is24Hour` → `Is24Hour` first, else
+    `InitialIs24Hour`). `_state` is auto-created in the ctor
+    (`_state = state ?? new T()`), so the field is guaranteed
+    non-null inside `Render` and `Jvm` population is unguarded
+    (`if (_state.Jvm is null) …`). The PascalCase-first rule lets a
+    wrapper's live getter that falls back to its initial-value
+    backing field (`Is24Hour => Jvm?.Is24hour() ?? InitialIs24Hour`)
+    be the natural match — at remember-time `Jvm` is null, so it
+    returns the initial value correctly. The Phase 4b shape
+    requires `StateType` to be constructible with no arguments
+    (either a declared parameterless ctor, or a ctor whose every
+    parameter has a `HasExplicitDefaultValue` default).
+
   `StateType` must declare an instance, writable, non-readonly,
   accessible field named `Jvm` whose declared type is the
-  binding-generated state interface (e.g. `IDatePickerState`). Cannot
-  be combined with `[PainterResource]` on the same parameter.
+  binding-generated state interface (e.g. `IDatePickerState`).
+  Cannot be combined with `[PainterResource]` on the same parameter.
 
 Each facade is emitted to a unique hint name
 (`ComposeNet.Facade.<ClassName>.g.cs`) so the `[CallerFilePath]` +
@@ -437,10 +461,15 @@ The generator now supports a wide range of facade shapes (Phases 1,
 - **Phase 4** — `[StateHolder(...)]` state-holder facades that need
   a `RememberXxxState(composer)` round-trip and a `.Jvm` population
   for the caller-supplied wrapper (`DatePicker`, `DateRangePicker`).
-  Limited to Remember bridges with signature `(IComposer) -> IntPtr`;
-  parameterised remembers (`TimePicker`, `TimeInput`, `SearchBar`,
-  `SnackbarHost`, `ModalBottomSheet`, `BottomSheetScaffold`) stay
-  hand-written until Phase 4b.
+- **Phase 4b** — `[StateHolder(...)]` with a parameterised Remember
+  bridge that takes user parameters resolved against `StateType`
+  members (`TimePicker`). The facade auto-creates the wrapper when
+  the caller leaves `state` null, then forwards init-value member
+  reads as the Remember args. `TimeInput`, `SearchBar`,
+  `SnackbarHost`, `ModalBottomSheet`, `BottomSheetScaffold` stay
+  hand-written — they need either a per-instance `confirmValueChange`
+  veto adapter (drawer pattern) or shared-state caching across
+  sibling facades, neither of which Phase 4b models.
 - **Phase 6** — `[ComposeFacade(DefaultColorFromTheme = "...")]`
   for drawer sheets and similar containers that fall back to a
   `ColorScheme` slot when the caller doesn't override.
@@ -506,11 +535,15 @@ can't model:
   permanent drawer doesn't actually need a veto adapter, but it
   shares the hand-written family for consistency.
 - State-holder facades whose `RememberXxxState` bridge takes user
-  parameters (`TimePicker` / `TimeInput` need
-  `initialHour`/`initialMinute`/`is24Hour`; `SearchBar`,
-  `ModalBottomSheet`, `BottomSheetScaffold` similarly). Phase 4
-  supports the zero-user-param shape (`DatePicker`,
-  `DateRangePicker`); parameterised remembers wait for Phase 4b.
+  parameters AND combine that with either a per-instance
+  `confirmValueChange` veto adapter or shared-state caching across
+  sibling facades: `TimeInput` (shares state with `TimePicker`),
+  `SearchBar` (shared-state caching across the bar + view facades),
+  `ModalBottomSheet`, `BottomSheetScaffold` (both need a
+  `confirmValueChange` adapter on top of parameterised Remember).
+  Phase 4 covers the zero-user-param shape (`DatePicker`,
+  `DateRangePicker`); Phase 4b covers the parameterised case where
+  no extra adapter / caching is needed (`TimePicker`).
 - Scope facades whose bodies do non-trivial work beyond
   `RenderContext.PushScope` (`SegmentedButton`,
   `SingleChoice`/`MultiChoiceSegmentedButtonRow`, the segmented

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -823,8 +823,12 @@ internal static partial class ComposeBridges
         Signature = "(Landroidx/compose/material3/TimePickerState;Landroidx/compose/ui/Modifier;" +
                     "Landroidx/compose/material3/TimePickerColors;ILandroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(TimePickerDefault))]
-    public static partial void TimePicker(IntPtr state, IModifier? modifier,
-                                          int defaults, IComposer composer);
+    [ComposeFacade]
+    public static partial void TimePicker(
+        [StateHolder(Remember = nameof(RememberTimePickerState),
+                     StateType = typeof(TimePickerState))] IntPtr state,
+        IModifier? modifier,
+        int defaults, IComposer composer);
 
     // androidx.compose.material3.TimePickerDialogKt.TimePickerDialog-FItCLgY
     [ComposeBridge(

--- a/src/ComposeNet.Compose/TimePicker.cs
+++ b/src/ComposeNet.Compose/TimePicker.cs
@@ -1,29 +1,11 @@
-using Android.Runtime;
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>TimePicker</c>. Resolves <c>TimePickerState</c> via
-/// raw JNI (<c>rememberTimePickerState</c> takes a <see cref="IComposer"/>
-/// so it requires the composer-aware bridge). Pass an explicit
-/// <see cref="ComposeNet.TimePickerState"/> to read the picked
-/// hour/minute from a button callback.
+/// Material 3 <c>TimePicker</c>. The generator wires the
+/// <c>rememberTimePickerState(initialHour, initialMinute, is24Hour, composer)</c>
+/// round-trip and auto-creates a <see cref="TimePickerState"/> wrapper
+/// when the caller leaves the <c>state</c> ctor argument null, so reading
+/// <see cref="TimePickerState.Hour"/> / <see cref="TimePickerState.Minute"/>
+/// from a button callback Just Works without manual <c>remember</c> plumbing.
 /// </summary>
-public sealed class TimePicker : ComposableNode
-{
-    readonly TimePickerState _state;
-    public TimePicker(TimePickerState? state = null) => _state = state ?? new TimePickerState();
-
-    internal override void Render(IComposer composer)
-    {
-        var stateHandle = ComposeBridges.RememberTimePickerState(_state.InitialHour, _state.InitialMinute, _state.InitialIs24Hour, composer);
-        if (_state.Jvm is null)
-            _state.Jvm = Java.Lang.Object.GetObject<ITimePickerState>(stateHandle, JniHandleOwnership.DoNotTransfer)!;
-        var modifier = BuildModifier();
-        int defaults = (int)TimePickerDefault.All;
-        if (modifier is not null) defaults &= ~(int)TimePickerDefault.Modifier;
-        ComposeBridges.TimePicker(stateHandle, modifier, defaults, composer);
-    }
-}
+public sealed partial class TimePicker;

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -1531,6 +1531,265 @@ public class FacadeGeneratorTests
             emitted);
     }
 
+    // ─── Phase 4b — parameterised Remember*State (TimePicker-style) ──
+
+    /// <summary>Shared snippet stubbing a TimePicker-style state class
+    /// with the Kotlin "initialX → live X" convention.</summary>
+    const string TimePickerStateStubs = """
+        namespace AndroidX.Compose.Material3
+        {
+            public interface ITimePickerState
+            {
+                int Hour { get; set; }
+                int Minute { get; set; }
+                bool Is24hour();
+            }
+        }
+        namespace ComposeNet
+        {
+            public sealed class TimePickerState
+            {
+                internal AndroidX.Compose.Material3.ITimePickerState? Jvm;
+                public TimePickerState(int initialHour = 12, int initialMinute = 0, bool is24Hour = true)
+                {
+                    InitialHour = initialHour;
+                    InitialMinute = initialMinute;
+                    InitialIs24Hour = is24Hour;
+                }
+                internal int InitialHour { get; }
+                internal int InitialMinute { get; }
+                internal bool InitialIs24Hour { get; }
+                public int Hour => Jvm?.Hour ?? InitialHour;
+                public int Minute => Jvm?.Minute ?? InitialMinute;
+                public bool Is24Hour => Jvm?.Is24hour() ?? InitialIs24Hour;
+            }
+        }
+        """;
+
+    const string TimePickerSig =
+        "(Landroidx/compose/material3/TimePickerState;Landroidx/compose/ui/Modifier;Landroidx/compose/material3/TimePickerColors;ILandroidx/compose/runtime/Composer;II)V";
+
+    [Fact]
+    public void TimePicker_ParameterisedStateHolder_GeneratesAutoCreateAndArgs()
+    {
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("TimePickerDefault",
+                "!state", "modifier", "colors", "layoutType")]
+
+            {{TimePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/TimePickerKt",
+                                   JvmName="TimePicker-mT9BvqQ",
+                                   Signature="{{TimePickerSig}}",
+                                   Defaults=typeof(TimePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void TimePicker(
+                        [StateHolder(Remember = nameof(RememberTimePickerState),
+                                     StateType = typeof(TimePickerState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberTimePickerState(int initialHour, int initialMinute,
+                                                                 bool is24Hour, IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "TimePicker");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Ctor: parameterised StateHolder auto-creates the wrapper when
+        // the caller passes null, so the field is guaranteed non-null
+        // even though the ctor param keeps its = null default.
+        Assert.Contains("readonly global::ComposeNet.TimePickerState? _state;", emitted);
+        Assert.Contains("public TimePicker(global::ComposeNet.TimePickerState? state = null)", emitted);
+        Assert.Contains("_state = state ?? new global::ComposeNet.TimePickerState();", emitted);
+
+        // Render: Remember called with wrapper-sourced init args.
+        // InitialHour/InitialMinute resolve via Pascal match;
+        // is24Hour falls back to Is24Hour (live getter), which returns
+        // InitialIs24Hour while Jvm is still null on first render.
+        Assert.Contains(
+            "var __state = global::ComposeNet.ComposeBridges.RememberTimePickerState(_state!.InitialHour, _state!.InitialMinute, _state!.Is24Hour, composer);",
+            emitted);
+        // Unguarded Jvm population — Phase 4b knows _state is non-null.
+        Assert.Contains("if (_state.Jvm is null)", emitted);
+        Assert.DoesNotContain("if (_state is not null && _state.Jvm is null)", emitted);
+        Assert.Contains(
+            "_state.Jvm = global::Java.Lang.Object.GetObject<global::AndroidX.Compose.Material3.ITimePickerState>(__state, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;",
+            emitted);
+
+        // Bridge call uses __state in the IntPtr slot.
+        Assert.Contains(
+            "global::ComposeNet.ComposeBridges.TimePicker(__state, __modifier, __defaults, composer);",
+            emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ParameterisedStateHolder_UnresolvedMember_FailsCN3009()
+    {
+        // RememberFooState takes 'mystery' which is not a member of
+        // TimePickerState (and 'InitialMystery' doesn't exist either),
+        // so the generator must reject.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("TimePickerDefault",
+                "!state", "modifier", "colors", "layoutType")]
+
+            {{TimePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/TimePickerKt", JvmName="TimePicker-mT9BvqQ",
+                                   Signature="{{TimePickerSig}}",
+                                   Defaults=typeof(TimePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void TimePicker(
+                        [StateHolder(Remember = nameof(RememberTimePickerState),
+                                     StateType = typeof(TimePickerState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberTimePickerState(int mystery, IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "TimePicker");
+        Assert.Null(emitted);
+        Assert.Contains(diags, d => d.Id == "CN3009"
+            && d.GetMessage().Contains("cannot resolve Remember parameter 'mystery'")
+            && d.GetMessage().Contains("InitialMystery"));
+    }
+
+    [Fact]
+    public void ParameterisedStateHolder_NoParameterlessCtor_FailsCN3009()
+    {
+        // StateType only has an all-required-params ctor, so the
+        // facade can't auto-create it. CN3009 fires.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("TimePickerDefault",
+                "!state", "modifier", "colors", "layoutType")]
+            namespace AndroidX.Compose.Material3 { public interface ITimePickerState { } }
+            namespace ComposeNet
+            {
+                public sealed class TimePickerState
+                {
+                    internal AndroidX.Compose.Material3.ITimePickerState? Jvm;
+                    public TimePickerState(int initialHour, int initialMinute, bool is24Hour) { }
+                    public int InitialHour => 0;
+                    public int InitialMinute => 0;
+                    public bool Is24Hour => false;
+                }
+            }
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/TimePickerKt", JvmName="TimePicker-mT9BvqQ",
+                                   Signature="{{TimePickerSig}}",
+                                   Defaults=typeof(TimePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void TimePicker(
+                        [StateHolder(Remember = nameof(RememberTimePickerState),
+                                     StateType = typeof(TimePickerState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberTimePickerState(int initialHour, int initialMinute,
+                                                                 bool is24Hour, IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "TimePicker");
+        Assert.Null(emitted);
+        Assert.Contains(diags, d => d.Id == "CN3009"
+            && d.GetMessage().Contains("parameterised Remember requires StateType")
+            && d.GetMessage().Contains("constructible with no arguments"));
+    }
+
+    [Fact]
+    public void StateHolder_Phase4_StillEmitsGuardedJvmPopulation()
+    {
+        // Belt+suspenders: confirm the existing Phase 4 (zero-user-param
+        // Remember) path still emits the nullable guard `if (_state is
+        // not null && ...)`. Phase 4b's stricter unguarded path is only
+        // for parameterised remembers.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DatePickerDefault",
+                "!state", "modifier", "dateFormatter", "colors", "title", "headline", "showModeToggle")]
+
+            {{DatePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/DatePickerKt", JvmName="DatePicker",
+                                   Signature="{{DatePickerSig}}",
+                                   Defaults=typeof(DatePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void DatePicker(
+                        [StateHolder(Remember = nameof(RememberDatePickerState),
+                                     StateType = typeof(DatePickerState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDatePickerState(IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "DatePicker");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("if (_state is not null && _state.Jvm is null)", emitted);
+        Assert.DoesNotContain("_state = state ?? new", emitted);
+    }
+
     // ---------------------------------------------------------------
     // OptionalValue — Compose value-class types (Sp/Dp/Em/TextAlign)
     // and reference-typed wrappers (FontWeight/TextDecoration/Shape)

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -250,12 +250,22 @@ internal static class Attributes
             /// </summary>
             /// <remarks>
             /// <para><b>Remember</b>: the <c>nameof(ComposeBridges.X)</c>
-            /// of a static partial bridge on <c>ComposeBridges</c> with
-            /// signature <c>(IComposer composer) -&gt; IntPtr</c>. Phase
-            /// 4 supports only zero-user-param remembers; bridges that
-            /// take initialization values (e.g.
-            /// <c>RememberTimePickerState(int, int, bool, composer)</c>)
-            /// stay hand-written until Phase 4b.</para>
+            /// of a static partial bridge on <c>ComposeBridges</c> whose
+            /// last parameter is an <c>IComposer</c> and that returns
+            /// <c>IntPtr</c>. The remaining (leading) parameters are
+            /// treated as init values — each one is read off the
+            /// caller-supplied <c>StateType</c> wrapper at render time.
+            /// Phase 4 covers the zero-user-param shape (e.g.
+            /// <c>RememberDatePickerState(IComposer) -&gt; IntPtr</c>);
+            /// Phase 4b adds support for parameterised remembers (e.g.
+            /// <c>RememberTimePickerState(int, int, bool, IComposer)</c>).
+            /// Each Remember user param must resolve to a readable
+            /// instance member on <see cref="StateType"/>: the generator
+            /// looks up the PascalCased name first (e.g.
+            /// <c>initialHour</c> → <c>InitialHour</c>) and falls back
+            /// to <c>Initial&lt;PascalCase&gt;</c> for the Kotlin
+            /// convention where <c>initialX</c> remember args correspond
+            /// to live wrapper property <c>X</c>.</para>
             /// <para><b>StateType</b>: the C# wrapper class that exposes
             /// the state-holder's properties. It must declare an
             /// instance, writable, non-readonly field named <c>Jvm</c>
@@ -263,7 +273,11 @@ internal static class Attributes
             /// (e.g. <c>IDatePickerState</c>) — the generator emits
             /// <c>state.Jvm = Java.Lang.Object.GetObject&lt;IXxxState&gt;
             /// (handle, JniHandleOwnership.DoNotTransfer)!</c> the first
-            /// time <c>Render</c> sees a non-null wrapper.</para>
+            /// time <c>Render</c> sees a non-null wrapper. For Phase 4b
+            /// (parameterised Remember) the type must also be
+            /// constructible with no arguments (parameterless ctor or
+            /// all-defaulted-params ctor) so the facade can auto-create
+            /// a default wrapper when the caller passes <c>null</c>.</para>
             /// </remarks>
             [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
                                            AllowMultiple = false)]

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -393,8 +393,10 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 return null;
             }
 
-            // Validate the Remember bridge resolves to a static
-            // `(IComposer) -> IntPtr` method on ComposeNet.ComposeBridges.
+            // Validate the Remember bridge resolves to a static method on
+            // ComposeNet.ComposeBridges whose last parameter is an
+            // IComposer and that returns IntPtr. Any number of leading
+            // user parameters is allowed (Phase 4 = zero, Phase 4b = N).
             var bridgesType = c.Compilation.GetTypeByMetadataName("ComposeNet.ComposeBridges");
             if (bridgesType is null)
             {

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -411,13 +411,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             }
             var rememberFit = rememberMethods.FirstOrDefault(m =>
                 m.IsStatic &&
-                m.Parameters.Length == 1 &&
-                ComposeDefaultsGenerator.IsComposer(m.Parameters[0].Type) &&
+                m.Parameters.Length >= 1 &&
+                ComposeDefaultsGenerator.IsComposer(m.Parameters[m.Parameters.Length - 1].Type) &&
                 m.ReturnType.SpecialType == SpecialType.System_IntPtr);
             if (rememberFit is null)
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
-                    $"[StateHolder] on '{p.Name}': 'ComposeBridges.{remember}' must be a static method with signature '(IComposer) -> IntPtr' (Phase 4 supports only zero-user-param remembers)"));
+                    $"[StateHolder] on '{p.Name}': 'ComposeBridges.{remember}' must be a static method whose last parameter is an IComposer and that returns IntPtr"));
                 return null;
             }
 
@@ -442,10 +442,47 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 return null;
             }
 
+            // Phase 4b — Remember has N user params before composer. Each
+            // user param must resolve to a readable instance member on
+            // the StateType (case-insensitive PascalCase match; fall back
+            // to `Initial<PascalCase>` for the Kotlin "initialX → live X"
+            // wrapper convention). Phase 4b also requires an accessible
+            // parameterless construction path on the StateType so the
+            // ctor can auto-create a default wrapper when the caller
+            // passes null.
+            var rememberUserParams = rememberFit.Parameters
+                .Take(rememberFit.Parameters.Length - 1)
+                .ToArray();
+            string[] rememberArgExpressions = System.Array.Empty<string>();
+            if (rememberUserParams.Length > 0)
+            {
+                if (!HasAccessibleParameterlessConstructor(stateType))
+                {
+                    diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                        $"[StateHolder] on '{p.Name}': parameterised Remember requires StateType '{stateType.ToDisplayString()}' to be constructible with no arguments (parameterless ctor or all-defaulted-param ctor)"));
+                    return null;
+                }
+
+                rememberArgExpressions = new string[rememberUserParams.Length];
+                for (int i = 0; i < rememberUserParams.Length; i++)
+                {
+                    var up = rememberUserParams[i];
+                    var resolved = ResolveStateMember(stateType, up.Name);
+                    if (resolved is null)
+                    {
+                        diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                            $"[StateHolder] on '{p.Name}': cannot resolve Remember parameter '{up.Name}' on StateType '{stateType.ToDisplayString()}'; expected a readable instance member named '{Pascal(up.Name)}' or 'Initial{Pascal(up.Name)}'"));
+                        return null;
+                    }
+                    rememberArgExpressions[i] = "_state!." + resolved;
+                }
+            }
+
             return new FacadeSlot(p, FacadeSlotKind.StateHolder,
                 rememberMethodName: remember,
                 stateWrapperType: stateType,
-                stateJvmType: jvmMember.Type);
+                stateJvmType: jvmMember.Type,
+                rememberArgExpressions: rememberArgExpressions);
         }
 
         // [PainterResource] — annotates the IntPtr bridge param that
@@ -618,7 +655,23 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             sb.AppendLine(")");
             sb.AppendLine("        {");
             foreach (var s in ctorSlots)
-                sb.Append("            _").Append(CtorIdentifier(s)).Append(" = ").Append(EscapeIdent(CtorIdentifier(s))).AppendLine(";");
+            {
+                // Phase 4b — auto-create wrapper instance when the
+                // Remember bridge has user params. The Render body
+                // reads init values off `_state` to pass into Remember,
+                // so the field must be non-null on entry.
+                if (s.IsParameterisedStateHolder)
+                {
+                    var fqType = s.StateWrapperType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                        .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+                    sb.Append("            _").Append(CtorIdentifier(s)).Append(" = ")
+                      .Append(EscapeIdent(CtorIdentifier(s))).Append(" ?? new ").Append(fqType).AppendLine("();");
+                }
+                else
+                {
+                    sb.Append("            _").Append(CtorIdentifier(s)).Append(" = ").Append(EscapeIdent(CtorIdentifier(s))).AppendLine(";");
+                }
+            }
             sb.AppendLine("        }");
         }
 
@@ -638,19 +691,36 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         }
 
         // StateHolder preamble — call RememberXxxState and (optionally)
-        // populate the caller-supplied wrapper's Jvm field.
+        // populate the caller-supplied wrapper's Jvm field. Phase 4
+        // (zero-user-param Remember): _state is nullable, Jvm is only
+        // populated when the caller supplied a wrapper. Phase 4b
+        // (parameterised Remember): the ctor guaranteed _state is
+        // non-null, so we read init values off it and skip the
+        // null-guard on the Jvm assignment.
         foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.StateHolder))
         {
             var id = CtorIdentifier(s);
             var jvmFqn = s.StateJvmType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                 .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
             sb.Append("            var __").Append(s.Param.Name)
-              .Append(" = global::ComposeNet.ComposeBridges.").Append(s.RememberMethodName)
-              .Append('(').Append(composerName).AppendLine(");");
-            sb.Append("            if (_").Append(id).Append(" is not null && _").Append(id).AppendLine(".Jvm is null)");
-            sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
-              .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
-              .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+              .Append(" = global::ComposeNet.ComposeBridges.").Append(s.RememberMethodName).Append('(');
+            foreach (var argExpr in s.RememberArgExpressions)
+                sb.Append(argExpr).Append(", ");
+            sb.Append(composerName).AppendLine(");");
+            if (s.IsParameterisedStateHolder)
+            {
+                sb.Append("            if (_").Append(id).AppendLine(".Jvm is null)");
+                sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                  .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                  .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+            }
+            else
+            {
+                sb.Append("            if (_").Append(id).Append(" is not null && _").Append(id).AppendLine(".Jvm is null)");
+                sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                  .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                  .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+            }
         }
 
         // OnClick wrappers — one per line so slot-table keys stay distinct.
@@ -1050,6 +1120,66 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     static string EscapeIdent(string name) =>
         SyntaxFacts.GetKeywordKind(name) == SyntaxKind.None ? name : "@" + name;
 
+    /// <summary>
+    /// Phase 4b — resolve the wrapper-side member name for a Remember
+    /// bridge user parameter. Tries an exact <see cref="Pascal"/> match
+    /// first, then falls back to <c>Initial&lt;Pascal&gt;</c> for the
+    /// Kotlin convention where <c>initialX</c> remember args correspond
+    /// to live wrapper property <c>X</c>. Looks at both properties and
+    /// fields, accepting any readable, non-static, accessible member.
+    /// Returns the resolved C# identifier or <c>null</c> when no match.
+    /// </summary>
+    static string? ResolveStateMember(INamedTypeSymbol stateType, string paramName)
+    {
+        var pascal = Pascal(paramName);
+        if (FindReadableMember(stateType, pascal) is { } direct) return direct;
+        if (FindReadableMember(stateType, "Initial" + pascal) is { } prefixed) return prefixed;
+        return null;
+    }
+
+    static string? FindReadableMember(INamedTypeSymbol stateType, string name)
+    {
+        // Walk the inheritance chain so inherited members count. We stop
+        // at the first match — properties and fields share a name space
+        // in C#, so a class can't declare both with the same name.
+        for (var t = (INamedTypeSymbol?)stateType; t is not null; t = t.BaseType)
+        {
+            foreach (var m in t.GetMembers(name))
+            {
+                if (m.IsStatic) continue;
+                if (m.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal
+                    or Accessibility.ProtectedOrInternal))
+                    continue;
+                if (m is IPropertySymbol prop && prop.GetMethod is not null) return prop.Name;
+                if (m is IFieldSymbol f) return f.Name;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// True when <paramref name="stateType"/> exposes an accessible
+    /// (public or internal) parameterless construction path —
+    /// <c>new T()</c> compiles. Counts an explicit parameterless ctor
+    /// as well as an all-defaulted-params ctor (e.g.
+    /// <c>TimePickerState(int initialHour = 12, …)</c>). Also accepts
+    /// the implicit ctor when no instance ctors are declared.
+    /// </summary>
+    static bool HasAccessibleParameterlessConstructor(INamedTypeSymbol stateType)
+    {
+        var ctors = stateType.InstanceConstructors;
+        if (ctors.Length == 0) return true;
+        foreach (var c in ctors)
+        {
+            if (c.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal
+                or Accessibility.ProtectedOrInternal))
+                continue;
+            if (c.Parameters.Length == 0) return true;
+            if (c.Parameters.All(p => p.HasExplicitDefaultValue)) return true;
+        }
+        return false;
+    }
+
     static bool HasMethodBody(IMethodSymbol method)
     {
         if (HasBodyInRefs(method)) return true;
@@ -1095,7 +1225,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         public FacadeSlot(IParameterSymbol param, FacadeSlotKind kind,
             ITypeSymbol? callbackType = null, string? slotPropertyName = null,
             string? rememberMethodName = null, INamedTypeSymbol? stateWrapperType = null,
-            ITypeSymbol? stateJvmType = null)
+            ITypeSymbol? stateJvmType = null, string[]? rememberArgExpressions = null)
         {
             Param = param;
             Kind = kind;
@@ -1104,6 +1234,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             RememberMethodName = rememberMethodName;
             StateWrapperType = stateWrapperType;
             StateJvmType = stateJvmType;
+            RememberArgExpressions = rememberArgExpressions ?? System.Array.Empty<string>();
         }
         public IParameterSymbol Param { get; }
         public FacadeSlotKind Kind { get; }
@@ -1112,14 +1243,25 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         public string? RememberMethodName { get; }
         public INamedTypeSymbol? StateWrapperType { get; }
         public ITypeSymbol? StateJvmType { get; }
+        /// <summary>
+        /// Phase 4b — one C# expression per user parameter of the
+        /// <c>Remember*State</c> bridge (composer excluded). Each expression
+        /// reads a member of the caller-supplied state wrapper, e.g.
+        /// <c>_state!.InitialHour</c>. Empty when the Remember bridge has
+        /// zero user params (Phase 4).
+        /// </summary>
+        public string[] RememberArgExpressions { get; }
         public bool HasSlotAttribute => SlotPropertyName is not null;
         public bool IsNullableSlot => Param.NullableAnnotation == NullableAnnotation.Annotated
             && KindIsFnSlot(Kind);
+        public bool IsParameterisedStateHolder =>
+            Kind == FacadeSlotKind.StateHolder && RememberArgExpressions.Length > 0;
         static bool KindIsFnSlot(FacadeSlotKind k) =>
             k is FacadeSlotKind.Content2 or FacadeSlotKind.Content3
               or FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3
               or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3;
         public FacadeSlot WithKind(FacadeSlotKind newKind) =>
-            new(Param, newKind, CallbackType, SlotPropertyName, RememberMethodName, StateWrapperType, StateJvmType);
+            new(Param, newKind, CallbackType, SlotPropertyName, RememberMethodName,
+                StateWrapperType, StateJvmType, RememberArgExpressions);
     }
 }


### PR DESCRIPTION
Extends `ComposeFacadeGenerator` to accept `RememberXxxState` bridges
with user parameters (in addition to the trailing `IComposer`), then
converts `TimePicker.cs` to a 3-line `[ComposeFacade]` stub.

### How it works

Each Remember user parameter is resolved to a readable instance member
on `StateType` by:

1. PascalCase exact match (`initialHour` → `InitialHour`)
2. `Initial<PascalCase>` fallback (`is24Hour` → `Is24Hour` then
   `InitialIs24Hour`)

The PascalCase-first rule lets a wrapper's live getter that falls back
to its initial-value backing field be the natural match — at
remember-time `Jvm` is still null, so a getter like
`Is24Hour => Jvm?.Is24hour() ?? InitialIs24Hour` returns the initial
value correctly.

Parameterised StateHolder auto-creates the wrapper in the facade ctor
(`_state = state ?? new T()`), so `_state` is guaranteed non-null in
`Render` and `Jvm` population is unguarded. Requires `StateType` to be
constructible with no arguments (declared parameterless ctor, or a
ctor with all-defaulted params).

The zero-user-param Phase 4 path (`DatePicker`, `DateRangePicker`) is
unchanged: `_state` stays nullable, `Jvm` only populates when the
caller supplies a wrapper.

### TimePicker conversion

Before (29 lines):

```csharp
public sealed class TimePicker : ComposableNode
{
    readonly TimePickerState _state;
    public TimePicker(TimePickerState? state = null) =>
        _state = state ?? new TimePickerState();

    internal override void Render(IComposer composer)
    {
        var stateHandle = ComposeBridges.RememberTimePickerState(
            _state.InitialHour, _state.InitialMinute,
            _state.InitialIs24Hour, composer);
        if (_state.Jvm is null)
            _state.Jvm = Java.Lang.Object.GetObject<ITimePickerState>(
                stateHandle, JniHandleOwnership.DoNotTransfer)!;
        var modifier = BuildModifier();
        int defaults = (int)TimePickerDefault.All;
        if (modifier is not null) defaults &= ~(int)TimePickerDefault.Modifier;
        ComposeBridges.TimePicker(stateHandle, modifier, defaults, composer);
    }
}
```

After (3 lines + bridge attribute):

```csharp
public sealed partial class TimePicker;
```

```csharp
[ComposeBridge(...) Defaults = typeof(TimePickerDefault))]
[ComposeFacade]
public static partial void TimePicker(
    [StateHolder(Remember = nameof(RememberTimePickerState),
                 StateType = typeof(TimePickerState))] IntPtr state,
    IModifier? modifier,
    int defaults, IComposer composer);
```

Generated emit matches the hand-written behaviour byte-for-byte.

### Tests

- `TimePicker_ParameterisedStateHolder_GeneratesAutoCreateAndArgs` —
  happy path
- `ParameterisedStateHolder_UnresolvedMember_FailsCN3009` — Remember
  arg can't be resolved as `Pascal` or `Initial<Pascal>` member
- `ParameterisedStateHolder_NoParameterlessCtor_FailsCN3009` —
  `StateType` lacks a callable parameterless ctor
- `StateHolder_Phase4_StillEmitsGuardedJvmPopulation` — regression
  guard for the existing Phase 4 emit shape

87/87 tests pass. `dotnet build src/ComposeNet.Sample` succeeds.

### Why not the other parameterised remembers

Phase 4b deliberately stops at `TimePicker`. The remaining
state-holder facades need machinery Phase 4b doesn't model:

- `TimeInput` — shares state with `TimePicker` (sibling-facade
  caching)
- `SearchBar` family — shared-state caching across multiple facades
- `ModalBottomSheet`, `BottomSheetScaffold` — need a per-instance
  `confirmValueChange` veto adapter (drawer pattern) on top of
  parameterised Remember
- `SnackbarHost` — no `Remember` call at all; caller pre-creates the
  state via `Remember(() => new ...)`

Progress on #67.