### PR TITLE
Add BranchOn/AlternateBridge to [ComposeFacade] (Phase 9)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -461,7 +461,7 @@ stay distinct per facade.
 ### When to use it
 
 The generator now supports a wide range of facade shapes (Phases 1,
-2, 3, 4, 6, 7, 8 are implemented):
+2, 3, 4, 6, 7, 8, 9 are implemented):
 
 - **Phase 1** — container with content lambda + ctor primitives
   (`Button`, `Card`, `Text`, `Column`, `Row`, `Box`).
@@ -535,6 +535,32 @@ The generator now supports a wide range of facade shapes (Phases 1,
   required Function2 is a label, not a content slot). Used for
   `BottomAppBar`.
 
+- **Phase 9** — bridge branching via
+  `[ComposeFacade(BranchOn = "Subtitle", AlternateBridge = nameof(AltBridge))]`
+  (issue #122). One facade routes between two `[ComposeBridge]`
+  methods based on whether a single optional slot is supplied.
+  The partial method carries the **primary** (smaller) bridge — no
+  branched slot. `AlternateBridge` names a sibling
+  `ComposeBridges` method whose user parameters are the primary's
+  set plus exactly one extra `IFunction2`/`IFunction3` slot whose
+  PascalCased name matches `BranchOn`. Both bridges must declare a
+  trailing `int defaults` parameter (the caller-managed-mask shape),
+  and each must reference its own `Defaults = typeof(XxxDefault)`
+  enum so the per-branch mask can be computed independently.
+  The generator emits a single facade that exposes the extra slot
+  as a nullable `ComposableNode?` property and renders
+  `if (Subtitle is not null) { …alt-bridge call… } else { …primary
+  call… }`. Shared lambdas (`__title`, `__navigationIcon`, …) and
+  `__modifier = BuildModifier()` are hoisted ABOVE the if/else;
+  the branched slot's wrapper, the per-branch mask, and each
+  bridge call live INSIDE their respective branches. Parameter
+  order may differ between primary and alternate — the emitter
+  walks each bridge's actual `Parameters` list (not the slots
+  list) to keep arguments correctly positioned. Used for
+  `TopAppBar` (branches to `TopAppBarWithSubtitle`), `MediumTopAppBar`
+  (→ `MediumFlexibleTopAppBar`), `LargeTopAppBar` (→
+  `LargeFlexibleTopAppBar`). Errors are reported as CN3010.
+
 Facades that still stay hand-written are the ones the generator
 can't model:
 
@@ -542,9 +568,6 @@ can't model:
   `[ComposeBridge]` to attach to) — `DropdownMenuItem`, `Icon`
   (`ImageVector` overload). `WideNavigationRailItem` was migrated
   to a Phase 8 wrapper-passthrough in issue #67.
-- Facades that branch between two bridges based on an optional
-  slot (`TopAppBar` — Subtitle toggles between `TopAppBar-GHTll3U`
-  and `MediumFlexibleTopAppBar-eXZ4JBQ`).
 - Drawer facades with a `confirmStateChange` adapter — the
   per-`ComposableNode`-instance `DrawerConfirmStateChange` Java peer
   has to live in a field on the facade (it's part of
@@ -581,8 +604,8 @@ can't model:
 Trying to apply `[ComposeFacade]` to an unsupported bridge will
 emit CN3002 (unsupported parameter), CN3003 (scope misuse), CN3005
 (invalid callback type), CN3006 (slot conflict), CN3007 (color
-theme binding failed), CN3008 (painter misuse), or CN3009
-(state-holder misuse) at build time —
+theme binding failed), CN3008 (painter misuse), CN3009
+(state-holder misuse), or CN3010 (branching misuse) at build time —
 back out the attribute and write the facade by hand.
 
 ### Adding a new generated facade
@@ -613,7 +636,7 @@ end-to-end recipe is:
    the stub** — without it the generated class has no XML docs.
 4. **Build the sample** (`dotnet build src/ComposeNet.Sample`) to
    verify the bridge + facade compile together. The supported
-   shapes are validated at build time; CN3001-CN3009 will fire if
+   shapes are validated at build time; CN3001-CN3010 will fire if
    the generator can't accept the bridge.
 5. **If CN3002 fires**, the bridge has a parameter outside the
    table above — either an unmarked `IFunction1` callback, a
@@ -639,6 +662,7 @@ end-to-end recipe is:
 | CN3007  | `DefaultColorFromTheme` cannot bind to any `long` user param (or `ColorParameter` is ambiguous / missing). |
 | CN3008  | `[PainterResource]` annotates a non-`IntPtr` parameter.            |
 | CN3009  | `[StateHolder]` is invalid: applied to a non-`IntPtr` param, combined with `[PainterResource]`, missing or unidentifier-valued `Remember` / `StateType`, the named `Remember` method is not a static `(IComposer) -> IntPtr` on `ComposeBridges`, or `StateType` has no accessible writable instance field named `Jvm`. |
+| CN3010  | `BranchOn` / `AlternateBridge` is invalid: only one of the two is set, primary or alternate is missing a trailing `int defaults` parameter, the named alternate is not resolvable or ambiguous on `ComposeBridges`, alternate is not a strict superset (missing a primary param or has more than one extra), the extra param's PascalCased name doesn't match `BranchOn`, the extra param isn't `IFunction2`/`IFunction3`, a shared param has incompatible types, branching is used on a hybrid container shape, or the alternate has no resolvable `[ComposeBridge].Defaults` enum. |
 
 ### Migration rule
 

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -2041,6 +2041,9 @@ internal static partial class ComposeBridges
         JvmName   = "TopAppBar-GHTll3U",
         Signature = TopAppBarSig,
         Defaults  = typeof(TopAppBarDefault))]
+    [ComposeFacade(
+        BranchOn        = "Subtitle",
+        AlternateBridge = nameof(TopAppBarWithSubtitle))]
     public static partial void TopAppBar(
         IFunction2  title,
         IModifier?  modifier,
@@ -2078,7 +2081,9 @@ internal static partial class ComposeBridges
         JvmName   = "MediumTopAppBar-oKE7A98",
         Signature = TwoRowsTopAppBarSig,
         Defaults  = typeof(TwoRowsTopAppBarDefault))]
