### PR TITLE
Expand modifier surface for issue #63 — scope alignment, gestures, focus, semantics

### DIFF
--- a/src/ComposeNet.Compose/Alignment.cs
+++ b/src/ComposeNet.Compose/Alignment.cs
@@ -1,0 +1,84 @@
+using AndroidX.Compose.UI;
+
+namespace ComposeNet;
+
+/// <summary>
+/// C# wrapper around the <c>androidx.compose.ui.Alignment</c> singletons
+/// exposed by Kotlin's <c>Alignment.Companion</c> object. Each public
+/// static property forwards to the bound
+/// <c>AndroidX.Compose.UI.IAlignment.Companion</c> singleton and caches
+/// the wrapper for the lifetime of the process.
+///
+/// Use these with <see cref="Modifier.Align(ComposeNet.Alignment)"/>
+/// inside a <see cref="Box"/> child to position the child within the
+/// parent. Use the nested <see cref="Vertical"/> singletons inside a
+/// <see cref="Row"/> and the nested <see cref="Horizontal"/> singletons
+/// inside a <see cref="Column"/>.
+/// </summary>
+public sealed class Alignment
+{
+    internal IAlignment Java { get; }
+
+    Alignment(IAlignment java) => Java = java;
+
+    static Alignment? s_topStart, s_topCenter, s_topEnd, s_centerStart, s_center, s_centerEnd, s_bottomStart, s_bottomCenter, s_bottomEnd;
+
+    /// <summary><c>Alignment.TopStart</c> — top-left in LTR, top-right in RTL.</summary>
+    public static Alignment TopStart => s_topStart ??= new Alignment(IAlignment.Companion.TopStart);
+    /// <summary><c>Alignment.TopCenter</c> — top-center.</summary>
+    public static Alignment TopCenter => s_topCenter ??= new Alignment(IAlignment.Companion.TopCenter);
+    /// <summary><c>Alignment.TopEnd</c> — top-right in LTR, top-left in RTL.</summary>
+    public static Alignment TopEnd => s_topEnd ??= new Alignment(IAlignment.Companion.TopEnd);
+    /// <summary><c>Alignment.CenterStart</c> — vertically centered, leading edge.</summary>
+    public static Alignment CenterStart => s_centerStart ??= new Alignment(IAlignment.Companion.CenterStart);
+    /// <summary><c>Alignment.Center</c> — centered both axes.</summary>
+    public static Alignment Center => s_center ??= new Alignment(IAlignment.Companion.Center);
+    /// <summary><c>Alignment.CenterEnd</c> — vertically centered, trailing edge.</summary>
+    public static Alignment CenterEnd => s_centerEnd ??= new Alignment(IAlignment.Companion.CenterEnd);
+    /// <summary><c>Alignment.BottomStart</c> — bottom-left in LTR, bottom-right in RTL.</summary>
+    public static Alignment BottomStart => s_bottomStart ??= new Alignment(IAlignment.Companion.BottomStart);
+    /// <summary><c>Alignment.BottomCenter</c> — bottom-center.</summary>
+    public static Alignment BottomCenter => s_bottomCenter ??= new Alignment(IAlignment.Companion.BottomCenter);
+    /// <summary><c>Alignment.BottomEnd</c> — bottom-right in LTR, bottom-left in RTL.</summary>
+    public static Alignment BottomEnd => s_bottomEnd ??= new Alignment(IAlignment.Companion.BottomEnd);
+
+    /// <summary>
+    /// Vertical-only alignment singletons (<c>Alignment.Vertical</c>) for
+    /// use with <see cref="Modifier.Align(ComposeNet.Alignment.Vertical)"/>
+    /// inside a <see cref="Row"/>.
+    /// </summary>
+    public sealed class Vertical
+    {
+        internal IAlignmentVertical Java { get; }
+        Vertical(IAlignmentVertical java) => Java = java;
+
+        static Vertical? s_top, s_center, s_bottom;
+
+        /// <summary><c>Alignment.Top</c> — align to the top of the row.</summary>
+        public static Vertical Top => s_top ??= new Vertical(IAlignment.Companion.Top);
+        /// <summary><c>Alignment.CenterVertically</c> — align to the vertical center.</summary>
+        public static Vertical CenterVertically => s_center ??= new Vertical(IAlignment.Companion.CenterVertically);
+        /// <summary><c>Alignment.Bottom</c> — align to the bottom of the row.</summary>
+        public static Vertical Bottom => s_bottom ??= new Vertical(IAlignment.Companion.Bottom);
+    }
+
+    /// <summary>
+    /// Horizontal-only alignment singletons (<c>Alignment.Horizontal</c>)
+    /// for use with <see cref="Modifier.Align(ComposeNet.Alignment.Horizontal)"/>
+    /// inside a <see cref="Column"/>.
+    /// </summary>
+    public sealed class Horizontal
+    {
+        internal IAlignmentHorizontal Java { get; }
+        Horizontal(IAlignmentHorizontal java) => Java = java;
+
+        static Horizontal? s_start, s_center, s_end;
+
+        /// <summary><c>Alignment.Start</c> — align to the leading edge.</summary>
+        public static Horizontal Start => s_start ??= new Horizontal(IAlignment.Companion.Start);
+        /// <summary><c>Alignment.CenterHorizontally</c> — align to the horizontal center.</summary>
+        public static Horizontal CenterHorizontally => s_center ??= new Horizontal(IAlignment.Companion.CenterHorizontally);
+        /// <summary><c>Alignment.End</c> — align to the trailing edge.</summary>
+        public static Horizontal End => s_end ??= new Horizontal(IAlignment.Companion.End);
+    }
+}

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1699,6 +1699,230 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/Modifier;")]
     internal static partial IntPtr ModifierTestTag(IntPtr modifier, string tag);
 
