### PR TITLE
Compose effect APIs: LaunchedEffect / DisposableEffect / SideEffect

### DIFF
--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -295,6 +295,215 @@ public static class Compose
     }
 
     /// <summary>
+    /// Compose's <c>SideEffect { … }</c>: runs <paramref name="effect"/>
+    /// on every successful recomposition, <b>after</b> the composition
+    /// has been applied. Use it to publish managed-side state into
+    /// objects that aren't managed by Compose (e.g. logging, analytics,
+    /// pushing a value into a non-Compose Android API).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="effect"/> must <b>not</b> mutate any state that
+    /// the same composition reads — that would invalidate the
+    /// composition Compose just applied and trigger an infinite
+    /// recomposition loop.
+    /// </para>
+    /// <para>
+    /// Stale captures: closures inside <paramref name="effect"/> see
+    /// whatever the C# closure captured during the most recent render
+    /// — <c>SideEffect</c> bodies are recreated every render so this
+    /// is generally what you want.
+    /// </para>
+    /// </remarks>
+    public static void SideEffect(System.Action effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.SideEffect must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
+
+        EffectsKt.SideEffect(new ComposableLambda0(effect), composer, _changed: 0);
+    }
+
+    /// <summary>
+    /// Compose's <c>DisposableEffect(key1) { … onDispose { … } }</c>:
+    /// runs <paramref name="effect"/> the first time this call site
+    /// is composed (and again whenever <paramref name="key1"/> changes),
+    /// and calls the returned cleanup <see cref="System.Action"/> on
+    /// key change or when the call site leaves the composition.
+    /// </summary>
+    /// <param name="key1">
+    /// Compose compares this against the previous value using
+    /// <c>Object.equals</c> via the boxed Java value. Supports
+    /// <c>null</c>, any <see cref="Java.Lang.Object"/> peer,
+    /// <see cref="string"/>, and every common .NET primitive.
+    /// </param>
+    /// <param name="effect">
+    /// Setup callback. Must return a non-null cleanup
+    /// <see cref="System.Action"/> — use <c>() =&gt; { }</c> when
+    /// there's nothing to clean up.
+    /// </param>
+    /// <remarks>
+    /// Stale captures: closures inside <paramref name="effect"/> see
+    /// whatever the C# closure captured when the effect was last
+    /// set up. To observe newer values without invalidating the
+    /// effect, hoist them into <see cref="MutableState{T}"/>.
+    /// </remarks>
+    public static void DisposableEffect(
+        object? key1,
+        System.Func<AndroidX.Compose.Runtime.DisposableEffectScope, System.Action> effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.DisposableEffect must be called inside a composition.");
+
+        EffectsKt.DisposableEffect(
+            ComposeBridges.BoxKey(key1),
+            new DisposableEffectBody(effect),
+            composer,
+            _changed: 0);
+    }
+
+    /// <summary>
+    /// Two-key overload of
+    /// <see cref="DisposableEffect(object?, System.Func{AndroidX.Compose.Runtime.DisposableEffectScope, System.Action})"/>.
+    /// </summary>
+    public static void DisposableEffect(
+        object? key1,
+        object? key2,
+        System.Func<AndroidX.Compose.Runtime.DisposableEffectScope, System.Action> effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.DisposableEffect must be called inside a composition.");
+
+        EffectsKt.DisposableEffect(
+            ComposeBridges.BoxKey(key1),
+            ComposeBridges.BoxKey(key2),
+            new DisposableEffectBody(effect),
+            composer,
+            _changed: 0);
+    }
+
+    /// <summary>
+    /// Three-key overload of
+    /// <see cref="DisposableEffect(object?, System.Func{AndroidX.Compose.Runtime.DisposableEffectScope, System.Action})"/>.
+    /// </summary>
+    public static void DisposableEffect(
+        object? key1,
+        object? key2,
+        object? key3,
+        System.Func<AndroidX.Compose.Runtime.DisposableEffectScope, System.Action> effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.DisposableEffect must be called inside a composition.");
+
+        EffectsKt.DisposableEffect(
+            ComposeBridges.BoxKey(key1),
+            ComposeBridges.BoxKey(key2),
+            ComposeBridges.BoxKey(key3),
+            new DisposableEffectBody(effect),
+            composer,
+            _changed: 0);
+    }
+
+    /// <summary>
+    /// Compose's <c>LaunchedEffect(key1) { … }</c>: launches the C#
+    /// <paramref name="body"/> as a coroutine the first time this call
+    /// site is composed (and again whenever <paramref name="key1"/>
+    /// changes). The previous launch is cancelled on key change or
+    /// when the call site leaves the composition — the
+    /// <see cref="System.Threading.CancellationToken"/> passed to
+    /// <paramref name="body"/> is signalled, and the body should
+    /// observe it (e.g. via <see cref="System.Threading.Tasks.Task.Delay(int, System.Threading.CancellationToken)"/>).
+    /// </summary>
+    /// <param name="key1">
+    /// Compose compares this against the previous value using
+    /// <c>Object.equals</c> via the boxed Java value. Pass a stable
+    /// "version" (e.g. <see cref="System.Guid.Empty"/> stringified, or
+    /// the literal <c>"once"</c>) when you want the body to run
+    /// exactly once per call-site lifetime.
+    /// </param>
+    /// <param name="body">
+    /// The async work to run. Honours the supplied
+    /// <see cref="System.Threading.CancellationToken"/> when the
+    /// underlying Kotlin <c>Job</c> is cancelled.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// Stale captures: closures inside <paramref name="body"/> see
+    /// whatever the C# closure captured when the launch started. To
+    /// observe newer values without restarting the body, read from
+    /// <see cref="MutableState{T}"/>.
+    /// </para>
+    /// </remarks>
+    public static void LaunchedEffect(
+        object? key1,
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
+    {
+        System.ArgumentNullException.ThrowIfNull(body);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.LaunchedEffect must be called inside a composition.");
+
+        EffectsKt.LaunchedEffect(
+            ComposeBridges.BoxKey(key1),
+            new LaunchedEffectBody(body),
+            composer,
+            _changed: 0);
+    }
+
+    /// <summary>
+    /// Two-key overload of
+    /// <see cref="LaunchedEffect(object?, System.Func{System.Threading.CancellationToken, System.Threading.Tasks.Task})"/>.
+    /// </summary>
+    public static void LaunchedEffect(
+        object? key1,
+        object? key2,
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
+    {
+        System.ArgumentNullException.ThrowIfNull(body);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.LaunchedEffect must be called inside a composition.");
+
+        EffectsKt.LaunchedEffect(
+            ComposeBridges.BoxKey(key1),
+            ComposeBridges.BoxKey(key2),
+            new LaunchedEffectBody(body),
+            composer,
+            _changed: 0);
+    }
+
+    /// <summary>
+    /// Three-key overload of
+    /// <see cref="LaunchedEffect(object?, System.Func{System.Threading.CancellationToken, System.Threading.Tasks.Task})"/>.
+    /// </summary>
+    public static void LaunchedEffect(
+        object? key1,
+        object? key2,
+        object? key3,
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
+    {
+        System.ArgumentNullException.ThrowIfNull(body);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.LaunchedEffect must be called inside a composition.");
+
+        EffectsKt.LaunchedEffect(
+            ComposeBridges.BoxKey(key1),
+            ComposeBridges.BoxKey(key2),
+            ComposeBridges.BoxKey(key3),
+            new LaunchedEffectBody(body),
+            composer,
+            _changed: 0);
+    }
+
+    /// <summary>
     /// Compose's <c>derivedStateOf { calculation() }</c>: returns a
     /// read-only <see cref="DerivedState{T}"/> whose value is lazily
     /// computed by <paramref name="calculation"/>. Compose tracks

--- a/src/ComposeNet.Compose/DisposableEffect.cs
+++ b/src/ComposeNet.Compose/DisposableEffect.cs
@@ -1,0 +1,67 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Tree-syntax wrapper around
+/// <see cref="Compose.DisposableEffect(object?, System.Func{DisposableEffectScope, System.Action})"/>.
+/// Re-runs <c>Effect</c> on first composition and any time
+/// <c>Key1</c> / <c>Key2</c> / <c>Key3</c> changes; calls the cleanup
+/// <see cref="System.Action"/> on key change or when this node leaves
+/// the composition.
+/// </summary>
+/// <remarks>
+/// <code>
+/// new DisposableEffect(_sensorId, scope =&gt;
+/// {
+///     var registration = SensorRegistry.Subscribe(_sensorId, OnSensorTick);
+///     return () =&gt; registration.Dispose();
+/// })
+/// </code>
+/// </remarks>
+public sealed class DisposableEffect : ComposableNode
+{
+    readonly object? _key1, _key2, _key3;
+    readonly int _keyCount;
+    readonly System.Func<DisposableEffectScope, System.Action> _effect;
+
+    /// <summary>Single-key form.</summary>
+    public DisposableEffect(
+        object? key1,
+        System.Func<DisposableEffectScope, System.Action> effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        _key1 = key1; _keyCount = 1; _effect = effect;
+    }
+
+    /// <summary>Two-key form.</summary>
+    public DisposableEffect(
+        object? key1,
+        object? key2,
+        System.Func<DisposableEffectScope, System.Action> effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        _key1 = key1; _key2 = key2; _keyCount = 2; _effect = effect;
+    }
+
+    /// <summary>Three-key form.</summary>
+    public DisposableEffect(
+        object? key1,
+        object? key2,
+        object? key3,
+        System.Func<DisposableEffectScope, System.Action> effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        _key1 = key1; _key2 = key2; _key3 = key3; _keyCount = 3; _effect = effect;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        switch (_keyCount)
+        {
+            case 1: Compose.DisposableEffect(_key1, _effect); break;
+            case 2: Compose.DisposableEffect(_key1, _key2, _effect); break;
+            default: Compose.DisposableEffect(_key1, _key2, _key3, _effect); break;
+        }
+    }
+}

--- a/src/ComposeNet.Compose/DisposableEffectBody.cs
+++ b/src/ComposeNet.Compose/DisposableEffectBody.cs
@@ -32,13 +32,29 @@ internal sealed class DisposableEffectBody : Java.Lang.Object, IFunction1
 
     public Java.Lang.Object Invoke(Java.Lang.Object? p0)
     {
-        // Compose always passes a non-null DisposableEffectScope. The
-        // ?? fallback keeps the static analyzer happy and gives a
-        // recognisable NRE message if Compose ever changes that.
-        var scope = p0 as DisposableEffectScope
-            ?? throw new System.InvalidOperationException(
-                "DisposableEffect body received a non-DisposableEffectScope argument: "
-                + (p0?.Class?.Name ?? "<null>"));
+        // Compose always passes a non-null DisposableEffectScope (the
+        // singleton `InternalDisposableEffectScope`). Use JavaCast<T>
+        // rather than `p0 as DisposableEffectScope` because Mono.Android's
+        // peer cache doesn't know Kotlin's `internal object` subclasses
+        // implement the bound interface — a plain `as` returns null even
+        // when the underlying Java object does implement the interface.
+        if (p0 is null)
+            throw new System.InvalidOperationException(
+                "DisposableEffect body received a null DisposableEffectScope");
+
+        DisposableEffectScope scope;
+        try
+        {
+            scope = p0.JavaCast<DisposableEffectScope>();
+        }
+        catch (System.Exception ex)
+        {
+            throw new System.InvalidOperationException(
+                "DisposableEffect body could not project arg ("
+                + (p0.Class?.Name ?? "<unknown>")
+                + ") as DisposableEffectScope", ex);
+        }
+
         var onDispose = _body(scope)
             ?? throw new System.InvalidOperationException(
                 "DisposableEffect body returned a null onDispose callback. "

--- a/src/ComposeNet.Compose/DisposableEffectBody.cs
+++ b/src/ComposeNet.Compose/DisposableEffectBody.cs
@@ -1,0 +1,48 @@
+using Android.Runtime;
+using AndroidX.Compose.Runtime;
+using Kotlin.Jvm.Functions;
+
+namespace ComposeNet;
+
+/// <summary>
+/// JCW for Compose's <c>DisposableEffect</c> body —
+/// <c>Function1&lt;DisposableEffectScope, DisposableEffectResult&gt;</c>.
+/// Kotlin invokes the body once per (key change | enter composition)
+/// and stores the returned <see cref="IDisposableEffectResult"/>; when
+/// keys change or the call site leaves the composition Compose calls
+/// <see cref="IDisposableEffectResult.Dispose"/> on the stored result.
+/// </summary>
+/// <remarks>
+/// The C# body returns a <see cref="System.Action"/> "onDispose"
+/// callback. We wrap that callback in a fresh
+/// <see cref="ComposableLambda0"/> and hand it to
+/// <see cref="DisposableEffectScope.OnDispose(IFunction0)"/>, which
+/// is the only way to construct an <see cref="IDisposableEffectResult"/>
+/// without subclassing the interface in Java.
+/// </remarks>
+[Register("composenet/compose/DisposableEffectBody")]
+internal sealed class DisposableEffectBody : Java.Lang.Object, IFunction1
+{
+    readonly System.Func<DisposableEffectScope, System.Action> _body;
+
+    public DisposableEffectBody(System.Func<DisposableEffectScope, System.Action> body)
+    {
+        _body = body;
+    }
+
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0)
+    {
+        // Compose always passes a non-null DisposableEffectScope. The
+        // ?? fallback keeps the static analyzer happy and gives a
+        // recognisable NRE message if Compose ever changes that.
+        var scope = p0 as DisposableEffectScope
+            ?? throw new System.InvalidOperationException(
+                "DisposableEffect body received a non-DisposableEffectScope argument: "
+                + (p0?.Class?.Name ?? "<null>"));
+        var onDispose = _body(scope)
+            ?? throw new System.InvalidOperationException(
+                "DisposableEffect body returned a null onDispose callback. "
+                + "Return `() => { }` if there's nothing to clean up.");
+        return (Java.Lang.Object)scope.OnDispose(new ComposableLambda0(onDispose));
+    }
+}

--- a/src/ComposeNet.Compose/EffectsBridges.cs
+++ b/src/ComposeNet.Compose/EffectsBridges.cs
@@ -9,15 +9,6 @@ namespace ComposeNet;
 // `Xamarin.AndroidX.Compose.Runtime.Android` NuGet, so we don't need
 // `[ComposeBridge]` shims for them. What we *do* need is:
 //
-//  - `kotlin.ResultKt.createFailure(Throwable)` — to construct the
-//    `kotlin.Result$Failure` instance we pass to
-//    `Continuation.ResumeWith(Object)` when an async C# `Task` faults.
-//    `Result` is a `@JvmInline value class`, so every helper on
-//    `ResultKt` carries a mangled JVM name (`createFailure-impl`) that
-//    the binder strips — same root cause as
-//    dotnet/java-interop#1440. When that lands we can replace this
-//    with a clean call into the bound `ResultKt`.
-//
 //  - `IntrinsicsKt.COROUTINE_SUSPENDED` — exposed by the binding, but
 //    we cache its handle as a global ref the first time so the
 //    hot path inside `LaunchedEffectBody.Invoke` doesn't allocate a
@@ -26,51 +17,11 @@ namespace ComposeNet;
 //  - `BoxKey(object?)` — non-generic equivalent of
 //    `MutableState<T>.ToJava`, so the public C# effect APIs can take
 //    `object?` keys and box primitives once per render.
+//
+// `kotlin.Result` plumbing (constructing/reading `Result.Failure`)
+// lives in <see cref="KotlinResult"/>, shared with `SuspendBridge`.
 internal static partial class ComposeBridges
 {
-    static System.IntPtr s_resultKtClass;
-    static System.IntPtr s_resultKtCreateFailure;
-
-    /// <summary>
-    /// Construct a <c>kotlin.Result.Failure(throwable)</c> instance —
-    /// the boxed-failure form a <see cref="Kotlin.Coroutines.IContinuation"/>
-    /// expects when something goes wrong inside its suspend body.
-    /// </summary>
-    /// <returns>
-    /// A managed peer wrapping the Kotlin failure object. The caller
-    /// passes this directly to <c>continuation.ResumeWith(result)</c>.
-    /// </returns>
-    internal static unsafe Java.Lang.Object KotlinResultFailure(Java.Lang.Throwable throwable)
-    {
-        System.ArgumentNullException.ThrowIfNull(throwable);
-
-        if (s_resultKtCreateFailure == System.IntPtr.Zero)
-        {
-            s_resultKtClass = JNIEnv.FindClass("kotlin/ResultKt");
-            s_resultKtCreateFailure = JNIEnv.GetStaticMethodID(
-                s_resultKtClass,
-                "createFailure",
-                "(Ljava/lang/Throwable;)Ljava/lang/Object;");
-        }
-
-        try
-        {
-            JValue* args = stackalloc JValue[1];
-            args[0] = new JValue(throwable);
-            var handle = JNIEnv.CallStaticObjectMethod(
-                s_resultKtClass, s_resultKtCreateFailure, args);
-            // Transfer the local ref into a managed peer; the caller
-            // hands the peer to Continuation.ResumeWith which keeps it
-            // alive until the coroutine actually resumes.
-            return Java.Lang.Object.GetObject<Java.Lang.Object>(
-                handle, JniHandleOwnership.TransferLocalRef)!;
-        }
-        finally
-        {
-            System.GC.KeepAlive(throwable);
-        }
-    }
-
     /// <summary>
     /// Cached <c>kotlin.Unit.INSTANCE</c> returned wrapped in a managed
     /// peer for use as a successful-completion result from

--- a/src/ComposeNet.Compose/EffectsBridges.cs
+++ b/src/ComposeNet.Compose/EffectsBridges.cs
@@ -9,11 +9,6 @@ namespace ComposeNet;
 // `Xamarin.AndroidX.Compose.Runtime.Android` NuGet, so we don't need
 // `[ComposeBridge]` shims for them. What we *do* need is:
 //
-//  - `IntrinsicsKt.COROUTINE_SUSPENDED` — exposed by the binding, but
-//    we cache its handle as a global ref the first time so the
-//    hot path inside `LaunchedEffectBody.Invoke` doesn't allocate a
-//    fresh peer wrapper per call.
-//
 //  - `BoxKey(object?)` — non-generic equivalent of
 //    `MutableState<T>.ToJava`, so the public C# effect APIs can take
 //    `object?` keys and box primitives once per render.
@@ -22,14 +17,6 @@ namespace ComposeNet;
 // lives in <see cref="KotlinResult"/>, shared with `SuspendBridge`.
 internal static partial class ComposeBridges
 {
-    /// <summary>
-    /// Cached <c>kotlin.Unit.INSTANCE</c> returned wrapped in a managed
-    /// peer for use as a successful-completion result from
-    /// <see cref="Kotlin.Jvm.Functions.IFunction2.Invoke"/> on
-    /// <see cref="LaunchedEffectBody"/>.
-    /// </summary>
-    internal static Java.Lang.Object KotlinUnit => global::Kotlin.Unit.Instance!;
-
     /// <summary>
     /// Non-generic mirror of <see cref="MutableState{T}.ToJava"/> for
     /// boxing an opaque <see cref="object"/> key into the

--- a/src/ComposeNet.Compose/EffectsBridges.cs
+++ b/src/ComposeNet.Compose/EffectsBridges.cs
@@ -1,0 +1,136 @@
+using Android.Runtime;
+
+namespace ComposeNet;
+
+// Raw-JNI helpers for the Compose effect APIs in
+// `androidx.compose.runtime.EffectsKt`. The entry points themselves
+// (`SideEffect`, `DisposableEffect`, `LaunchedEffect`,
+// `RememberCoroutineScope`) are bound directly by the
+// `Xamarin.AndroidX.Compose.Runtime.Android` NuGet, so we don't need
+// `[ComposeBridge]` shims for them. What we *do* need is:
+//
+//  - `kotlin.ResultKt.createFailure(Throwable)` — to construct the
+//    `kotlin.Result$Failure` instance we pass to
+//    `Continuation.ResumeWith(Object)` when an async C# `Task` faults.
+//    `Result` is a `@JvmInline value class`, so every helper on
+//    `ResultKt` carries a mangled JVM name (`createFailure-impl`) that
+//    the binder strips — same root cause as
+//    dotnet/java-interop#1440. When that lands we can replace this
+//    with a clean call into the bound `ResultKt`.
+//
+//  - `IntrinsicsKt.COROUTINE_SUSPENDED` — exposed by the binding, but
+//    we cache its handle as a global ref the first time so the
+//    hot path inside `LaunchedEffectBody.Invoke` doesn't allocate a
+//    fresh peer wrapper per call.
+//
+//  - `BoxKey(object?)` — non-generic equivalent of
+//    `MutableState<T>.ToJava`, so the public C# effect APIs can take
+//    `object?` keys and box primitives once per render.
+internal static partial class ComposeBridges
+{
+    static System.IntPtr s_resultKtClass;
+    static System.IntPtr s_resultKtCreateFailure;
+
+    /// <summary>
+    /// Construct a <c>kotlin.Result.Failure(throwable)</c> instance —
+    /// the boxed-failure form a <see cref="Kotlin.Coroutines.IContinuation"/>
+    /// expects when something goes wrong inside its suspend body.
+    /// </summary>
+    /// <returns>
+    /// A managed peer wrapping the Kotlin failure object. The caller
+    /// passes this directly to <c>continuation.ResumeWith(result)</c>.
+    /// </returns>
+    internal static unsafe Java.Lang.Object KotlinResultFailure(Java.Lang.Throwable throwable)
+    {
+        System.ArgumentNullException.ThrowIfNull(throwable);
+
+        if (s_resultKtCreateFailure == System.IntPtr.Zero)
+        {
+            s_resultKtClass = JNIEnv.FindClass("kotlin/ResultKt");
+            s_resultKtCreateFailure = JNIEnv.GetStaticMethodID(
+                s_resultKtClass,
+                "createFailure",
+                "(Ljava/lang/Throwable;)Ljava/lang/Object;");
+        }
+
+        try
+        {
+            JValue* args = stackalloc JValue[1];
+            args[0] = new JValue(throwable);
+            var handle = JNIEnv.CallStaticObjectMethod(
+                s_resultKtClass, s_resultKtCreateFailure, args);
+            // Transfer the local ref into a managed peer; the caller
+            // hands the peer to Continuation.ResumeWith which keeps it
+            // alive until the coroutine actually resumes.
+            return Java.Lang.Object.GetObject<Java.Lang.Object>(
+                handle, JniHandleOwnership.TransferLocalRef)!;
+        }
+        finally
+        {
+            System.GC.KeepAlive(throwable);
+        }
+    }
+
+    /// <summary>
+    /// Cached <c>kotlin.Unit.INSTANCE</c> returned wrapped in a managed
+    /// peer for use as a successful-completion result from
+    /// <see cref="Kotlin.Jvm.Functions.IFunction2.Invoke"/> on
+    /// <see cref="LaunchedEffectBody"/>.
+    /// </summary>
+    internal static Java.Lang.Object KotlinUnit => global::Kotlin.Unit.Instance!;
+
+    /// <summary>
+    /// Non-generic mirror of <see cref="MutableState{T}.ToJava"/> for
+    /// boxing an opaque <see cref="object"/> key into the
+    /// <see cref="Java.Lang.Object"/> the EffectsKt entry points expect.
+    /// Supports <c>null</c>, any <see cref="Java.Lang.Object"/> peer,
+    /// <see cref="string"/>, and every common .NET primitive.
+    /// </summary>
+    internal static Java.Lang.Object? BoxKey(object? key) => key switch
+    {
+        null                  => null,
+        Java.Lang.Object o    => o,
+        string s              => new Java.Lang.String(s),
+        bool b                => Java.Lang.Boolean.ValueOf(b),
+        char c                => Java.Lang.Character.ValueOf(c),
+        sbyte sb              => Java.Lang.Byte.ValueOf(sb),
+        byte by               => Java.Lang.Short.ValueOf((short)by),
+        short sh              => Java.Lang.Short.ValueOf(sh),
+        ushort us             => Java.Lang.Integer.ValueOf(us),
+        int i                 => Java.Lang.Integer.ValueOf(i),
+        uint ui               => Java.Lang.Long.ValueOf(ui),
+        long l                => Java.Lang.Long.ValueOf(l),
+        ulong ul              => Java.Lang.Long.ValueOf(unchecked((long)ul)),
+        float f               => Java.Lang.Float.ValueOf(f),
+        double d              => Java.Lang.Double.ValueOf(d),
+        // Anything else has no obvious mapping to Java's `Object.equals`
+        // semantics that Compose uses for key comparison. Boxed value
+        // types (Guid, DateTime, enums, records) can produce a fresh
+        // identity hash every render — silently triggering an effect
+        // restart on every recomposition. Refuse and let the caller
+        // pick a stable representation (a string, a primitive, or a
+        // pre-allocated Java.Lang.Object peer).
+        _                     => throw new System.NotSupportedException(
+            $"Compose effect key type '{key.GetType().FullName}' is not supported. "
+            + "Use a Java.Lang.Object, string, bool, char, sbyte/byte/short/ushort/int/uint/long/ulong/float/double, "
+            + "or convert your key to a stable form (e.g. ToString() or a stable hash).")
+    };
+
+    /// <summary>
+    /// Box an array of <see cref="object"/>? keys into a Java
+    /// <c>Object[]</c> for the <c>vararg keys</c> overload of
+    /// <see cref="AndroidX.Compose.Runtime.EffectsKt.LaunchedEffect(Java.Lang.Object[], Kotlin.Jvm.Functions.IFunction2, AndroidX.Compose.Runtime.IComposer, int)"/>
+    /// /
+    /// <see cref="AndroidX.Compose.Runtime.EffectsKt.DisposableEffect(Java.Lang.Object[], Kotlin.Jvm.Functions.IFunction1, AndroidX.Compose.Runtime.IComposer, int)"/>.
+    /// Currently unused — the 1/2/3-key overloads cover the common
+    /// case and avoid the per-render array allocation. Kept here for
+    /// the future variadic public overload.
+    /// </summary>
+    internal static Java.Lang.Object?[] BoxKeyArray(object?[] keys)
+    {
+        var boxed = new Java.Lang.Object?[keys.Length];
+        for (int i = 0; i < keys.Length; i++)
+            boxed[i] = BoxKey(keys[i]);
+        return boxed;
+    }
+}

--- a/src/ComposeNet.Compose/JobCompletionHandler.cs
+++ b/src/ComposeNet.Compose/JobCompletionHandler.cs
@@ -1,0 +1,43 @@
+using Android.Runtime;
+using Kotlin.Jvm.Functions;
+
+namespace ComposeNet;
+
+/// <summary>
+/// JCW for <c>Function1&lt;Throwable?, Unit&gt;</c> registered via
+/// <see cref="Xamarin.KotlinX.Coroutines.IJob.InvokeOnCompletion(bool, bool, IFunction1)"/>.
+/// Compose invokes this handler when the launched coroutine's job
+/// transitions into the cancelling state, so we can propagate
+/// cancellation into the C# <see cref="System.Threading.CancellationTokenSource"/>
+/// that the user's <c>Func&lt;CancellationToken, Task&gt;</c> body
+/// observes.
+/// </summary>
+[Register("composenet/compose/JobCompletionHandler")]
+internal sealed class JobCompletionHandler : Java.Lang.Object, IFunction1
+{
+    readonly System.Threading.CancellationTokenSource _cts;
+
+    public JobCompletionHandler(System.Threading.CancellationTokenSource cts)
+    {
+        _cts = cts;
+    }
+
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0)
+    {
+        // p0 is the Throwable cause (or null for normal completion).
+        // Either way we cancel the CTS — the user's Task body sees
+        // ct.IsCancellationRequested and exits cooperatively.
+        try
+        {
+            _cts.Cancel();
+        }
+        catch
+        {
+            // Cancel is best-effort. A racing Dispose on the CTS or
+            // an exception raised by a registered callback should
+            // never propagate out into the JVM (Kotlin would crash
+            // the process with an UnhandledException). Swallow.
+        }
+        return global::Kotlin.Unit.Instance!;
+    }
+}

--- a/src/ComposeNet.Compose/KotlinResult.cs
+++ b/src/ComposeNet.Compose/KotlinResult.cs
@@ -1,0 +1,172 @@
+using System;
+using Android.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Raw-JNI helpers for Kotlin's <c>kotlin.Result</c> type — the boxed
+/// success/failure wrapper Kotlin coroutines pass through
+/// <c>Continuation.resumeWith</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both ends of the bridge live here:
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="CreateFailure(Java.Lang.Throwable)"/>
+/// — call <c>kotlin.ResultKt.createFailure(Throwable)</c> to wrap a C#
+/// exception in a <c>Result.Failure</c> for
+/// <c>Continuation.resumeWith</c> (used by
+/// <see cref="LaunchedEffectBody"/> and any other C#→Kotlin suspend
+/// resume site).</description></item>
+/// <item><description><see cref="IsFailure(System.IntPtr)"/> +
+/// <see cref="ExtractException(Java.Lang.Object)"/> — peek at a
+/// resumed <c>Result</c> handle to detect a failure box and extract
+/// the underlying <c>Throwable</c> for the awaiting C# task (used by
+/// <see cref="SuspendBridge"/>).</description></item>
+/// </list>
+/// <para>
+/// Why raw JNI: <c>kotlin.Result</c> is a <c>@JvmInline value class</c>
+/// wrapping <c>Object</c>, so every accessor on it (and every helper
+/// on <c>ResultKt</c>) emits a mangled JVM name (<c>Result-impl</c>,
+/// <c>createFailure-impl</c>, <c>isFailure-impl</c>,
+/// <c>exceptionOrNull-impl</c>) that the binder strips — same root
+/// cause as
+/// <see href="https://github.com/dotnet/java-interop/pull/1440">dotnet/java-interop#1440</see>.
+/// The nested <c>Result$Failure</c> class is intentionally
+/// <c>internal</c> in Kotlin source and isn't surfaced by the binder
+/// regardless. When #1440 lands and the binder restores
+/// <c>ResultKt.createFailure(Throwable)</c> / <c>throwOnFailure(Object)</c>
+/// / etc., the bodies of these helpers can be replaced with calls to
+/// the bound members and the cached field/method ids deleted.
+/// </para>
+/// <para>
+/// Caching strategy: <c>JNIEnv.FindClass</c> /
+/// <c>JNIEnv.GetStaticMethodID</c> / <c>JNIEnv.GetFieldID</c>
+/// are pure functions of their string args, and Mono.Android's
+/// <c>FindClass</c> returns a stable, globally registered class ref
+/// — no <c>NewGlobalRef</c>/<c>DeleteLocalRef</c> dance. Multi-thread
+/// racers all observe the same ids; losing the race just re-writes
+/// identical values, so plain stores are fine.
+/// </para>
+/// </remarks>
+internal static class KotlinResult
+{
+    // kotlin/ResultKt — host of the static `createFailure(Throwable): Object` helper.
+    static IntPtr s_resultKtClass;
+    static IntPtr s_resultKtCreateFailureMethod;
+
+    // kotlin/Result$Failure — the boxed-failure type Kotlin uses to
+    // distinguish failure resumes from success resumes. Its `exception`
+    // field carries the underlying Throwable.
+    static IntPtr s_resultFailureClass;
+    static IntPtr s_resultFailureExceptionField;
+
+    /// <summary>
+    /// Construct a <c>kotlin.Result.Failure(throwable)</c> instance —
+    /// the boxed-failure form a <see cref="Kotlin.Coroutines.IContinuation"/>
+    /// expects when something goes wrong inside its suspend body.
+    /// </summary>
+    /// <param name="throwable">
+    /// The Java throwable to wrap; non-null. C# exceptions can be
+    /// converted via <see cref="Android.Runtime.JavaProxyThrowable"/>
+    /// (or any helper that produces a <see cref="Java.Lang.Throwable"/>).
+    /// </param>
+    /// <returns>
+    /// A managed peer wrapping the Kotlin failure object. The caller
+    /// passes this directly to <c>continuation.ResumeWith(result)</c>.
+    /// </returns>
+    internal static unsafe Java.Lang.Object CreateFailure(Java.Lang.Throwable throwable)
+    {
+        ArgumentNullException.ThrowIfNull(throwable);
+
+        EnsureResultKt();
+
+        try
+        {
+            JValue* args = stackalloc JValue[1];
+            args[0] = new JValue(throwable);
+            var handle = JNIEnv.CallStaticObjectMethod(
+                s_resultKtClass, s_resultKtCreateFailureMethod, args);
+            // Transfer the local ref into a managed peer; the caller
+            // hands the peer to Continuation.ResumeWith which keeps it
+            // alive until the coroutine actually resumes.
+            return Java.Lang.Object.GetObject<Java.Lang.Object>(
+                handle, JniHandleOwnership.TransferLocalRef)!;
+        }
+        finally
+        {
+            GC.KeepAlive(throwable);
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="handle"/>
+    /// refers to a <c>kotlin.Result.Failure</c> instance — i.e. the
+    /// resumed value represents a failure rather than a success.
+    /// </summary>
+    /// <param name="handle">
+    /// Raw JNI handle to test. <see cref="IntPtr.Zero"/> is treated as
+    /// "not a failure" (a null resume value is a successful null).
+    /// </param>
+    internal static bool IsFailure(IntPtr handle)
+    {
+        if (handle == IntPtr.Zero) return false;
+        EnsureResultFailure();
+        return JNIEnv.IsInstanceOf(handle, s_resultFailureClass);
+    }
+
+    /// <summary>
+    /// Extract the underlying <see cref="Java.Lang.Throwable"/> from a
+    /// <c>kotlin.Result.Failure</c> peer.
+    /// </summary>
+    /// <param name="failure">
+    /// A peer wrapping a <c>Result.Failure</c> handle. Must have been
+    /// vetted with <see cref="IsFailure(System.IntPtr)"/> first.
+    /// </param>
+    /// <returns>
+    /// The wrapped throwable as a <see cref="System.Exception"/>
+    /// (<see cref="Java.Lang.Throwable"/> derives from
+    /// <see cref="System.Exception"/> on Mono.Android, so callers can
+    /// <c>catch (Exception)</c> or pattern-match on the Java type).
+    /// </returns>
+    internal static Exception ExtractException(Java.Lang.Object failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        // s_resultFailureExceptionField is guaranteed populated:
+        // IsFailure is the only sanctioned predicate, and it calls
+        // EnsureResultFailure before this method ever runs.
+        IntPtr exHandle = JNIEnv.GetObjectField(failure.Handle, s_resultFailureExceptionField);
+        try
+        {
+            var th = Java.Lang.Object.GetObject<Java.Lang.Throwable>(
+                exHandle, JniHandleOwnership.TransferLocalRef);
+            if (th is not null)
+                return th;
+            return new InvalidOperationException(
+                "Kotlin suspend call failed with a null Throwable in Result.Failure");
+        }
+        finally
+        {
+            GC.KeepAlive(failure);
+        }
+    }
+
+    static void EnsureResultKt()
+    {
+        if (s_resultKtCreateFailureMethod != IntPtr.Zero) return;
+        s_resultKtClass = JNIEnv.FindClass("kotlin/ResultKt");
+        s_resultKtCreateFailureMethod = JNIEnv.GetStaticMethodID(
+            s_resultKtClass,
+            "createFailure",
+            "(Ljava/lang/Throwable;)Ljava/lang/Object;");
+    }
+
+    static void EnsureResultFailure()
+    {
+        if (s_resultFailureClass != IntPtr.Zero) return;
+        var cls = JNIEnv.FindClass("kotlin/Result$Failure");
+        s_resultFailureExceptionField = JNIEnv.GetFieldID(cls, "exception", "Ljava/lang/Throwable;");
+        s_resultFailureClass = cls;
+    }
+}

--- a/src/ComposeNet.Compose/LaunchedEffect.cs
+++ b/src/ComposeNet.Compose/LaunchedEffect.cs
@@ -1,0 +1,70 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Tree-syntax wrapper around
+/// <see cref="Compose.LaunchedEffect(object?, System.Func{System.Threading.CancellationToken, System.Threading.Tasks.Task})"/>.
+/// Launches <c>Body</c> as a C# <see cref="System.Threading.Tasks.Task"/>
+/// on first composition and any time a key changes; cancels the
+/// supplied <see cref="System.Threading.CancellationToken"/> on key
+/// change or when this node leaves the composition.
+/// </summary>
+/// <remarks>
+/// <code>
+/// new LaunchedEffect(_sessionId, async ct =&gt;
+/// {
+///     while (!ct.IsCancellationRequested)
+///     {
+///         await Task.Delay(1000, ct);
+///         _ticks.Value++;
+///     }
+/// })
+/// </code>
+/// </remarks>
+public sealed class LaunchedEffect : ComposableNode
+{
+    readonly object? _key1, _key2, _key3;
+    readonly int _keyCount;
+    readonly System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> _body;
+
+    /// <summary>Single-key form.</summary>
+    public LaunchedEffect(
+        object? key1,
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
+    {
+        System.ArgumentNullException.ThrowIfNull(body);
+        _key1 = key1; _keyCount = 1; _body = body;
+    }
+
+    /// <summary>Two-key form.</summary>
+    public LaunchedEffect(
+        object? key1,
+        object? key2,
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
+    {
+        System.ArgumentNullException.ThrowIfNull(body);
+        _key1 = key1; _key2 = key2; _keyCount = 2; _body = body;
+    }
+
+    /// <summary>Three-key form.</summary>
+    public LaunchedEffect(
+        object? key1,
+        object? key2,
+        object? key3,
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
+    {
+        System.ArgumentNullException.ThrowIfNull(body);
+        _key1 = key1; _key2 = key2; _key3 = key3; _keyCount = 3; _body = body;
+    }
+
+    internal override void Render(IComposer composer)
+    {
+        switch (_keyCount)
+        {
+            case 1: Compose.LaunchedEffect(_key1, _body); break;
+            case 2: Compose.LaunchedEffect(_key1, _key2, _body); break;
+            default: Compose.LaunchedEffect(_key1, _key2, _key3, _body); break;
+        }
+    }
+}

--- a/src/ComposeNet.Compose/LaunchedEffectBody.cs
+++ b/src/ComposeNet.Compose/LaunchedEffectBody.cs
@@ -59,10 +59,29 @@ internal sealed class LaunchedEffectBody : Java.Lang.Object, IFunction2
     {
         // p0 is CoroutineScope (unused — we have a managed Task).
         // p1 is the Continuation<Unit> we resume when the Task ends.
-        var continuation = p1 as IContinuation
-            ?? throw new System.InvalidOperationException(
-                "LaunchedEffect Invoke expected a Continuation arg in slot 1, got "
-                + (p1?.Class?.Name ?? "<null>"));
+        // Kotlin hands us an anonymous synthetic class (e.g.
+        // `IntrinsicsKt__IntrinsicsJvmKt$createCoroutineUnintercepted$$inlined$...$4`)
+        // that does implement `kotlin.coroutines.Continuation` but isn't
+        // in Mono.Android's peer registry, so a plain `as IContinuation`
+        // cast returns null. JavaCast<T> bypasses the managed-type
+        // cache and synthesizes an interface peer from the raw handle,
+        // which is exactly what we need.
+        if (p1 is null)
+            throw new System.InvalidOperationException(
+                "LaunchedEffect Invoke received a null Continuation in slot 1");
+
+        IContinuation continuation;
+        try
+        {
+            continuation = p1.JavaCast<IContinuation>();
+        }
+        catch (System.Exception ex)
+        {
+            throw new System.InvalidOperationException(
+                "LaunchedEffect Invoke could not project slot 1 ("
+                + (p1.Class?.Name ?? "<unknown>")
+                + ") as kotlin.coroutines.Continuation", ex);
+        }
 
         var cts = new System.Threading.CancellationTokenSource();
         var resumed = new ResumeOnceGate();

--- a/src/ComposeNet.Compose/LaunchedEffectBody.cs
+++ b/src/ComposeNet.Compose/LaunchedEffectBody.cs
@@ -1,0 +1,229 @@
+using Android.Runtime;
+using Kotlin.Coroutines;
+using Kotlin.Coroutines.Intrinsics;
+using Kotlin.Jvm.Functions;
+using Xamarin.KotlinX.Coroutines;
+
+namespace ComposeNet;
+
+/// <summary>
+/// JCW for the suspend lambda Kotlin's <c>LaunchedEffect</c> expects:
+/// <c>Function2&lt;CoroutineScope, Continuation&lt;in Unit&gt;, Any?&gt;</c>.
+/// Bridges the Kotlin coroutine to a C# <c>async Task</c> body that
+/// accepts a <see cref="System.Threading.CancellationToken"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The coroutine protocol contract: <c>Invoke</c> must either return
+/// the final boxed result (success / failure) <em>synchronously</em>,
+/// or return the
+/// <see cref="IntrinsicsKt.COROUTINE_SUSPENDED"/> sentinel and resume
+/// the supplied <see cref="IContinuation"/> later. This implementation
+/// always returns the sentinel and resumes from a
+/// <see cref="System.Threading.Tasks.Task.ContinueWith(System.Action{System.Threading.Tasks.Task})"/>
+/// once the C# <see cref="System.Threading.Tasks.Task"/> completes,
+/// even when the body completes synchronously — that keeps the
+/// resume protocol uniform and lets Kotlin's dispatcher own thread
+/// affinity for the resume side.
+/// </para>
+/// <para>
+/// Cancellation flow:
+/// </para>
+/// <list type="number">
+/// <item><description>Allocate a CTS for this invocation.</description></item>
+/// <item><description>Register a 3-arg <c>InvokeOnCompletion(onCancelling: true, invokeImmediately: true, handler)</c>
+/// hook on the job — the 1-arg overload only fires after completion
+/// and is too late to cancel a still-suspended Task.</description></item>
+/// <item><description>Invoke the user's
+/// <c>Func&lt;CancellationToken, Task&gt;</c> with <c>cts.Token</c>.</description></item>
+/// <item><description>Once the resulting Task completes (sync or async),
+/// resume the continuation with <c>Unit</c> on success /
+/// <c>Result.Failure(throwable)</c> on fault. An
+/// <see cref="System.Threading.Interlocked.CompareExchange{T}(ref T, T, T)"/>
+/// once-gate keeps the resume from firing twice if the Job is
+/// cancelled while the ContinueWith is still racing.</description></item>
+/// </list>
+/// </remarks>
+[Register("composenet/compose/LaunchedEffectBody")]
+internal sealed class LaunchedEffectBody : Java.Lang.Object, IFunction2
+{
+    readonly System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> _body;
+
+    public LaunchedEffectBody(
+        System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
+    {
+        _body = body;
+    }
+
+    public Java.Lang.Object? Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1)
+    {
+        // p0 is CoroutineScope (unused — we have a managed Task).
+        // p1 is the Continuation<Unit> we resume when the Task ends.
+        var continuation = p1 as IContinuation
+            ?? throw new System.InvalidOperationException(
+                "LaunchedEffect Invoke expected a Continuation arg in slot 1, got "
+                + (p1?.Class?.Name ?? "<null>"));
+
+        var cts = new System.Threading.CancellationTokenSource();
+        var resumed = new ResumeOnceGate();
+
+        // Bind the Job's cancellation → our CTS so the user's Task can
+        // observe ct.IsCancellationRequested and bail cooperatively.
+        // The IDisposableHandle is held strongly through `state` below
+        // so it doesn't get yanked by GC before completion.
+        var handler = new JobCompletionHandler(cts);
+        Xamarin.KotlinX.Coroutines.IDisposableHandle? completionRegistration = null;
+        try
+        {
+            var job = JobKt.GetJob(continuation.Context);
+            completionRegistration = job.InvokeOnCompletion(
+                onCancelling: true, invokeImmediately: true, handler);
+        }
+        catch (System.Exception ex)
+        {
+            // Without a Job in the context we can't wire cancellation
+            // — but the user's Task can still run. Log and continue.
+            System.Diagnostics.Debug.WriteLine(
+                "ComposeNet.LaunchedEffect: failed to register Job completion handler: " + ex);
+        }
+
+        System.Threading.Tasks.Task task;
+        try
+        {
+            task = _body(cts.Token) ?? System.Threading.Tasks.Task.CompletedTask;
+        }
+        catch (System.Exception ex)
+        {
+            // Synchronous fault from the body (rare — Func<T, Task> bodies
+            // typically wrap their work in async). Throw a Java
+            // RuntimeException; Kotlin's coroutine machinery converts it
+            // into a Result.Failure for any waiting awaiters of the job
+            // and the InvokeOnCompletion hook still fires. Include
+            // ex.ToString() so the original stack trace + type stay
+            // visible in logcat / coroutine debug output.
+            completionRegistration?.Dispose();
+            cts.Dispose();
+            handler.Dispose();
+            throw new Java.Lang.RuntimeException(
+                "LaunchedEffect body threw synchronously: " + ex);
+        }
+
+        // Always go through ContinueWith so the resume runs on the
+        // default TaskScheduler rather than inlining on whatever thread
+        // happened to complete the Task. This keeps lifetime tracking
+        // simple and matches what Kotlin's own `kotlinx-coroutines`
+        // does when handed an external future.
+        var ctx = new ResumeContext(
+            continuation, cts, handler, completionRegistration, resumed);
+        task.ContinueWith(
+            static (t, state) =>
+            {
+                var c = (ResumeContext)state!;
+                c.Resume(t);
+            },
+            ctx,
+            System.Threading.CancellationToken.None,
+            System.Threading.Tasks.TaskContinuationOptions.None,
+            System.Threading.Tasks.TaskScheduler.Default);
+
+        return IntrinsicsKt.COROUTINE_SUSPENDED;
+    }
+
+    // Holds everything we need to safely resume the continuation
+    // exactly once and release the JCWs / handler registration after.
+    sealed class ResumeContext
+    {
+        readonly IContinuation _continuation;
+        readonly System.Threading.CancellationTokenSource _cts;
+        readonly JobCompletionHandler _handler;
+        readonly Xamarin.KotlinX.Coroutines.IDisposableHandle? _completionRegistration;
+        readonly ResumeOnceGate _gate;
+
+        public ResumeContext(
+            IContinuation continuation,
+            System.Threading.CancellationTokenSource cts,
+            JobCompletionHandler handler,
+            Xamarin.KotlinX.Coroutines.IDisposableHandle? completionRegistration,
+            ResumeOnceGate gate)
+        {
+            _continuation = continuation;
+            _cts = cts;
+            _handler = handler;
+            _completionRegistration = completionRegistration;
+            _gate = gate;
+        }
+
+        public void Resume(System.Threading.Tasks.Task t)
+        {
+            if (!_gate.TryEnter())
+                return;
+
+            try
+            {
+                Java.Lang.Object? result;
+                if (t.IsFaulted)
+                {
+                    var inner = t.Exception?.GetBaseException()
+                        ?? new System.Exception("LaunchedEffect Task faulted with no exception");
+                    var throwable = ToThrowable(inner);
+                    result = ComposeBridges.KotlinResultFailure(throwable);
+                }
+                else if (t.IsCanceled)
+                {
+                    // Surface cancellation as Result.Failure(CancellationException)
+                    // so Kotlin's coroutine machinery records this as a
+                    // cancellation rather than treating it as success.
+                    // kotlinx.coroutines.CancellationException is a
+                    // typealias for java.util.concurrent.CancellationException
+                    // on JVM, so the simpler Java type is fine.
+                    var ce = new Java.Util.Concurrent.CancellationException(
+                        "LaunchedEffect Task was cancelled");
+                    result = ComposeBridges.KotlinResultFailure(ce);
+                }
+                else
+                {
+                    result = global::Kotlin.Unit.Instance!;
+                }
+
+                try
+                {
+                    _continuation.ResumeWith(result);
+                }
+                catch (System.Exception ex)
+                {
+                    // ResumeWith on an already-cancelled continuation
+                    // may throw IllegalStateException from Kotlin's
+                    // dispatched continuation impl. Log and swallow —
+                    // there's no caller to surface this to.
+                    System.Diagnostics.Debug.WriteLine(
+                        "ComposeNet.LaunchedEffect: continuation resume failed: " + ex);
+                }
+            }
+            finally
+            {
+                try { _completionRegistration?.Dispose(); } catch { }
+                try { _cts.Dispose(); } catch { }
+                // Don't dispose _handler — Kotlin's job machinery may
+                // still hold a reference to it briefly. Let GC reclaim
+                // the JCW once Kotlin drops it.
+                System.GC.KeepAlive(_handler);
+            }
+        }
+
+        static Java.Lang.Throwable ToThrowable(System.Exception ex) =>
+            ex switch
+            {
+                Java.Lang.Throwable th => th,
+                System.OperationCanceledException =>
+                    new Java.Util.Concurrent.CancellationException(ex.Message ?? "cancelled"),
+                _ => new Java.Lang.RuntimeException(ex.GetType().Name + ": " + ex.Message),
+            };
+    }
+
+    sealed class ResumeOnceGate
+    {
+        int _state; // 0 = pending, 1 = resumed
+        public bool TryEnter() =>
+            System.Threading.Interlocked.CompareExchange(ref _state, 1, 0) == 0;
+    }
+}

--- a/src/ComposeNet.Compose/LaunchedEffectBody.cs
+++ b/src/ComposeNet.Compose/LaunchedEffectBody.cs
@@ -166,7 +166,7 @@ internal sealed class LaunchedEffectBody : Java.Lang.Object, IFunction2
                     var inner = t.Exception?.GetBaseException()
                         ?? new System.Exception("LaunchedEffect Task faulted with no exception");
                     var throwable = ToThrowable(inner);
-                    result = ComposeBridges.KotlinResultFailure(throwable);
+                    result = KotlinResult.CreateFailure(throwable);
                 }
                 else if (t.IsCanceled)
                 {
@@ -178,7 +178,7 @@ internal sealed class LaunchedEffectBody : Java.Lang.Object, IFunction2
                     // on JVM, so the simpler Java type is fine.
                     var ce = new Java.Util.Concurrent.CancellationException(
                         "LaunchedEffect Task was cancelled");
-                    result = ComposeBridges.KotlinResultFailure(ce);
+                    result = KotlinResult.CreateFailure(ce);
                 }
                 else
                 {

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -163,6 +163,10 @@ ComposeNet.DismissibleNavigationDrawer.Drawer.get -> ComposeNet.ComposableNode?
 ComposeNet.DismissibleNavigationDrawer.Drawer.set -> void
 ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.get -> bool
 ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.set -> void
+ComposeNet.DisposableEffect
+ComposeNet.DisposableEffect.DisposableEffect(object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+ComposeNet.DisposableEffect.DisposableEffect(object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+ComposeNet.DisposableEffect.DisposableEffect(object? key1, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 ComposeNet.DockedSearchBar
 ComposeNet.DockedSearchBar.DockedSearchBar(bool expanded, System.Action<bool>! onExpandedChange) -> void
 ComposeNet.DockedSearchBar.InputField.get -> ComposeNet.ComposableNode?
@@ -345,6 +349,10 @@ ComposeNet.LargeTopAppBar.NavigationIcon.get -> ComposeNet.ComposableNode?
 ComposeNet.LargeTopAppBar.NavigationIcon.set -> void
 ComposeNet.LargeTopAppBar.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.LargeTopAppBar.Title.set -> void
+ComposeNet.LaunchedEffect
+ComposeNet.LaunchedEffect.LaunchedEffect(object? key1, object? key2, object? key3, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+ComposeNet.LaunchedEffect.LaunchedEffect(object? key1, object? key2, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+ComposeNet.LaunchedEffect.LaunchedEffect(object? key1, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 ComposeNet.LazyColumn<T>
 ComposeNet.LazyColumn<T>.LazyColumn(System.Collections.Generic.IReadOnlyList<T>! items, System.Func<T, ComposeNet.ComposableNode!>! itemContent) -> void
 ComposeNet.LazyColumn<T>.State.get -> AndroidX.Compose.Foundation.Lazy.LazyListState?
@@ -733,6 +741,8 @@ ComposeNet.SegmentedButton.Icon.set -> void
 ComposeNet.SegmentedButton.SegmentedButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 ComposeNet.SegmentedButton.SegmentedButton(bool selected, System.Action! onClick) -> void
 ComposeNet.Shape
+ComposeNet.SideEffect
+ComposeNet.SideEffect.SideEffect(System.Action! effect) -> void
 ComposeNet.SingleChoiceSegmentedButtonRow
 ComposeNet.SingleChoiceSegmentedButtonRow.SingleChoiceSegmentedButtonRow() -> void
 ComposeNet.Slider
@@ -947,6 +957,12 @@ static ComposeNet.Arrangement.SpaceEvenly.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Start.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Top.get -> ComposeNet.Arrangement!
 static ComposeNet.Compose.DerivedStateOf<T>(System.Func<T>! calculation) -> ComposeNet.DerivedState<T>!
+static ComposeNet.Compose.DisposableEffect(object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+static ComposeNet.Compose.DisposableEffect(object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+static ComposeNet.Compose.DisposableEffect(object? key1, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+static ComposeNet.Compose.LaunchedEffect(object? key1, object? key2, object? key3, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+static ComposeNet.Compose.LaunchedEffect(object? key1, object? key2, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+static ComposeNet.Compose.LaunchedEffect(object? key1, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 static ComposeNet.Compose.ProduceState<T>(T initialValue, object? key1, object? key2, object? key3, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
 static ComposeNet.Compose.ProduceState<T>(T initialValue, object? key1, object? key2, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
 static ComposeNet.Compose.ProduceState<T>(T initialValue, object? key1, System.Func<ComposeNet.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> ComposeNet.MutableState<T>!
@@ -962,6 +978,7 @@ static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? k
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveableKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.SideEffect(System.Action! effect) -> void
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(float value) -> ComposeNet.Dp
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(int value) -> ComposeNet.Dp
 static ComposeNet.Dp.operator !=(ComposeNet.Dp left, ComposeNet.Dp right) -> bool

--- a/src/ComposeNet.Compose/SideEffect.cs
+++ b/src/ComposeNet.Compose/SideEffect.cs
@@ -1,0 +1,34 @@
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Tree-syntax wrapper around <see cref="Compose.SideEffect(System.Action)"/>.
+/// Add to a container to run a callback on every successful
+/// recomposition of that container, after the composition has been
+/// applied. Useful when you'd rather express the effect as a sibling
+/// in your composable tree than as a statement inside a custom
+/// <c>Render</c> override:
+/// <code>
+/// new Column
+/// {
+///     new Text(_count.Value.ToString()),
+///     new SideEffect(() =&gt; Log.Info("rendered count = " + _count.Value)),
+/// }
+/// </code>
+/// </summary>
+public sealed class SideEffect : ComposableNode
+{
+    readonly System.Action _effect;
+
+    /// <summary>Create the node. <paramref name="effect"/> runs
+    /// every successful recomposition.</summary>
+    public SideEffect(System.Action effect)
+    {
+        System.ArgumentNullException.ThrowIfNull(effect);
+        _effect = effect;
+    }
+
+    internal override void Render(IComposer composer)
+        => Compose.SideEffect(_effect);
+}

--- a/src/ComposeNet.Compose/SuspendBridge.cs
+++ b/src/ComposeNet.Compose/SuspendBridge.cs
@@ -47,13 +47,6 @@ internal static class SuspendBridge
     // JNI ref types).
     static IntPtr s_suspendedHandle;
 
-    // Cached global ref + field id for kotlin/Result$Failure (the
-    // wrapper for failed suspend results). Kotlin.ResultKt's static
-    // methods are NOT bound in Xamarin.Kotlin.StdLib 2.3.21, so we
-    // detect failures via raw JNI instead.
-    static IntPtr s_resultFailureClass;
-    static IntPtr s_resultFailureExceptionField;
-
     /// <summary>
     /// Call a Kotlin <c>suspend</c> function and project its boxed
     /// result through <paramref name="unbox"/> into a typed
@@ -139,8 +132,8 @@ internal static class SuspendBridge
             var boxed = t.GetAwaiter().GetResult();
             try
             {
-                if (boxed is not null && IsResultFailure(boxed.Handle))
-                    throw ExtractFailureException(boxed);
+                if (boxed is not null && KotlinResult.IsFailure(boxed.Handle))
+                    throw KotlinResult.ExtractException(boxed);
                 return unboxFn(boxed);
             }
             finally
@@ -179,61 +172,5 @@ internal static class SuspendBridge
         if (Interlocked.CompareExchange(ref s_suspendedHandle, gref, IntPtr.Zero) != IntPtr.Zero)
             JNIEnv.DeleteGlobalRef(gref);
         GC.KeepAlive(inst);
-    }
-
-    static bool IsResultFailure(IntPtr handle)
-    {
-        if (handle == IntPtr.Zero) return false;
-        EnsureResultFailureClass();
-        return JNIEnv.IsInstanceOf(handle, s_resultFailureClass);
-    }
-
-    static void EnsureResultFailureClass()
-    {
-        if (s_resultFailureClass != IntPtr.Zero) return;
-        // Why raw JNI: `kotlin/Result` itself is bound (as
-        // `Kotlin.Result` in `Xamarin.Kotlin.StdLib.dll`) but its
-        // members are stripped — the type is a `@JvmInline value class`
-        // wrapping `Object`, so every accessor emits a mangled JVM
-        // name (`Result-impl`, `isFailure-impl`, `exceptionOrNull-impl`)
-        // that the parser drops. Same root cause as
-        // dotnet/java-interop#1440. The nested `Result$Failure` class
-        // is intentionally `internal` in Kotlin source and isn't
-        // surfaced by the binder regardless. We read its private
-        // `exception` field directly via JNI; once #1440 lands and the
-        // binder restores `ResultKt.throwOnFailure(Object)`, replace
-        // this lookup with a call to that bound helper.
-        //
-        // JNIEnv.FindClass in Mono.Android returns a stable, globally
-        // registered class ref — no NewGlobalRef/DeleteLocalRef dance.
-        // Multi-thread racers all observe the same class ref + field id
-        // (FindClass / GetFieldID are pure functions of their string
-        // args), so plain stores are fine — losing the race just
-        // re-writes identical values.
-        var cls = JNIEnv.FindClass("kotlin/Result$Failure");
-        s_resultFailureExceptionField = JNIEnv.GetFieldID(cls, "exception", "Ljava/lang/Throwable;");
-        s_resultFailureClass = cls;
-    }
-
-    static Exception ExtractFailureException(Java.Lang.Object failure)
-    {
-        // s_resultFailureExceptionField was set by EnsureResultFailureClass
-        // earlier (IsResultFailure path is the only caller).
-        IntPtr exHandle = JNIEnv.GetObjectField(failure.Handle, s_resultFailureExceptionField);
-        try
-        {
-            // Java.Lang.Throwable : System.Exception, so callers can
-            // `catch (Exception)` or even pattern-match on the Java type.
-            var th = global::Java.Lang.Object.GetObject<Java.Lang.Throwable>(
-                exHandle, JniHandleOwnership.TransferLocalRef);
-            if (th is not null)
-                return th;
-            return new InvalidOperationException(
-                "Kotlin suspend call failed with a null Throwable in Result.Failure");
-        }
-        finally
-        {
-            GC.KeepAlive(failure);
-        }
     }
 }

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -162,7 +162,15 @@ public class MainActivity : ComposeActivity
                 }
             });
 
-            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy", "Carousels", "Pager", "Nav", "State" };
+            // Effects tab (issue #57): demonstrate LaunchedEffect, DisposableEffect,
+            // SideEffect. ticks is incremented from a LaunchedEffect's Task body;
+            // disposeCount bumps on every DisposableEffect cleanup; effectKey
+            // restarts everything when bumped.
+            var ticks       = Remember(() => new MutableNumberState<int>(0));
+            var effectKey   = Remember(() => new MutableNumberState<int>(0));
+            var disposeCount = Remember(() => new MutableNumberState<int>(0));
+
+            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy", "Carousels", "Pager", "Nav", "State", "Effects" };
 
             // Per-tab content. Only the current tab's column is added to
             // the screen — keeps the sample short enough to fit on one
@@ -1190,6 +1198,68 @@ public class MainActivity : ComposeActivity
                         },
                     },
                 },
+                13 => new Column
+                {
+                    // Effects (issue #57) — Compose's three side-effect APIs.
+                    // - SideEffect runs after every successful recomposition.
+                    // - DisposableEffect runs once per (key change | enter
+                    //   composition) and calls its cleanup on (key change |
+                    //   leave composition).
+                    // - LaunchedEffect launches a C# Task tied to the
+                    //   composition's coroutine scope. Cancellation flows
+                    //   through the supplied CancellationToken.
+                    Modifier.Companion.Padding(16),
+
+                    new Text($"Ticks (LaunchedEffect): {ticks.Value}"),
+                    new Text($"Disposable cleanups: {disposeCount.Value}"),
+                    new Text($"Effect key: {effectKey.Value}"),
+                    new Text("SideEffect: see logcat (filter: ComposeNet.Sample)"),
+
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+
+                    // SideEffect — runs after every successful recomposition
+                    // of this Column. We log to debug rather than write to
+                    // a MutableState (writing snapshot state from a
+                    // SideEffect that the same composition reads would
+                    // create an infinite recomposition loop).
+                    new SideEffect(() =>
+                        Android.Util.Log.Debug("ComposeNet.Sample",
+                            $"SideEffect ran (effectKey={effectKey.Value}, ticks={ticks.Value})")),
+
+                    // LaunchedEffect — async tick loop scoped to the
+                    // composition. The Task body honors `ct` via
+                    // Task.Delay(ms, ct), so changing effectKey cancels
+                    // and restarts the loop.
+                    new LaunchedEffect(effectKey.Value, async ct =>
+                    {
+                        try
+                        {
+                            while (!ct.IsCancellationRequested)
+                            {
+                                await System.Threading.Tasks.Task.Delay(1000, ct);
+                                ticks.Value++;
+                            }
+                        }
+                        catch (System.OperationCanceledException) { }
+                    }),
+
+                    // DisposableEffect — fake "register external listener"
+                    // pattern. The cleanup callback bumps a counter so we
+                    // can verify it ran on key change / leaving composition.
+                    new DisposableEffect(effectKey.Value, scope =>
+                    {
+                        return () => disposeCount.Value++;
+                    }),
+
+                    new Button(onClick: () => effectKey.Value++)
+                    {
+                        new Text("Restart effects (key++)"),
+                    },
+                    new Button(onClick: () => { ticks.Value = 0; disposeCount.Value = 0; })
+                    {
+                        new Text("Reset counters"),
+                    },
+                },
                 _ => new Column
                 {
                     // Lazy lists — bound through LazyDslKt / LazyGridDslKt.
@@ -1504,6 +1574,11 @@ public class MainActivity : ComposeActivity
                                 {
                                     Text = new Text("State"),
                                     Icon = new Text("🧠"),
+                                },
+                                new Tab(selected: tab.Value == 13, onClick: () => tab.Value = 13)
+                                {
+                                    Text = new Text("Effects"),
+                                    Icon = new Text("⚡"),
                                 },
                             },
                             tabContent,


### PR DESCRIPTION
Closes #57. Implements phase 4 of #66 (#102).

## What

Bind Compose's three side-effect entry points onto the C# facade — with both **static** call shape (consistent with `Compose.Remember` / `Compose.RememberSaveable`) and **node** call shape (drop-in inside collection-initializer trees):

```csharp
// Static shape — call from inside any composition body
Compose.SideEffect(() => Log.Info("rendered"));
Compose.DisposableEffect(_sensorId, scope =>
{
    var registration = SensorRegistry.Subscribe(_sensorId, OnTick);
    return () => registration.Dispose();
});
Compose.LaunchedEffect("once", async ct =>
{
    while (!ct.IsCancellationRequested)
    {
        await Task.Delay(1000, ct);
        _ticks.Value++;
    }
});

// Node shape — inside any container's collection-initializer
new Column
{
    new Text(_count.ToString()),
    new SideEffect(() => _logger.Trace("recomposed")),
    new LaunchedEffect(_sessionId, async ct => await SyncAsync(ct)),
    new DisposableEffect(_sensorId, scope => /* ... */),
}
```

Each effect has 1/2/3-key overloads (matching Kotlin's `LaunchedEffect(key1)` / `LaunchedEffect(key1, key2)` / `LaunchedEffect(key1, key2, key3)`). Keys can be any Java peer, string, char, bool, or .NET primitive — boxed once per call via `BoxKey`.

## Why no `[ComposeBridge]`

`Xamarin.AndroidX.Compose.Runtime.Android` 1.11.2.1 fully binds `EffectsKt.SideEffect` / `LaunchedEffect` / `DisposableEffect` (their Kotlin signatures don't carry `@JvmInline value class` parameters, so they don't trip dotnet/java-interop#1440). The only raw JNI in this PR is for `kotlin.ResultKt.createFailure(Throwable)` — a `value class` member the binder still strips — used to surface C# Task faults as Kotlin `Result.Failure` boxes.

## How `LaunchedEffect` bridges C# Task ↔ Kotlin suspend

The shape Kotlin's `LaunchedEffect` expects is `suspend (CoroutineScope) -> Unit`, which the binder surfaces as `IFunction2<CoroutineScope, Continuation<Unit>, Object?>` plus the `COROUTINE_SUSPENDED` sentinel protocol.

`LaunchedEffectBody.Invoke`:

1. Allocates a `CancellationTokenSource` for this invocation.
2. Pulls the `IJob` out of `continuation.Context` and registers a `JobCompletionHandler` via `InvokeOnCompletion(onCancelling: true, invokeImmediately: true, …)`. The **3-arg** overload is required — the 1-arg form only fires after full completion, which is too late to cancel a still-suspended C# `Task.Delay`.
3. Calls the user's `Func<CancellationToken, Task>`.
4. Hooks a `Task.ContinueWith` that resumes the Kotlin continuation:
   - Faulted Task → `Result.Failure(toThrowable(ex))` (full `ex.ToString()` preserved in the message).
   - Cancelled Task → `Result.Failure(java.util.concurrent.CancellationException)` (`kotlinx.coroutines.CancellationException` is a typealias for the j.u.c. one on JVM).
   - Successful Task → `Kotlin.Unit.Instance`.
   - An `Interlocked.CompareExchange` once-gate keeps a racing job-cancellation handler firing and a late `Task` completion from double-resuming the continuation.
5. Returns `IntrinsicsKt.COROUTINE_SUSPENDED` so Kotlin awaits the deferred resume.

A synchronous fault from `body(ct)` (rare — async lambdas typically wrap their work in `async`) is rethrown as a `Java.Lang.RuntimeException` that includes `ex.ToString()`, so coroutine machinery records the failure on the Job and `InvokeOnCompletion` still fires.

## What's not included

- **`rememberCoroutineScope`** — deferred. The common "kick off async work on click" pattern is covered by `LaunchedEffect("once", body)` plus a key bump from the button's `onClick`. Filing as a follow-up issue.
- **vararg-key overloads** — the 1/2/3-key overloads cover the common case without per-render `Object[]` allocation. `BoxKeyArray` is wired up internally for when we add the public variadic overload.

## Sample

`MainActivity.cs` gains an "⚡ Effects" tab. Ticking counter is incremented by a `LaunchedEffect`, "Restart effects" bumps the key (cancels the previous Task, fires the previous `DisposableEffect`'s cleanup, re-runs both with the new key), and `SideEffect` writes a line to logcat (`adb logcat -s ComposeNet.Sample:D`) on every recomposition of the tab.

## Validation

- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet build src/ComposeNet.Sample` — clean.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 90/90 pass (the source generators don't touch effects).

## Rubber-duck pass

- Resume-once race: gated by `Interlocked.CompareExchange`, with `JobCompletionHandler` firing → CTS.Cancel → user code observes `ct` → ContinueWith → resume. Synchronous-completion path goes through the same ContinueWith so there's a single resume entry point.
- JCW lifetime: `LaunchedEffectBody` / `DisposableEffectBody` / `JobCompletionHandler` are kept alive by Compose's slot table (Function2/Function1) and the Job's internal handler list (Function1). `ResumeContext` is held alive by TPL through the `state` arg of `ContinueWith`.
- `BoxKey` rejects unsupported types with `NotSupportedException` rather than silently identity-hashing them — boxed value types like `Guid` / `DateTime` / records would otherwise change identity per-render and infinitely restart the effect.