-    [ComposeFacade]
+    [ComposeFacade(
+        BranchOn        = "Subtitle",
+        AlternateBridge = nameof(MediumFlexibleTopAppBar))]
     public static partial void MediumTopAppBar(
         IFunction2  title,
         IModifier?  modifier,
@@ -2092,7 +2097,9 @@ internal static partial class ComposeBridges
         JvmName   = "LargeTopAppBar-oKE7A98",
         Signature = TwoRowsTopAppBarSig,
         Defaults  = typeof(TwoRowsTopAppBarDefault))]
-    [ComposeFacade]
+    [ComposeFacade(
+        BranchOn        = "Subtitle",
+        AlternateBridge = nameof(LargeFlexibleTopAppBar))]
     public static partial void LargeTopAppBar(
         IFunction2  title,
         IModifier?  modifier,

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -333,6 +333,8 @@ ComposeNet.LargeTopAppBar.Actions.set -> void
 ComposeNet.LargeTopAppBar.LargeTopAppBar() -> void
 ComposeNet.LargeTopAppBar.NavigationIcon.get -> ComposeNet.ComposableNode?
 ComposeNet.LargeTopAppBar.NavigationIcon.set -> void
+ComposeNet.LargeTopAppBar.Subtitle.get -> ComposeNet.ComposableNode?
+ComposeNet.LargeTopAppBar.Subtitle.set -> void
 ComposeNet.LargeTopAppBar.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.LargeTopAppBar.Title.set -> void
 ComposeNet.LazyColumn<T>
@@ -401,6 +403,8 @@ ComposeNet.MediumTopAppBar.Actions.set -> void
 ComposeNet.MediumTopAppBar.MediumTopAppBar() -> void
 ComposeNet.MediumTopAppBar.NavigationIcon.get -> ComposeNet.ComposableNode?
 ComposeNet.MediumTopAppBar.NavigationIcon.set -> void
+ComposeNet.MediumTopAppBar.Subtitle.get -> ComposeNet.ComposableNode?
+ComposeNet.MediumTopAppBar.Subtitle.set -> void
 ComposeNet.MediumTopAppBar.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.MediumTopAppBar.Title.set -> void
 ComposeNet.ModalBottomSheet

--- a/src/ComposeNet.Compose/TopAppBar.cs
+++ b/src/ComposeNet.Compose/TopAppBar.cs
@@ -1,11 +1,9 @@
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>TopAppBar</c>. <see cref="Title"/> is required;
-/// <see cref="Subtitle"/>, <see cref="NavigationIcon"/>, and
-/// <see cref="Actions"/> are optional slots:
+/// Material 3 <c>TopAppBar</c>. <c>Title</c> is required;
+/// <c>Subtitle</c>, <c>NavigationIcon</c>, and <c>Actions</c> are
+/// optional slots:
 /// <code>
 /// new TopAppBar
 /// {
@@ -15,59 +13,10 @@ namespace ComposeNet;
 ///     Actions        = new Row { new IconButton(...) { new Text("⋮") } },
 /// }
 /// </code>
-/// When <see cref="Subtitle"/> is set, the bar is rendered via the
-/// newer two-line <c>TopAppBar-cJHQLPU</c> overload; otherwise it uses
-/// the single-line <c>TopAppBar-GHTll3U</c> overload.
+/// When <c>Subtitle</c> is set, the bar is rendered via the newer
+/// two-line <c>TopAppBar-cJHQLPU</c> overload; otherwise it uses the
+/// single-line <c>TopAppBar-GHTll3U</c> overload. The branching is
+/// driven by the <c>[ComposeFacade(BranchOn=..., AlternateBridge=...)]</c>
+/// attribute on the corresponding bridge in <c>ComposeBridges.cs</c>.
 /// </summary>
-public sealed class TopAppBar : ComposableNode
-{
-    /// <summary>Required: the bar's title slot.</summary>
-    public ComposableNode? Title { get; set; }
-
-    /// <summary>
-    /// Optional: second-line slot below the title. Setting this routes
-    /// to the M3 two-line TopAppBar overload.
-    /// </summary>
-    public ComposableNode? Subtitle { get; set; }
-
-    /// <summary>Optional: leading slot, typically a menu / back button.</summary>
-    public ComposableNode? NavigationIcon { get; set; }
-
-    /// <summary>Optional: trailing slot, laid out in a <c>RowScope</c>.</summary>
-    public ComposableNode? Actions { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Title is null)
-            throw new System.InvalidOperationException(
-                "TopAppBar.Title is required (the Kotlin parameter has no default).");
-
-        var title = ComposableLambdas.Wrap2(composer, c => Title.Render(c));
-        var nav = NavigationIcon is null ? null
-            : ComposableLambdas.Wrap2(composer, c => NavigationIcon.Render(c));
-        var actions = Actions is null ? null
-            : ComposableLambdas.Wrap3(composer, c => Actions.Render(c));
-        var modifier = BuildModifier();
-
-        if (Subtitle is not null)
-        {
-            var subtitle = ComposableLambdas.Wrap2(composer, c => Subtitle.Render(c));
-
-            int defaults = (int)TopAppBarSubtitleDefault.All;
-            if (modifier is not null) defaults &= ~(int)TopAppBarSubtitleDefault.Modifier;
-            if (nav      is not null) defaults &= ~(int)TopAppBarSubtitleDefault.NavigationIcon;
-            if (actions  is not null) defaults &= ~(int)TopAppBarSubtitleDefault.Actions;
-
-            ComposeBridges.TopAppBarWithSubtitle(
-                title, subtitle, modifier, nav, actions, defaults, composer);
-            return;
-        }
-
-        int defaults0 = (int)TopAppBarDefault.All;
-        if (modifier is not null) defaults0 &= ~(int)TopAppBarDefault.Modifier;
-        if (nav      is not null) defaults0 &= ~(int)TopAppBarDefault.NavigationIcon;
-        if (actions  is not null) defaults0 &= ~(int)TopAppBarDefault.Actions;
-
-        ComposeBridges.TopAppBar(title, modifier, nav, actions, defaults0, composer);
-    }
-}
+public sealed partial class TopAppBar;

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -2299,4 +2299,388 @@ public class FacadeGeneratorTests
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
     }