+    // androidx.compose.foundation.FocusableKt.focusable$default —
+    // non-@Composable Modifier extension. Kotlin params after the
+    // receiver: enabled (Boolean), interactionSource (MutableInteractionSource).
+    // The C# wrapper always supplies enabled; interactionSource is left
+    // to Kotlin's default (Compose allocates one per-call).
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/FocusableKt",
+        JvmName   = "focusable$default",
+        Signature = "(Landroidx/compose/ui/Modifier;Z" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierFocusableDefault))]
+    internal static partial IntPtr ModifierFocusable(IntPtr modifier, bool enabled);
+
+    // androidx.compose.foundation.FocusableKt.focusGroup(Modifier) —
+    // groups focusable descendants so two-dimensional focus search
+    // treats them as a single unit. No defaults.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/FocusableKt",
+        JvmName   = "focusGroup",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierFocusGroup(IntPtr modifier);
+
+    // androidx.compose.ui.focus.FocusChangedModifierKt.onFocusChanged —
+    // (Modifier, Function1<FocusState, Unit>). No defaults — the
+    // listener is always supplied by the caller.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/focus/FocusChangedModifierKt",
+        JvmName   = "onFocusChanged",
+        Signature = "(Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)" +
+                    "Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierOnFocusChanged(IntPtr modifier, IFunction1 onFocusChanged);
+
+    // androidx.compose.ui.focus.FocusRequesterModifierKt.focusRequester —
+    // (Modifier, FocusRequester). No defaults.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/focus/FocusRequesterModifierKt",
+        JvmName   = "focusRequester",
+        Signature = "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/focus/FocusRequester;)" +
+                    "Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierFocusRequester(IntPtr modifier, IntPtr focusRequester);
+
+    // androidx.compose.foundation.ClickableKt.combinedClickable-cJG_KMw$default —
+    // the no-MutableInteractionSource overload. 7 Kotlin params after
+    // the receiver: enabled, onClickLabel, role, onLongClickLabel,
+    // onLongClick, onDoubleClick, onClick. C# wrapper always supplies
+    // onClick (bit 6 cleared); other bits are toggled per-call based
+    // on which arguments the caller passed.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/ClickableKt",
+        JvmName   = "combinedClickable-cJG_KMw$default",
+        Signature = "(Landroidx/compose/ui/Modifier;ZLjava/lang/String;" +
+                    "Landroidx/compose/ui/semantics/Role;Ljava/lang/String;" +
+                    "Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;" +
+                    "Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierCombinedClickableDefault))]
+    internal static partial IntPtr ModifierCombinedClickable(
+        IntPtr modifier,
+        IFunction0? onLongClick,
+        IFunction0? onDoubleClick,
+        IFunction0  onClick);
+
+    // androidx.compose.foundation.selection.SelectableKt.selectable-XHw0xAI$default —
+    // 4 Kotlin params after the receiver: selected, enabled, role, onClick.
+    // C# wrapper always supplies selected + onClick.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/selection/SelectableKt",
+        JvmName   = "selectable-XHw0xAI$default",
+        Signature = "(Landroidx/compose/ui/Modifier;ZZ" +
+                    "Landroidx/compose/ui/semantics/Role;" +
+                    "Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierSelectableDefault))]
+    internal static partial IntPtr ModifierSelectable(
+        IntPtr modifier, bool selected, IFunction0 onClick);
+
+    // androidx.compose.foundation.selection.ToggleableKt.toggleable-XHw0xAI$default —
+    // 4 Kotlin params after the receiver: value (Bool), enabled, role,
+    // onValueChange (Function1<Boolean, Unit>). C# wrapper always
+    // supplies value + onValueChange.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/selection/ToggleableKt",
+        JvmName   = "toggleable-XHw0xAI$default",
+        Signature = "(Landroidx/compose/ui/Modifier;ZZ" +
+                    "Landroidx/compose/ui/semantics/Role;" +
+                    "Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierToggleableDefault))]
+    internal static partial IntPtr ModifierToggleable(
+        IntPtr modifier, bool value, IFunction1 onValueChange);
+
+    // androidx.compose.ui.semantics.SemanticsModifierKt.semantics$default —
+    // 2 Kotlin params after the receiver: mergeDescendants (Bool),
+    // properties (Function1<SemanticsPropertyReceiver, Unit>). The C#
+    // wrapper always supplies the properties lambda.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsModifierKt",
+        JvmName   = "semantics$default",
+        Signature = "(Landroidx/compose/ui/Modifier;Z" +
+                    "Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierSemanticsDefault))]
+    internal static partial IntPtr ModifierSemantics(
+        IntPtr modifier, bool mergeDescendants, IFunction1 properties);
+
+    // androidx.compose.ui.semantics.SemanticsModifierKt.clearAndSetSemantics —
+    // (Modifier, Function1<SemanticsPropertyReceiver, Unit>). No defaults.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsModifierKt",
+        JvmName   = "clearAndSetSemantics",
+        Signature = "(Landroidx/compose/ui/Modifier;" +
+                    "Lkotlin/jvm/functions/Function1;)" +
+                    "Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierClearAndSetSemantics(IntPtr modifier, IFunction1 properties);
+
+    // BoxScope / RowScope / ColumnScope `align` and `matchParentSize`
+    // are abstract interface methods on the scope class (no static
+    // $default helper exists — the methods themselves don't have
+    // defaults). The [ComposeBridge] generator's static/ctor/instance-
+    // field shapes don't fit, so we hand-write the JNI lookup +
+    // CallObjectMethod here. The scope handle comes from
+    // RenderContext.CurrentScope, set by the enclosing Box/Row/Column
+    // facade for the duration of its content lambda.
+    static IntPtr s_boxScopeClass;
+    static IntPtr s_boxScopeAlignMethodId;
+    static IntPtr s_boxScopeMatchParentSizeMethodId;
+
+    internal static unsafe IntPtr BoxScopeAlign(IntPtr boxScope, IntPtr modifier, IntPtr alignment)
+    {
+        if (s_boxScopeAlignMethodId == IntPtr.Zero)
+        {
+            s_boxScopeClass = JNIEnv.FindClass("androidx/compose/foundation/layout/BoxScope");
+            s_boxScopeAlignMethodId = JNIEnv.GetMethodID(
+                s_boxScopeClass, "align",
+                "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;)Landroidx/compose/ui/Modifier;");
+        }
+        var args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(alignment);
+        return JNIEnv.CallObjectMethod(boxScope, s_boxScopeAlignMethodId, args);
+    }
+
+    internal static unsafe IntPtr BoxScopeMatchParentSize(IntPtr boxScope, IntPtr modifier)
+    {
+        if (s_boxScopeMatchParentSizeMethodId == IntPtr.Zero)
+        {
+            if (s_boxScopeClass == IntPtr.Zero)
+                s_boxScopeClass = JNIEnv.FindClass("androidx/compose/foundation/layout/BoxScope");
+            s_boxScopeMatchParentSizeMethodId = JNIEnv.GetMethodID(
+                s_boxScopeClass, "matchParentSize",
+                "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;");
+        }
+        var args = stackalloc JValue[1];
+        args[0] = new JValue(modifier);
+        return JNIEnv.CallObjectMethod(boxScope, s_boxScopeMatchParentSizeMethodId, args);
+    }
+
+    static IntPtr s_rowScopeClass;
+    static IntPtr s_rowScopeAlignMethodId;
+
+    internal static unsafe IntPtr RowScopeAlignVertical(IntPtr rowScope, IntPtr modifier, IntPtr verticalAlignment)
+    {
+        if (s_rowScopeAlignMethodId == IntPtr.Zero)
+        {
+            s_rowScopeClass = JNIEnv.FindClass("androidx/compose/foundation/layout/RowScope");
+            s_rowScopeAlignMethodId = JNIEnv.GetMethodID(
+                s_rowScopeClass, "align",
+                "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment$Vertical;)Landroidx/compose/ui/Modifier;");
+        }
+        var args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(verticalAlignment);
+        return JNIEnv.CallObjectMethod(rowScope, s_rowScopeAlignMethodId, args);
+    }
+
+    static IntPtr s_columnScopeClass;
+    static IntPtr s_columnScopeAlignMethodId;
+
+    internal static unsafe IntPtr ColumnScopeAlignHorizontal(IntPtr columnScope, IntPtr modifier, IntPtr horizontalAlignment)
+    {
+        if (s_columnScopeAlignMethodId == IntPtr.Zero)
+        {
+            s_columnScopeClass = JNIEnv.FindClass("androidx/compose/foundation/layout/ColumnScope");
+            s_columnScopeAlignMethodId = JNIEnv.GetMethodID(
+                s_columnScopeClass, "align",
+                "(Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment$Horizontal;)Landroidx/compose/ui/Modifier;");
+        }
+        var args = stackalloc JValue[2];
+        args[0] = new JValue(modifier);
+        args[1] = new JValue(horizontalAlignment);
+        return JNIEnv.CallObjectMethod(columnScope, s_columnScopeAlignMethodId, args);
+    }
+
+    // androidx.compose.ui.focus.FocusRequester.requestFocus()V —
+    // the no-arg overload the binding doesn't surface (it only exposed
+    // the parameterised `requestFocus-3ESFkO8(int):Boolean`). Wrapped
+    // hand-written because [ComposeBridge] doesn't support instance
+    // method calls.
+    static IntPtr s_focusRequesterClass;
+    static IntPtr s_focusRequesterRequestFocusMethodId;
+
+    internal static void FocusRequesterRequestFocus(IntPtr focusRequester)
+    {
+        if (s_focusRequesterRequestFocusMethodId == IntPtr.Zero)
+        {
+            s_focusRequesterClass = JNIEnv.FindClass("androidx/compose/ui/focus/FocusRequester");
+            s_focusRequesterRequestFocusMethodId = JNIEnv.GetMethodID(
+                s_focusRequesterClass, "requestFocus", "()V");
+        }
+        JNIEnv.CallVoidMethod(focusRequester, s_focusRequesterRequestFocusMethodId);
+    }
+
+    // androidx.compose.ui.semantics.SemanticsPropertiesKt.setContentDescription(
+    //   SemanticsPropertyReceiver, String) — called from inside the
+    // Function1 body built by Modifier.Semantics(string)/.ClearAndSetSemantics(string).
+    // Static helper, no $default — wrap with the bridge generator.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsPropertiesKt",
+        JvmName   = "setContentDescription",
+        Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;" +
+                    "Ljava/lang/String;)V")]
+    internal static partial void SemanticsSetContentDescription(IntPtr receiver, string description);
+
     // Shape factories — additional overloads of RoundedCornerShape /
     // CutCornerShape beyond the existing Dp variant. The Int (percent)
     // overloads aren't mangled because Int isn't an inline class. The
