### PR TITLE
Phase 4c — StateHolder.SharedState + TimeInput facade

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -434,6 +434,19 @@ Parameter-level attributes the generator recognizes:
     requires `StateType` to be constructible with no arguments
     (either a declared parameterless ctor, or a ctor whose every
     parameter has a `HasExplicitDefaultValue` default).
+  - **Phase 4c** — opt in to shared-state caching with
+    `SharedState = true`. When two sibling facades share a single
+    `StateType` wrapper (e.g. `TimePicker` + `TimeInput` reading the
+    same `TimePickerState`), the second facade to render would
+    otherwise call `RememberXxxState` again and overwrite the
+    wrapper's `Jvm` field with a new peer — losing the value the
+    first facade just bound. With `SharedState = true` the Render
+    preamble first checks `_state.Jvm` and reuses the cached JNI
+    handle when present, only calling `Remember` on the first-render
+    (cache-miss) path. Both Phase 4 (nullable `_state`) and Phase 4b
+    (auto-created `_state`) honour the flag — the cache-hit branch
+    just casts to `IJavaObject` and reads `.Handle`; the cache-miss
+    branch is identical to the non-shared path.
 
   `StateType` must declare an instance, writable, non-readonly,
   accessible field named `Jvm` whose declared type is the
@@ -463,13 +476,22 @@ The generator now supports a wide range of facade shapes (Phases 1,
   for the caller-supplied wrapper (`DatePicker`, `DateRangePicker`).
 - **Phase 4b** — `[StateHolder(...)]` with a parameterised Remember
   bridge that takes user parameters resolved against `StateType`
-  members (`TimePicker`). The facade auto-creates the wrapper when
-  the caller leaves `state` null, then forwards init-value member
-  reads as the Remember args. `TimeInput`, `SearchBar`,
-  `SnackbarHost`, `ModalBottomSheet`, `BottomSheetScaffold` stay
-  hand-written — they need either a per-instance `confirmValueChange`
-  veto adapter (drawer pattern) or shared-state caching across
-  sibling facades, neither of which Phase 4b models.
+  members (`TimePicker`, `TimeInput`). The facade auto-creates the
+  wrapper when the caller leaves `state` null, then forwards
+  init-value member reads as the Remember args.
+- **Phase 4c** — `[StateHolder(SharedState = true)]` skips the
+  `Remember` call when a sibling facade already bound the wrapper's
+  `Jvm` field. Use this on every facade that shares a `StateType`
+  with another facade — both `TimePicker` and `TimeInput` opt in so
+  the user can swap between clock and keyboard entry while keeping a
+  single Kotlin state peer; otherwise the second render rebuilds the
+  state and loses the entered value. `SearchBar`, `SnackbarHost`,
+  `ModalBottomSheet`, `BottomSheetScaffold` still stay hand-written
+  — they need either a per-instance `confirmValueChange` veto
+  adapter or shared-state semantics beyond what `SharedState` alone
+  models (e.g. SearchBar's collapsed-bar + expanded-popup pair also
+  needs a hybrid-container generator extension for the expanded
+  variants).
 - **Phase 6** — `[ComposeFacade(DefaultColorFromTheme = "...")]`
   for drawer sheets and similar containers that fall back to a
   `ColorScheme` slot when the caller doesn't override.
@@ -535,15 +557,18 @@ can't model:
   permanent drawer doesn't actually need a veto adapter, but it
   shares the hand-written family for consistency.
 - State-holder facades whose `RememberXxxState` bridge takes user
-  parameters AND combine that with either a per-instance
-  `confirmValueChange` veto adapter or shared-state caching across
-  sibling facades: `TimeInput` (shares state with `TimePicker`),
-  `SearchBar` (shared-state caching across the bar + view facades),
+  parameters AND combine that with a per-instance
+  `confirmValueChange` veto adapter:
   `ModalBottomSheet`, `BottomSheetScaffold` (both need a
   `confirmValueChange` adapter on top of parameterised Remember).
-  Phase 4 covers the zero-user-param shape (`DatePicker`,
-  `DateRangePicker`); Phase 4b covers the parameterised case where
-  no extra adapter / caching is needed (`TimePicker`).
+  `SearchBar` also stays hand-written until the hybrid-container
+  generator extension lands — its expanded variants pair a required
+  `inputField IFunction2` slot with a separate `content IFunction3`,
+  which the generator can't classify yet. Phase 4 covers the
+  zero-user-param shape (`DatePicker`, `DateRangePicker`); Phase 4b
+  covers parameterised Remember (`TimePicker`); Phase 4c adds
+  shared-state caching for sibling facades (`TimePicker` +
+  `TimeInput`).
 - Scope facades whose bodies do non-trivial work beyond
   `RenderContext.PushScope` (`SegmentedButton`,
   `SingleChoice`/`MultiChoiceSegmentedButtonRow`, the segmented

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -885,7 +885,23 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void TimePicker(
         [StateHolder(Remember = nameof(RememberTimePickerState),
-                     StateType = typeof(TimePickerState))] IntPtr state,
+                     StateType = typeof(TimePickerState),
+                     SharedState = true)] IntPtr state,
+        IModifier? modifier,
+        int defaults, IComposer composer);
+
+    // androidx.compose.material3.TimePickerKt.TimeInput
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/TimePickerKt",
+        JvmName   = "TimeInput",
+        Signature = "(Landroidx/compose/material3/TimePickerState;Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/material3/TimePickerColors;Landroidx/compose/runtime/Composer;II)V",
+        Defaults  = typeof(TimeInputDefault))]
+    [ComposeFacade]
+    public static partial void TimeInput(
+        [StateHolder(Remember = nameof(RememberTimePickerState),
+                     StateType = typeof(TimePickerState),
+                     SharedState = true)] IntPtr state,
         IModifier? modifier,
         int defaults, IComposer composer);
 

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -271,6 +271,11 @@ using ComposeNet;
 [assembly: ComposeDefaults("TimePickerDefault",
     "!state", "modifier", "colors", "layoutType")]
 