+
+    // ---------------------------------------------------------------
+    // Branching — BranchOn / AlternateBridge (CN3010). The primary
+    // bridge is the smaller one; the alternate is a strict superset
+    // adding exactly one optional slot. The facade exposes the extra
+    // slot as a nullable property and routes to the alternate bridge
+    // when that property is non-null.
+    // ---------------------------------------------------------------
+
+    const string BranchPrimaryAttrs = """
+        [assembly: ComposeDefaults("BarDefault",
+            "!title", "modifier", "navigationIcon", "actions")]
+        [assembly: ComposeDefaults("BarSubtitleDefault",
+            "!title", "!subtitle", "modifier", "navigationIcon", "actions")]
+        """;
+
+    const string BranchBridges = """
+        namespace ComposeNet
+        {
+            public static partial class ComposeBridges
+            {
+                [ComposeBridge(Class="x/Y", JvmName="Bar",
+                               Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                               Defaults=typeof(BarDefault))]
+                [ComposeFacade(BranchOn="Subtitle", AlternateBridge=nameof(BarWithSubtitle))]
+                public static partial void Bar(
+                    IFunction2  title,
+                    IModifier?  modifier,
+                    IFunction2? navigationIcon,
+                    IFunction3? actions,
+                    int         defaults,
+                    IComposer   composer);
+
+                [ComposeBridge(Class="x/Y", JvmName="BarWithSubtitle",
+                               Signature="(Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                               Defaults=typeof(BarSubtitleDefault))]
+                public static partial void BarWithSubtitle(
+                    IFunction2  title,
+                    IFunction2  subtitle,
+                    IModifier?  modifier,
+                    IFunction2? navigationIcon,
+                    IFunction3? actions,
+                    int         defaults,
+                    IComposer   composer);
+            }
+        }
+        """;
+
+    [Fact]
+    public void Branching_EmitsIfElseWithPerBranchMasks()
+    {
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            {{BranchPrimaryAttrs}}
+
+            {{BranchBridges}}
+            """;
+
+        var (output, diags, emitted) = Run(code, "Bar");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // The facade exposes Subtitle (PascalCased BranchOn) plus the
+        // three shared optional slots as nullable ComposableNode?
+        // properties — and Title is required.
+        Assert.Contains("public global::ComposeNet.ComposableNode? Title { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Subtitle { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? NavigationIcon { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ComposableNode? Actions { get; set; }", emitted);
+
+        // Modifier is hoisted (both branches need it for the mask).
+        Assert.Contains("var __modifier = BuildModifier();", emitted);
+
+        // The branched slot's wrapper lives INSIDE the if-branch, not
+        // at the top alongside the shared wrappers.
+        var subtitleWrapIndex = emitted!.IndexOf("var __subtitle =", System.StringComparison.Ordinal);
+        var ifCondIndex = emitted.IndexOf("if (Subtitle is not null)", System.StringComparison.Ordinal);
+        Assert.True(ifCondIndex > 0, "expected `if (Subtitle is not null)`");
+        Assert.True(subtitleWrapIndex > ifCondIndex, "subtitle wrapper must appear inside the if-branch");
+
+        // Per-branch mask + call: alternate uses BarSubtitleDefault,
+        // primary uses BarDefault.
+        Assert.Contains("(int)global::ComposeNet.BarSubtitleDefault.All;", emitted);
+        Assert.Contains("(int)global::ComposeNet.BarDefault.All;", emitted);
+
+        // Alt branch calls the alternate bridge with the alt's actual
+        // parameter order (title, subtitle, modifier, nav, actions).
+        Assert.Contains("global::ComposeNet.ComposeBridges.BarWithSubtitle(__title, __subtitle, __modifier, __navigationIcon, __actions, __defaults, composer);", emitted);
+
+        // Primary branch calls the primary bridge (no subtitle).
+        Assert.Contains("global::ComposeNet.ComposeBridges.Bar(__title, __modifier, __navigationIcon, __actions, __defaults, composer);", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Branching_WalksAlternateParamOrder()
+    {
+        // Alternate bridge puts the extra slot in a DIFFERENT position
+        // (after modifier, not after title). The emitter must walk
+        // each bridge's actual parameter list — not the slots list —
+        // to keep argument order correct.
+        const string AltAttrs = """
+            [assembly: ComposeDefaults("BarDefault",
+                "!title", "modifier", "navigationIcon", "actions")]
+            [assembly: ComposeDefaults("BarFlexDefault",
+                "!title", "modifier", "subtitle", "navigationIcon", "actions")]
+            """;
+
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            {{AltAttrs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Y", JvmName="Bar",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarDefault))]
+                    [ComposeFacade(BranchOn="Subtitle", AlternateBridge=nameof(BarFlex))]
+                    public static partial void Bar(
+                        IFunction2  title,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+
+                    [ComposeBridge(Class="x/Y", JvmName="BarFlex",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V",
+                                   Defaults=typeof(BarFlexDefault))]
+                    public static partial void BarFlex(
+                        IFunction2  title,
+                        IModifier?  modifier,
+                        IFunction2? subtitle,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "Bar");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Alt branch walks BarFlex's order: title, modifier, subtitle,
+        // navigationIcon, actions — NOT the slots-list order.
+        Assert.Contains("global::ComposeNet.ComposeBridges.BarFlex(__title, __modifier, __subtitle, __navigationIcon, __actions, __defaults, composer);", emitted);
+        // The Subtitle bit IS in BarFlexDefault (not `!`-suppressed),
+        // so the alt-branch mask clears it for the supplied slot.
+        Assert.Contains("__defaults &= ~(int)global::ComposeNet.BarFlexDefault.Subtitle;", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Branching_MissingAlternate_EmitsCN3010()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BarDefault",
+                "!title", "modifier", "navigationIcon", "actions")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Y", JvmName="Bar",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarDefault))]
+                    [ComposeFacade(BranchOn="Subtitle", AlternateBridge="BarWithSubtitleMissing")]
+                    public static partial void Bar(
+                        IFunction2  title,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code, "Bar");
+        Assert.Contains(diags, d => d.Id == "CN3010" && d.GetMessage().Contains("BarWithSubtitleMissing"));
+    }
+
+    [Fact]
+    public void Branching_OnlyOneOfBranchOnAlternateBridge_EmitsCN3010()
+    {
+        // BranchOn without AlternateBridge.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BarDefault",
+                "!title", "modifier", "navigationIcon", "actions")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Y", JvmName="Bar",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarDefault))]
+                    [ComposeFacade(BranchOn="Subtitle")]
+                    public static partial void Bar(
+                        IFunction2  title,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code, "Bar");
+        Assert.Contains(diags, d => d.Id == "CN3010" && d.GetMessage().Contains("BranchOn and AlternateBridge"));
+    }
+
+    [Fact]
+    public void Branching_BranchOnMismatch_EmitsCN3010()
+    {
+        // Extra param is `subtitle` (Pascal "Subtitle"), but BranchOn
+        // names a different property — should fail with CN3010.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BarDefault",
+                "!title", "modifier", "navigationIcon", "actions")]
+            [assembly: ComposeDefaults("BarSubtitleDefault",
+                "!title", "!subtitle", "modifier", "navigationIcon", "actions")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Y", JvmName="Bar",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarDefault))]
+                    [ComposeFacade(BranchOn="Caption", AlternateBridge=nameof(BarWithSubtitle))]
+                    public static partial void Bar(
+                        IFunction2  title,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+
+                    [ComposeBridge(Class="x/Y", JvmName="BarWithSubtitle",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarSubtitleDefault))]
+                    public static partial void BarWithSubtitle(
+                        IFunction2  title,
+                        IFunction2  subtitle,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code, "Bar");
+        Assert.Contains(diags, d => d.Id == "CN3010" && d.GetMessage().Contains("Caption"));
+    }
+
+    [Fact]
+    public void Branching_AlternateHasMissingPrimaryParam_EmitsCN3010()
+    {
+        // Alternate is missing `actions`, so it's not a strict
+        // superset; CN3010 should fire.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BarDefault",
+                "!title", "modifier", "navigationIcon", "actions")]
+            [assembly: ComposeDefaults("BarBadDefault",
+                "!title", "!subtitle", "modifier", "navigationIcon")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Y", JvmName="Bar",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarDefault))]
+                    [ComposeFacade(BranchOn="Subtitle", AlternateBridge=nameof(BarBad))]
+                    public static partial void Bar(
+                        IFunction2  title,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+
+                    [ComposeBridge(Class="x/Y", JvmName="BarBad",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarBadDefault))]
+                    public static partial void BarBad(
+                        IFunction2  title,
+                        IFunction2  subtitle,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        int         defaults,
+                        IComposer   composer);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code, "Bar");
+        Assert.Contains(diags, d => d.Id == "CN3010" && d.GetMessage().Contains("actions"));
+    }
+
+    [Fact]
+    public void Branching_PrimaryMissingDefaultsParam_EmitsCN3010()
+    {
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("BarSubtitleDefault",
+                "!title", "!subtitle", "modifier", "navigationIcon", "actions")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/Y", JvmName="Bar",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V")]
+                    [ComposeFacade(BranchOn="Subtitle", AlternateBridge=nameof(BarWithSubtitle))]
+                    public static partial void Bar(
+                        IFunction2  title,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        IComposer   composer);
+
+                    [ComposeBridge(Class="x/Y", JvmName="BarWithSubtitle",
+                                   Signature="(Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(BarSubtitleDefault))]
+                    public static partial void BarWithSubtitle(
+                        IFunction2  title,
+                        IFunction2  subtitle,
+                        IModifier?  modifier,
+                        IFunction2? navigationIcon,
+                        IFunction3? actions,
+                        int         defaults,
+                        IComposer   composer);
+                }
+            }
+            """;
+
+        var (_, diags, _) = Run(code, "Bar");
+        Assert.Contains(diags, d => d.Id == "CN3010" && d.GetMessage().Contains("'int defaults'"));
+    }
 }

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -186,6 +186,38 @@ internal static class Attributes
                 /// instead — this property is ignored in that case.
                 /// </summary>
                 public global::System.Type? Defaults { get; set; }