@@ -2481,7 +2705,7 @@ internal static partial class ComposeBridges
     // call to the binding — no overload resolution magic, every arg
     // hand-picked.
 
-    [ComposeFacade(Defaults = typeof(BoxDefault))]
+    [ComposeFacade(Defaults = typeof(BoxDefault), Scope = "Box")]
     public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
 
     public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -352,6 +352,43 @@ using ComposeNet;
 [assembly: ComposeDefaults("ModifierClickableDefault",
     "enabled", "onClickLabel", "role", "!onClick")]
 
+// androidx.compose.foundation.ClickableKt.combinedClickable-cJG_KMw$default —
+// non-@Composable Modifier extension (no MutableInteractionSource overload).
+// 7 Kotlin params after the receiver. The C# wrapper always supplies
+// onClick (bit 6 always cleared); enabled / onClickLabel / role / onLongClickLabel
+// are left to Kotlin's defaults; the optional onLongClick / onDoubleClick
+// slots are auto-cleared per-call when the caller passes a non-null
+// IFunction0 (Kotlin requires nullability here — a null callback DOES
+// substitute Kotlin's default of "ignore that gesture").
+[assembly: ComposeDefaults("ModifierCombinedClickableDefault",
+    "enabled", "onClickLabel", "role", "onLongClickLabel",
+    "onLongClick", "onDoubleClick", "!onClick")]
+
+// androidx.compose.foundation.selection.SelectableKt.selectable-XHw0xAI$default —
+// 4 Kotlin params after the receiver: selected, enabled, role, onClick.
+// C# wrapper always supplies selected + onClick.
+[assembly: ComposeDefaults("ModifierSelectableDefault",
+    "!selected", "enabled", "role", "!onClick")]
+
+// androidx.compose.foundation.selection.ToggleableKt.toggleable-XHw0xAI$default —
+// 4 Kotlin params after the receiver: value, enabled, role, onValueChange.
+// C# wrapper always supplies value + onValueChange.
+[assembly: ComposeDefaults("ModifierToggleableDefault",
+    "!value", "enabled", "role", "!onValueChange")]
+
+// androidx.compose.foundation.FocusableKt.focusable$default — 2 Kotlin
+// params after the receiver: enabled (always supplied by C#) and
+// interactionSource (left to Kotlin's default).
+[assembly: ComposeDefaults("ModifierFocusableDefault",
+    "!enabled", "interactionSource")]
+
+// androidx.compose.ui.semantics.SemanticsModifierKt.semantics$default —
+// 2 Kotlin params after the receiver: mergeDescendants (always supplied
+// by the C# wrapper, the `Semantics(string)` helper hard-codes `false`)
+// and properties (the configuration Function1, always supplied).
+[assembly: ComposeDefaults("ModifierSemanticsDefault",
+    "mergeDescendants", "!properties")]
+
 // androidx.compose.foundation.ScrollKt.verticalScroll$default —
 // non-@Composable Modifier extension. 4 Kotlin params after the
 // receiver: state, enabled, flingBehavior, reverseScrolling. The C#

