### PR TITLE
Sample: drop count/sub subtitle from main scaffold top bar

### DIFF
--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -1163,12 +1163,9 @@ public class MainActivity : ComposeActivity
                 {
                     new Scaffold
                     {
-                        // The main TopAppBar uses the new Subtitle slot
-                        // (routes to the M3 two-line TopAppBar-cJHQLPU overload).
-                        TopBar = new TopAppBar
+                        TopBar = new CenterAlignedTopAppBar
                         {
-                            Title    = new Text(tabNames[tab.Value]),
-                            Subtitle = new Text($"count={count}  ·  sub={sub}"),
+                            Title = new Text(tabNames[tab.Value]),
                         },
                         SnackbarHost = showSnack.Value
                             ? new Snackbar


### PR DESCRIPTION
Restore the main `Scaffold.TopBar` in the sample app to a plain, center-aligned, single-line bar that shows just the current tab name (`Basics`, `Buttons`, `Cards`, …).

PR #40 (commit `1de32ee`) introduced `Subtitle = $"count={count}  ·  sub={sub}"` on the main bar as a demo of the new Subtitle slot. It's been a UX wart ever since — visually noisy, and the counter readout has nothing to do with most tabs.

### Change

```diff
- // The main TopAppBar uses the new Subtitle slot
- // (routes to the M3 two-line TopAppBar-cJHQLPU overload).
- TopBar = new TopAppBar
+ TopBar = new CenterAlignedTopAppBar
  {
-     Title    = new Text(tabNames[tab.Value]),
-     Subtitle = new Text($"count={count}  ·  sub={sub}"),
+     Title = new Text(tabNames[tab.Value]),
  },
```

### Subtitle coverage isn't lost

The `MediumFlexibleTopAppBar` / `LargeFlexibleTopAppBar` demos in Tab 7's **App-bar variants** sub-tab still exercise the `Subtitle` slot (lines ≈763-776, untouched).

### Verification

- `dotnet build src/ComposeNet.Sample` — clean.
- `dotnet build src/ComposeNet.Sample -t:Run` — deployed to Pixel device.
- adb screenshot confirms the main bar now reads just `Basics` (centered) with no subtitle line.