+
+                /// <summary>
+                /// Phase 9 — name of a synthetic facade property that
+                /// drives bridge branching. When the property is non-null
+                /// at render time the generated <c>Render</c> routes to
+                /// the <see cref="AlternateBridge"/> method on
+                /// <c>ComposeBridges</c>; otherwise it calls the primary
+                /// bridge (the one paired with this attribute's
+                /// <see cref="ComposeBridgeAttribute"/>).
+                /// </summary>
+                /// <remarks>
+                /// The property is synthesized from the extra
+                /// <c>IFunction2</c>/<c>IFunction3</c> parameter that the
+                /// alternate bridge has and the primary lacks. The value
+                /// of <c>BranchOn</c> must equal the PascalCased Kotlin
+                /// parameter name of that extra slot. The alternate's
+                /// user parameters must form the primary's user-param
+                /// name set plus exactly one extra slot. Must be paired
+                /// with <see cref="AlternateBridge"/>.
+                /// </remarks>
+                public string? BranchOn { get; set; }
+
+                /// <summary>
+                /// Phase 9 — name of the sibling static partial method on
+                /// <c>ComposeBridges</c> to route to when the facade's
+                /// <see cref="BranchOn"/> property is non-null. The
+                /// alternate must declare its own <see cref="ComposeBridgeAttribute"/>
+                /// with a matching <c>Defaults</c> enum and accept all
+                /// of the primary bridge's user parameters (by name) plus
+                /// exactly one extra slot matching <see cref="BranchOn"/>.
+                /// </summary>
+                public string? AlternateBridge { get; set; }
             }
 
             /// <summary>

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -150,6 +150,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         string? scope = ReadString(attr, "Scope");
         string? themeColor = ReadString(attr, "DefaultColorFromTheme");
         string? colorParameter = ReadString(attr, "ColorParameter");
