### PR TITLE
Add state primitives (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The facade [`ComposeNet.Compose`](src/ComposeNet.Compose) covers the common Mate
 | Sheets & pickers        | `ModalBottomSheet`, `BottomSheetScaffold`, `DatePicker`/`DatePickerDialog`, `TimePicker`/`TimePickerDialog` |
 | Overlays                | `AlertDialog`, `Snackbar` + `SnackbarHost`, `Tooltip` |
 | Modifier chains         | `Padding`, `FillMaxWidth/Height/Size`, `Width`, `Height`, `Size`, `SafeDrawingPadding`, `SystemBarsPadding` |
-| State                   | `Remember`, `MutableState<T>`, `MutableNumberState<T>`, plus `DatePickerState`, `TimePickerState`, `SearchBarState`, `SnackbarHostState` |
+| State                   | `Remember` (+ keyed `Remember(factory, key1, …)`, `RememberKeyed`), `RememberSaveable` (+ keyed), `MutableState<T>`, `MutableNumberState<T>`, `MutableStateList<T>`, `MutableStateMap<K,V>`, `DerivedStateOf`, `ProduceState`, plus `DatePickerState`, `TimePickerState`, `SearchBarState`, `SnackbarHostState` |
 
 ## Samples
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ declarative attribute can be swapped one-for-one to the generic form.
 | Kotlin                                  | C# today                                                       | Cost |
 | --------------------------------------- | -------------------------------------------------------------- | ---- |
 | Skipping / recomposition optimization   | `$changed = 0` everywhere → full subtree recomposes on every state change | Correctness ✅, perf 🙁 |
-| Slot-table-backed `remember`            | `Remember(() => …)` with `[CallerLineNumber]` keying into an activity-scoped cache | Works for top-level state; nested-scope / keyed `remember(key1, key2)` is Tier 2 |
+| Slot-table-backed `remember`            | `Remember(() => …)` with `[CallerLineNumber]` keying into an activity-scoped cache; `Remember(factory, key1, …)` (1–3 keys or `RememberKeyed(factory, keys[])`) resets the slot on key change | Lifetime is per call site, not per nested-scope as in Kotlin |
 | `@Composable` type-system enforcement   | None — calling a non-composable from a composable context fails at runtime, not compile-time | Footgun |
 | Per-call-site allocation                | Every recomposition allocates fresh `ComposableNode` objects (no slot-table reuse on the C# side) | Tier 2 codegen fixes |
 
@@ -164,8 +164,23 @@ class.
   `Modifier` class via a one-time JNI fetch of the `$$INSTANCE` field
   — invisible to callers. See [NOTES.md](NOTES.md) open issue #1 for
   the upstream-friendly fix.
-- **`remember(keys, …)` not yet supported.** Top-level `Remember(() =>
-  state)` works (state is keyed by `[CallerLineNumber]` into an
-  activity-scoped cache), but Compose's keyed/nested `remember` —
-  reset-on-key-change semantics, slot-table-scoped lifetime — needs a
-  real slot table on the C# side and is parked for Tier 2.
+- **`remember(keys, …)` is supported.** Use the keyed overloads
+  `Remember(factory, key1)`, `Remember(factory, key1, key2)`,
+  `Remember(factory, key1, key2, key3)`, or
+  `RememberKeyed(factory, object?[] keys)` — same shape for
+  `RememberSaveable`. Compose resets the slot when any key changes
+  (structural equality). The slot key still comes from
+  `[CallerLineNumber]/[CallerFilePath]`, so the slot's identity is
+  per call site (not per nested scope as in Kotlin). For
+  rotation/process-death survival use `RememberSaveable` — keys are
+  forwarded to Kotlin's `rememberSaveable(vararg inputs)` array so
+  the saveable registry uses the same invalidation semantics.
+- **State primitives.** `MutableStateList<T>`, `MutableStateMap<K,V>`,
+  `Compose.DerivedStateOf<T>(Func<T>)`, and
+  `Compose.ProduceState<T>(initialValue, [keys…], producer)` are
+  available. `ProduceState` is implemented purely in C# via an
+  `IRememberObserver` JCW — the producer is a plain
+  `Func<MutableState<T>, CancellationToken, Task>`, not a Kotlin
+  suspend lambda. Tracked in #62. Still missing:
+  `snapshotFlow { … }` (Flow → `IAsyncEnumerable` bridge) and custom
+  `Saver<T, S>` (only `autoSaver` is exposed today).

--- a/samples/Jetchat/ConversationUiState.cs
+++ b/samples/Jetchat/ConversationUiState.cs
@@ -6,7 +6,7 @@ namespace ComposeNet.Samples.Jetchat;
 /// Holds the chat's mutable message log, the currently selected
 /// channel, and channel metadata. Mirrors upstream's
 /// <c>ConversationUiState</c>, but uses our
-/// <see cref="ObservableList{T}"/> instead of Kotlin's
+/// <see cref="MutableStateList{T}"/> instead of Kotlin's
 /// <c>SnapshotStateList</c> (which isn't bound). The
 /// <see cref="CurrentChannel"/> property is backed by a
 /// <see cref="MutableState{T}"/> so drawer taps trigger recomposition
@@ -18,7 +18,7 @@ public sealed class ConversationUiState
     readonly MutableState<string> _currentChannel;
 
     public int ChannelMembers { get; }
-    public ObservableList<Message> Messages { get; }
+    public MutableStateList<Message> Messages { get; }
 
     /// <summary>
     /// Currently selected channel, displayed in the top app bar and
@@ -36,7 +36,7 @@ public sealed class ConversationUiState
     {
         _currentChannel = new MutableState<string>(channelName);
         ChannelMembers = channelMembers;
-        Messages = new ObservableList<Message>(initial);
+        Messages = new MutableStateList<Message>(initial);
     }
 
     /// <summary>Append a new user-authored message to the log.</summary>

--- a/samples/Jetchat/README.md
+++ b/samples/Jetchat/README.md
@@ -71,7 +71,7 @@ dotnet build samples/Jetchat -t:Run
   available width via `Modifier.Weight(1f)`, plus an `IconButton` send
   control. Newly sent messages are stamped `"now"` (matching
   upstream's `R.string.now`) instead of a wall-clock time.
-- Reactive message list via `ObservableList<Message>` — tapping send
+- Reactive message list via `MutableStateList<Message>` — tapping send
   appends a message and the UI recomposes.
 - Reactive channel selection via `MutableState<string>` — drawer taps
   flow into the title and bold the selected chat row in the drawer.
@@ -114,7 +114,7 @@ later round (Jun 5) closed three more — all now in use here:
   the enclosing `RenderContext.CurrentScopeKind`. The input row, the
   message list's vertical fill, and the day-separator dividers all use
   it.
-- **`ObservableList<T>`**: a managed `IList<T>` that participates in
+- **`MutableStateList<T>`**: a managed `IList<T>` that participates in
   Compose's snapshot system without needing a `SnapshotStateList`
   binding. Backs the message log.
 - **Drawable-resource `Image` / `Icon`** (PR #86, Phase 7
@@ -236,8 +236,8 @@ directly.
 
 Tapping `composers` / `droidcon-nyc` updates the title and selection
 highlight but the message list itself is shared across channels.
-Multi-channel state would refactor `ObservableList<Message>` into a
-`Dictionary<string, ObservableList<Message>>` or similar — out of
+Multi-channel state would refactor `MutableStateList<Message>` into a
+`Dictionary<string, MutableStateList<Message>>` or similar — out of
 scope for this port; the upstream sample's seed data lives in a
 separate `JetchatViewModel` + Hilt-injected fake repository.
 

--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -42,6 +42,55 @@ public static class Compose
         System.Func<T> factory,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
+        => RememberCore(factory, keys: null, line, file);
+
+    /// <summary>
+    /// Keyed <c>remember(key1) { factory() }</c>: the cached value is
+    /// re-created whenever <paramref name="key1"/> changes (structural
+    /// equality via <see cref="object.Equals(object?, object?)"/>).
+    /// Use to recompute derived values when their inputs change without
+    /// having to manually clear / rebuild state on every recomposition.
+    /// </summary>
+    public static T Remember<T>(
+        System.Func<T> factory,
+        object? key1,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberCore(factory, new[] { key1 }, line, file);
+
+    /// <summary>Keyed <c>remember(key1, key2) { factory() }</c>.</summary>
+    public static T Remember<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberCore(factory, new[] { key1, key2 }, line, file);
+
+    /// <summary>Keyed <c>remember(key1, key2, key3) { factory() }</c>.</summary>
+    public static T Remember<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        object? key3,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberCore(factory, new[] { key1, key2, key3 }, line, file);
+
+    /// <summary>
+    /// Array-form keyed <c>remember(vararg keys) { factory() }</c>.
+    /// Use when the caller has more than three keys or already has the
+    /// keys in an array. The array is cloned defensively so subsequent
+    /// caller mutation doesn't corrupt the "previous keys" comparison.
+    /// </summary>
+    public static T RememberKeyed<T>(
+        System.Func<T> factory,
+        object?[] keys,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberCore(factory, keys ?? throw new System.ArgumentNullException(nameof(keys)), line, file);
+
+    static T RememberCore<T>(System.Func<T> factory, object?[]? keys, int line, string file)
     {
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
@@ -50,10 +99,13 @@ public static class Compose
         composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
         try
         {
-            if (composer.RememberedValue() is RememberHolder existing)
+            if (composer.RememberedValue() is RememberHolder existing
+                && RememberHolder.KeysEqual(existing.Keys, keys))
+            {
                 return (T)existing.Value!;
+            }
             var value = factory();
-            composer.UpdateRememberedValue(new RememberHolder(value));
+            composer.UpdateRememberedValue(new RememberHolder(value, keys));
             return value;
         }
         finally
@@ -90,16 +142,59 @@ public static class Compose
     /// The slot is keyed by <see cref="SourceLocationKey"/>'s FNV-1a
     /// hash — deterministic across process restarts so the saveable-
     /// state registry can match the recomputed key to its stored value
-    /// on restore. The <c>vararg inputs</c> dependency-tracking
-    /// parameter isn't surfaced here — an empty <c>Object[]</c> is
-    /// passed, meaning the cached value is never invalidated on
-    /// dependency change. A future <c>params object?[]</c> overload
-    /// can lift that.
+    /// on restore.
     /// </summary>
     public static T RememberSaveable<T>(
         System.Func<T> factory,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
+        => RememberSaveableCore(factory, keys: null, line, file);
+
+    /// <summary>
+    /// Keyed <c>rememberSaveable(key1) { factory() }</c>: keys flow into
+    /// Kotlin's <c>inputs</c> array so Compose's saveable registry
+    /// invalidates the cached value when any key changes — matching the
+    /// in-memory behaviour of the keyed <see cref="Remember{T}(System.Func{T}, object?, int, string)"/>.
+    /// </summary>
+    public static T RememberSaveable<T>(
+        System.Func<T> factory,
+        object? key1,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberSaveableCore(factory, new[] { key1 }, line, file);
+
+    /// <summary>Keyed <c>rememberSaveable(key1, key2) { factory() }</c>.</summary>
+    public static T RememberSaveable<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberSaveableCore(factory, new[] { key1, key2 }, line, file);
+
+    /// <summary>Keyed <c>rememberSaveable(key1, key2, key3) { factory() }</c>.</summary>
+    public static T RememberSaveable<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        object? key3,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberSaveableCore(factory, new[] { key1, key2, key3 }, line, file);
+
+    /// <summary>
+    /// Array-form keyed <c>rememberSaveable(vararg inputs) { factory() }</c>.
+    /// Use when the caller has more than three keys or already has the
+    /// keys in an array.
+    /// </summary>
+    public static T RememberSaveableKeyed<T>(
+        System.Func<T> factory,
+        object?[] keys,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => RememberSaveableCore(factory, keys ?? throw new System.ArgumentNullException(nameof(keys)), line, file);
+
+    static T RememberSaveableCore<T>(System.Func<T> factory, object?[]? keys, int line, string file)
     {
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
@@ -113,9 +208,9 @@ public static class Compose
             // The `is`-check is type-metadata only — no reflection, no
             // member lookup, fully trim-safe.
             if (typeof(IMutableStateWrapper).IsAssignableFrom(typeof(T)))
-                return RememberSaveableWrapper(factory, composer);
+                return RememberSaveableWrapper(factory, keys, composer);
 
-            return RememberSaveableScalar(factory, composer);
+            return RememberSaveableScalar(factory, keys, composer);
         }
         finally
         {
@@ -123,11 +218,12 @@ public static class Compose
         }
     }
 
-    static T RememberSaveableScalar<T>(System.Func<T> factory, IComposer composer)
+    static T RememberSaveableScalar<T>(System.Func<T> factory, object?[]? keys, IComposer composer)
     {
+        var inputs = ComposeBridges.BuildKeysArray(keys, out var ownsInputs);
         var jcw = new ObjectFunction0(() => MutableState<T>.ToJava(factory()));
         var handle = ComposeBridges.RememberSaveableSimple(
-            ComposeBridges.EmptyObjectArray(),
+            inputs,
             jcw,
             ((Java.Lang.Object)composer).Handle,
             changed: 0);
@@ -143,21 +239,27 @@ public static class Compose
         {
             if (handle != System.IntPtr.Zero)
                 Android.Runtime.JNIEnv.DeleteLocalRef(handle);
+            if (ownsInputs && inputs != System.IntPtr.Zero)
+                Android.Runtime.JNIEnv.DeleteLocalRef(inputs);
             System.GC.KeepAlive(composer);
         }
     }
 
-    static T RememberSaveableWrapper<T>(System.Func<T> factory, IComposer composer)
+    static T RememberSaveableWrapper<T>(System.Func<T> factory, object?[]? keys, IComposer composer)
     {
         // Cache the C# wrapper across recompositions so we don't
         // allocate a fresh facade + Kotlin IMutableState on every
         // render. `Compose.Remember` opens its own nested replaceable
         // group; nesting is fine — Compose's slot table handles it.
+        // We use the keyless Remember on purpose: Compose's keyed
+        // rememberSaveable below already invalidates on key change
+        // and hands us a fresh IMutableState, which we then swap in.
         var wrapper = Remember(factory)
             ?? throw new System.InvalidOperationException(
                 $"Compose.RememberSaveable<{typeof(T).Name}>: factory returned null.");
         var iwrap = (IMutableStateWrapper)wrapper;
 
+        var inputs = ComposeBridges.BuildKeysArray(keys, out var ownsInputs);
         // Hand Compose's `rememberSaveable` the wrapper's underlying
         // IMutableState. On first composition Compose calls our JCW
         // and caches whatever we return. On a process-death restore
@@ -168,7 +270,7 @@ public static class Compose
         // to point at whatever Compose hands back.
         var jcw = new ObjectFunction0(() => (Java.Lang.Object)iwrap.State);
         var handle = ComposeBridges.RememberSaveableMutableState(
-            ComposeBridges.EmptyObjectArray(),
+            inputs,
             ComposeBridges.SaverAutoSaver(),
             jcw,
             ((Java.Lang.Object)composer).Handle,
@@ -186,8 +288,161 @@ public static class Compose
         {
             if (handle != System.IntPtr.Zero)
                 Android.Runtime.JNIEnv.DeleteLocalRef(handle);
+            if (ownsInputs && inputs != System.IntPtr.Zero)
+                Android.Runtime.JNIEnv.DeleteLocalRef(inputs);
             System.GC.KeepAlive(composer);
         }
     }
-}
 
+    /// <summary>
+    /// Compose's <c>derivedStateOf { calculation() }</c>: returns a
+    /// read-only <see cref="DerivedState{T}"/> whose value is lazily
+    /// computed by <paramref name="calculation"/>. Compose tracks
+    /// which state values <paramref name="calculation"/> reads and
+    /// only re-runs it when one of them changes. Cache the returned
+    /// instance via <see cref="Remember{T}(System.Func{T}, int, string)"/>
+    /// so it survives recomposition:
+    /// <code>
+    /// var name  = Remember(() =&gt; new MutableState&lt;string&gt;("Ada"));
+    /// var greet = Remember(() =&gt; Compose.DerivedStateOf(() =&gt; $"Hi, {name.Value}!"));
+    /// new Text(greet.Value); // recomposes only when name.Value changes
+    /// </code>
+    /// </summary>
+    public static DerivedState<T> DerivedStateOf<T>(System.Func<T> calculation)
+    {
+        if (calculation is null) throw new System.ArgumentNullException(nameof(calculation));
+        var jcw = new ObjectFunction0(() => MutableState<T>.ToJava(calculation()));
+        var state = SnapshotStateKt.DerivedStateOf(jcw);
+        return new DerivedState<T>(state);
+    }
+
+    /// <summary>
+    /// C# parity for Kotlin's
+    /// <c>produceState(initialValue, vararg keys) { producer }</c>:
+    /// remembers a <see cref="MutableState{T}"/> seeded with
+    /// <paramref name="initialValue"/>. Starts <paramref name="producer"/>
+    /// the first time this call site enters the composition. The
+    /// producer receives the state to write to plus a
+    /// <see cref="System.Threading.CancellationToken"/> that fires
+    /// when this call site leaves the composition.
+    ///
+    /// <code>
+    /// var clock = Compose.ProduceState(
+    ///     initialValue: "—",
+    ///     producer: async (state, ct) =&gt;
+    ///     {
+    ///         while (!ct.IsCancellationRequested)
+    ///         {
+    ///             state.Value = System.DateTime.Now.ToLongTimeString();
+    ///             await System.Threading.Tasks.Task.Delay(1000, ct);
+    ///         }
+    ///     });
+    /// new Text(clock.Value);
+    /// </code>
+    ///
+    /// Producer exceptions are logged via
+    /// <see cref="Android.Util.Log.Error(string?, string?)"/> under
+    /// the <c>ComposeNet</c> tag rather than becoming unobserved
+    /// task exceptions. Writes from the producer are forwarded to
+    /// the composition thread via <see cref="MutableState{T}.Value"/>
+    /// — Compose handles the recomposition scheduling.
+    /// </summary>
+    /// <remarks>
+    /// Implemented purely in C# (not via Kotlin's
+    /// <c>SnapshotStateKt.ProduceState</c>) to keep the producer a
+    /// plain <see cref="System.Threading.Tasks.Task"/> rather than a
+    /// Kotlin suspend lambda. The lifecycle is driven
+    /// by an <see cref="IRememberObserver"/> JCW that's the direct
+    /// slot value, so Compose's runtime fires
+    /// <c>onRemembered</c>/<c>onForgotten</c>/<c>onAbandoned</c>
+    /// at the right times.
+    /// </remarks>
+    public static MutableState<T> ProduceState<T>(
+        T initialValue,
+        System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => ProduceStateCore(initialValue, producer, keys: null, line, file);
+
+    /// <summary>
+    /// Keyed <c>produceState(initial, key1) { producer }</c>: cancels
+    /// the running producer and starts a fresh one whenever
+    /// <paramref name="key1"/> changes (structural equality).
+    /// </summary>
+    public static MutableState<T> ProduceState<T>(
+        T initialValue,
+        object? key1,
+        System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => ProduceStateCore(initialValue, producer, new[] { key1 }, line, file);
+
+    /// <summary>Keyed <c>produceState(initial, key1, key2) { producer }</c>.</summary>
+    public static MutableState<T> ProduceState<T>(
+        T initialValue,
+        object? key1,
+        object? key2,
+        System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => ProduceStateCore(initialValue, producer, new[] { key1, key2 }, line, file);
+
+    /// <summary>Keyed <c>produceState(initial, key1, key2, key3) { producer }</c>.</summary>
+    public static MutableState<T> ProduceState<T>(
+        T initialValue,
+        object? key1,
+        object? key2,
+        object? key3,
+        System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => ProduceStateCore(initialValue, producer, new[] { key1, key2, key3 }, line, file);
+
+    /// <summary>
+    /// Array-form keyed <c>produceState(initial, vararg keys) { producer }</c>.
+    /// Use when there are more than three keys.
+    /// </summary>
+    public static MutableState<T> ProduceStateKeyed<T>(
+        T initialValue,
+        object?[] keys,
+        System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => ProduceStateCore(initialValue, producer, keys ?? throw new System.ArgumentNullException(nameof(keys)), line, file);
+
+    static MutableState<T> ProduceStateCore<T>(
+        T initialValue,
+        System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
+        object?[]? keys,
+        int line,
+        string file)
+    {
+        if (producer is null) throw new System.ArgumentNullException(nameof(producer));
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.ProduceState<T> must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
+
+        composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
+        try
+        {
+            // The slot value MUST be the IRememberObserver itself —
+            // Compose only inspects what UpdateRememberedValue is
+            // handed for the IRememberObserver interface. Nesting it
+            // inside RememberHolder would silently break the
+            // OnRemembered/OnForgotten/OnAbandoned hooks.
+            if (composer.RememberedValue() is ProduceStateScope<T> existing)
+            {
+                if (!RememberHolder.KeysEqual(existing.Keys, keys))
+                    existing.Restart(keys);
+                return existing.State;
+            }
+            var scope = new ProduceStateScope<T>(initialValue, producer, keys);
+            composer.UpdateRememberedValue(scope);
+            return scope.State;
+        }
+        finally
+        {
+            composer.EndReplaceableGroup();
+        }
+    }
+}

--- a/src/ComposeNet.Compose/ComposeActivity.cs
+++ b/src/ComposeNet.Compose/ComposeActivity.cs
@@ -78,6 +78,41 @@ public abstract class ComposeActivity : ComponentActivity
         [CallerFilePath]   string file = "")
         => Compose.Remember(factory, line, file);
 
+    /// <summary>Keyed <c>remember(key1) { factory() }</c>; forwards to <see cref="Compose.Remember{T}(System.Func{T}, object?, int, string)"/>.</summary>
+    protected T Remember<T>(
+        System.Func<T> factory,
+        object? key1,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.Remember(factory, key1, line, file);
+
+    /// <summary>Keyed <c>remember(key1, key2) { factory() }</c>.</summary>
+    protected T Remember<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.Remember(factory, key1, key2, line, file);
+
+    /// <summary>Keyed <c>remember(key1, key2, key3) { factory() }</c>.</summary>
+    protected T Remember<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        object? key3,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.Remember(factory, key1, key2, key3, line, file);
+
+    /// <summary>Array-form keyed <c>remember(vararg keys) { factory() }</c>.</summary>
+    protected T RememberKeyed<T>(
+        System.Func<T> factory,
+        object?[] keys,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.RememberKeyed(factory, keys, line, file);
+
     /// <summary>
     /// Like <see cref="Remember{T}(System.Func{T}, int, string)"/>, but
     /// the cached value also survives process death / activity
@@ -93,6 +128,41 @@ public abstract class ComposeActivity : ComponentActivity
         [CallerLineNumber] int line = 0,
         [CallerFilePath]   string file = "")
         => Compose.RememberSaveable(factory, line, file);
+
+    /// <summary>Keyed <c>rememberSaveable(key1) { factory() }</c>; forwards to <see cref="Compose.RememberSaveable{T}(System.Func{T}, object?, int, string)"/>.</summary>
+    protected T RememberSaveable<T>(
+        System.Func<T> factory,
+        object? key1,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.RememberSaveable(factory, key1, line, file);
+
+    /// <summary>Keyed <c>rememberSaveable(key1, key2) { factory() }</c>.</summary>
+    protected T RememberSaveable<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.RememberSaveable(factory, key1, key2, line, file);
+
+    /// <summary>Keyed <c>rememberSaveable(key1, key2, key3) { factory() }</c>.</summary>
+    protected T RememberSaveable<T>(
+        System.Func<T> factory,
+        object? key1,
+        object? key2,
+        object? key3,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.RememberSaveable(factory, key1, key2, key3, line, file);
+
+    /// <summary>Array-form keyed <c>rememberSaveable(vararg inputs) { factory() }</c>.</summary>
+    protected T RememberSaveableKeyed<T>(
+        System.Func<T> factory,
+        object?[] keys,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath]   string file = "")
+        => Compose.RememberSaveableKeyed(factory, keys, line, file);
 
     /// <summary>
     /// Opts the window into edge-to-edge. Call <c>base.OnCreate</c>

--- a/src/ComposeNet.Compose/ComposeContext.cs
+++ b/src/ComposeNet.Compose/ComposeContext.cs
@@ -4,7 +4,7 @@ namespace ComposeNet;
 
 /// <summary>
 /// Holds the active <see cref="IComposer"/> for the current composition pass
-/// so APIs like <see cref="Compose.Remember{T}"/> can reach it without every
+/// so APIs like <see cref="Compose.Remember{T}(System.Func{T}, int, string)"/> can reach it without every
 /// helper composable having to thread <c>composer</c> through its signature.
 ///
 /// Compose's composition runs synchronously on a single thread per pass, so

--- a/src/ComposeNet.Compose/ComposeNet.Compose.csproj
+++ b/src/ComposeNet.Compose/ComposeNet.Compose.csproj
@@ -7,6 +7,19 @@
     <IsTrimmable>true</IsTrimmable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>ComposeNet</RootNamespace>
+    <!--
+      RS0026: "Do not add multiple overloads with optional parameters."
+      Triggers on our [CallerLineNumber]/[CallerFilePath]-bearing
+      overloads (Compose.Remember, Compose.RememberSaveable,
+      Compose.ProduceState). The new overloads add a REQUIRED key
+      parameter ahead of the optional caller-info ones — so callers
+      can never get into the "which overload did I want?" situation
+      the analyzer warns about. The BCL freely does this for the
+      same caller-info pattern; suppress here for the same reason.
+
+      RS0027: companion warning for the same scenario.
+    -->
+    <NoWarn>$(NoWarn);RS0026;RS0027</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ComposeNet.SourceGenerators\ComposeNet.SourceGenerators.csproj"

--- a/src/ComposeNet.Compose/DerivedState.cs
+++ b/src/ComposeNet.Compose/DerivedState.cs
@@ -1,0 +1,51 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Read-only state computed from other state, the C# parity for
+/// Kotlin's <c>derivedStateOf { … }</c>. Wraps Compose's
+/// <c>IState</c> (returned by
+/// <c>SnapshotStateKt.DerivedStateOf(IFunction0)</c>) so the value
+/// can be read from any composition that holds the instance —
+/// reading <see cref="Value"/> subscribes the calling composition
+/// scope, and any change to the underlying state read inside the
+/// calculation triggers a recomposition of those scopes.
+///
+/// <code>
+/// var name   = Remember(() =&gt; new MutableState&lt;string&gt;("Ada"));
+/// var greet  = Remember(() =&gt; Compose.DerivedStateOf(() =&gt; $"Hi, {name.Value}!"));
+/// // In a Render body:
+/// new Text(greet.Value); // recomposes when name.Value changes
+/// </code>
+///
+/// The calculation runs lazily and is memoised by Compose between
+/// reads — only re-runs when one of the state values it read changes.
+/// </summary>
+/// <remarks>
+/// Use <see cref="Compose.DerivedStateOf{T}(System.Func{T})"/> to
+/// build instances; the constructor is internal because the wrapped
+/// <c>IState</c> must come from a Kotlin <c>derivedStateOf</c> call
+/// to participate correctly in Compose's snapshot system.
+/// </remarks>
+public sealed class DerivedState<T>
+{
+    readonly IState _state;
+
+    internal DerivedState(IState state) => _state = state;
+
+    /// <summary>
+    /// The current derived value, recomputed lazily by Compose when
+    /// any of the state values read inside the calculation change.
+    /// Reading from a composition scope subscribes that scope so it
+    /// recomposes when this value changes.
+    /// </summary>
+    public T Value => MutableState<T>.FromJava(_state.Value);
+
+    /// <summary>
+    /// Returns the underlying value's string representation so
+    /// <c>$"...{state}..."</c> interpolation reads as Kotlin would
+    /// (a null value renders as <c>"null"</c>).
+    /// </summary>
+    public override string ToString() => Value?.ToString() ?? "null";
+}

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -342,7 +342,7 @@ public sealed class Modifier
     /// (e.g. a regular <see cref="Column"/> or <see cref="Box"/>)
     /// vertically scrollable when its content overflows. Hold the
     /// <paramref name="state"/> across recompositions with
-    /// <see cref="ComposeActivity.Remember{T}"/>:
+    /// <see cref="ComposeActivity.Remember{T}(System.Func{T}, int, string)"/>:
     /// <code>
     /// var scroll = Remember(() =&gt; new ScrollState());
     /// new Column { Modifier.Companion.VerticalScroll(scroll), /* children */ };

--- a/src/ComposeNet.Compose/MutableNumberState.cs
+++ b/src/ComposeNet.Compose/MutableNumberState.cs
@@ -35,7 +35,7 @@ namespace ComposeNet;
 /// picks the right Kotlin factory. It's <i>not</i> guaranteed when the
 /// wrapper is built around a state produced elsewhere, such as the
 /// boxed <c>mutableStateOf(restoredValue, policy)</c> that
-/// <see cref="Compose.RememberSaveable{T}"/> returns after a process
+/// <see cref="Compose.RememberSaveable{T}(System.Func{T}, int, string)"/> returns after a process
 /// death restore. The instance <c>_kind</c> field is probed from the
 /// supplied state once at construction so the <see cref="Value"/>
 /// getter/setter never attempts an invalid cast.

--- a/src/ComposeNet.Compose/MutableStateList.cs
+++ b/src/ComposeNet.Compose/MutableStateList.cs
@@ -5,15 +5,16 @@ namespace ComposeNet;
 
 /// <summary>
 /// A managed <see cref="IList{T}"/> wrapper that participates in
-/// Compose's snapshot system without needing a Kotlin
-/// <c>SnapshotStateList</c> binding. Every read (<see cref="Count"/>,
+/// Compose's recomposition system without needing a Kotlin
+/// <c>SnapshotStateList</c> binding. C# parity for Kotlin's
+/// <c>mutableStateListOf&lt;T&gt;()</c>: every read (<see cref="Count"/>,
 /// the indexer, <see cref="GetEnumerator"/>) touches an internal
 /// <see cref="MutableNumberState{Int32}"/> version counter so the
 /// composition scope subscribes; every mutation increments that
 /// counter, triggering a recomposition.
 ///
 /// <code>
-/// var messages = Remember(() => new ObservableList&lt;Message&gt;());
+/// var messages = Remember(() => new MutableStateList&lt;Message&gt;());
 /// // In a Render body:
 /// foreach (var m in messages)
 ///     new Text(m.Content);
@@ -26,44 +27,65 @@ namespace ComposeNet;
 /// composition) are fine — the next recomposition will see the new
 /// version. Not thread-safe; intended for UI/composition-thread use.
 /// </summary>
-public sealed class ObservableList<T> : IList<T>, IReadOnlyList<T>
+/// <remarks>
+/// This is a *managed* observable list, not a true Kotlin
+/// <c>SnapshotStateList</c>. It tracks change-vs-no-change at the
+/// list level (single tick counter), not per-index. Snapshot
+/// isolation, custom <c>SnapshotMutationPolicy</c>, and per-read
+/// fine-grained dependency tracking are not provided. For UI lists
+/// where "any mutation triggers recomposition of any reader" is the
+/// desired behaviour — which covers ~all typical Compose UI list
+/// patterns — that's exactly the contract you want.
+/// </remarks>
+public sealed class MutableStateList<T> : IList<T>, IReadOnlyList<T>
 {
     readonly List<T> _items;
     readonly MutableNumberState<int> _tick = new(0);
 
-    public ObservableList() => _items = new List<T>();
-    public ObservableList(IEnumerable<T> initial) => _items = new List<T>(initial);
+    /// <summary>Creates an empty observable list.</summary>
+    public MutableStateList() => _items = new List<T>();
+
+    /// <summary>Creates an observable list pre-populated with <paramref name="initial"/>.</summary>
+    public MutableStateList(IEnumerable<T> initial) => _items = new List<T>(initial);
 
     // Subscribe the current composition scope to mutations.
     void Track() { _ = _tick.Value; }
     // Notify all subscribed scopes that the list has changed.
     void Bump() => _tick.Value++;
 
+    /// <inheritdoc/>
     public int Count
     {
         get { Track(); return _items.Count; }
     }
 
+    /// <inheritdoc/>
     public bool IsReadOnly => false;
 
+    /// <inheritdoc/>
     public T this[int index]
     {
         get { Track(); return _items[index]; }
         set { _items[index] = value; Bump(); }
     }
 
+    /// <inheritdoc/>
     public void Add(T item) { _items.Add(item); Bump(); }
 
+    /// <inheritdoc/>
     public void Insert(int index, T item) { _items.Insert(index, item); Bump(); }
 
+    /// <inheritdoc/>
     public bool Remove(T item)
     {
         if (_items.Remove(item)) { Bump(); return true; }
         return false;
     }
 
+    /// <inheritdoc/>
     public void RemoveAt(int index) { _items.RemoveAt(index); Bump(); }
 
+    /// <inheritdoc/>
     public void Clear()
     {
         if (_items.Count == 0) return;
@@ -71,10 +93,14 @@ public sealed class ObservableList<T> : IList<T>, IReadOnlyList<T>
         Bump();
     }
 
+    /// <inheritdoc/>
     public bool Contains(T item) { Track(); return _items.Contains(item); }
+    /// <inheritdoc/>
     public int IndexOf(T item)  { Track(); return _items.IndexOf(item); }
+    /// <inheritdoc/>
     public void CopyTo(T[] array, int arrayIndex) { Track(); _items.CopyTo(array, arrayIndex); }
 
+    /// <inheritdoc/>
     public IEnumerator<T> GetEnumerator() { Track(); return _items.GetEnumerator(); }
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }

--- a/src/ComposeNet.Compose/MutableStateMap.cs
+++ b/src/ComposeNet.Compose/MutableStateMap.cs
@@ -1,0 +1,147 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ComposeNet;
+
+/// <summary>
+/// A managed <see cref="IDictionary{TKey, TValue}"/> wrapper that
+/// participates in Compose's recomposition system without needing a
+/// Kotlin <c>SnapshotStateMap</c> binding. C# parity for Kotlin's
+/// <c>mutableStateMapOf&lt;K, V&gt;()</c>: every read touches an
+/// internal <see cref="MutableNumberState{Int32}"/> version counter
+/// so the composition scope subscribes; every mutation increments
+/// that counter, triggering a recomposition.
+///
+/// <code>
+/// var prefs = Remember(() => new MutableStateMap&lt;string, bool&gt;());
+/// // In a Render body:
+/// new Text(prefs.TryGetValue("dark", out var v) &amp;&amp; v ? "Dark" : "Light");
+/// // Anywhere — triggers recomposition:
+/// prefs["dark"] = true;
+/// </code>
+///
+/// Reads MUST happen during composition for the subscription to take
+/// effect. Mutations from a UI button handler (which run outside
+/// composition) are fine — the next recomposition will see the new
+/// version. Not thread-safe; intended for UI/composition-thread use.
+/// </summary>
+/// <remarks>
+/// This is a *managed* observable map, not a true Kotlin
+/// <c>SnapshotStateMap</c>. It tracks change-vs-no-change at the
+/// map level (single tick counter), not per-key. Snapshot isolation,
+/// custom <c>SnapshotMutationPolicy</c>, and per-read fine-grained
+/// dependency tracking are not provided. For UI maps where "any
+/// mutation triggers recomposition of any reader" is the desired
+/// behaviour — which covers ~all typical Compose UI map patterns —
+/// that's exactly the contract you want.
+/// </remarks>
+public sealed class MutableStateMap<TKey, TValue>
+    : IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
+    where TKey : notnull
+{
+    readonly Dictionary<TKey, TValue> _items;
+    readonly MutableNumberState<int> _tick = new(0);
+
+    /// <summary>Creates an empty observable map.</summary>
+    public MutableStateMap() => _items = new Dictionary<TKey, TValue>();
+
+    /// <summary>Creates an observable map pre-populated with <paramref name="initial"/>.</summary>
+    public MutableStateMap(IEnumerable<KeyValuePair<TKey, TValue>> initial)
+    {
+        _items = new Dictionary<TKey, TValue>();
+        foreach (var kv in initial) _items[kv.Key] = kv.Value;
+    }
+
+    void Track() { _ = _tick.Value; }
+    void Bump() => _tick.Value++;
+
+    /// <inheritdoc/>
+    public int Count { get { Track(); return _items.Count; } }
+
+    /// <inheritdoc/>
+    public bool IsReadOnly => false;
+
+    /// <inheritdoc/>
+    public TValue this[TKey key]
+    {
+        get { Track(); return _items[key]; }
+        set { _items[key] = value; Bump(); }
+    }
+
+    /// <inheritdoc/>
+    public ICollection<TKey> Keys { get { Track(); return _items.Keys; } }
+    /// <inheritdoc/>
+    public ICollection<TValue> Values { get { Track(); return _items.Values; } }
+
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys { get { Track(); return _items.Keys; } }
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values { get { Track(); return _items.Values; } }
+
+    /// <inheritdoc/>
+    public void Add(TKey key, TValue value) { _items.Add(key, value); Bump(); }
+
+    /// <inheritdoc/>
+    public void Add(KeyValuePair<TKey, TValue> item) { _items.Add(item.Key, item.Value); Bump(); }
+
+    /// <inheritdoc/>
+    public bool ContainsKey(TKey key) { Track(); return _items.ContainsKey(key); }
+
+    /// <inheritdoc/>
+    public bool Contains(KeyValuePair<TKey, TValue> item)
+    {
+        Track();
+        return _items.TryGetValue(item.Key, out var v)
+            && EqualityComparer<TValue>.Default.Equals(v, item.Value);
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(TKey key)
+    {
+        if (_items.Remove(key)) { Bump(); return true; }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public bool Remove(KeyValuePair<TKey, TValue> item)
+    {
+        if (_items.TryGetValue(item.Key, out var v)
+            && EqualityComparer<TValue>.Default.Equals(v, item.Value)
+            && _items.Remove(item.Key))
+        {
+            Bump();
+            return true;
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public void Clear()
+    {
+        if (_items.Count == 0) return;
+        _items.Clear();
+        Bump();
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+    {
+        Track();
+        return _items.TryGetValue(key, out value);
+    }
+
+    /// <inheritdoc/>
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+    {
+        Track();
+        ((ICollection<KeyValuePair<TKey, TValue>>)_items).CopyTo(array, arrayIndex);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+    {
+        Track();
+        return _items.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/ComposeNet.Compose/NavController.cs
+++ b/src/ComposeNet.Compose/NavController.cs
@@ -15,7 +15,7 @@ namespace ComposeNet;
 /// <para>
 /// Hold a single instance per logical navigation graph (typically one
 /// per <see cref="NavHost"/>) inside a
-/// <see cref="ComposeActivity.Remember{T}"/> callback so the controller
+/// <see cref="ComposeActivity.Remember{T}(System.Func{T}, int, string)"/> callback so the controller
 /// survives recompositions:
 /// </para>
 /// <code>

--- a/src/ComposeNet.Compose/ObjectFunction0.cs
+++ b/src/ComposeNet.Compose/ObjectFunction0.cs
@@ -11,7 +11,7 @@ namespace ComposeNet;
 /// the binding can consume.
 ///
 /// Used wherever a Kotlin API takes a <c>() -&gt; T</c> producer of
-/// a non-<c>Unit</c> value, e.g. <see cref="Compose.RememberSaveable{T}"/>
+/// a non-<c>Unit</c> value, e.g. <see cref="Compose.RememberSaveable{T}(System.Func{T}, int, string)"/>
 /// for the value the saveable registry should cache.
 /// </summary>
 [Register("composenet/compose/ObjectFunction0")]

--- a/src/ComposeNet.Compose/ProduceStateScope.cs
+++ b/src/ComposeNet.Compose/ProduceStateScope.cs
@@ -1,0 +1,107 @@
+using Android.Runtime;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Slot value used by <see cref="Compose.ProduceState{T}(T, System.Func{MutableState{T}, System.Threading.CancellationToken, System.Threading.Tasks.Task}, int, string)"/>:
+/// holds the <see cref="MutableState{T}"/> the caller writes to,
+/// plus the producer task / cancellation lifecycle. Implements
+/// <see cref="IRememberObserver"/> so it starts the producer when
+/// Compose adds the value to the composition
+/// (<see cref="OnRemembered"/>) and cancels it when the value is
+/// removed (<see cref="OnForgotten"/> / <see cref="OnAbandoned"/>).
+///
+/// <c>ProduceStateScope</c> must be the <em>direct</em> slot value
+/// (not wrapped in <see cref="RememberHolder"/>) — Compose only
+/// inspects the exact object handed to
+/// <see cref="IComposer.UpdateRememberedValue"/> for the
+/// <see cref="IRememberObserver"/> interface.
+/// </summary>
+[Register("composenet/compose/ProduceStateScope")]
+internal sealed class ProduceStateScope<T> : Java.Lang.Object, IRememberObserver
+{
+    public readonly MutableState<T> State;
+    public object?[]? Keys;
+
+    readonly System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> _producer;
+    System.Threading.CancellationTokenSource? _cts;
+    bool _started;
+    bool _disposed;
+
+    public ProduceStateScope(
+        T initial,
+        System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
+        object?[]? keys)
+    {
+        State = new MutableState<T>(initial);
+        _producer = producer;
+        Keys = keys is null ? null : (object?[])keys.Clone();
+    }
+
+    // Peer-rehydration ctor — the .NET-for-Android runtime invokes
+    // this when an existing JNI handle for our [Register]'d class
+    // crosses back into managed code without a live peer. We never
+    // create new scope instances this way (Compose hands back the
+    // original peer from its slot table), but the runtime requires
+    // the constructor to exist.
+    internal ProduceStateScope(System.IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer)
+    {
+        // Make non-nullable fields satisfied; this peer will never be
+        // used by managed callers — only the slot-table identity is.
+        State = null!;
+        _producer = null!;
+    }
+
+    /// <summary>
+    /// Replace the active producer task — used when caller keys
+    /// change between compositions: cancel the running task and
+    /// kick off a fresh one with the new keys recorded.
+    /// </summary>
+    public void Restart(object?[]? newKeys)
+    {
+        Stop();
+        Keys = newKeys is null ? null : (object?[])newKeys.Clone();
+        _disposed = false;
+        _started = false;
+        Start();
+    }
+
+    public void OnRemembered() => Start();
+
+    public void OnForgotten() => Stop();
+
+    public void OnAbandoned() => Stop();
+
+    void Start()
+    {
+        if (_started || _disposed) return;
+        _started = true;
+        _cts = new System.Threading.CancellationTokenSource();
+        var token = _cts.Token;
+        var task = _producer(State, token);
+        // Surface producer faults to logcat instead of leaving them
+        // as unobserved task exceptions. Match ComposeActivity's
+        // logging tag so all our diagnostics share a single filter.
+        _ = task.ContinueWith(static t =>
+        {
+            if (t.Exception is { } ex)
+            {
+                Android.Util.Log.Error(
+                    "ComposeNet",
+                    "ProduceState producer faulted: " + ex);
+            }
+        }, System.Threading.Tasks.TaskScheduler.Default);
+    }
+
+    void Stop()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try { _cts?.Cancel(); }
+        catch { /* token source may already be disposed */ }
+        _cts?.Dispose();
+        _cts = null;
+    }
+}

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -90,7 +90,15 @@ ComposeNet.Compose
 ComposeNet.ComposeActivity
 ComposeNet.ComposeActivity.ComposeActivity() -> void
 ComposeNet.ComposeActivity.Remember<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.Remember<T>(System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.Remember<T>(System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.Remember<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.RememberKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 ComposeNet.ComposeActivity.RememberSaveable<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.RememberSaveable<T>(System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
+ComposeNet.ComposeActivity.RememberSaveableKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 ComposeNet.ComposeActivity.SetContent(System.Func<ComposeNet.ComposableNode!>! content) -> void
 ComposeNet.CustomTab
 ComposeNet.CustomTab.CustomTab(bool selected, System.Action! onClick) -> void
@@ -129,6 +137,8 @@ ComposeNet.DateRangePickerState.SelectedEndDateMillis.set -> void
 ComposeNet.DateRangePickerState.SelectedStartDateMillis.get -> long?
 ComposeNet.DateRangePickerState.SelectedStartDateMillis.set -> void
 ComposeNet.DateRangePickerState.SetSelection(long? startDateMillis, long? endDateMillis) -> void
+ComposeNet.DerivedState<T>
+ComposeNet.DerivedState<T>.Value.get -> T
 ComposeNet.DismissibleDrawerSheet
 ComposeNet.DismissibleDrawerSheet.ContainerColor.get -> long
 ComposeNet.DismissibleDrawerSheet.ContainerColor.set -> void
@@ -476,22 +486,41 @@ ComposeNet.NavigationRailItem.Icon.set -> void
 ComposeNet.NavigationRailItem.Label.get -> ComposeNet.ComposableNode?
 ComposeNet.NavigationRailItem.Label.set -> void
 ComposeNet.NavigationRailItem.NavigationRailItem(bool selected, System.Action! onClick) -> void
-ComposeNet.ObservableList<T>
-ComposeNet.ObservableList<T>.Add(T item) -> void
-ComposeNet.ObservableList<T>.Clear() -> void
-ComposeNet.ObservableList<T>.Contains(T item) -> bool
-ComposeNet.ObservableList<T>.CopyTo(T[]! array, int arrayIndex) -> void
-ComposeNet.ObservableList<T>.Count.get -> int
-ComposeNet.ObservableList<T>.GetEnumerator() -> System.Collections.Generic.IEnumerator<T>!
-ComposeNet.ObservableList<T>.IndexOf(T item) -> int
-ComposeNet.ObservableList<T>.Insert(int index, T item) -> void
-ComposeNet.ObservableList<T>.IsReadOnly.get -> bool
-ComposeNet.ObservableList<T>.ObservableList() -> void
-ComposeNet.ObservableList<T>.ObservableList(System.Collections.Generic.IEnumerable<T>! initial) -> void
-ComposeNet.ObservableList<T>.Remove(T item) -> bool
-ComposeNet.ObservableList<T>.RemoveAt(int index) -> void
-ComposeNet.ObservableList<T>.this[int index].get -> T
-ComposeNet.ObservableList<T>.this[int index].set -> void
+ComposeNet.MutableStateList<T>
+ComposeNet.MutableStateList<T>.Add(T item) -> void
+ComposeNet.MutableStateList<T>.Clear() -> void
+ComposeNet.MutableStateList<T>.Contains(T item) -> bool
+ComposeNet.MutableStateList<T>.CopyTo(T[]! array, int arrayIndex) -> void
+ComposeNet.MutableStateList<T>.Count.get -> int
+ComposeNet.MutableStateList<T>.GetEnumerator() -> System.Collections.Generic.IEnumerator<T>!
+ComposeNet.MutableStateList<T>.IndexOf(T item) -> int
+ComposeNet.MutableStateList<T>.Insert(int index, T item) -> void
+ComposeNet.MutableStateList<T>.IsReadOnly.get -> bool
+ComposeNet.MutableStateList<T>.MutableStateList() -> void
+ComposeNet.MutableStateList<T>.MutableStateList(System.Collections.Generic.IEnumerable<T>! initial) -> void
+ComposeNet.MutableStateList<T>.Remove(T item) -> bool
+ComposeNet.MutableStateList<T>.RemoveAt(int index) -> void
+ComposeNet.MutableStateList<T>.this[int index].get -> T
+ComposeNet.MutableStateList<T>.this[int index].set -> void
+ComposeNet.MutableStateMap<TKey, TValue>
+ComposeNet.MutableStateMap<TKey, TValue>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) -> void
+ComposeNet.MutableStateMap<TKey, TValue>.Add(TKey key, TValue value) -> void
+ComposeNet.MutableStateMap<TKey, TValue>.Clear() -> void
+ComposeNet.MutableStateMap<TKey, TValue>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) -> bool
+ComposeNet.MutableStateMap<TKey, TValue>.ContainsKey(TKey key) -> bool
+ComposeNet.MutableStateMap<TKey, TValue>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[]! array, int arrayIndex) -> void
+ComposeNet.MutableStateMap<TKey, TValue>.Count.get -> int
+ComposeNet.MutableStateMap<TKey, TValue>.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>!
+ComposeNet.MutableStateMap<TKey, TValue>.IsReadOnly.get -> bool
+ComposeNet.MutableStateMap<TKey, TValue>.Keys.get -> System.Collections.Generic.ICollection<TKey>!
+ComposeNet.MutableStateMap<TKey, TValue>.MutableStateMap() -> void
+ComposeNet.MutableStateMap<TKey, TValue>.MutableStateMap(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>! initial) -> void
+ComposeNet.MutableStateMap<TKey, TValue>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) -> bool
+ComposeNet.MutableStateMap<TKey, TValue>.Remove(TKey key) -> bool
+ComposeNet.MutableStateMap<TKey, TValue>.this[TKey key].get -> TValue
+ComposeNet.MutableStateMap<TKey, TValue>.this[TKey key].set -> void
+ComposeNet.MutableStateMap<TKey, TValue>.TryGetValue(TKey key, out TValue value) -> bool
+ComposeNet.MutableStateMap<TKey, TValue>.Values.get -> System.Collections.Generic.ICollection<TValue>!
 ComposeNet.OutlinedButton
 ComposeNet.OutlinedButton.OutlinedButton(System.Action! onClick) -> void
 ComposeNet.OutlinedCard
@@ -817,6 +846,7 @@ ComposeNet.WideNavigationRailItem.Label.get -> ComposeNet.ComposableNode?
 ComposeNet.WideNavigationRailItem.Label.set -> void
 ComposeNet.WideNavigationRailItem.WideNavigationRailItem(bool selected, System.Action! onClick) -> void
 override ComposeNet.ComposeActivity.OnCreate(Android.OS.Bundle? savedInstanceState) -> void
+override ComposeNet.DerivedState<T>.ToString() -> string!
 override ComposeNet.Dp.Equals(object? obj) -> bool
 override ComposeNet.Dp.GetHashCode() -> int
 override ComposeNet.Dp.ToString() -> string!
@@ -836,8 +866,22 @@ static ComposeNet.Arrangement.SpacedBy(int dp) -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.SpaceEvenly.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Start.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Top.get -> ComposeNet.Arrangement!
+static ComposeNet.Compose.DerivedStateOf<T>(System.Func<T>! calculation) -> ComposeNet.DerivedState<T>!
+static ComposeNet.Compose.ProduceState<T>(T initialValue, object? key1, object? key2, object? key3, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
+static ComposeNet.Compose.ProduceState<T>(T initialValue, object? key1, object? key2, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
+static ComposeNet.Compose.ProduceState<T>(T initialValue, object? key1, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
+static ComposeNet.Compose.ProduceState<T>(T initialValue, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
+static ComposeNet.Compose.ProduceStateKeyed<T>(T initialValue, object?[]! keys, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
 static ComposeNet.Compose.Remember<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.Remember<T>(System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.Remember<T>(System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.Remember<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.RememberKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.RememberSaveableKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(float value) -> ComposeNet.Dp
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(int value) -> ComposeNet.Dp
 static ComposeNet.Dp.operator !=(ComposeNet.Dp left, ComposeNet.Dp right) -> bool

--- a/src/ComposeNet.Compose/RememberHolder.cs
+++ b/src/ComposeNet.Compose/RememberHolder.cs
@@ -4,7 +4,7 @@ namespace ComposeNet;
 
 /// <summary>
 /// Single-field <see cref="Java.Lang.Object"/> wrapper that lets
-/// <see cref="Compose.Remember{T}"/> store an arbitrary managed
+/// <see cref="Compose.Remember{T}(System.Func{T}, int, string)"/> store an arbitrary managed
 /// <c>T</c> (often a <see cref="MutableState{T}"/>) in Compose's slot
 /// table, which only holds <see cref="Java.Lang.Object"/> references.
 ///
@@ -15,6 +15,11 @@ namespace ComposeNet;
 /// <c>RememberHolder</c> peer rather than a plain
 /// <see cref="Java.Lang.Object"/> shell — which would lose the
 /// <see cref="Value"/> field and force the factory to re-run.
+///
+/// When a keyed <see cref="Compose.Remember{T}(System.Func{T}, object?, int, string)"/> overload is used,
+/// the supplied keys are cloned into <see cref="Keys"/> so a later
+/// recomposition can compare them via <see cref="KeysEqual"/>; mismatch
+/// invalidates the slot and forces the factory to re-run.
 /// </summary>
 [Register("composenet/compose/RememberHolder")]
 internal sealed class RememberHolder : Java.Lang.Object
@@ -22,9 +27,23 @@ internal sealed class RememberHolder : Java.Lang.Object
     /// <summary>The remembered managed value (boxed if a value type).</summary>
     public object? Value;
 
+    /// <summary>
+    /// Defensive snapshot of the caller-supplied keys, or <c>null</c>
+    /// for the keyless overload. Cloned at construction so later
+    /// caller mutation of the original array doesn't corrupt the
+    /// "previous keys" comparison.
+    /// </summary>
+    public object?[]? Keys;
+
     public RememberHolder() { }
 
     public RememberHolder(object? value) => Value = value;
+
+    public RememberHolder(object? value, object?[]? keys)
+    {
+        Value = value;
+        Keys = keys is null ? null : (object?[])keys.Clone();
+    }
 
     // Peer-rehydration ctor: called by the .NET-for-Android runtime when
     // a JNI handle for our [Register]'d class crosses back into managed
@@ -33,4 +52,22 @@ internal sealed class RememberHolder : Java.Lang.Object
     // whichever peer the runtime returns from its peer cache.
     internal RememberHolder(IntPtr handle, JniHandleOwnership transfer)
         : base(handle, transfer) { }
+
+    /// <summary>
+    /// Structural-equality comparison of two key arrays, matching
+    /// Kotlin's <c>remember(k1, k2, …) { … }</c> invalidation rules:
+    /// two <c>null</c> arrays are equal, length mismatch is unequal,
+    /// elements are compared with <see cref="object.Equals(object?, object?)"/>.
+    /// </summary>
+    internal static bool KeysEqual(object?[]? a, object?[]? b)
+    {
+        if (ReferenceEquals(a, b)) return true;
+        if (a is null || b is null) return false;
+        if (a.Length != b.Length) return false;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (!object.Equals(a[i], b[i])) return false;
+        }
+        return true;
+    }
 }

--- a/src/ComposeNet.Compose/SaveableBridges.cs
+++ b/src/ComposeNet.Compose/SaveableBridges.cs
@@ -202,37 +202,47 @@ internal static partial class ComposeBridges
         var array = JNIEnv.NewObjectArray(keys.Length, objectClass.Handle, System.IntPtr.Zero);
         for (int i = 0; i < keys.Length; i++)
         {
-            var boxed = BoxKey(keys[i]);
+            var boxed = BoxKey(keys[i], out var ownsBoxed);
             if (boxed is null)
             {
                 JNIEnv.SetObjectArrayElement(array, i, System.IntPtr.Zero);
                 continue;
             }
             JNIEnv.SetObjectArrayElement(array, i, boxed.Handle);
-            // Disposing releases the local ref the boxing constructor
-            // created; the array now holds its own ref to the element.
-            boxed.Dispose();
+            // Only dispose freshly created boxing wrappers — disposing
+            // a pass-through caller-owned Java.Lang.Object would
+            // invalidate their managed peer.
+            if (ownsBoxed) boxed.Dispose();
         }
         return array;
     }
 
-    static Java.Lang.Object? BoxKey(object? key) => key switch
+    static Java.Lang.Object? BoxKey(object? key, out bool owns)
     {
-        null               => null,
-        Java.Lang.Object o => o,
-        string s           => new Java.Lang.String(s),
-        bool b             => Java.Lang.Boolean.ValueOf(b),
-        char c             => Java.Lang.Character.ValueOf(c),
-        sbyte sb           => Java.Lang.Byte.ValueOf(sb),
-        byte by            => Java.Lang.Short.ValueOf((short)by),
-        short sh           => Java.Lang.Short.ValueOf(sh),
-        ushort us          => Java.Lang.Integer.ValueOf(us),
-        int i              => Java.Lang.Integer.ValueOf(i),
-        uint ui            => Java.Lang.Long.ValueOf(ui),
-        long l             => Java.Lang.Long.ValueOf(l),
-        ulong ul           => Java.Lang.Long.ValueOf(unchecked((long)ul)),
-        float f            => Java.Lang.Float.ValueOf(f),
-        double d           => Java.Lang.Double.ValueOf(d),
-        _                  => new Java.Lang.String(key.ToString() ?? string.Empty),
-    };
+        switch (key)
+        {
+            case null:
+                owns = false;
+                return null;
+            case Java.Lang.Object o:
+                // Caller-owned — do NOT dispose; the array still
+                // takes its own JNI ref via SetObjectArrayElement.
+                owns = false;
+                return o;
+            case string s:           owns = true; return new Java.Lang.String(s);
+            case bool b:             owns = true; return Java.Lang.Boolean.ValueOf(b);
+            case char c:             owns = true; return Java.Lang.Character.ValueOf(c);
+            case sbyte sb:           owns = true; return Java.Lang.Byte.ValueOf(sb);
+            case byte by:            owns = true; return Java.Lang.Short.ValueOf((short)by);
+            case short sh:           owns = true; return Java.Lang.Short.ValueOf(sh);
+            case ushort us:          owns = true; return Java.Lang.Integer.ValueOf(us);
+            case int i:              owns = true; return Java.Lang.Integer.ValueOf(i);
+            case uint ui:            owns = true; return Java.Lang.Long.ValueOf(ui);
+            case long l:             owns = true; return Java.Lang.Long.ValueOf(l);
+            case ulong ul:           owns = true; return Java.Lang.Long.ValueOf(unchecked((long)ul));
+            case float f:            owns = true; return Java.Lang.Float.ValueOf(f);
+            case double d:           owns = true; return Java.Lang.Double.ValueOf(d);
+            default:                 owns = true; return new Java.Lang.String(key.ToString() ?? string.Empty);
+        }
+    }
 }

--- a/src/ComposeNet.Compose/SaveableBridges.cs
+++ b/src/ComposeNet.Compose/SaveableBridges.cs
@@ -176,4 +176,63 @@ internal static partial class ComposeBridges
             System.GC.KeepAlive(init);
         }
     }
+
+    // Builds a Kotlin-compatible `Object[]` from a managed `object?[]`
+    // for the `inputs` (vararg) parameter of `rememberSaveable`. Each
+    // element is boxed via the same primitive→Java.Lang.Object switch
+    // MutableState<T> uses, so primitives compare structurally rather
+    // than by reference. Returns a JNI local ref the caller MUST free
+    // (call DeleteLocalRef inside a finally). Also creates local refs
+    // for each boxed element; we delete each one immediately after
+    // setting it into the array (the array owns its own ref).
+    //
+    // Null/empty keys array → `EmptyObjectArray()`, a cached global
+    // ref — `ownsHandle` is false, signalling the caller MUST NOT
+    // delete the returned handle.
+    internal static System.IntPtr BuildKeysArray(object?[]? keys, out bool ownsHandle)
+    {
+        if (keys is null || keys.Length == 0)
+        {
+            ownsHandle = false;
+            return EmptyObjectArray();
+        }
+
+        ownsHandle = true;
+        var objectClass = Java.Lang.Class.FromType(typeof(Java.Lang.Object));
+        var array = JNIEnv.NewObjectArray(keys.Length, objectClass.Handle, System.IntPtr.Zero);
+        for (int i = 0; i < keys.Length; i++)
+        {
+            var boxed = BoxKey(keys[i]);
+            if (boxed is null)
+            {
+                JNIEnv.SetObjectArrayElement(array, i, System.IntPtr.Zero);
+                continue;
+            }
+            JNIEnv.SetObjectArrayElement(array, i, boxed.Handle);
+            // Disposing releases the local ref the boxing constructor
+            // created; the array now holds its own ref to the element.
+            boxed.Dispose();
+        }
+        return array;
+    }
+
+    static Java.Lang.Object? BoxKey(object? key) => key switch
+    {
+        null               => null,
+        Java.Lang.Object o => o,
+        string s           => new Java.Lang.String(s),
+        bool b             => Java.Lang.Boolean.ValueOf(b),
+        char c             => Java.Lang.Character.ValueOf(c),
+        sbyte sb           => Java.Lang.Byte.ValueOf(sb),
+        byte by            => Java.Lang.Short.ValueOf((short)by),
+        short sh           => Java.Lang.Short.ValueOf(sh),
+        ushort us          => Java.Lang.Integer.ValueOf(us),
+        int i              => Java.Lang.Integer.ValueOf(i),
+        uint ui            => Java.Lang.Long.ValueOf(ui),
+        long l             => Java.Lang.Long.ValueOf(l),
+        ulong ul           => Java.Lang.Long.ValueOf(unchecked((long)ul)),
+        float f            => Java.Lang.Float.ValueOf(f),
+        double d           => Java.Lang.Double.ValueOf(d),
+        _                  => new Java.Lang.String(key.ToString() ?? string.Empty),
+    };
 }

--- a/src/ComposeNet.Compose/ScrollState.cs
+++ b/src/ComposeNet.Compose/ScrollState.cs
@@ -11,7 +11,7 @@ namespace ComposeNet;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Construct one inside a <see cref="ComposeActivity.Remember{T}"/>
+/// Construct one inside a <see cref="ComposeActivity.Remember{T}(System.Func{T}, int, string)"/>
 /// callback so the scroll position survives recompositions:
 /// <code>
 /// var scroll = Remember(() =&gt; new ScrollState());

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -118,7 +118,33 @@ public class MainActivity : ComposeActivity
             // controller into NavController.Jvm on first NavHost render.
             var navController = Remember(() => new NavController());
 
-            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy", "Carousels", "Nav" };
+            // State primitives demo (issue #62). The `seed` value is the
+            // key for the keyed-Remember overload — bumping it via the
+            // "New seed" button restarts the slot, forcing the wrapped
+            // counter back to its initial value and the ProduceState
+            // ticker back to 0. `wordMap` and `wordList` show the
+            // dictionary- and list-shaped observables. `derived` reads
+            // `wordList.Count` so Compose recomposes anything that
+            // reads `derived.Value` whenever the list mutates.
+            var seed       = Remember(() => new MutableNumberState<int>(0));
+            var keyedCount = Remember(() => new MutableNumberState<int>(0), seed.Value);
+            var wordList   = Remember(() => new MutableStateList<string> { "alpha", "beta" });
+            var wordMap    = Remember(() => new MutableStateMap<string, int> { ["alpha"] = 1, ["beta"] = 2 });
+            var derived    = Compose.DerivedStateOf(() => wordList.Count);
+            // Producer increments `ticker` once a second on a background
+            // task; the keyed overload (`seed.Value`) restarts the
+            // producer with a fresh CancellationToken when seed changes.
+            var ticker = Compose.ProduceState<int>(0, seed.Value, async (state, ct) =>
+            {
+                while (!ct.IsCancellationRequested)
+                {
+                    try { await System.Threading.Tasks.Task.Delay(1000, ct); }
+                    catch (System.OperationCanceledException) { return; }
+                    state.Value = state.Value + 1;
+                }
+            });
+
+            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy", "Carousels", "Nav", "State" };
 
             // Per-tab content. Only the current tab's column is added to
             // the screen — keeps the sample short enough to fit on one
@@ -935,6 +961,60 @@ public class MainActivity : ComposeActivity
                         }),
                     },
                 },
+                11 => new Column
+                {
+                    Modifier.Companion.Padding(16),
+                    new Text("State primitives (issue #62)"),
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text($"Seed: {seed.Value}"),
+                    new Text($"Keyed counter: {keyedCount.Value}"),
+                    new Text($"ProduceState ticker: {ticker.Value}s"),
+                    new Row
+                    {
+                        new Button(onClick: () => keyedCount.Value++)
+                        {
+                            new Text("count++"),
+                        },
+                        new Spacer { Modifier = Modifier.Companion.Padding(4) },
+                        new Button(onClick: () => seed.Value++)
+                        {
+                            new Text("New seed (resets keyed + ticker)"),
+                        },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text($"DerivedState (wordList.Count): {derived.Value}"),
+                    new Text($"List: [{string.Join(", ", wordList)}]"),
+                    new Row
+                    {
+                        new Button(onClick: () => wordList.Add($"item{wordList.Count}"))
+                        {
+                            new Text("Add to list"),
+                        },
+                        new Spacer { Modifier = Modifier.Companion.Padding(4) },
+                        new Button(onClick: () => { if (wordList.Count > 0) wordList.RemoveAt(wordList.Count - 1); })
+                        {
+                            new Text("Remove last"),
+                        },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                    new Text($"Map: {{{string.Join(", ", wordMap.Select(kv => $"{kv.Key}={kv.Value}"))}}}"),
+                    new Row
+                    {
+                        new Button(onClick: () =>
+                        {
+                            var key = $"k{wordMap.Count}";
+                            wordMap[key] = wordMap.Count + 1;
+                        })
+                        {
+                            new Text("Add to map"),
+                        },
+                        new Spacer { Modifier = Modifier.Companion.Padding(4) },
+                        new Button(onClick: () => wordMap.Clear())
+                        {
+                            new Text("Clear map"),
+                        },
+                    },
+                },
                 _ => new Column
                 {
                     // Lazy lists — bound through LazyDslKt / LazyGridDslKt.
@@ -1239,6 +1319,11 @@ public class MainActivity : ComposeActivity
                                 {
                                     Text = new Text("Nav"),
                                     Icon = new Text("🧭"),
+                                },
+                                new Tab(selected: tab.Value == 11, onClick: () => tab.Value = 11)
+                                {
+                                    Text = new Text("State"),
+                                    Icon = new Text("🧠"),
                                 },
                             },
                             tabContent,

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -120,22 +120,26 @@ public class MainActivity : ComposeActivity
 
             // State primitives demo (issue #62). The `seed` value is the
             // key for the keyed-Remember overload — bumping it via the
-            // "New seed" button restarts the slot, forcing the wrapped
-            // counter back to its initial value and the ProduceState
-            // ticker back to 0. `wordMap` and `wordList` show the
-            // dictionary- and list-shaped observables. `derived` reads
-            // `wordList.Count` so Compose recomposes anything that
-            // reads `derived.Value` whenever the list mutates.
+            // "New seed" button resets the wrapped counter back to its
+            // initial value and cancels-and-restarts the ProduceState
+            // producer with a fresh CancellationToken (the producer
+            // explicitly resets state.Value = 0 at the top of the
+            // lambda; Kotlin's produceState semantics preserve state
+            // across key changes by default). `wordMap` and `wordList`
+            // show the dictionary- and list-shaped observables.
+            // `derived` reads `wordList.Count` so Compose recomposes
+            // anything that reads `derived.Value` whenever the list
+            // mutates — wrapped in Remember so the same DerivedState
+            // instance survives recomposition (otherwise we'd allocate
+            // a new Kotlin IState every pass).
             var seed       = Remember(() => new MutableNumberState<int>(0));
             var keyedCount = Remember(() => new MutableNumberState<int>(0), seed.Value);
             var wordList   = Remember(() => new MutableStateList<string> { "alpha", "beta" });
             var wordMap    = Remember(() => new MutableStateMap<string, int> { ["alpha"] = 1, ["beta"] = 2 });
-            var derived    = Compose.DerivedStateOf(() => wordList.Count);
-            // Producer increments `ticker` once a second on a background
-            // task; the keyed overload (`seed.Value`) restarts the
-            // producer with a fresh CancellationToken when seed changes.
+            var derived    = Remember(() => Compose.DerivedStateOf(() => wordList.Count));
             var ticker = Compose.ProduceState<int>(0, seed.Value, async (state, ct) =>
             {
+                state.Value = 0;
                 while (!ct.IsCancellationRequested)
                 {
                     try { await System.Threading.Tasks.Task.Delay(1000, ct); }


### PR DESCRIPTION
Closes #62.

Implements keyed `Remember` / `RememberSaveable`, `MutableStateList<T>` (renamed from `ObservableList<T>`), `MutableStateMap<K, V>`, `Compose.DerivedStateOf<T>(Func<T>)`, and `Compose.ProduceState<T>`.

## Keyed `Remember` / `RememberSaveable`

- `Remember(factory, key1)`, `(factory, key1, key2)`, `(factory, key1, key2, key3)`, and `RememberKeyed(factory, keys[])` invalidate the slot when any key changes (structural equality via `object.Equals`). Slot key still comes from `[CallerLineNumber]` / `[CallerFilePath]` so the SaveableStateRegistry hash stays stable across process restarts.
- `RememberSaveable*` keys are forwarded to Kotlin's `rememberSaveable(vararg inputs)` array so Compose's saveable registry uses the same invalidation semantics — not just a C#-side compare.
- New `BuildKeysArray(object?[]?, out bool)` helper in `SaveableBridges` boxes primitives via the same switch pattern as `MutableState<T>.ToJava` and returns either the cached empty global ref or a fresh local-ref `Object[]`.
- `RememberHolder` gains `Keys` + `KeysEqual` static; keys are cloned defensively at construction so caller-side mutation can't corrupt the "previous keys" comparison.

## `MutableStateList<T>` / `MutableStateMap<K, V>`

- `ObservableList<T>` renamed to match Kotlin's `mutableStateListOf<T>()`; same tick-counter pattern.
- New `MutableStateMap<K, V>` (`where K : notnull`) backing a `Dictionary<K,V>` with the same tick-counter recomposition trigger.
- Jetchat sample + README updated for the rename.

## `DerivedStateOf<T>(Func<T>)`

- Wraps Kotlin `SnapshotStateKt.DerivedStateOf(calculation)` and returns a read-only `DerivedState<T>` (`MutableState<T>`-shaped).
- Compose only re-runs `calculation` when one of the state reads inside it changes — useful for `isAtTop = lazyListState.firstVisibleItem... == 0` patterns.

## `ProduceState<T>(initialValue, [keys...], producer)`

- Pure C# — the producer is a plain `Func<MutableState<T>, CancellationToken, Task>`, not a Kotlin suspend lambda.
- Lifecycle driven by `ProduceStateScope<T>`, an `IRememberObserver` JCW that is the **direct** slot value (Compose only inspects what `UpdateRememberedValue` is handed for the interface — nesting it inside `RememberHolder` would silently break the hooks).
- `OnRemembered` starts the producer with a fresh `CancellationTokenSource`; `OnForgotten` / `OnAbandoned` cancel cooperatively. All three are idempotent.
- Producer faults surface to logcat under the `ComposeNet` tag instead of becoming unobserved task exceptions.
- Keyed overloads cancel-and-restart the producer when keys change.

## Deferred to follow-up PRs

- **`snapshotFlow { ... }`** — needs either a Kotlin `Flow` → `IAsyncEnumerable` bridge (depends on coroutine continuation marshalling) or a raw-JNI `Snapshot.Companion.RegisterApplyObserver` call. Both want a clear design first.
- **Custom `Saver<T, S>`** — only `autoSaver` / `mutableStateSaver` are exposed today; documenting as a follow-up.

## Sample

New tab 11 ("State 🧠") in `ComposeNet.Sample/MainActivity.cs` demonstrates keyed `Remember`, `MutableStateList`, `MutableStateMap`, `DerivedStateOf`, and `ProduceState` together. "New seed" button bumps the key — keyed counter resets, ticker restarts from 0.

## Docs

- `docs/architecture.md` — `remember(keys, ...)` row reflects new support; "Known issues" entry on keyed remember replaced with a positive entry covering all new state primitives + deferred items.
- `README.md` State row lists the new APIs.

## Notes

RS0026 / RS0027 are suppressed in `ComposeNet.Compose.csproj` with a rationale comment — the keyed overloads add a *required* `key1` parameter before the `[CallerLineNumber]` / `[CallerFilePath]` defaults, so callers can't get ambiguous resolution at the source level. The BCL does this freely.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — **90 passed**
- `dotnet build src/ComposeNet.Compose` — **0 warnings, 0 errors**
- `dotnet build src/ComposeNet.Sample` — **0 warnings, 0 errors**