### PR TITLE
Fix #119: eager PagerState construction for snapshot reactivity

### DIFF
--- a/src/ComposeNet.Compose/HorizontalPager.cs
+++ b/src/ComposeNet.Compose/HorizontalPager.cs
@@ -49,24 +49,35 @@ public sealed class HorizontalPager<T> : ComposableNode
 
     internal override void Render(IComposer composer)
     {
-        // Compose's rememberPagerState reads the pageCount lambda on
-        // every measure pass, so the lambda has to close over the live
-        // _items reference (count can change between recompositions
-        // when callers swap in a new list).
-        _pageCountFn ??= new ComposableLambda0Int(() => _items.Count);
-
-        var rememberedState = PagerStateKt.RememberPagerState(
-            p0:                        0,
-            initialPageOffsetFraction: 0f,
-            pageCount:                 _pageCountFn,
-            _composer:                 composer,
-            initialPage:               0,
-            _changed:                  0);
-
-        // Refresh the wrapper's Jvm field every render so the pageCount
-        // lambda observes recompositions (rubber-duck #1).
-        if (State is not null) State.Jvm = rememberedState;
-        var jvmState = State?.Jvm ?? rememberedState;
+        // When the caller supplies a PagerState wrapper its Jvm is
+        // built eagerly in the wrapper's ctor (via the non-@Composable
+        // PagerStateKt.PagerState factory), so we just pass it through
+        // and reads from C# build code subscribe to snapshot changes
+        // regardless of render order — see issue #119.
+        //
+        // When State == null we fall back to rememberPagerState so the
+        // pager owns an internal scroll-position-preserving state
+        // across recompositions.
+        AndroidX.Compose.Foundation.Pager.PagerState jvmState;
+        if (State is not null)
+        {
+            jvmState = State.Jvm;
+        }
+        else
+        {
+            // Compose's rememberPagerState reads the pageCount lambda
+            // on every measure pass, so the lambda has to close over
+            // the live _items reference (count can change between
+            // recompositions when callers swap in a new list).
+            _pageCountFn ??= new ComposableLambda0Int(() => _items.Count);
+            jvmState = PagerStateKt.RememberPagerState(
+                p0:                        0,
+                initialPageOffsetFraction: 0f,
+                pageCount:                 _pageCountFn,
+                _composer:                 composer,
+                initialPage:               0,
+                _changed:                  0);
+        }
 
         var modifier = BuildModifier();
         var content  = ComposableLambdas.Wrap4(composer, (_, indexBoxed, comp) =>

--- a/src/ComposeNet.Compose/PagerState.cs
+++ b/src/ComposeNet.Compose/PagerState.cs
@@ -1,3 +1,4 @@
+using System;
 using AndroidX.Compose.Foundation.Pager;
 
 namespace ComposeNet;
@@ -5,101 +6,127 @@ namespace ComposeNet;
 /// <summary>
 /// Caller-supplied state holder for <see cref="HorizontalPager{T}"/> /
 /// <see cref="VerticalPager{T}"/>. Wraps the bound
-/// <c>androidx.compose.foundation.pager.PagerState</c>; the underlying
-/// JVM instance is rebound every recomposition by the pager facade
-/// (mirroring Kotlin's <c>rememberPagerState { pageCount }</c>), so
-/// reads like <see cref="CurrentPage"/> always reflect the latest
-/// remembered state.
+/// <c>androidx.compose.foundation.pager.PagerState</c> — the
+/// <c>PagerStateKt.PagerState(currentPage, currentPageOffsetFraction,
+/// pageCount)</c> factory is bound and not <c>@Composable</c>, so the
+/// JVM peer is built eagerly in the constructor and reads like
+/// <see cref="CurrentPage"/> hit Compose's snapshot system from the
+/// first composition pass — no render-order dependency.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Typical usage — <c>Remember</c> a state instance and pass it to a
-/// pager so other UI can react to scroll position:
+/// Construct one inside a <see cref="ComposeActivity.Remember{T}"/>
+/// callback so the page position survives recompositions. The
+/// <c>pageCount</c> lambda must be supplied (the Kotlin
+/// runtime calls it on every measure pass) and should close over a
+/// stable source that matches the <see cref="HorizontalPager{T}"/> /
+/// <see cref="VerticalPager{T}"/> items list — otherwise the indicator
+/// and the rendered pages can drift.
 /// </para>
 /// <code>
-/// var pagerState = Remember(() =&gt; new PagerState());
+/// var items      = new[] { 0, 1, 2 };
+/// var pagerState = Remember(() =&gt; new PagerState(pageCount: () =&gt; items.Length));
 ///
 /// new Column
 /// {
 ///     new HorizontalPager&lt;int&gt;(
-///         items:        new[] { 0, 1, 2 },
+///         items:        items,
 ///         itemContent:  i =&gt; new Text($"Page {i}"))
 ///     {
 ///         State = pagerState,
 ///     },
-///     new Text($"Page {pagerState.CurrentPage} of 3"),
+///     // Reactive — snapshot read on PagerState.currentPage is
+///     // recorded for this composition scope regardless of order.
+///     new Text($"Page {pagerState.CurrentPage + 1} of {pagerState.PageCount}"),
 /// }
 /// </code>
 /// <para>
-/// <strong>Render order matters in v1.</strong> Place readers
-/// (indicators, text overlays, etc.) <em>after</em> the pager in the
-/// node tree so the pager's first render binds <c>Jvm</c> before the
-/// reader's render reads it. A reader rendered <em>before</em> the
-/// pager on first composition will read the pre-binding fallback
-/// (<c>0</c> / <c>0f</c>) and won't subscribe to the underlying
-/// snapshot — it will only become reactive after another recomposition
-/// re-runs the outer build code. Reads return safe fallbacks until
-/// the first pager render binds this state to its remembered Kotlin
-/// peer.
+/// Unlike Kotlin's <c>rememberPagerState()</c> (which uses
+/// <c>rememberSaveable</c>), this state is held in the
+/// <see cref="ComposeActivity"/>-scoped Remember cache, so it survives
+/// recompositions but not process death / configuration changes. For
+/// most apps that's fine; if you need savable scroll position, track
+/// it yourself with the rest of your view-model state.
 /// </para>
 /// </remarks>
 public sealed class PagerState
 {
+    // Kept on the wrapper so the JVM-side reference to the lambda
+    // outlives any temporary parameter slot — matches the pattern
+    // other wrappers use for stored callbacks.
+    readonly ComposableLambda0Int _pageCountFn;
+
     /// <summary>
-    /// Create a new <see cref="PagerState"/>. The wrapper starts
-    /// unbound; the underlying Kotlin
-    /// <c>androidx.compose.foundation.pager.PagerState</c> is bound on
-    /// the first render of the pager facade this instance is passed to,
-    /// and refreshed every recomposition thereafter. Property reads
-    /// return safe fallbacks (<c>0</c> / <c>0f</c>) until the first
-    /// bind.
+    /// Create a new <see cref="PagerState"/>. The underlying Kotlin
+    /// <c>androidx.compose.foundation.pager.PagerState</c> is built
+    /// immediately via <c>PagerStateKt.PagerState(...)</c>, so reads
+    /// like <see cref="CurrentPage"/> can be subscribed to from the
+    /// first composition pass — even when read from C# build code
+    /// rendered <em>before</em> the pager.
     /// </summary>
-    public PagerState()
+    /// <param name="pageCount">
+    /// Lambda invoked by the pager on every measure pass to determine
+    /// the total page count. Must close over a stable source that
+    /// matches the <see cref="HorizontalPager{T}"/> /
+    /// <see cref="VerticalPager{T}"/> items list passed alongside this
+    /// state — recomposition-local list rebuilds will be missed.
+    /// </param>
+    /// <param name="initialPage">
+    /// Index of the page to start on (default <c>0</c>).
+    /// </param>
+    /// <param name="initialPageOffsetFraction">
+    /// Initial fractional offset in <c>[-0.5, 0.5)</c> (default
+    /// <c>0f</c>).
+    /// </param>
+    public PagerState(Func<int> pageCount, int initialPage = 0, float initialPageOffsetFraction = 0f)
     {
+        if (pageCount is null) throw new ArgumentNullException(nameof(pageCount));
+        _pageCountFn = new ComposableLambda0Int(pageCount);
+        Jvm = PagerStateKt.PagerState(
+            currentPage:               initialPage,
+            currentPageOffsetFraction: initialPageOffsetFraction,
+            pageCount:                 _pageCountFn);
     }
 
     /// <summary>
     /// Underlying <c>androidx.compose.foundation.pager.PagerState</c>
-    /// returned by <c>rememberPagerState</c>. Refreshed every render so
-    /// the Kotlin <c>pageCount</c> lambda observes recomposition-time
-    /// changes (e.g. an item list growing).
+    /// built by <c>PagerStateKt.PagerState(...)</c>. Non-null from
+    /// construction.
     /// </summary>
-    internal AndroidX.Compose.Foundation.Pager.PagerState? Jvm { get; set; }
+    internal AndroidX.Compose.Foundation.Pager.PagerState Jvm { get; }
 
     /// <summary>
     /// Index of the page closest to the snapped position. Mirrors
-    /// Kotlin's <c>PagerState.currentPage</c>. Returns <c>0</c> until
-    /// the state is bound by the first pager render.
+    /// Kotlin's <c>PagerState.currentPage</c>. Snapshot-tracked — reads
+    /// from a live composition scope subscribe to page changes.
     /// </summary>
-    public int CurrentPage => Jvm?.CurrentPage ?? 0;
+    public int CurrentPage => Jvm.CurrentPage;
 
     /// <summary>
     /// Index of the page the pager has settled on after a fling or
     /// programmatic scroll completes. Mirrors Kotlin's
-    /// <c>PagerState.settledPage</c>. Returns <c>0</c> until bound.
+    /// <c>PagerState.settledPage</c>.
     /// </summary>
-    public int SettledPage => Jvm?.SettledPage ?? 0;
+    public int SettledPage => Jvm.SettledPage;
 
     /// <summary>
     /// Index of the page the pager is currently animating toward
     /// (== <see cref="CurrentPage"/> when no scroll is in flight).
-    /// Mirrors Kotlin's <c>PagerState.targetPage</c>. Returns <c>0</c>
-    /// until bound.
+    /// Mirrors Kotlin's <c>PagerState.targetPage</c>.
     /// </summary>
-    public int TargetPage => Jvm?.TargetPage ?? 0;
+    public int TargetPage => Jvm.TargetPage;
 
     /// <summary>
     /// Fractional offset of the current page in <c>[-0.5, 0.5)</c>,
     /// where <c>0</c> means the page is fully snapped. Mirrors Kotlin's
-    /// <c>PagerState.currentPageOffsetFraction</c>. Returns <c>0f</c>
-    /// until bound.
+    /// <c>PagerState.currentPageOffsetFraction</c>.
     /// </summary>
-    public float CurrentPageOffsetFraction => Jvm?.CurrentPageOffsetFraction ?? 0f;
+    public float CurrentPageOffsetFraction => Jvm.CurrentPageOffsetFraction;
 
     /// <summary>
-    /// Total number of pages reported by the pager's <c>pageCount</c>
-    /// lambda. Mirrors Kotlin's <c>PagerState.pageCount</c>. Returns
-    /// <c>0</c> until bound.
+    /// Total number of pages reported by the <c>pageCount</c> lambda
+    /// supplied at construction. Mirrors Kotlin's
+    /// <c>PagerState.pageCount</c>.
     /// </summary>
-    public int PageCount => Jvm?.PageCount ?? 0;
+    public int PageCount => Jvm.PageCount;
 }

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -573,7 +573,7 @@ ComposeNet.PagerState
 ComposeNet.PagerState.CurrentPage.get -> int
 ComposeNet.PagerState.CurrentPageOffsetFraction.get -> float
 ComposeNet.PagerState.PageCount.get -> int
-ComposeNet.PagerState.PagerState() -> void
+ComposeNet.PagerState.PagerState(System.Func<int>! pageCount, int initialPage = 0, float initialPageOffsetFraction = 0) -> void
 ComposeNet.PagerState.SettledPage.get -> int
 ComposeNet.PagerState.TargetPage.get -> int
 ComposeNet.PermanentDrawerSheet

--- a/src/ComposeNet.Compose/VerticalPager.cs
+++ b/src/ComposeNet.Compose/VerticalPager.cs
@@ -45,18 +45,23 @@ public sealed class VerticalPager<T> : ComposableNode
 
     internal override void Render(IComposer composer)
     {
-        _pageCountFn ??= new ComposableLambda0Int(() => _items.Count);
-
-        var rememberedState = PagerStateKt.RememberPagerState(
-            p0:                        0,
-            initialPageOffsetFraction: 0f,
-            pageCount:                 _pageCountFn,
-            _composer:                 composer,
-            initialPage:               0,
-            _changed:                  0);
-
-        if (State is not null) State.Jvm = rememberedState;
-        var jvmState = State?.Jvm ?? rememberedState;
+        // See HorizontalPager.Render — same eager-vs-remember path.
+        AndroidX.Compose.Foundation.Pager.PagerState jvmState;
+        if (State is not null)
+        {
+            jvmState = State.Jvm;
+        }
+        else
+        {
+            _pageCountFn ??= new ComposableLambda0Int(() => _items.Count);
+            jvmState = PagerStateKt.RememberPagerState(
+                p0:                        0,
+                initialPageOffsetFraction: 0f,
+                pageCount:                 _pageCountFn,
+                _composer:                 composer,
+                initialPage:               0,
+                _changed:                  0);
+        }
 
         var modifier = BuildModifier();
         var content  = ComposableLambdas.Wrap4(composer, (_, indexBoxed, comp) =>

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -98,8 +98,11 @@ public class MainActivity : ComposeActivity
             var searchQuery   = Remember(() => new MutableState<string>(""));
 
             // Pager tab: PagerState exposes CurrentPage to a reactive
-            // indicator rendered after the pager.
-            var pagerState    = Remember(() => new PagerState());
+            // indicator rendered after the pager. The same items array
+            // is closed over by both the state's pageCount lambda and
+            // the pager facade so the two stay in sync.
+            var pagerItems = new[] { 0, 1, 2 };
+            var pagerState = Remember(() => new PagerState(pageCount: () => pagerItems.Length));
 
             // Lazy tab: pull-to-refresh demo state. `refreshing` drives the
             // PullToRefreshBox indicator; `refreshTick` bumps once per
@@ -883,7 +886,7 @@ public class MainActivity : ComposeActivity
                     // gets its own pastel slot so swipes feel obvious.
                     new Text("HorizontalPager (swipe between 3 screens)"),
                     new HorizontalPager<int>(
-                        items:       new[] { 0, 1, 2 },
+                        items:       pagerItems,
                         itemContent: i => new Box
                         {
                             Modifier.Companion
@@ -899,7 +902,7 @@ public class MainActivity : ComposeActivity
                         State    = pagerState,
                         Modifier = Modifier.Companion.FillMaxWidth().Height(200),
                     },
-                    new Text($"Page {pagerState.CurrentPage + 1} of 3"),
+                    new Text($"Page {pagerState.CurrentPage + 1} of {pagerState.PageCount}"),
                     new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
 
                     // FlowRow — chip-style group that wraps when it
@@ -1319,6 +1322,11 @@ public class MainActivity : ComposeActivity
                                     Icon = new Text("🎠"),
                                 },
                                 new Tab(selected: tab.Value == 10, onClick: () => tab.Value = 10)
+                                {
+                                    Text = new Text("Pager"),
+                                    Icon = new Text("📑"),
+                                },
+                                new Tab(selected: tab.Value == 11, onClick: () => tab.Value = 11)
                                 {
                                     Text = new Text("Nav"),
                                     Icon = new Text("🧭"),


### PR DESCRIPTION
Closes #119.

## Problem

`PagerState.Jvm` was bound lazily inside `HorizontalPager.Render` via `PagerStateKt.RememberPagerState`. C# build code that read `pagerState.CurrentPage` **before** the pager render bound `Jvm` hit the `Jvm?.CurrentPage ?? 0` fallback, which performed no Compose snapshot read — so the read site never subscribed to recomposition when `currentPage` later changed. The "Page X of 3" indicator stayed at "Page 1 of 3" no matter how far the user swiped.

## Fix — Option A (eager construction)

The non-`@Composable` factory `PagerStateKt.PagerState(currentPage, currentPageOffsetFraction, pageCount: Function0<Int>)` is bound and callable outside composition. The wrapper now constructs the underlying Kotlin `PagerState` eagerly in its ctor (mirroring what `ScrollState(int initial)` already does), so `Jvm` is non-null from construction and C# reads hit Compose's real snapshot system from the first composition pass — regardless of render order.

### Changes

- **`PagerState`** ctor is now `PagerState(Func<int> pageCount, int initialPage = 0, float initialPageOffsetFraction = 0f)`. `Jvm` is non-nullable (stored alongside the JVM lambda wrapper for GC safety). Property accessors drop their `?? 0` / `?? 0f` fallbacks. The `pageCount` lambda is the one Kotlin re-reads on every measure pass.
- **`HorizontalPager.Render` / `VerticalPager.Render`** pass `State.Jvm` straight to `PagerKt` when the caller supplied a state holder. The `State == null` path keeps the existing `rememberPagerState` fallback for pager-owned state.
- **Sample** updates: `new PagerState(pageCount: () => pagerItems.Length)`, indicator reads `pagerState.PageCount`. The sample's `ScrollableTabRow` also gained a dedicated "Pager" tab — previously the "Nav" tab triggered the Pager content and tab 11 / Nav content was unreachable from the UI.
- **PublicAPI** updated.

## Validation

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 90 / 90 pass.
- `dotnet build src/ComposeNet.Compose` — clean (no RS0016 / RS0017).
- `dotnet build src/ComposeNet.Sample` — clean.
- **On-device**: swiping the pager updates "Page X of 3" reactively. Screenshots from each page:

| Initial | After 1st swipe | After 2nd swipe |
|---|---|---|
| Page 1 of 3 (purple) | Page 2 of 3 (blue) | Page 3 of 3 (green) |

## Out of scope

Same gap exists on `DatePickerState`, `TimePickerState`, `DateRangePickerState`, `SearchBarState`, etc. — those are follow-ups; this PR focuses on `PagerState` per the issue.

## Relation to #114

Independent — this PR can land before or after #114. Both touch the same Pager facades but in non-overlapping ways.