+        string? branchOn = ReadString(attr, "BranchOn");
+        string? alternateBridgeName = ReadString(attr, "AlternateBridge");
 
         // Composer is the trailing param for @Composable bridges (the only
         // shape facade generation supports).
@@ -336,13 +338,258 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             diags.Add(Diagnostic.Create(Diagnostics.FacadeSlotConflict, loc, method.Name, reason));
         }
 
+        // Branching (CN3010). When BranchOn/AlternateBridge are set, the
+        // facade dispatches between this primary bridge and a sibling
+        // bridge whose param list is a strict superset (one extra
+        // optional slot). The extra slot becomes a nullable property on
+        // the facade; the if-branch passes it, the else-branch omits it.
+        BranchInfo? branchInfo = null;
+        if (!string.IsNullOrEmpty(branchOn) || !string.IsNullOrEmpty(alternateBridgeName))
+        {
+            branchInfo = BuildBranchInfo(c, method, branchOn, alternateBridgeName, loc,
+                userParams, slots, callerProvidesDefaults, isHybridContainer, diags);
+            if (branchInfo is not null)
+            {
+                // Append the synthesised slot, force the facade into
+                // multi-slot leaf shape.
+                slots.Add(branchInfo.BranchedSlot);
+                for (int i = 0; i < slots.Count; i++)
+                {
+                    var s = slots[i];
+                    if (s.Kind == FacadeSlotKind.Content2)
+                        slots[i] = s.WithKind(s.Param.NullableAnnotation == NullableAnnotation.Annotated
+                            ? FacadeSlotKind.NamedFunction2 : FacadeSlotKind.RequiredFunction2);
+                    else if (s.Kind == FacadeSlotKind.Content3)
+                        slots[i] = s.WithKind(s.Param.NullableAnnotation == NullableAnnotation.Annotated
+                            ? FacadeSlotKind.NamedFunction3 : FacadeSlotKind.RequiredFunction3);
+                }
+                hasMultiSlot = true;
+            }
+        }
+
         if (diags.Count > 0)
             return new GenerationResult(null, null, diags);
 
         var source = Emit(className, method.Name, scope, composerParam, slots, hasMultiSlot,
-            callerProvidesDefaults, defaultsParam, defaults, defaultsType?.Name, themeColor, colorSlot);
+            callerProvidesDefaults, defaultsParam, defaults, defaultsType?.Name, themeColor, colorSlot,
+            userParams, branchInfo);
         var hint = $"ComposeNet.Facade.{className}.g.cs";
         return new GenerationResult(source, hint, Array.Empty<Diagnostic>());