--- a/src/ComposeNet.Compose/FocusRequester.cs
+++ b/src/ComposeNet.Compose/FocusRequester.cs
@@ -1,0 +1,54 @@
+using Android.Runtime;
+using JFocusRequester = AndroidX.Compose.UI.Focus.FocusRequester;
+
+namespace ComposeNet;
+
+/// <summary>
+/// C# wrapper around <c>androidx.compose.ui.focus.FocusRequester</c>.
+/// Pair it with <see cref="Modifier.FocusRequester(ComposeNet.FocusRequester)"/>
+/// to install the requester on a focusable node, then call
+/// <see cref="RequestFocus"/> (e.g. from a button click) to programmatically
+/// move focus there.
+///
+/// <para>
+/// Holds a Compose <c>FocusRequester</c> instance. The instance must
+/// outlive the composition that wired it — store one
+/// <see cref="FocusRequester"/> per logical focus target on the activity
+/// (or on a state holder) and reuse the same instance across renders.
+/// Constructing a new instance per recomposition would silently drop
+/// any pending request.
+/// </para>
+/// </summary>
+public sealed class FocusRequester
+{
+    internal JFocusRequester Java { get; }
+
+    /// <summary>
+    /// Construct a new focus requester. Allocates a fresh Compose
+    /// <c>FocusRequester</c> instance.
+    /// </summary>
+    public FocusRequester() => Java = new JFocusRequester();
+
+    /// <summary>
+    /// Equivalent to Kotlin's no-arg <c>focusRequester.requestFocus()</c> —
+    /// asks Compose to move focus to the node currently wearing this
+    /// requester. Safe to call from event handlers (button clicks,
+    /// LaunchedEffect bodies, etc.). The .NET binding does not surface
+    /// the no-arg overload, so we call it directly via JNI.
+    /// </summary>
+    public void RequestFocus() =>
+        ComposeBridges.FocusRequesterRequestFocus(((Java.Lang.Object)Java).Handle);
+
+    /// <summary>
+    /// Captures focus on the node — input is pinned here until
+    /// <see cref="FreeFocus"/> is called. Returns <c>true</c> if the
+    /// capture succeeded.
+    /// </summary>
+    public bool CaptureFocus() => Java.CaptureFocus();
+
+    /// <summary>
+    /// Releases a previously-<see cref="CaptureFocus">captured</see>
+    /// focus. Returns <c>true</c> if focus was released.
+    /// </summary>
+    public bool FreeFocus() => Java.FreeFocus();
+}

--- a/src/ComposeNet.Compose/FocusState.cs
+++ b/src/ComposeNet.Compose/FocusState.cs
@@ -1,0 +1,47 @@
+using AndroidX.Compose.UI.Focus;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Immutable snapshot of a Compose <c>FocusState</c>. Produced inside
+/// the callback passed to
+/// <see cref="Modifier.OnFocusChanged(System.Action{ComposeNet.FocusState})"/>
+/// — Compose reuses one <c>FocusState</c> JNI instance per node and
+/// mutates it across recompositions, so we read all three booleans
+/// once and hand back a value type the caller can keep without worrying
+/// about peer lifetime.
+/// </summary>
+public readonly struct FocusState
+{
+    /// <summary>
+    /// <c>true</c> if the node owning the modifier currently has focus.
+    /// </summary>
+    public bool IsFocused { get; }
+
+    /// <summary>
+    /// <c>true</c> if focus is held by this node or any of its
+    /// descendants (mirrors Kotlin's <c>FocusState.hasFocus</c>).
+    /// </summary>
+    public bool HasFocus { get; }
+
+    /// <summary>
+    /// <c>true</c> if focus was captured via
+    /// <c>FocusRequester.captureFocus()</c> — keystrokes are pinned
+    /// to this node until <c>freeFocus()</c> is called.
+    /// </summary>
+    public bool IsCaptured { get; }
+
+    /// <summary>
+    /// Construct a snapshot directly. Public so test code can build
+    /// fixtures without going through JNI.
+    /// </summary>
+    public FocusState(bool isFocused, bool hasFocus, bool isCaptured)
+    {
+        IsFocused = isFocused;
+        HasFocus = hasFocus;
+        IsCaptured = isCaptured;
+    }
+
+    internal static FocusState From(IFocusState state) =>
+        new(state.IsFocused, state.HasFocus, state.IsCaptured);
+}

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -758,8 +758,9 @@ public sealed class Modifier
         System.ArgumentNullException.ThrowIfNull(onFocusChanged);
         var f1 = new ComposableLambda1(arg =>
         {
-            if (arg is AndroidX.Compose.UI.Focus.IFocusState fs)
-                onFocusChanged(FocusState.From(fs));
+            if (arg is null) return;
+            var fs = Android.Runtime.Extensions.JavaCast<AndroidX.Compose.UI.Focus.IFocusState>(arg);
+            onFocusChanged(FocusState.From(fs));
         });
         return Append(curr => ComposeBridges.ModifierOnFocusChanged(curr, f1));
     }

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -657,6 +657,225 @@ public sealed class Modifier
     }
 
     /// <summary>