+// androidx.compose.material3.TimePickerKt.TimeInput:
+// 3 user params; bit 0 (state) always provided.
+[assembly: ComposeDefaults("TimeInputDefault",
+    "!state", "modifier", "colors")]
+
 // androidx.compose.material3.TimePickerDialogKt.TimePickerDialog-FItCLgY:
 // 10 user params; bits 0 (onDismissRequest), 1 (confirmButton),
 // 2 (dismissButton), 9 (content) always provided.

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -791,10 +791,10 @@ ComposeNet.TextOverflow.TextOverflow() -> void
 ComposeNet.TextOverflow.TextOverflow(int Value) -> void
 ComposeNet.TextOverflow.Value.get -> int
 ComposeNet.TextOverflow.Value.init -> void
-ComposeNet.TimePicker
-ComposeNet.TimePicker.TimePicker(ComposeNet.TimePickerState? state = null) -> void
 ComposeNet.TimeInput
 ComposeNet.TimeInput.TimeInput(ComposeNet.TimePickerState? state = null) -> void
+ComposeNet.TimePicker
+ComposeNet.TimePicker.TimePicker(ComposeNet.TimePickerState? state = null) -> void
 ComposeNet.TimePickerDialog
 ComposeNet.TimePickerDialog.Body.get -> ComposeNet.ComposableNode?
 ComposeNet.TimePickerDialog.Body.set -> void

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -793,6 +793,8 @@ ComposeNet.TextOverflow.Value.get -> int
 ComposeNet.TextOverflow.Value.init -> void
 ComposeNet.TimePicker
 ComposeNet.TimePicker.TimePicker(ComposeNet.TimePickerState? state = null) -> void
+ComposeNet.TimeInput
+ComposeNet.TimeInput.TimeInput(ComposeNet.TimePickerState? state = null) -> void
 ComposeNet.TimePickerDialog
 ComposeNet.TimePickerDialog.Body.get -> ComposeNet.ComposableNode?
 ComposeNet.TimePickerDialog.Body.set -> void

