### PR TITLE
Add review-comments skill

### DIFF
--- a/.github/skills/review-comments/SKILL.md
+++ b/.github/skills/review-comments/SKILL.md
@@ -93,9 +93,9 @@ Group related comments and apply edits together. Run whatever the repo's
 build/test commands are after the edits — for this repo specifically:
 
 ```pwsh
-dotnet test  src\ComposeNet.SourceGenerators.Tests
-dotnet build src\ComposeNet.Compose
-dotnet build src\ComposeNet.Sample
+dotnet test  src/ComposeNet.SourceGenerators.Tests
+dotnet build src/ComposeNet.Compose
+dotnet build src/ComposeNet.Sample
 ```
 
 Only run the suites whose inputs you actually changed. See

--- a/.github/skills/review-comments/SKILL.md
+++ b/.github/skills/review-comments/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: review-comments
+description: Address unresolved review comments on the current branch's PR — classify each, apply code changes when warranted, and reply to every thread with what was done and why. Use whenever the user wants to review, address, respond to, triage, or handle PR reviewer feedback.
+---
+
+# Review Comments
+
+Address reviewer feedback on the current branch's pull request end-to-end:
+discover the PR, read every **unresolved** comment thread, decide whether
+each is actionable, make the code changes (if any), and post a reply on
+each thread explaining what changed and **why** (or why no change was
+needed). The reasoning is the point — a reply that just says "done" is a
+failure mode.
+
+## When to use this skill
+
+Trigger whenever the user wants to deal with reviewer feedback on the
+PR associated with the current session/branch. Examples:
+
+- "review the comments on this PR"
+- "address the review feedback"
+- "go through the PR comments and reply"
+- "respond to the reviewer"
+- "handle the open threads"
+
+If the current branch has no PR, say so and stop — don't invent one.
+
+## Workflow
+
+### 1. Locate the PR for this branch
+
+```pwsh
+$branch = git rev-parse --abbrev-ref HEAD
+gh pr list --head $branch --state open --json number,url,headRefName,baseRefName,title
+```
+
+If zero matches, stop and tell the user the branch has no open PR. If
+multiple, ask the user which one. Cache the PR number in `$pr` for the
+rest of the run.
+
+### 2. Pull *unresolved* review threads via GraphQL
+
+`gh pr view --json comments,reviews` does **not** expose `isResolved` on
+review threads — you have to use GraphQL. Save the query to a temp
+file so PowerShell quoting doesn't mangle it:
+
+```pwsh
+$owner, $repo = (gh repo view --json nameWithOwner -q .nameWithOwner) -split '/'
+$query = @'
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first:50) {
+            nodes {
+              id
+              databaseId
+              author { login }
+              body
+              url
+              diffHunk
+            }
+          }
+        }
+      }
+    }
+  }
+}
+'@
+$tmp = New-TemporaryFile
+Set-Content -Path $tmp -Value $query -Encoding utf8
+gh api graphql -F owner=$owner -F repo=$repo -F pr=$pr --field query="@$tmp"
+Remove-Item $tmp
+```
+
+Filter to `isResolved == false`. Also pull standalone issue comments
+(`gh pr view $pr --json comments`) — those have no resolved state, so
+treat any since the last commit you pushed as fair game.
+
+### 3. Classify each comment
+
+For each unresolved thread, pick one of:
+
+| Category | Action |
+|----------|--------|
+| **Actionable code change** | Make the edit in this worktree |
+| **Question** | Answer it in the reply (no code change) |
+| **Suggestion you disagree with** | Reply with reasoning; don't change code |
+| **Already addressed** | Reply pointing at the commit/line that addressed it |
+| **Out of scope / follow-up** | Reply acknowledging, suggest a follow-up issue |
+| **Praise / "LGTM"** | Skip — no reply needed |
+
+Stay inside the scope of the PR. If a reviewer asks for a big
+refactor that isn't what this PR is about, push back politely and
+propose a follow-up issue rather than expanding scope.
+
+### 4. Make the code changes
+
+Group related comments and apply edits together. Run whatever the repo's
+build/test commands are after the edits — for this repo specifically:
+
+```pwsh
+dotnet test  src\ComposeNet.SourceGenerators.Tests
+dotnet build src\ComposeNet.Compose
+dotnet build src\ComposeNet.Sample
+```
+
+Only run the suites whose inputs you actually changed. See
+`.github/copilot-instructions.md` for the full build matrix.
+
+Commit with a focused message that references the PR; include the
+standard trailer:
+
+```
+Address review feedback
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```
+
+Push to the PR branch (`git push`). Do **not** force-push unless the
+user explicitly asked.
+
+### 5. Reply to every thread (except skipped praise/off-topic)
+
+The reply is the visible artifact of this skill — invest in it.
+
+**Reply structure** (keep it tight, 2–5 sentences):
+
+1. **What was done** — one line. e.g. "Renamed `Foo` → `Bar` in `X.cs`
+   and updated callers."
+2. **Why** — one or two lines of reasoning. Reference the relevant
+   convention, doc, or prior art when possible.
+3. **Pointer** — link the commit SHA or file:line when helpful.
+
+Use the right reply API depending on the thread type:
+
+**Inline review-comment thread** (has `path` and `line`) — reply to
+the existing thread so it stays threaded, then resolve it:
+
+```pwsh
+# Reply to the thread (uses the first comment's databaseId as the parent)
+gh api -X POST "/repos/$owner/$repo/pulls/$pr/comments/$parentCommentId/replies" `
+       -f body="$replyBody"
+
+# Resolve the thread (GraphQL — needs the thread node id, not databaseId)
+$resolveQuery = 'mutation($id:ID!) { resolveReviewThread(input:{threadId:$id}) { thread { isResolved } } }'
+gh api graphql -F id=$threadId -f query=$resolveQuery
+```
+
+**Standalone PR comment** (no `path`/`line`):
+
+```pwsh
+gh pr comment $pr --body $replyBody
+```
+
+Only resolve threads where you either (a) made the change the reviewer
+asked for, or (b) the reviewer's concern is genuinely answered by your
+reply. Leave threads open when you've declined to act and want the
+reviewer to weigh in — that's an explicit handoff, not avoidance.
+
+### 6. Summarize for the user
+
+End with a compact summary in the chat — not on GitHub:
+
+- How many threads were unresolved going in
+- How many you addressed with code (with commit SHA)
+- How many you replied-and-resolved without code
+- How many you replied to but left open for the reviewer
+- Any threads you intentionally skipped (praise, off-topic) and why
+
+This lets the user verify your judgment before the reviewer sees the
+replies.
+
+## Tone for replies
+
+Write as the PR author talking to a colleague — direct, specific, no
+filler. Skip "Thanks for the great feedback!" preambles. Reasoning
+beats deference: a reply that says *why* you did or didn't do something
+is more useful than one that just agrees.
+
+**Bad:**
+> Done!
+
+**Bad:**
+> Thanks so much for catching this! You're absolutely right — I've gone
+> ahead and made that change as you suggested.
+
+**Good:**
+> Renamed to `ButtonDefault.All` for consistency with the other
+> generated `$default` enums in `ComposeDefaults.cs` (`ColumnDefault.All`,
+> `RowDefault.All`). Fixed in 3f1c8a2.
+
+**Good (declining):**
+> Leaving as-is. `IntPtr.Zero` is the documented sentinel for "Kotlin
+> default" throughout `ComposeBridges.cs` — switching just this one
+> bridge to `null` would break the pattern. Happy to do a sweep across
+> all bridges in a follow-up if you'd prefer that direction.
+
+## Common failure modes to avoid
+
+- **Replying "done" with no reasoning.** The reasoning is the entire
+  point of this skill.
+- **Silently expanding scope** to satisfy a reviewer's tangential
+  comment. Propose a follow-up issue instead.
+- **Resolving threads you didn't actually address.** Resolution is the
+  reviewer's call when you push back — leave it open.
+- **Force-pushing** without being asked. This repo uses normal pushes
+  to PR branches.
+- **Editing files in `main_checkout_path`** (the main checkout) instead
+  of `workspace_path` (the worktree). Always work in the worktree.
+- **Skipping the build/test commands.** A reply that says "fixed" on a
+  change that doesn't compile is worse than no reply.

--- a/.github/skills/review-comments/SKILL.md
+++ b/.github/skills/review-comments/SKILL.md
@@ -12,19 +12,6 @@ each thread explaining what changed and **why** (or why no change was
 needed). The reasoning is the point — a reply that just says "done" is a
 failure mode.
 
-## When to use this skill
-
-Trigger whenever the user wants to deal with reviewer feedback on the
-PR associated with the current session/branch. Examples:
-
-- "review the comments on this PR"
-- "address the review feedback"
-- "go through the PR comments and reply"
-- "respond to the reviewer"
-- "handle the open threads"
-
-If the current branch has no PR, say so and stop — don't invent one.
-
 ## Workflow
 
 ### 1. Locate the PR for this branch


### PR DESCRIPTION
Adds a project-scoped Copilot CLI skill at `.github/skills/review-comments/SKILL.md` that addresses unresolved review comments on the current branch's PR: classifies each thread, applies code changes when warranted, and replies with what was done and why.

## Evaluation

Ran 3 synthetic PR scenarios × 2 configs (with-skill vs. baseline) = 6 parallel subagent runs, each producing a Markdown plan (classification, drafted reply, resolve decision, reasoning per thread). Graded programmatically against 20 assertions.

### Scenarios

| Scenario | What it tests |
|---|---|
| `mixed-bag` | 5 threads: 2 actionable, 1 question, 1 already-addressed, 1 LGTM |
| `out-of-scope` | Reviewer asks for unrelated refactor on a typo-fix PR |
| `single-bridge` | JNI subtlety — should reviewer's suggestion be declined? |

### Results

| Scenario | with_skill | without_skill | Δ |
|---|---|---|---|
| `mixed-bag` | 10/10 (100%) | 9/10 (90%) | **+1** |
| `out-of-scope` | 5/5 (100%) | 4/5 (80%) | **+1** |
| `single-bridge` | 5/5 (100%) | 5/5 (100%) | 0 |
| **Overall** | **20/20 (100%)** | **18/20 (90%)** | **+10 pp** |

Time cost: 134s (with-skill) vs. 107s (baseline) — a ~25% premium for the +10pp pass rate.

### What the baseline failed on

Both baseline failures hit the **same assertion**: `No 'Done' / 'Thanks' sycophancy in replies`.

- `mixed-bag` baseline RT_2 reply: `"Done — added [ComposeFacade] to the OutlinedCard bridge..."`
- `out-of-scope` baseline RT_A reply: `"Thanks for the suggestion. This PR is scoped to..."`

These are exactly the patterns the skill's **Tone for replies** section flags as "Bad" with explicit good/bad examples. The skill moved the needle on the failure mode it most directly tries to address.

### What both versions got right

- All thread classifications (actionable / question / praise / already-addressed / out-of-scope)
- Skipping the LGTM thread without replying
- Referencing repo convention (`ComposableContainer` / `[ComposeFacade]`) for the actionable threads
- Declining the out-of-scope refactor and citing scope rationale
- Citing the existing `SuspendBridges.cs` `FindClass` policy for the JNI question

The baseline isn't *bad* — Claude in the underlying compose-net repo already has strong conventions in `copilot-instructions.md`. The skill's marginal value is concentrated on reply tone and the `isResolved` GraphQL guidance.

### Caveats

- Synthetic scenarios — no real `gh` calls or PR data, so the GraphQL/`isResolved` portion of the skill wasn't exercised. That guidance is judged on inspection, not measurement.
- 1 sample per (scenario × config) — no variance estimate. With n=1 the +10pp delta is directional, not statistically significant.
- Subagents both used Claude Sonnet via the same harness, so the comparison isolates the skill text reasonably well.

### What was intentionally skipped

The full skill-creator harness (eval-viewer browser UI, iterative feedback loops, description optimization via `run_loop.py`). For a focused project skill, programmatic grading + this PR description is the right granularity.

Raw outputs and `benchmark.json` live in the session artifact folder, not the repo.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>