+    /// <c>Modifier.align(alignment)</c> — positions the child within
+    /// a parent <see cref="Box"/>. Only valid inside a <see cref="Box"/>
+    /// (any container that publishes <see cref="ScopeKind.Box"/>).
+    /// </summary>
+    public Modifier Align(Alignment alignment)
+    {
+        System.ArgumentNullException.ThrowIfNull(alignment);
+        return Append(curr =>
+        {
+            IntPtr scope = RenderContext.CurrentScope;
+            if (RenderContext.CurrentScopeKind != ScopeKind.Box)
+                throw new System.InvalidOperationException(
+                    "Modifier.Align(Alignment) is only valid inside a Box. " +
+                    $"Current scope kind: {RenderContext.CurrentScopeKind}.");
+            return ComposeBridges.BoxScopeAlign(scope, curr, ((Java.Lang.Object)alignment.Java).Handle);
+        });
+    }
+
+    /// <summary>
+    /// <c>Modifier.align(alignment)</c> for a Row child — aligns the
+    /// child vertically within the row. Only valid inside a
+    /// <see cref="Row"/>.
+    /// </summary>
+    public Modifier Align(Alignment.Vertical alignment)
+    {
+        System.ArgumentNullException.ThrowIfNull(alignment);
+        return Append(curr =>
+        {
+            IntPtr scope = RenderContext.CurrentScope;
+            if (RenderContext.CurrentScopeKind != ScopeKind.Row)
+                throw new System.InvalidOperationException(
+                    "Modifier.Align(Alignment.Vertical) is only valid inside a Row. " +
+                    $"Current scope kind: {RenderContext.CurrentScopeKind}.");
+            return ComposeBridges.RowScopeAlignVertical(scope, curr, ((Java.Lang.Object)alignment.Java).Handle);
+        });
+    }
+
+    /// <summary>
+    /// <c>Modifier.align(alignment)</c> for a Column child — aligns the
+    /// child horizontally within the column. Only valid inside a
+    /// <see cref="Column"/>.
+    /// </summary>
+    public Modifier Align(Alignment.Horizontal alignment)
+    {
+        System.ArgumentNullException.ThrowIfNull(alignment);
+        return Append(curr =>
+        {
+            IntPtr scope = RenderContext.CurrentScope;
+            if (RenderContext.CurrentScopeKind != ScopeKind.Column)
+                throw new System.InvalidOperationException(
+                    "Modifier.Align(Alignment.Horizontal) is only valid inside a Column. " +
+                    $"Current scope kind: {RenderContext.CurrentScopeKind}.");
+            return ComposeBridges.ColumnScopeAlignHorizontal(scope, curr, ((Java.Lang.Object)alignment.Java).Handle);
+        });
+    }
+
+    /// <summary>
+    /// <c>Modifier.matchParentSize()</c> — sizes the child to match
+    /// the parent <see cref="Box"/>'s measured size without
+    /// participating in measurement. Only valid inside a
+    /// <see cref="Box"/>.
+    /// </summary>
+    public Modifier MatchParentSize() =>
+        Append(curr =>
+        {
+            IntPtr scope = RenderContext.CurrentScope;
+            if (RenderContext.CurrentScopeKind != ScopeKind.Box)
+                throw new System.InvalidOperationException(
+                    "Modifier.MatchParentSize() is only valid inside a Box. " +
+                    $"Current scope kind: {RenderContext.CurrentScopeKind}.");
+            return ComposeBridges.BoxScopeMatchParentSize(scope, curr);
+        });
+
+    /// <summary>
+    /// <c>Modifier.focusable(enabled = true)</c> — marks the node as a
+    /// focus target. Combine with <see cref="FocusRequester(ComposeNet.FocusRequester)"/>
+    /// to programmatically move focus, or with
+    /// <see cref="OnFocusChanged(System.Action{ComposeNet.FocusState})"/>
+    /// to observe focus changes.
+    /// </summary>
+    public Modifier Focusable(bool enabled = true) =>
+        Append(curr => ComposeBridges.ModifierFocusable(curr, enabled));
+
+    /// <summary>
+    /// <c>Modifier.focusGroup()</c> — groups focusable descendants so
+    /// two-dimensional focus search treats them as a single unit.
+    /// </summary>
+    public Modifier FocusGroup() =>
+        Append(curr => ComposeBridges.ModifierFocusGroup(curr));
+
+    /// <summary>
+    /// <c>Modifier.onFocusChanged { ... }</c> — invokes <paramref name="onFocusChanged"/>
+    /// whenever the node gains, loses, or has its focus state mutated
+    /// (capture / release). The callback receives an immutable
+    /// <see cref="FocusState"/> snapshot.
+    /// </summary>
+    public Modifier OnFocusChanged(System.Action<FocusState> onFocusChanged)
+    {
+        System.ArgumentNullException.ThrowIfNull(onFocusChanged);
+        var f1 = new ComposableLambda1(arg =>
+        {
+            if (arg is AndroidX.Compose.UI.Focus.IFocusState fs)
+                onFocusChanged(FocusState.From(fs));
+        });
+        return Append(curr => ComposeBridges.ModifierOnFocusChanged(curr, f1));
+    }
+
+    /// <summary>
+    /// <c>Modifier.focusRequester(requester)</c> — installs
+    /// <paramref name="requester"/> on the node so the caller can
+    /// programmatically move focus by calling
+    /// <see cref="ComposeNet.FocusRequester.RequestFocus"/>.
+    /// </summary>
+    public Modifier FocusRequester(FocusRequester requester)
+    {
+        System.ArgumentNullException.ThrowIfNull(requester);
+        return Append(curr =>
+            ComposeBridges.ModifierFocusRequester(curr, ((Java.Lang.Object)requester.Java).Handle));
+    }
+
+    /// <summary>
+    /// <c>Modifier.combinedClickable(...)</c> — clickable with optional
+    /// long-press and double-tap handlers. <paramref name="onClick"/> is
+    /// required; pass <c>null</c> for either of the other two to fall
+    /// back to Kotlin's "ignore that gesture" defaults.
+    /// </summary>
+    public Modifier CombinedClickable(
+        System.Action onClick,
+        System.Action? onLongClick = null,
+        System.Action? onDoubleClick = null)
+    {
+        System.ArgumentNullException.ThrowIfNull(onClick);
+        var click = new ComposableLambda0(onClick);
+        var longClick = onLongClick is null ? null : new ComposableLambda0(onLongClick);
+        var doubleClick = onDoubleClick is null ? null : new ComposableLambda0(onDoubleClick);
+        return Append(curr =>
+            ComposeBridges.ModifierCombinedClickable(curr, longClick, doubleClick, click));
+    }
+
+    /// <summary>
+    /// <c>Modifier.selectable(selected, onClick)</c> — marks the node
+    /// as a selectable choice in a single-selection group (e.g. a
+    /// radio button group). Sets up the right accessibility semantics
+    /// and forwards taps to <paramref name="onClick"/>.
+    /// </summary>
+    public Modifier Selectable(bool selected, System.Action onClick)
+    {
+        System.ArgumentNullException.ThrowIfNull(onClick);
+        var click = new ComposableLambda0(onClick);
+        return Append(curr =>
+            ComposeBridges.ModifierSelectable(curr, selected, click));
+    }
+
+    /// <summary>
+    /// <c>Modifier.toggleable(value, onValueChange)</c> — marks the
+    /// node as a binary toggle (e.g. a checkbox row). Sets up the
+    /// right accessibility semantics and forwards taps to
+    /// <paramref name="onValueChange"/> with the negated value.
+    /// </summary>
+    public Modifier Toggleable(bool value, System.Action<bool> onValueChange)
+    {
+        System.ArgumentNullException.ThrowIfNull(onValueChange);
+        var f1 = new ComposableLambda1(arg =>
+        {
+            bool v = arg is Java.Lang.Boolean jb && jb.BooleanValue();
+            onValueChange(v);
+        });
+        return Append(curr =>
+            ComposeBridges.ModifierToggleable(curr, value, f1));
+    }
+
+    /// <summary>
+    /// <c>Modifier.semantics { contentDescription = ... }</c> — adds
+    /// a content description for accessibility (TalkBack reads it
+    /// aloud when the node is focused). Doesn't merge descendant
+    /// semantics; call the overload taking <c>mergeDescendants</c> for
+    /// that.
+    /// </summary>
+    public Modifier Semantics(string contentDescription) =>
+        Semantics(mergeDescendants: false, contentDescription);
+
+    /// <summary>
+    /// <c>Modifier.semantics(mergeDescendants) { contentDescription = ... }</c> —
+    /// set <paramref name="mergeDescendants"/> to <c>true</c> for a
+    /// container that should announce itself instead of its children
+    /// (e.g. a card with a label and a value).
+    /// </summary>
+    public Modifier Semantics(bool mergeDescendants, string contentDescription)
+    {
+        System.ArgumentNullException.ThrowIfNull(contentDescription);
+        var properties = new ComposableLambda1(arg =>
+        {
+            if (arg is Java.Lang.Object obj)
+                ComposeBridges.SemanticsSetContentDescription(obj.Handle, contentDescription);
+        });
+        return Append(curr =>
+            ComposeBridges.ModifierSemantics(curr, mergeDescendants, properties));
+    }
+
+    /// <summary>
+    /// <c>Modifier.clearAndSetSemantics { contentDescription = ... }</c> —
+    /// like <see cref="Semantics(string)"/>, but discards the
+    /// descendant semantics first. Use when a custom composable
+    /// should appear as a single accessibility node with a curated
+    /// description, hiding implementation details.
+    /// </summary>
+    public Modifier ClearAndSetSemantics(string contentDescription)
+    {
+        System.ArgumentNullException.ThrowIfNull(contentDescription);
+        var properties = new ComposableLambda1(arg =>
+        {
+            if (arg is Java.Lang.Object obj)
+                ComposeBridges.SemanticsSetContentDescription(obj.Handle, contentDescription);
+        });
+        return Append(curr =>
+            ComposeBridges.ModifierClearAndSetSemantics(curr, properties));
+    }
+
+    /// <summary>
     /// Materialize the chain into a managed <c>IModifier</c> wrapper.
     /// Returns <c>null</c> when the chain is empty (no ops appended) so
     /// callers can keep the Kotlin <c>$default</c> bit set and let

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -1,5 +1,4 @@
 #nullable enable