--- a/src/ComposeNet.Compose/TimeInput.cs
+++ b/src/ComposeNet.Compose/TimeInput.cs
@@ -1,0 +1,19 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Material 3 <c>TimeInput</c> — the keyboard-entry counterpart to
+/// <see cref="TimePicker"/>. Share a single <see cref="TimePickerState"/>
+/// across both facades and the user can switch between the clock and
+/// keyboard layouts without losing the entered value; the generator
+/// emits a shared-state preamble (<c>StateHolder.SharedState</c>) that
+/// reuses the same <c>rememberTimePickerState</c> peer for both
+/// facades so the cached hour/minute survive the toggle.
+/// </summary>
+/// <remarks>
+/// As with <see cref="TimePicker"/>, leaving the <c>state</c> ctor
+/// argument null auto-creates a fresh <see cref="TimePickerState"/>
+/// wrapper. Reading <see cref="TimePickerState.Hour"/> /
+/// <see cref="TimePickerState.Minute"/> from a button callback Just
+/// Works without manual <c>remember</c> plumbing.
+/// </remarks>
+public sealed partial class TimeInput;

--- a/src/ComposeNet.Compose/TimePicker.cs
+++ b/src/ComposeNet.Compose/TimePicker.cs
@@ -8,4 +8,13 @@ namespace ComposeNet;
 /// <see cref="TimePickerState.Hour"/> / <see cref="TimePickerState.Minute"/>
 /// from a button callback Just Works without manual <c>remember</c> plumbing.
 /// </summary>
+/// <remarks>
+/// Opts in to <c>StateHolder.SharedState</c> so a caller-supplied
+/// <see cref="TimePickerState"/> can be passed to a sibling
+/// <see cref="TimeInput"/> facade without triggering a duplicate
+/// <c>rememberTimePickerState</c> call — both facades reuse the same
+/// Kotlin peer and stay in sync as the user toggles between clock and
+/// keyboard entry.
+/// </remarks>
 public sealed partial class TimePicker;
+

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -35,6 +35,10 @@ public class FacadeGeneratorTests
                 public static unsafe System.IntPtr NewObject(System.IntPtr cls, System.IntPtr m, Android.Runtime.JValue* args) => default;
             }
             public enum JniHandleOwnership { TransferLocalRef = 0, DoNotTransfer = 1 }