+    }
+
+    static BranchInfo? BuildBranchInfo(Context c, IMethodSymbol primary,
+        string? branchOn, string? alternateBridgeName, Location loc,
+        IReadOnlyList<IParameterSymbol> primaryUserParams,
+        IReadOnlyList<FacadeSlot> primarySlots,
+        bool callerProvidesDefaults, bool isHybridContainer,
+        List<Diagnostic> diags)
+    {
+        // Both required.
+        if (string.IsNullOrEmpty(branchOn) || string.IsNullOrEmpty(alternateBridgeName))
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                "BranchOn and AlternateBridge must both be set"));
+            return null;
+        }
+
+        // Primary must use the caller-managed-defaults shape.
+        if (!callerProvidesDefaults)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                "branching requires the primary bridge to declare a trailing 'int defaults' parameter"));
+            return null;
+        }
+
+        // Container shape disallowed — branching only supports multi-slot
+        // leafs (every slot exposed as a property). Hybrid containers
+        // (Scope opt-in with a named-slot mix) are explicitly rejected
+        // because the container body would bleed across branches in
+        // surprising ways. Pure Phase 1 container shapes are silently
+        // reclassified to leaf at the call site in Build().
+        if (isHybridContainer)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                "branching is not supported on hybrid container shapes (Scope opt-in with named slots)"));
+            return null;
+        }
+
+        // Resolve alternate method symbol on ComposeBridges.
+        var bridgesType = c.Compilation.GetTypeByMetadataName("ComposeNet.ComposeBridges");
+        if (bridgesType is null)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                "ComposeNet.ComposeBridges not found in compilation"));
+            return null;
+        }
+
+        var allOverloads = bridgesType.GetMembers(alternateBridgeName!).OfType<IMethodSymbol>()
+            .Where(m => m.IsStatic).ToArray();
+        // Require @Composable shape: trailing IComposer + (optionally) a
+        // [ComposeBridge] attribute. Filter to the candidate set first
+        // (this matches what the StateHolder validator does for Remember).
+        var candidates = allOverloads.Where(m =>
+            m.Parameters.Length >= 1 &&
+            ComposeDefaultsGenerator.IsComposer(m.Parameters[m.Parameters.Length - 1].Type) &&
+            (c.BridgeAttr is null ||
+             m.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.BridgeAttr)))
+        ).ToArray();
+
+        if (candidates.Length == 0)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"no static @Composable method 'ComposeBridges.{alternateBridgeName}' with [ComposeBridge] and a trailing IComposer parameter was found"));
+            return null;
+        }
+        if (candidates.Length > 1)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"AlternateBridge='{alternateBridgeName}' is ambiguous — {candidates.Length} matching overloads of ComposeBridges.{alternateBridgeName} found"));
+            return null;
+        }
+
+        var altMethod = candidates[0];
+        // Strip trailing composer + (optional) `int defaults`.
+        var altAll = altMethod.Parameters;
+        var altUser = altAll.Take(altAll.Length - 1).ToArray();
+        IParameterSymbol? altDefaultsParam = null;
+        if (altUser.Length > 0 &&
+            altUser[altUser.Length - 1].Type.SpecialType == SpecialType.System_Int32 &&
+            altUser[altUser.Length - 1].Name == "defaults")
+        {
+            altDefaultsParam = altUser[altUser.Length - 1];
+            altUser = altUser.Take(altUser.Length - 1).ToArray();
+        }
+        if (altDefaultsParam is null)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"alternate bridge 'ComposeBridges.{alternateBridgeName}' must declare a trailing 'int defaults' parameter"));
+            return null;
+        }
+
+        // Compute the diff. Alternate's user-param set must be exactly
+        // primary's set plus one extra whose Pascal-cased name matches
+        // BranchOn.
+        var primaryNames = new HashSet<string>(primaryUserParams.Select(p => p.Name), StringComparer.Ordinal);
+        var altNames = new HashSet<string>(altUser.Select(p => p.Name), StringComparer.Ordinal);
+        var missing = primaryNames.Where(n => !altNames.Contains(n)).ToArray();
+        if (missing.Length > 0)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"alternate bridge 'ComposeBridges.{alternateBridgeName}' is missing primary parameters: {string.Join(", ", missing)}"));
+            return null;
+        }
+        var extras = altUser.Where(p => !primaryNames.Contains(p.Name)).ToArray();
+        if (extras.Length != 1)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"alternate bridge 'ComposeBridges.{alternateBridgeName}' must add exactly one parameter vs primary; found {extras.Length} ({string.Join(", ", extras.Select(e => e.Name))})"));
+            return null;
+        }
+        var extra = extras[0];
+        var pascalExtra = Pascal(extra.Name);
+        if (!string.Equals(pascalExtra, branchOn, StringComparison.Ordinal))
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"extra parameter '{extra.Name}' (Pascal '{pascalExtra}') does not match BranchOn='{branchOn}'"));
+            return null;
+        }
+
+        // Shape compatibility on shared params. Compose function types
+        // are compared by Kotlin arity (nullability is allowed to differ
+        // because the facade hides it); everything else is compared by
+        // canonical type symbol equality (nullable-aware).
+        foreach (var pp in primaryUserParams)
+        {
+            var ap = altUser.First(a => a.Name == pp.Name);
+            if (!AreCompatibleSharedParams(pp, ap))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                    $"shared parameter '{pp.Name}' has incompatible types between primary ({pp.Type.ToDisplayString()}) and alternate ({ap.Type.ToDisplayString()})"));
+                return null;
+            }
+        }
+
+        // Synthesise the branched slot. It must be a Kotlin function so
+        // the facade can expose it as a ComposableNode? property.
+        var extraArity = KotlinFunctionArity(extra.Type);
+        FacadeSlotKind branchedKind;
+        if (extraArity == 2) branchedKind = FacadeSlotKind.NamedFunction2;
+        else if (extraArity == 3) branchedKind = FacadeSlotKind.NamedFunction3;
+        else
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"extra parameter '{extra.Name}' must be Kotlin.Jvm.Functions.IFunction2 or IFunction3; was '{extra.Type.ToDisplayString()}'"));
+            return null;
+        }
+
+        // Resolve the alternate's Defaults enum (declarative first, then
+        // generic-form enum walk).
+        AttributeData? altBridgeAttr = c.BridgeAttr is null ? null
+            : altMethod.GetAttributes().FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.BridgeAttr));
+        INamedTypeSymbol? altDefaultsType = altBridgeAttr is not null ? ReadType(altBridgeAttr, "Defaults") : null;
+        if (altDefaultsType is null)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"alternate bridge 'ComposeBridges.{alternateBridgeName}' has no '[ComposeBridge].Defaults' enum to drive the per-branch defaults mask"));
+            return null;
+        }
+        DefaultsInfo? altDefaults = null;
+        if (c.DeclarativeAttr is not null)
+            altDefaults = DefaultsInfo.TryRead(c.Compilation, c.DeclarativeAttr, altDefaultsType.Name);
+        altDefaults ??= DefaultsInfo.TryReadFromEnum(altDefaultsType);
+        if (altDefaults is null)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeBranchInvalid, loc, primary.Name,
+                $"could not resolve [assembly: ComposeDefaults(\"{altDefaultsType.Name}\", ...)] for the alternate bridge"));
+            return null;
+        }
+
+        // Note: the branched slot's SlotPropertyName is the PascalCased
+        // BranchOn; we pass it explicitly so PropertyName() agrees with
+        // the if-condition the emitter produces.
+        var branchedSlot = new FacadeSlot(extra, branchedKind, slotPropertyName: branchOn);
+
+        return new BranchInfo(
+            alternateMethodName: altMethod.Name,
+            alternateUserParams: altUser,
+            alternateDefaults: altDefaults!.Value,
+            alternateDefaultsEnumName: altDefaultsType.Name,
+            branchedSlot: branchedSlot,
+            branchProperty: branchOn!);
+    }
+
+    static bool AreCompatibleSharedParams(IParameterSymbol a, IParameterSymbol b)
+    {
+        var aArity = KotlinFunctionArity(a.Type);
+        var bArity = KotlinFunctionArity(b.Type);
+        if (aArity >= 0 || bArity >= 0) return aArity == bArity;
+        // Strip nullability and compare type symbols.
+        var aType = a.Type.WithNullableAnnotation(NullableAnnotation.None);
+        var bType = b.Type.WithNullableAnnotation(NullableAnnotation.None);
+        return SymbolEqualityComparer.Default.Equals(aType, bType);
+    }
+
+    internal sealed class BranchInfo
+    {
+        public BranchInfo(string alternateMethodName, IReadOnlyList<IParameterSymbol> alternateUserParams,
+            DefaultsInfo alternateDefaults, string alternateDefaultsEnumName,
+            FacadeSlot branchedSlot, string branchProperty)
+        {
+            AlternateMethodName = alternateMethodName;
+            AlternateUserParams = alternateUserParams;
+            AlternateDefaults = alternateDefaults;
+            AlternateDefaultsEnumName = alternateDefaultsEnumName;
+            BranchedSlot = branchedSlot;
+            BranchProperty = branchProperty;
+        }
+        public string AlternateMethodName { get; }
+        /// <summary>Alternate bridge's user parameters, in declaration order, excluding trailing IComposer and `int defaults`.</summary>
+        public IReadOnlyList<IParameterSymbol> AlternateUserParams { get; }
+        public DefaultsInfo AlternateDefaults { get; }
+        public string AlternateDefaultsEnumName { get; }
+        public FacadeSlot BranchedSlot { get; }
+        /// <summary>The PascalCased property name on the facade (e.g. "Subtitle").</summary>
+        public string BranchProperty { get; }
     }
 
     static FacadeSlot? Classify(IParameterSymbol p, Context c, string methodName, Location loc, List<Diagnostic> diags)