-
 ~override ComposeNet.TextAlign.Equals(object obj) -> bool
 ~override ComposeNet.TextAlign.ToString() -> string
 ComposeNet.AlertDialog
@@ -14,6 +13,9 @@ ComposeNet.AlertDialog.Text.get -> ComposeNet.ComposableNode?
 ComposeNet.AlertDialog.Text.set -> void
 ComposeNet.AlertDialog.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.AlertDialog.Title.set -> void
+ComposeNet.Alignment
+ComposeNet.Alignment.Horizontal
+ComposeNet.Alignment.Vertical
 ComposeNet.Arrangement
 ComposeNet.AssistChip
 ComposeNet.AssistChip.AssistChip(System.Action! onClick) -> void
@@ -221,6 +223,17 @@ ComposeNet.FlexibleBottomAppBar
 ComposeNet.FlexibleBottomAppBar.FlexibleBottomAppBar() -> void
 ComposeNet.FloatingActionButton
 ComposeNet.FloatingActionButton.FloatingActionButton(System.Action! onClick) -> void
+ComposeNet.FocusRequester
+ComposeNet.FocusRequester.CaptureFocus() -> bool
+ComposeNet.FocusRequester.FocusRequester() -> void
+ComposeNet.FocusRequester.FreeFocus() -> bool
+ComposeNet.FocusRequester.RequestFocus() -> void
+ComposeNet.FocusState
+ComposeNet.FocusState.FocusState() -> void
+ComposeNet.FocusState.FocusState(bool isFocused, bool hasFocus, bool isCaptured) -> void
+ComposeNet.FocusState.HasFocus.get -> bool
+ComposeNet.FocusState.IsCaptured.get -> bool
+ComposeNet.FocusState.IsFocused.get -> bool
 ComposeNet.FontWeight
 ComposeNet.GridCells
 ComposeNet.HorizontalCenteredHeroCarousel<T>
@@ -381,27 +394,37 @@ ComposeNet.ModalWideNavigationRail.Header.set -> void
 ComposeNet.ModalWideNavigationRail.ModalWideNavigationRail() -> void
 ComposeNet.Modifier
 ComposeNet.Modifier.AbsoluteOffset(ComposeNet.Dp? x = null, ComposeNet.Dp? y = null) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Align(ComposeNet.Alignment! alignment) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Align(ComposeNet.Alignment.Horizontal! alignment) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Align(ComposeNet.Alignment.Vertical! alignment) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Alpha(float alpha) -> ComposeNet.Modifier!
 ComposeNet.Modifier.AspectRatio(float ratio, bool matchHeightConstraintsFirst = false) -> ComposeNet.Modifier!