+            public interface IJavaObject
+            {
+                System.IntPtr Handle { get; }
+            }
             public readonly struct JValue
             {
                 public JValue(System.IntPtr v) { } public JValue(bool v) { } public JValue(int v) { }
@@ -43,7 +47,7 @@ public class FacadeGeneratorTests
         }
         namespace Java.Lang
         {
-            public class Object
+            public class Object : Android.Runtime.IJavaObject
             {
                 public System.IntPtr Handle => default;
                 public static T? GetObject<T>(System.IntPtr handle, Android.Runtime.JniHandleOwnership transfer) where T : class => default;
@@ -1642,6 +1646,217 @@ public class FacadeGeneratorTests
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
+    }
+
+    // ─── Phase 4c — shared-state caching (StateHolder.SharedState) ────
+
+    [Fact]
+    public void SharedState_Phase4b_GeneratesCachedHandleReuse()
+    {
+        // TimePicker / TimeInput share the same TimePickerState wrapper
+        // across sibling facades. When the first facade renders it
+        // calls Remember and binds Jvm; subsequent siblings must skip
+        // the Remember call and reuse the cached handle.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("TimePickerDefault",
+                "!state", "modifier", "colors", "layoutType")]
+
+            {{TimePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/TimePickerKt",
+                                   JvmName="TimePicker-mT9BvqQ",
+                                   Signature="{{TimePickerSig}}",
+                                   Defaults=typeof(TimePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void TimePicker(
+                        [StateHolder(Remember = nameof(RememberTimePickerState),
+                                     StateType = typeof(TimePickerState),
+                                     SharedState = true)]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberTimePickerState(int initialHour, int initialMinute,
+                                                                 bool is24Hour, IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "TimePicker");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Declares a local IntPtr the bridge will consume.
+        Assert.Contains("global::System.IntPtr __state;", emitted);
+
+        // Cache-hit branch — Jvm already bound by a sibling.
+        Assert.Contains("if (_state!.Jvm is not null)", emitted);
+        Assert.Contains(
+            "__state = ((global::Android.Runtime.IJavaObject)_state.Jvm!).Handle;",
+            emitted);
+
+        // Cache-miss branch — call Remember, populate Jvm so the next
+        // sibling will hit the cached path.
+        Assert.Contains(
+            "__state = global::ComposeNet.ComposeBridges.RememberTimePickerState(_state!.InitialHour, _state!.InitialMinute, _state!.Is24Hour, composer);",
+            emitted);
+        // Phase 4b assigns unguarded (ctor auto-create guarantees non-null).
+        Assert.Contains(
+            "_state.Jvm = global::Java.Lang.Object.GetObject<global::AndroidX.Compose.Material3.ITimePickerState>(__state, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;",
+            emitted);
+
+        // Must NOT emit the non-shared "always call Remember" preamble.
+        Assert.DoesNotContain(
+            "var __state = global::ComposeNet.ComposeBridges.RememberTimePickerState",
+            emitted);
+
+        // Bridge call still uses __state.
+        Assert.Contains(
+            "global::ComposeNet.ComposeBridges.TimePicker(__state, __modifier, __defaults, composer);",
+            emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void SharedState_Phase4_GeneratesNullableCachedHandleReuse()
+    {
+        // Zero-user-param Remember (DatePicker-style). _state is
+        // nullable because there's no auto-create. SharedState must
+        // skip Remember when the caller supplied a wrapper with a
+        // populated Jvm field.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DatePickerDefault",
+                "!state", "modifier", "dateFormatter", "colors", "title", "headline", "showModeToggle")]
+
+            {{DatePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/DatePickerKt",
+                                   JvmName="DatePicker",
+                                   Signature="{{DatePickerSig}}",
+                                   Defaults=typeof(DatePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void DatePicker(
+                        [StateHolder(Remember = nameof(RememberDatePickerState),
+                                     StateType = typeof(DatePickerState),
+                                     SharedState = true)]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDatePickerState(IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "DatePicker");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Phase 4 field stays nullable (no auto-create in ctor).
+        Assert.Contains("readonly global::ComposeNet.DatePickerState? _state;", emitted);
+        Assert.DoesNotContain("_state = state ?? new global::ComposeNet.DatePickerState();", emitted);
+
+        // Cache-hit branch — guarded with explicit null check on _state.
+        Assert.Contains("if (_state is not null && _state.Jvm is not null)", emitted);
+        Assert.Contains(
+            "__state = ((global::Android.Runtime.IJavaObject)_state.Jvm).Handle;",
+            emitted);
+
+        // Cache-miss branch — Remember + null-guarded Jvm assignment.
+        Assert.Contains(
+            "__state = global::ComposeNet.ComposeBridges.RememberDatePickerState(composer);",
+            emitted);
+        Assert.Contains("if (_state is not null)", emitted);
+        Assert.Contains(
+            "_state.Jvm = global::Java.Lang.Object.GetObject<global::AndroidX.Compose.Material3.IDatePickerState>(__state, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;",
+            emitted);
+
+        // Must NOT emit the non-shared "always call Remember" preamble.
+        Assert.DoesNotContain(
+            "var __state = global::ComposeNet.ComposeBridges.RememberDatePickerState",
+            emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void SharedState_DefaultsFalse_FallsBackToNonSharedPreamble()
+    {
+        // Regression: when SharedState is omitted, the generator emits
+        // the existing "always call Remember" preamble, not the cached
+        // path. Guards against the SharedState branch being accidentally
+        // promoted to the default behavior.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("TimePickerDefault",
+                "!state", "modifier", "colors", "layoutType")]
+
+            {{TimePickerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/TimePickerKt",
+                                   JvmName="TimePicker-mT9BvqQ",
+                                   Signature="{{TimePickerSig}}",
+                                   Defaults=typeof(TimePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void TimePicker(
+                        [StateHolder(Remember = nameof(RememberTimePickerState),
+                                     StateType = typeof(TimePickerState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberTimePickerState(int initialHour, int initialMinute,
+                                                                 bool is24Hour, IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "TimePicker");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Non-shared shape: unconditional Remember call, no cache check.
+        Assert.Contains(
+            "var __state = global::ComposeNet.ComposeBridges.RememberTimePickerState(_state!.InitialHour, _state!.InitialMinute, _state!.Is24Hour, composer);",
+            emitted);
+        Assert.DoesNotContain("global::System.IntPtr __state;", emitted);
+        Assert.DoesNotContain("if (_state!.Jvm is not null)", emitted);
+        Assert.DoesNotContain("if (_state is not null && _state.Jvm is not null)", emitted);
     }
 
     [Fact]

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -278,6 +278,20 @@ internal static class Attributes
             /// constructible with no arguments (parameterless ctor or
             /// all-defaulted-params ctor) so the facade can auto-create
             /// a default wrapper when the caller passes <c>null</c>.</para>
+            /// <para><b>SharedState</b> (Phase 4c): when <c>true</c>,
+            /// the generated <c>Render</c> preamble checks whether
+            /// <c>_state.Jvm</c> is already populated (from an earlier
+            /// sibling render that received the same wrapper instance)
+            /// and skips the <c>RememberXxxState</c> call in that case,
+            /// reusing the cached JNI handle directly. This lets two or
+            /// more sibling facades share the same state-holder peer
+            /// (e.g. a <see cref="TimePicker"/> and a
+            /// <see cref="TimeInput"/> driven by the same
+            /// <see cref="TimePickerState"/>). Defaults to <c>false</c>
+            /// — every render calls Remember and Compose's slot-table
+            /// caches per-call-site. Opt in only when the facade is
+            /// designed to be paired with at least one sibling that
+            /// uses the same <see cref="StateType"/>.</para>
             /// </remarks>
             [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
                                            AllowMultiple = false)]
@@ -286,6 +300,7 @@ internal static class Attributes
                 public StateHolderAttribute() { }
                 public string Remember { get; set; } = "";
                 public global::System.Type StateType { get; set; } = null!;
+                public bool SharedState { get; set; }
             }
         }
         """;

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -484,7 +484,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 rememberMethodName: remember,
                 stateWrapperType: stateType,
                 stateJvmType: jvmMember.Type,
-                rememberArgExpressions: rememberArgExpressions);
+                rememberArgExpressions: rememberArgExpressions,
+                sharedState: ReadBool(stateAttr, "SharedState"));
         }
 
         // [PainterResource] — annotates the IntPtr bridge param that
@@ -698,30 +699,43 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         // populated when the caller supplied a wrapper. Phase 4b
         // (parameterised Remember): the ctor guaranteed _state is
         // non-null, so we read init values off it and skip the
-        // null-guard on the Jvm assignment.
+        // null-guard on the Jvm assignment. Phase 4c (SharedState=true):
+        // when _state.Jvm is already populated (because an earlier
+        // sibling render bound the same wrapper), skip the Remember
+        // call entirely and reuse the cached JNI handle — this is what
+        // lets a TimePicker and a TimeInput share state, or the
+        // SearchBar family share a SearchBarState peer across the
+        // collapsed bar + expanded popup.
         foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.StateHolder))
         {
             var id = CtorIdentifier(s);
             var jvmFqn = s.StateJvmType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                 .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
-            sb.Append("            var __").Append(s.Param.Name)
-              .Append(" = global::ComposeNet.ComposeBridges.").Append(s.RememberMethodName).Append('(');
-            foreach (var argExpr in s.RememberArgExpressions)
-                sb.Append(argExpr).Append(", ");
-            sb.Append(composerName).AppendLine(");");
-            if (s.IsParameterisedStateHolder)
+            if (s.SharedState)
             {
-                sb.Append("            if (_").Append(id).AppendLine(".Jvm is null)");
-                sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
-                  .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
-                  .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+                EmitStateHolderPreambleShared(sb, s, id, jvmFqn, composerName);
             }
             else
             {
-                sb.Append("            if (_").Append(id).Append(" is not null && _").Append(id).AppendLine(".Jvm is null)");
-                sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
-                  .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
-                  .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+                sb.Append("            var __").Append(s.Param.Name)
+                  .Append(" = global::ComposeNet.ComposeBridges.").Append(s.RememberMethodName).Append('(');
+                foreach (var argExpr in s.RememberArgExpressions)
+                    sb.Append(argExpr).Append(", ");
+                sb.Append(composerName).AppendLine(");");
+                if (s.IsParameterisedStateHolder)
+                {
+                    sb.Append("            if (_").Append(id).AppendLine(".Jvm is null)");
+                    sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                      .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+                }
+                else
+                {
+                    sb.Append("            if (_").Append(id).Append(" is not null && _").Append(id).AppendLine(".Jvm is null)");
+                    sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                      .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+                }
             }
         }
 
@@ -869,6 +883,63 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         sb.Append("            var __").Append(s.Param.Name)
           .Append(" = new global::ComposeNet.ComposableLambda1(v => _")
           .Append(s.Param.Name).Append('(').Append(expr).AppendLine("));");
+    }
+
+    static void EmitStateHolderPreambleShared(StringBuilder sb, FacadeSlot s,
+        string id, string jvmFqn, string composerName)
+    {
+        // Phase 4c: skip the RememberXxxState call when _state.Jvm is
+        // already populated (a sibling facade rendered first and bound
+        // this wrapper to its peer). When the cache miss path runs,
+        // populate _state.Jvm so the next sibling reuses the handle.
+        sb.Append("            global::System.IntPtr __").Append(s.Param.Name).AppendLine(";");
+        if (s.IsParameterisedStateHolder)
+        {
+            // Phase 4b shape: _state is non-null thanks to ctor auto-create.
+            // The `!` on the first dereference flow-narrows _state to
+            // non-null for the rest of the method (matches the existing
+            // non-shared Phase 4b convention).
+            sb.Append("            if (_").Append(id).AppendLine("!.Jvm is not null)");
+            sb.AppendLine("            {");
+            sb.Append("                __").Append(s.Param.Name)
+              .Append(" = ((global::Android.Runtime.IJavaObject)_").Append(id).AppendLine(".Jvm!).Handle;");
+            sb.AppendLine("            }");
+            sb.AppendLine("            else");
+            sb.AppendLine("            {");
+            sb.Append("                __").Append(s.Param.Name)
+              .Append(" = global::ComposeNet.ComposeBridges.").Append(s.RememberMethodName).Append('(');
+            foreach (var argExpr in s.RememberArgExpressions)
+                sb.Append(argExpr).Append(", ");
+            sb.Append(composerName).AppendLine(");");
+            sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+              .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+              .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+            sb.AppendLine("            }");
+        }
+        else
+        {
+            // Phase 4 shape: _state may be null; only cache when present.
+            // Use an explicit `if (_state is not null)` so flow narrowing
+            // applies to both branches without sprinkling null-forgiving
+            // operators throughout.
+            sb.Append("            if (_").Append(id).Append(" is not null && _").Append(id).AppendLine(".Jvm is not null)");
+            sb.AppendLine("            {");
+            sb.Append("                __").Append(s.Param.Name)
+              .Append(" = ((global::Android.Runtime.IJavaObject)_").Append(id).AppendLine(".Jvm).Handle;");
+            sb.AppendLine("            }");
+            sb.AppendLine("            else");
+            sb.AppendLine("            {");
+            sb.Append("                __").Append(s.Param.Name)
+              .Append(" = global::ComposeNet.ComposeBridges.").Append(s.RememberMethodName).Append('(');
+            foreach (var argExpr in s.RememberArgExpressions)
+                sb.Append(argExpr).Append(", ");
+            sb.Append(composerName).AppendLine(");");
+            sb.Append("                if (_").Append(id).AppendLine(" is not null)");
+            sb.Append("                    _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+              .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+              .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+            sb.AppendLine("            }");
+        }
     }
 
     static void EmitDefaultsMask(StringBuilder sb, string indent, DefaultsInfo d,
@@ -1138,6 +1209,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         return null;
     }
 
+    static bool ReadBool(AttributeData attr, string name)
+    {
+        foreach (var na in attr.NamedArguments)
+            if (na.Key == name && na.Value.Value is bool b) return b;
+        return false;
+    }
+
     static string? ReadSlotAttribute(IParameterSymbol p, INamedTypeSymbol? slotAttr)
     {
         if (slotAttr is null) return null;
@@ -1255,7 +1333,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         public FacadeSlot(IParameterSymbol param, FacadeSlotKind kind,
             ITypeSymbol? callbackType = null, string? slotPropertyName = null,
             string? rememberMethodName = null, INamedTypeSymbol? stateWrapperType = null,
-            ITypeSymbol? stateJvmType = null, string[]? rememberArgExpressions = null)
+            ITypeSymbol? stateJvmType = null, string[]? rememberArgExpressions = null,
+            bool sharedState = false)
         {
             Param = param;
             Kind = kind;
@@ -1265,6 +1344,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             StateWrapperType = stateWrapperType;
             StateJvmType = stateJvmType;
             RememberArgExpressions = rememberArgExpressions ?? System.Array.Empty<string>();
+            SharedState = sharedState;
         }
         public IParameterSymbol Param { get; }
         public FacadeSlotKind Kind { get; }
@@ -1281,6 +1361,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         /// zero user params (Phase 4).
         /// </summary>
         public string[] RememberArgExpressions { get; }
+        /// <summary>
+        /// Phase 4c — when <c>true</c>, the generated Render preamble
+        /// checks whether <c>_state.Jvm</c> is already populated (from an
+        /// earlier sibling render) and skips the <c>RememberXxxState</c>
+        /// call in that case, reusing the cached JNI handle.
+        /// </summary>
+        public bool SharedState { get; }
         public bool HasSlotAttribute => SlotPropertyName is not null;
         public bool IsNullableSlot => Param.NullableAnnotation == NullableAnnotation.Annotated
             && KindIsFnSlot(Kind);
@@ -1292,6 +1379,6 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
               or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3;
         public FacadeSlot WithKind(FacadeSlotKind newKind) =>
             new(Param, newKind, CallbackType, SlotPropertyName, RememberMethodName,
-                StateWrapperType, StateJvmType, RememberArgExpressions);
+                StateWrapperType, StateJvmType, RememberArgExpressions, SharedState);
     }
 }


### PR DESCRIPTION
Implements the shared-state-caching sub-feature of #120. Defers the
`confirmValueChange` adapter and SnackbarHost's custom content lambda
to follow-ups (the issue allows incremental landing).

## What changes

- Adds `bool SharedState { get; set; }` to `[StateHolder]`. When
  `true`, the generated `Render` preamble first checks
  `_state.Jvm` and reuses the cached JNI handle, only calling
  `Remember*State` on the first-render (cache-miss) path. The
  cache-hit branch casts to `IJavaObject` and reads `.Handle`; the
  cache-miss branch is identical to the non-shared path.
- Honours both Phase 4 (nullable `_state`) and Phase 4b (auto-created
  `_state`) — the Phase 4 path uses an explicit `is not null`
  guard, the Phase 4b path leans on `_state!` flow narrowing the way
  the existing non-shared Phase 4b preamble already does.
- Opts `TimePicker` into `SharedState=true` and adds a new
  `TimeInput` facade (also opted in). Both share `TimePickerState`,
  so a UI offering a clock/keyboard toggle keeps the entered value
  across the swap.

## Why this matters

Without the flag, the second sibling facade to render calls
`rememberTimePickerState(...)` again and overwrites the wrapper's
`Jvm` field with a new peer — the user's entered hour/minute is lost
the moment they toggle between layouts. `SharedState` is what makes
multi-facade state holders viable in C#.

## Tests

- `SharedState_Phase4b_GeneratesCachedHandleReuse` — TimePicker
  shape: ctor auto-creates the wrapper, `_state!.Jvm is not null`
  cache check, unguarded `_state.Jvm = ...` assignment, no leading
  `var __state = Remember(...)` line.
- `SharedState_Phase4_GeneratesNullableCachedHandleReuse` —
  DatePicker shape: nullable field stays nullable, explicit
  `_state is not null && _state.Jvm is not null` cache check,
  null-guarded `Jvm` assignment.
- `SharedState_DefaultsFalse_FallsBackToNonSharedPreamble` —
  regression: omitting the flag yields the existing
  unconditional-`Remember` preamble.

All 93 generator tests pass; the sample app builds clean
(`dotnet build src/ComposeNet.Sample`).

## Deferred to follow-ups (still tracked by #120)

- `SearchBar` / `TopSearchBar` / `ExpandedDockedSearchBar` /
  `ExpandedFullScreenSearchBar` — need a `Required = true` flag on
  `[StateHolder]` (so the state arg stays a positional non-default
  ctor param) **and** the hybrid-container generator extension for
  required `[Slot]` siblings (the expanded variants pair an
  `inputField IFunction2` slot with a `content IFunction3`).
- `SnackbarHost` — content lambda dispatches `SnackbarFromData(p0)`,
  which the generator can't emit.
- `ModalBottomSheet` / `BottomSheetScaffold` — need a
  `confirmValueChange` veto adapter feature (per-instance JCW) on
  top of parameterised Remember.

## Docs

- `.github/copilot-instructions.md` Phase 4 section updated with a
  new Phase 4c sub-bullet, and the "stays hand-written" list updated
  to reflect that TimeInput now ships generated.
- `TimePicker.cs` / `TimeInput.cs` stubs document the
  shared-state-pair pattern.