@@ -579,7 +826,9 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         IParameterSymbol composerParam, IReadOnlyList<FacadeSlot> slots,
         bool isMultiSlot, bool callerProvidesDefaults, IParameterSymbol? defaultsParam,
         DefaultsInfo? defaults, string? defaultsEnumName,
-        string? themeColor, FacadeSlot? colorSlot)
+        string? themeColor, FacadeSlot? colorSlot,
+        IReadOnlyList<IParameterSymbol> primaryUserParams,
+        BranchInfo? branchInfo)
     {
         // After classification, only the container's body survives as
         // Content2/3 (multi-slot leafs re-classified to Named/Required).
@@ -755,16 +1004,25 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         // Modifier evaluation. Only hoist to a local when needed for
         // the auto-mask (callerProvidesDefaults). Otherwise the bridge
         // call uses BuildModifier() inline to keep Phase 1 output stable.
+        // Branching always hoists (both branches reference __modifier in
+        // their per-branch mask).
         var modifierSlot = slots.FirstOrDefault(s => s.Kind == FacadeSlotKind.Modifier);
-        bool hoistModifier = modifierSlot.Param is not null && callerProvidesDefaults;
+        bool hoistModifier = modifierSlot.Param is not null && (callerProvidesDefaults || branchInfo is not null);
         if (hoistModifier)
         {
             sb.AppendLine("            var __modifier = BuildModifier();");
         }
 
-        // Named slot wrappers (Phase 3). One per line.
+        // Named slot wrappers (Phase 3). One per line. When branching,
+        // skip the branched slot — it gets wrapped inside the if-branch
+        // only (the primary bridge has no corresponding parameter).
         foreach (var s in namedSlots)
         {
+            if (branchInfo is not null &&
+                SymbolEqualityComparer.Default.Equals(s.Param, branchInfo.BranchedSlot.Param))
+            {
+                continue;
+            }
             var name = PropertyName(s);
             string wrap = s.Kind is FacadeSlotKind.NamedFunction3 or FacadeSlotKind.RequiredFunction3
                 ? "Wrap3"
@@ -828,32 +1086,40 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
         string indent = hasPainter ? "                " : "            ";
 
-        // Phase 3 — auto-mask defaults.
-        if (callerProvidesDefaults && defaults is { } d)
+        // Phase 3 — auto-mask defaults + bridge call.
+        if (branchInfo is not null)
         {
-            EmitDefaultsMask(sb, indent, d, slots, namedSlots, modifierSlot.Param is not null, hasPainter);
+            EmitBranchedRender(sb, indent, bridgeMethodName, slots, primaryUserParams,
+                defaults!.Value, defaultsEnumName!, branchInfo, composerName, hoistModifier);
         }
+        else
+        {
+            if (callerProvidesDefaults && defaults is { } d)
+            {
+                EmitDefaultsMask(sb, indent, d, slots, namedSlots, modifierSlot.Param is not null, hasPainter);
+            }
 
-        // Bridge call. Preserve original bridge param order.
-        sb.Append(indent).Append("global::ComposeNet.ComposeBridges.").Append(bridgeMethodName).Append('(');
-        bool first = true;
-        // Walk method.Parameters via slots in their original order; the
-        // defaults param (if any) was removed from `slots` so we add it
-        // back here from the local __defaults symbol.
-        foreach (var s in slots)
-        {
+            // Bridge call. Preserve original bridge param order.
+            sb.Append(indent).Append("global::ComposeNet.ComposeBridges.").Append(bridgeMethodName).Append('(');
+            bool first = true;
+            // Walk method.Parameters via slots in their original order; the
+            // defaults param (if any) was removed from `slots` so we add it
+            // back here from the local __defaults symbol.
+            foreach (var s in slots)
+            {
+                if (!first) sb.Append(", ");
+                first = false;
+                sb.Append(BridgeArgExpr(s, hoistModifier));
+            }
+            if (callerProvidesDefaults)
+            {
+                if (!first) sb.Append(", ");
+                sb.Append("__defaults");
+                first = false;
+            }
             if (!first) sb.Append(", ");
-            first = false;
-            sb.Append(BridgeArgExpr(s, hoistModifier));
+            sb.Append(composerName).AppendLine(");");
         }
-        if (callerProvidesDefaults)
-        {
-            if (!first) sb.Append(", ");
-            sb.Append("__defaults");
-            first = false;
-        }
-        if (!first) sb.Append(", ");
-        sb.Append(composerName).AppendLine(");");
 
         if (hasPainter)
         {
@@ -868,6 +1134,70 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         sb.AppendLine("    }");
         sb.AppendLine("}");
         return sb.ToString();
+    }
+
+    static void EmitBranchedRender(StringBuilder sb, string indent,
+        string primaryMethodName, IReadOnlyList<FacadeSlot> slots,
+        IReadOnlyList<IParameterSymbol> primaryUserParams,
+        DefaultsInfo primaryDefaults, string primaryDefaultsEnumName,
+        BranchInfo branch, string composerName, bool hoistModifier)
+    {
+        // Lookup table from bridge-param-name to facade slot. Built once
+        // and reused for both branches' call emission. Names that only
+        // exist in the alternate (the branched slot) map to the
+        // synthesized slot; names shared by both bridges map to the
+        // primary's classification.
+        var slotByName = new Dictionary<string, FacadeSlot>(StringComparer.Ordinal);
+        foreach (var s in slots)
+            slotByName[s.Param.Name] = s;
+
+        var branched = branch.BranchedSlot;
+        var branchPropName = branch.BranchProperty;
+        int arity = branched.Kind == FacadeSlotKind.NamedFunction3 ? 3 : 2;
+        string wrap = arity == 3 ? "Wrap3" : "Wrap2";
+
+        var allNamedSlots = slots.Where(s => s.Kind is FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3
+            or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3).ToArray();
+
+        // Alternate branch: the branched slot is provided.
+        sb.Append(indent).Append("if (").Append(branchPropName).AppendLine(" is not null)");
+        sb.Append(indent).AppendLine("{");
+        var inner = indent + "    ";
+        sb.Append(inner).Append("var __").Append(branched.Param.Name)
+          .Append(" = global::ComposeNet.ComposableLambdas.").Append(wrap)
+          .Append('(').Append(composerName).Append(", c => ")
+          .Append(branchPropName).AppendLine("!.Render(c));");
+        EmitDefaultsMask(sb, inner, branch.AlternateDefaults, slots, allNamedSlots,
+            hasModifier: hoistModifier, hasPainter: false);
+        EmitBridgeCallByParams(sb, inner, branch.AlternateMethodName, branch.AlternateUserParams,
+            slotByName, composerName, hoistModifier);
+        sb.Append(indent).AppendLine("}");
+
+        // Primary branch: branched slot is null.
+        sb.Append(indent).AppendLine("else");
+        sb.Append(indent).AppendLine("{");
+        EmitDefaultsMask(sb, inner, primaryDefaults, slots, allNamedSlots,
+            hasModifier: hoistModifier, hasPainter: false);
+        EmitBridgeCallByParams(sb, inner, primaryMethodName, primaryUserParams,
+            slotByName, composerName, hoistModifier);
+        sb.Append(indent).AppendLine("}");
+    }
+
+    static void EmitBridgeCallByParams(StringBuilder sb, string indent,
+        string bridgeMethodName, IReadOnlyList<IParameterSymbol> bridgeUserParams,
+        IReadOnlyDictionary<string, FacadeSlot> slotByName,
+        string composerName, bool hoistModifier)
+    {
+        sb.Append(indent).Append("global::ComposeNet.ComposeBridges.").Append(bridgeMethodName).Append('(');
+        foreach (var p in bridgeUserParams)
+        {
+            if (slotByName.TryGetValue(p.Name, out var slot))
+                sb.Append(BridgeArgExpr(slot, hoistModifier));
+            else
+                sb.Append("default");
+            sb.Append(", ");
+        }
+        sb.Append("__defaults, ").Append(composerName).AppendLine(");");
     }
 
     static void EmitCallbackWrapper(StringBuilder sb, FacadeSlot s)

--- a/src/ComposeNet.SourceGenerators/Diagnostics.cs
+++ b/src/ComposeNet.SourceGenerators/Diagnostics.cs
@@ -163,4 +163,12 @@ internal static class Diagnostics
         category: "ComposeNet",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor FacadeBranchInvalid = new(
+        id: "CN3010",
+        title: "[ComposeFacade(BranchOn=..., AlternateBridge=...)] is invalid",
+        messageFormat: "Facade for bridge '{0}': {1}",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }


### PR DESCRIPTION
Closes #122.

Adds bridge branching to the `[ComposeFacade]` source generator so a single facade can route between two `[ComposeBridge]` methods based on whether one optional slot is supplied. Folds the hand-written `TopAppBar.cs` into the generator and extends the same shape to `MediumTopAppBar` and `LargeTopAppBar`.

## Attribute shape

```csharp
[ComposeFacade(
    BranchOn        = "Subtitle",
    AlternateBridge = nameof(ComposeBridges.TopAppBarWithSubtitle))]
```

- The partial method describes the **primary** (smaller) bridge.
- `AlternateBridge` names a sibling `ComposeBridges` method whose user params are the primary's set plus exactly one extra `IFunction2`/`IFunction3` slot whose PascalCased name matches `BranchOn`.
- Both bridges must declare a trailing `int defaults` parameter; each must carry `[ComposeBridge].Defaults = typeof(XDefault)` so the per-branch mask can be computed independently.
- Parameter order may differ between primary and alternate — the emitter walks each bridge's actual `Parameters` list (not the slots list) to keep arguments correctly positioned. This matters for `MediumTopAppBar`/`LargeTopAppBar` where the Flexible bridge places `subtitle` between `modifier` and `navigationIcon`.

## Generated shape

The facade exposes the extra slot as a `ComposableNode?` property and emits:

```csharp
if (Subtitle is not null)
{
    var __subtitle = ComposableLambdas.Wrap2(composer, c => Subtitle!.Render(c));
    int __defaults = (int)TopAppBarSubtitleDefault.All;
    // …per-branch mask clears…
    ComposeBridges.TopAppBarWithSubtitle(__title, __subtitle, __modifier, …);
}
else
{
    int __defaults = (int)TopAppBarDefault.All;
    // …per-branch mask clears…
    ComposeBridges.TopAppBar(__title, __modifier, …);
}
```

Shared lambdas and `__modifier = BuildModifier()` are hoisted above the branch (both branches reference them); the branched slot's wrapper, the per-branch mask, and each bridge call live inside their respective branches.

## CN3010

New diagnostic flags every misuse: only one of `BranchOn` / `AlternateBridge` set, primary or alternate missing `int defaults`, unresolvable / ambiguous alternate, alternate not a strict superset (missing primary param or has more than one extra), extra param Pascal name doesn't match `BranchOn`, non-`IFunction2`/`IFunction3` extra param, incompatible shared param types, hybrid container shape, or unresolvable alternate `Defaults` enum.

## Wired up

- `TopAppBar` → `TopAppBarWithSubtitle`
- `MediumTopAppBar` → `MediumFlexibleTopAppBar`
- `LargeTopAppBar` → `LargeFlexibleTopAppBar`

`TopAppBar.cs` is now a single-line stub matching the rest of the generated-facade convention. `MediumFlexibleTopAppBar` and `LargeFlexibleTopAppBar` retain their own `[ComposeFacade]` — they expose explicit collapsed/expanded heights, a distinct API surface from the new branching variants.

## Validation

- 7 new branching tests in `FacadeGeneratorTests.cs` cover happy path + walks-alternate-param-order + 5 CN3010 negatives.
- All 100 generator tests pass.
- `ComposeNet.Compose` and the Android sample app both build cleanly (0 errors / 0 warnings).
- Generated `TopAppBar.g.cs` and `MediumTopAppBar.g.cs` were inspected and match the prior hand-written shape exactly.

## Docs

`copilot-instructions.md` gains a Phase 9 description, removes the TopAppBar entry from the "still hand-written" list, and adds the CN3010 row to the diagnostic table.