-ComposeNet.Modifier.Background(long color) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Background(long color, ComposeNet.Shape? shape) -> ComposeNet.Modifier!
-ComposeNet.Modifier.Border(ComposeNet.Dp width, long color) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Background(long color) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Border(ComposeNet.Dp width, long color, ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Border(ComposeNet.Dp width, long color, ComposeNet.Shape? shape) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Border(ComposeNet.Dp width, long color) -> ComposeNet.Modifier!
+ComposeNet.Modifier.ClearAndSetSemantics(string! contentDescription) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clickable(System.Action! onClick) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Shape! shape) -> ComposeNet.Modifier!
+ComposeNet.Modifier.CombinedClickable(System.Action! onClick, System.Action? onLongClick = null, System.Action? onDoubleClick = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.DefaultMinSize(ComposeNet.Dp? minWidth = null, ComposeNet.Dp? minHeight = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.DisplayCutoutPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxHeight(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxSize(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxWidth(float fraction = 1) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Focusable(bool enabled = true) -> ComposeNet.Modifier!
+ComposeNet.Modifier.FocusGroup() -> ComposeNet.Modifier!
+ComposeNet.Modifier.FocusRequester(ComposeNet.FocusRequester! requester) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Height(ComposeNet.Dp height) -> ComposeNet.Modifier!
 ComposeNet.Modifier.HeightIn(ComposeNet.Dp? min = null, ComposeNet.Dp? max = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.HorizontalScroll(ComposeNet.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> ComposeNet.Modifier!
 ComposeNet.Modifier.ImePadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.MatchParentSize() -> ComposeNet.Modifier!
 ComposeNet.Modifier.NavigationBarsPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.Offset(ComposeNet.Dp? x = null, ComposeNet.Dp? y = null) -> ComposeNet.Modifier!
+ComposeNet.Modifier.OnFocusChanged(System.Action<ComposeNet.FocusState>! onFocusChanged) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Padding(ComposeNet.Dp all) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Padding(ComposeNet.Dp horizontal, ComposeNet.Dp vertical) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Padding(ComposeNet.Dp start, ComposeNet.Dp top, ComposeNet.Dp end, ComposeNet.Dp bottom) -> ComposeNet.Modifier!
@@ -413,6 +436,9 @@ ComposeNet.Modifier.Rotate(float degrees) -> ComposeNet.Modifier!
 ComposeNet.Modifier.SafeDrawingPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.Scale(float scale) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Scale(float scaleX, float scaleY) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Selectable(bool selected, System.Action! onClick) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Semantics(bool mergeDescendants, string! contentDescription) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Semantics(string! contentDescription) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Shadow(ComposeNet.Dp elevation, ComposeNet.Shape? shape = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp size) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp width, ComposeNet.Dp height) -> ComposeNet.Modifier!
@@ -421,6 +447,7 @@ ComposeNet.Modifier.StatusBarsPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.SystemBarsPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.TestTag(string! tag) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Then(ComposeNet.Modifier! other) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Toggleable(bool value, System.Action<bool>! onValueChange) -> ComposeNet.Modifier!
 ComposeNet.Modifier.VerticalScroll(ComposeNet.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Weight(float weight, bool fill = true) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Width(ComposeNet.Dp width) -> ComposeNet.Modifier!
@@ -733,6 +760,21 @@ override ComposeNet.Sp.Equals(object? obj) -> bool
 override ComposeNet.Sp.GetHashCode() -> int
 override ComposeNet.Sp.ToString() -> string!
 override ComposeNet.TextAlign.GetHashCode() -> int
+static ComposeNet.Alignment.BottomCenter.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.BottomEnd.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.BottomStart.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.Center.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.CenterEnd.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.CenterStart.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.Horizontal.CenterHorizontally.get -> ComposeNet.Alignment.Horizontal!
+static ComposeNet.Alignment.Horizontal.End.get -> ComposeNet.Alignment.Horizontal!
+static ComposeNet.Alignment.Horizontal.Start.get -> ComposeNet.Alignment.Horizontal!
+static ComposeNet.Alignment.TopCenter.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.TopEnd.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.TopStart.get -> ComposeNet.Alignment!
+static ComposeNet.Alignment.Vertical.Bottom.get -> ComposeNet.Alignment.Vertical!
+static ComposeNet.Alignment.Vertical.CenterVertically.get -> ComposeNet.Alignment.Vertical!
+static ComposeNet.Alignment.Vertical.Top.get -> ComposeNet.Alignment.Vertical!
 static ComposeNet.Arrangement.Bottom.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Center.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.End.get -> ComposeNet.Arrangement!

--- a/src/ComposeNet.Compose/ScopeKind.cs
+++ b/src/ComposeNet.Compose/ScopeKind.cs
@@ -26,6 +26,15 @@ internal enum ScopeKind
     Column,
 
     /// <summary>
+    /// The scope is an
+    /// <c>androidx.compose.foundation.layout.BoxScope</c>. Read by
+    /// alignment-extension modifiers (<c>Modifier.Align</c>,
+    /// <c>Modifier.MatchParentSize</c>) to dispatch through the right
+    /// Kotlin interface method.
+    /// </summary>
+    Box,
+
+    /// <summary>
     /// The scope is some other receiver type (e.g.
     /// <c>SingleChoiceSegmentedButtonRowScope</c>) that doesn't
     /// participate in Row/Column weight. Modifiers like

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -50,6 +50,13 @@ public class MainActivity : ComposeActivity
             var showModalRail = Remember(() => new MutableState<bool>(false));
             var modalRailIdx  = Remember(() => new MutableNumberState<int>(0));
 
+            // Issue #63: focus/toggle/semantics modifier demo state.
+            var toggle63        = Remember(() => new MutableState<bool>(false));
+            var focusReq63      = Remember(() => new FocusRequester());
+            var focusStatus63   = Remember(() => new MutableState<string>("not focused"));
+            var selectedRow63   = Remember(() => new MutableNumberState<int>(0));
+            var taps63          = Remember(() => new MutableNumberState<int>(0));
+
             var checkbox    = Remember(() => new MutableState<bool>(true));
             var switchOn    = Remember(() => new MutableState<bool>(false));
             var radioPick   = Remember(() => new MutableNumberState<int>(0));
@@ -190,6 +197,73 @@ public class MainActivity : ComposeActivity
                                     .Border(2, ColorKt.Color(red: 0x0D, green: 0x47, blue: 0xA1, alpha: 0xFF), cornerRadius: 12)
                                     .Clickable(() => count++)
                                     .Padding(horizontal: 16, vertical: 8),
+                            },
+                            // Issue #63 modifier demo — scope alignment inside a Box,
+                            // Toggleable row with semantic merge, programmatic focus
+                            // via FocusRequester + OnFocusChanged + Focusable, and
+                            // CombinedClickable + Selectable + Semantics.
+                            new Text("Issue #63 modifiers:"),
+                            new Box
+                            {
+                                Modifier.Companion
+                                    .FillMaxWidth()
+                                    .Height(72)
+                                    .Border(1, ColorKt.Color(red: 0x90, green: 0x90, blue: 0x90, alpha: 0xFF)),
+                                new Text("TopStart")    { Modifier = Modifier.Companion.Align(Alignment.TopStart) },
+                                new Text("Center")      { Modifier = Modifier.Companion.Align(Alignment.Center) },
+                                new Text("BottomEnd")   { Modifier = Modifier.Companion.Align(Alignment.BottomEnd) },
+                                new Text("MatchParent") { Modifier = Modifier.Companion
+                                    .MatchParentSize()
+                                    .Semantics("Background overlay that fills the box") },
+                            },
+                            // Toggleable row — whole row is a single accessibility
+                            // node that announces "Liked" / "Not liked".
+                            new Row
+                            {
+                                Modifier.Companion
+                                    .FillMaxWidth()
+                                    .Toggleable(toggle63.Value, v => toggle63.Value = v)
+                                    .Semantics(mergeDescendants: true, toggle63.Value ? "Liked" : "Not liked")
+                                    .Padding(8),
+                                new Text(toggle63.Value ? "♥ Liked" : "♡ Tap to like"),
+                            },
+                            // Programmatic focus via FocusRequester + Focusable +
+                            // OnFocusChanged. Tapping the button moves focus to the
+                            // first Text; the status line below updates.
+                            new Text($"Focus status: {focusStatus63.Value}"),
+                            new Text("Focus target")
+                            {
+                                Modifier = Modifier.Companion
+                                    .FocusRequester(focusReq63)
+                                    .OnFocusChanged(fs => focusStatus63.Value =
+                                        fs.IsFocused ? "focused" : (fs.HasFocus ? "child has focus" : "not focused"))
+                                    .Focusable()
+                                    .Padding(8)
+                                    .Border(1, ColorKt.Color(red: 0x55, green: 0x55, blue: 0xAA, alpha: 0xFF))
+                                    .Padding(4),
+                            },
+                            new Button(onClick: () => focusReq63.RequestFocus()) { new Text("Request focus") },
+                            // CombinedClickable + Selectable in a small list.
+                            new Text($"Taps (single/long/double): {taps63.Value}"),
+                            new Text("Hold or double-tap me")
+                            {
+                                Modifier = Modifier.Companion
+                                    .FillMaxWidth()
+                                    .CombinedClickable(
+                                        onClick:       () => taps63.Value += 1,
+                                        onLongClick:   () => taps63.Value += 10,
+                                        onDoubleClick: () => taps63.Value += 100)
+                                    .Padding(8),
+                            },
+                            new Column
+                            {
+                                new Text($"Selected row: {selectedRow63.Value}"),
+                                new Text("Row 0") { Modifier = Modifier.Companion
+                                    .FillMaxWidth().Selectable(selectedRow63.Value == 0, () => selectedRow63.Value = 0).Padding(6) },
+                                new Text("Row 1") { Modifier = Modifier.Companion
+                                    .FillMaxWidth().Selectable(selectedRow63.Value == 1, () => selectedRow63.Value = 1).Padding(6) },
+                                new Text("Row 2") { Modifier = Modifier.Companion
+                                    .FillMaxWidth().Selectable(selectedRow63.Value == 2, () => selectedRow63.Value = 2).Padding(6) },
                             },
                                 // Secure text inputs — exercise both
                                 // SecureTextField (filled) and

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -116,6 +116,7 @@ public class MainActivity : ComposeActivity
             // VerticalScroll modifier and the SuspendBridge demo buttons
             // that programmatically scroll back to the top.
             var buttonsScroll = Remember(() => new ScrollState());
+            var greetingScroll = Remember(() => new ScrollState());
 
             // Compose Navigation demo state (issue #60). The NavController
             // is the externally-driven entry point — Button onClicks call
@@ -162,6 +163,7 @@ public class MainActivity : ComposeActivity
                     {
                         0 => (ComposableNode)new Column
                         {
+                            Modifier.Companion.VerticalScroll(greetingScroll),
                             new Text("Hello from .NET"),
                             new OutlinedTextField(name),
                             new Text($"Hi {(string.IsNullOrEmpty(name.Value) ? "stranger" : name.Value)}"),
@@ -272,18 +274,28 @@ public class MainActivity : ComposeActivity
                             // via FocusRequester + OnFocusChanged + Focusable, and
                             // CombinedClickable + Selectable + Semantics.
                             new Text("Issue #63 modifiers:"),
+                            // Box with three corner-aligned labels (TopStart, Center,
+                            // BottomEnd). The fourth child is an explicit colored
+                            // Box that uses MatchParentSize() to fill the parent —
+                            // the parent draws underneath the labels, which sit on
+                            // top of it. This is the standard "background overlay"
+                            // use of MatchParentSize.
                             new Box
                             {
                                 Modifier.Companion
                                     .FillMaxWidth()
                                     .Height(72)
                                     .Border(1, ColorKt.Color(red: 0x90, green: 0x90, blue: 0x90, alpha: 0xFF)),
+                                new Box
+                                {
+                                    Modifier.Companion
+                                        .MatchParentSize()
+                                        .Background(ColorKt.Color(red: 0xFF, green: 0xF0, blue: 0xE0, alpha: 0xFF))
+                                        .Semantics("Background overlay that fills the box"),
+                                },
                                 new Text("TopStart")    { Modifier = Modifier.Companion.Align(Alignment.TopStart) },
                                 new Text("Center")      { Modifier = Modifier.Companion.Align(Alignment.Center) },
                                 new Text("BottomEnd")   { Modifier = Modifier.Companion.Align(Alignment.BottomEnd) },
-                                new Text("MatchParent") { Modifier = Modifier.Companion
-                                    .MatchParentSize()
-                                    .Semantics("Background overlay that fills the box") },
                             },
                             // Toggleable row — whole row is a single accessibility
                             // node that announces "Liked" / "Not liked".


### PR DESCRIPTION
Adds the remaining modifier categories called out in #63 (the size / transform / wrap subset already landed in #112).

## What's in this PR

* **Scope alignment** — `Modifier.Align(Alignment)`, `Modifier.Align(Alignment.Vertical)`, `Modifier.Align(Alignment.Horizontal)`, `Modifier.MatchParentSize()`. Wraps the `androidx.compose.ui.Alignment` singletons via the existing `IAlignment.Companion` binding (no JNI required for the singletons themselves). Dispatches through `RenderContext.CurrentScopeKind` with a new `ScopeKind.Box` value, throwing a clear `InvalidOperationException` if used outside the matching scope.
* **Gestures** — `Modifier.CombinedClickable(onClick, onLongClick?, onDoubleClick?)`, `Modifier.Selectable(selected, onClick)`, `Modifier.Toggleable(value, onValueChange)`.
* **Focus** — `Modifier.Focusable`, `Modifier.FocusGroup`, `Modifier.OnFocusChanged`, `Modifier.FocusRequester`. New `FocusState` immutable snapshot wrapper and `FocusRequester` state-holder facade. `RequestFocus()` uses a raw-JNI bridge for the no-arg overload because the binding only exposes the parameterised `RequestFocus(int)`.
* **Semantics** — `Modifier.Semantics(contentDescription, mergeDescendants?)` and `Modifier.ClearAndSetSemantics(contentDescription)`, built via a `SemanticsPropertyReceiver` lambda that calls a `SemanticsPropertiesKt.setContentDescription` helper.

## Implementation notes

* All Modifier methods are `[ComposeBridge]` partial methods. The four scope-extension methods (`BoxScope.align`, `BoxScope.matchParentSize`, `RowScope.align(Alignment.Vertical)`, `ColumnScope.align(Alignment.Horizontal)`) are abstract interface methods on the scope class with no static `$default` helper, so they use raw-JNI `CallObjectMethod` bridges following the `ExposedDropdownMenu` pattern.
* Five new `[assembly: ComposeDefaults(...)]` declarations were added for the bridges that have a Kotlin `$default` slot.

## Sample demo

`MainActivity` gets a small demo on Tab 0 exercising:
- `Align` / `MatchParentSize` inside a `Box`
- A `Toggleable` row that's a single merged accessibility node
- `FocusRequester` + `OnFocusChanged` + `Focusable` with a programmatic focus button
- `CombinedClickable` (single / long / double-tap counters)
- A small list of `Selectable` rows

## Deferred (out of scope)

- GraphicsLayer unified block — needs a `SemanticsPropertyReceiver`-style DSL surface AND the full property set, and is largely subsumed by the per-property `Alpha`/`Rotate`/`Scale` we already have.
- Draggable / PointerInput — pulls in `DraggableState`, `Orientation`, `PointerInputScope`, `AwaitPointerEventScope`. Large surface; deserves its own PR.
- Generic `WindowInsetsPadding(insets)` — needs a `WindowInsets` wrapper. Deferred.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 83 passed
- `dotnet build src/ComposeNet.Compose` — 0 warnings, 0 errors
- `dotnet build src/ComposeNet.Sample` — 0 warnings, 0 errors

Closes part of #63 (with the deferred items tracked above).