### PR TITLE
Finish Modifier surface (issue #63)

### DIFF
--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -189,5 +189,52 @@ public static class Compose
             System.GC.KeepAlive(composer);
         }
     }
+
+    /// <summary>
+    /// Compose's <c>rememberDraggableState(onDelta)</c>: build a
+    /// <see cref="DraggableState"/> whose underlying Kotlin handle is
+    /// cached in the active composer's slot table for the lifetime of
+    /// this call site. The <paramref name="onDelta"/> callback is
+    /// wrapped through Kotlin's <c>rememberUpdatedState</c>, so passing
+    /// a fresh lambda each recomposition is safe — the Java
+    /// <c>DraggableState</c> identity stays stable while the callback
+    /// can capture changing recomposition-time state.
+    ///
+    /// Must be called inside a composition (e.g. inside a
+    /// <c>SetContent</c> body or a <see cref="ComposableNode.Render(IComposer)"/>
+    /// override). Pair with
+    /// <see cref="Modifier.Draggable(DraggableState, ComposeNet.Orientation, bool)"/>
+    /// — the returned state is the value to hand to that modifier.
+    /// </summary>
+    public static DraggableState RememberDraggableState(
+        System.Action<float> onDelta,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+    {
+        System.ArgumentNullException.ThrowIfNull(onDelta);
+        var composer = ComposeContext.Current
+            ?? throw new System.InvalidOperationException(
+                "Compose.RememberDraggableState must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
+
+        composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
+        try
+        {
+            var jcw = new ComposableLambda1(boxed =>
+            {
+                var f = boxed as Java.Lang.Float
+                    ?? throw new System.InvalidCastException(
+                        $"Expected java.lang.Float in DraggableState.onDelta; got '{boxed?.Class?.Name ?? "null"}'.");
+                onDelta(f.FloatValue());
+            });
+            var jvm = AndroidX.Compose.Foundation.Gestures.DraggableKt.RememberDraggableState(jcw, composer, 0)
+                ?? throw new System.InvalidOperationException(
+                    "DraggableKt.RememberDraggableState returned null.");
+            return new DraggableState(jvm);
+        }
+        finally
+        {
+            composer.EndReplaceableGroup();
+        }
+    }
 }
 

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1769,6 +1769,42 @@ internal static partial class ComposeBridges
         Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
     internal static partial IntPtr ModifierDisplayCutoutPadding(IntPtr modifier);
 
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "captionBarPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierCaptionBarPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "mandatorySystemGesturesPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierMandatorySystemGesturesPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "safeContentPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierSafeContentPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "safeGesturesPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierSafeGesturesPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "systemGesturesPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierSystemGesturesPadding(IntPtr modifier);
+
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/layout/WindowInsetsPadding_androidKt",
+        JvmName   = "waterfallPadding",
+        Signature = "(Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;")]
+    internal static partial IntPtr ModifierWaterfallPadding(IntPtr modifier);
+
     // androidx.compose.ui.platform.TestTagKt.testTag(Modifier, String) —
     // attaches a test tag for UI testing frameworks.
     [ComposeBridge(
@@ -1869,6 +1905,27 @@ internal static partial class ComposeBridges
         Defaults  = typeof(ModifierToggleableDefault))]
     internal static partial IntPtr ModifierToggleable(
         IntPtr modifier, bool value, IFunction1 onValueChange);
+
+    // androidx.compose.foundation.gestures.DraggableKt.draggable$default —
+    // non-@Composable Modifier extension. 8 Kotlin params after the
+    // receiver: state, orientation, enabled, interactionSource,
+    // startDragImmediately, onDragStarted, onDragStopped,
+    // reverseDirection. The C# wrapper always supplies state /
+    // orientation / enabled (bits 0/1/2 cleared); the other five slots
+    // (interactionSource + the two suspend Function3s + the two
+    // booleans) stay defaulted in v1.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/gestures/DraggableKt",
+        JvmName   = "draggable$default",
+        Signature = "(Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/foundation/gestures/DraggableState;" +
+                    "Landroidx/compose/foundation/gestures/Orientation;Z" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;Z" +
+                    "Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Z" +
+                    "ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierDraggableDefault))]
+    internal static partial IntPtr ModifierDraggable(
+        IntPtr modifier, IntPtr state, IntPtr orientation, bool enabled);
 
     // androidx.compose.ui.semantics.SemanticsModifierKt.semantics$default —
     // 2 Kotlin params after the receiver: mergeDescendants (Bool),
@@ -2946,7 +3003,7 @@ internal static partial class ComposeBridges
     // `maxItemsInEachRow`/`maxItemsInEachColumn` is the Kotlin `maxLines`
     // Int. The `maxLines` slot in C# is the JVM `$changed` int; `_changed`
     // is `$default`.
-    [ComposeFacade(Defaults = typeof(FlowRowDefault))]
+    [ComposeFacade(Defaults = typeof(FlowRowDefault), Scope = "Row")]
     public static partial void FlowRow(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
 
     public static partial void FlowRow(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)
@@ -2962,7 +3019,7 @@ internal static partial class ComposeBridges
             maxLines:              0,
             _changed:              defaults);
 
-    [ComposeFacade(Defaults = typeof(FlowColumnDefault))]
+    [ComposeFacade(Defaults = typeof(FlowColumnDefault), Scope = "Column")]
     public static partial void FlowColumn(IModifier? modifier, IFunction3 content, int defaults, IComposer composer);
 
     public static partial void FlowColumn(IModifier? modifier, IFunction3 content, int defaults, IComposer composer)

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -443,6 +443,17 @@ using ComposeNet;
 [assembly: ComposeDefaults("ModifierSemanticsDefault",
     "mergeDescendants", "!properties")]
 
+// androidx.compose.foundation.gestures.DraggableKt.draggable$default —
+// non-@Composable Modifier extension. 8 Kotlin params after the
+// receiver: state, orientation, enabled, interactionSource,
+// startDragImmediately, onDragStarted, onDragStopped, reverseDirection.
+// C# wrapper supplies state/orientation/enabled (bits 0/1/2 cleared);
+// the remaining five slots fall through to Kotlin's defaults.
+[assembly: ComposeDefaults("ModifierDraggableDefault",
+    "!state", "!orientation", "!enabled",
+    "interactionSource", "startDragImmediately",
+    "onDragStarted", "onDragStopped", "reverseDirection")]
+
 // androidx.compose.foundation.ScrollKt.verticalScroll$default —
 // non-@Composable Modifier extension. 4 Kotlin params after the
 // receiver: state, enabled, flingBehavior, reverseScrolling. The C#

--- a/src/ComposeNet.Compose/DraggableState.cs
+++ b/src/ComposeNet.Compose/DraggableState.cs
@@ -1,0 +1,76 @@
+using AndroidX.Compose.Foundation.Gestures;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Caller-supplied state holder for <see cref="Modifier.Draggable(DraggableState, ComposeNet.Orientation, bool)"/>.
+/// Wraps the bound <c>androidx.compose.foundation.gestures.DraggableState</c>
+/// interface. The constructor calls the bound
+/// <c>DraggableKt.DraggableState(onDelta)</c> factory under the hood.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Construct one inside a <see cref="Compose.Remember{T}"/> callback so
+/// the same state survives recompositions:
+/// <code>
+/// var offset = RememberSaveable(() =&gt; new MutableNumberState&lt;float&gt;(0f));
+/// var drag   = Remember(() =&gt; new DraggableState(delta =&gt; offset.Value += delta));
+///
+/// new Box
+/// {
+///     Modifier.Companion.Draggable(drag, Orientation.Horizontal),
+///     // ... draggable content ...
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// For per-recomposition delegate identity, prefer
+/// <see cref="Compose.RememberDraggableState(System.Action{float}, int, string)"/>
+/// — Kotlin's <c>rememberDraggableState</c> wraps your callback in a
+/// <c>rememberUpdatedState</c> cell so the underlying Java
+/// <c>DraggableState</c> stays stable while the lambda can change.
+/// </para>
+/// </remarks>
+public sealed class DraggableState
+{
+    internal IDraggableState Jvm { get; }
+
+    /// <summary>
+    /// Build a new <see cref="DraggableState"/> backed by a fresh Kotlin
+    /// <c>DraggableState</c>. The <paramref name="onDelta"/> callback
+    /// receives the raw drag delta in pixels along the chosen
+    /// <see cref="Orientation"/>; mutate whatever offset state your
+    /// composables read so the dragged content moves on the next
+    /// recomposition.
+    /// </summary>
+    public DraggableState(System.Action<float> onDelta)
+    {
+        System.ArgumentNullException.ThrowIfNull(onDelta);
+        var jcw = new ComposableLambda1(boxed =>
+        {
+            var f = boxed as Java.Lang.Float
+                ?? throw new System.InvalidCastException(
+                    $"Expected java.lang.Float in DraggableState.onDelta; got '{boxed?.Class?.Name ?? "null"}'.");
+            onDelta(f.FloatValue());
+        });
+        Jvm = DraggableKt.DraggableState(jcw)
+            ?? throw new System.InvalidOperationException(
+                "DraggableKt.DraggableState returned null.");
+    }
+
+    // Constructor used by Compose.RememberDraggableState to wrap the
+    // remember-cached IDraggableState handle that Kotlin built.
+    internal DraggableState(IDraggableState jvm)
+    {
+        Jvm = jvm;
+    }
+
+    /// <summary>
+    /// Dispatch a raw drag delta to this state without going through the
+    /// gesture pipeline. Mirrors Kotlin's
+    /// <c>DraggableState.dispatchRawDelta(delta)</c>; useful for
+    /// programmatically nudging a draggable from outside a touch
+    /// gesture (e.g. animation, keyboard handler).
+    /// </summary>
+    public void DispatchRawDelta(float delta) => Jvm.DispatchRawDelta(delta);
+}

--- a/src/ComposeNet.Compose/FlowColumn.cs
+++ b/src/ComposeNet.Compose/FlowColumn.cs
@@ -16,7 +16,12 @@ namespace ComposeNet;
 /// </code>
 ///
 /// As with <see cref="FlowRow"/>, the v1 facade uses the simpler
-/// 7-param overload — no <c>FlowColumnOverflow</c> slot or scope
-/// helpers.
+/// 7-param overload — no <c>FlowColumnOverflow</c> slot and no
+/// scope-receiver helper for <c>fillMaxColumnWidth</c>. Because
+/// <c>FlowColumnScope</c> extends <c>ColumnScope</c>, scope-aware
+/// modifiers like <see cref="Modifier.Weight(float, bool)"/> and
+/// <see cref="Modifier.Align(Alignment.Horizontal)"/> work on
+/// children here exactly as they do inside a plain
+/// <see cref="Column"/>.
 /// </summary>
 public sealed partial class FlowColumn;

--- a/src/ComposeNet.Compose/FlowRow.cs
+++ b/src/ComposeNet.Compose/FlowRow.cs
@@ -16,8 +16,12 @@ namespace ComposeNet;
 /// </code>
 ///
 /// v1 wires up the simplest 7-param Kotlin overload (no
-/// <c>FlowRowOverflow</c> handle and no scope-receiver helpers). The
-/// scope-only <c>Modifier.weight</c> extension and overflow indicator
-/// slot are intentional follow-ups.
+/// <c>FlowRowOverflow</c> handle and no scope-receiver helpers for
+/// <c>fillMaxRowHeight</c>). Because <c>FlowRowScope</c> extends
+/// <c>RowScope</c>, scope-aware modifiers like
+/// <see cref="Modifier.Weight(float, bool)"/> and
+/// <see cref="Modifier.Align(Alignment.Vertical)"/> work on children
+/// here exactly as they do inside a plain <see cref="Row"/>. The
+/// overflow indicator slot remains a follow-up.
 /// </summary>
 public sealed partial class FlowRow;

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -401,6 +401,42 @@ public sealed class Modifier
     }
 
     /// <summary>
+    /// <c>Modifier.draggable(state, orientation, enabled)</c> — drag
+    /// gesture handler that reports raw drag deltas (in pixels along
+    /// the chosen <see cref="Orientation"/>) to the supplied
+    /// <see cref="DraggableState"/>. Unlike scroll, this modifier does
+    /// not consume the deltas itself — your <c>onDelta</c> callback
+    /// inside <see cref="DraggableState"/> decides what to do with the
+    /// movement (typically: update an offset state that another
+    /// modifier reads).
+    /// </summary>
+    /// <param name="state">State holder that receives drag deltas.
+    /// Build via <c>new DraggableState(delta =&gt; ...)</c> inside a
+    /// <see cref="Compose.Remember{T}"/> call, or via
+    /// <see cref="Compose.RememberDraggableState(System.Action{float}, int, string)"/>
+    /// for stable Java identity across recompositions when the
+    /// callback closure changes.</param>
+    /// <param name="orientation">Axis the gesture operates on —
+    /// <see cref="Orientation.Vertical"/> for up-down drags,
+    /// <see cref="Orientation.Horizontal"/> for left-right drags.</param>
+    /// <param name="enabled">When <c>false</c>, the modifier ignores
+    /// touch input. Defaults to <c>true</c>.</param>
+    public Modifier Draggable(DraggableState state, Orientation orientation, bool enabled = true)
+    {
+        System.ArgumentNullException.ThrowIfNull(state);
+        var jvm = state.Jvm;
+        var jvmOrientation = orientation == Orientation.Horizontal
+            ? AndroidX.Compose.Foundation.Gestures.Orientation.Horizontal!
+            : AndroidX.Compose.Foundation.Gestures.Orientation.Vertical!;
+        return Append(curr =>
+            ComposeBridges.ModifierDraggable(
+                curr,
+                ((Java.Lang.Object)jvm).Handle,
+                ((Java.Lang.Object)jvmOrientation).Handle,
+                enabled));
+    }
+
+    /// <summary>
     /// <c>Modifier.weight(weight, fill = true)</c> — only valid inside a
     /// <see cref="Row"/> or <see cref="Column"/> (or any container that
     /// publishes <see cref="ScopeKind.Row"/> / <see cref="ScopeKind.Column"/>).
@@ -644,6 +680,58 @@ public sealed class Modifier
     /// </summary>
     public Modifier DisplayCutoutPadding() =>
         Append(curr => ComposeBridges.ModifierDisplayCutoutPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.captionBarPadding()</c> — pads for the caption bar
+    /// inset (window decorations on freeform / desktop windowing modes).
+    /// On phones without a caption bar this is a no-op.
+    /// </summary>
+    public Modifier CaptionBarPadding() =>
+        Append(curr => ComposeBridges.ModifierCaptionBarPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.mandatorySystemGesturesPadding()</c> — pads for the
+    /// subset of gesture insets the system always reserves for itself
+    /// (e.g. the bottom home-gesture strip), even when the user opts
+    /// out of edge gestures.
+    /// </summary>
+    public Modifier MandatorySystemGesturesPadding() =>
+        Append(curr => ComposeBridges.ModifierMandatorySystemGesturesPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.safeContentPadding()</c> — union of
+    /// <see cref="SafeDrawingPadding"/> and
+    /// <see cref="SafeGesturesPadding"/>. Use for content that should
+    /// avoid both visual obstructions and gesture zones.
+    /// </summary>
+    public Modifier SafeContentPadding() =>
+        Append(curr => ComposeBridges.ModifierSafeContentPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.safeGesturesPadding()</c> — union of
+    /// <see cref="MandatorySystemGesturesPadding"/> +
+    /// <see cref="SystemGesturesPadding"/> + the tappable-element
+    /// insets. Use to keep interactive UI out of the system's gesture
+    /// zones.
+    /// </summary>
+    public Modifier SafeGesturesPadding() =>
+        Append(curr => ComposeBridges.ModifierSafeGesturesPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.systemGesturesPadding()</c> — pads for the system
+    /// gesture insets (the edge regions where the OS may interpret
+    /// swipes as system gestures such as back / home).
+    /// </summary>
+    public Modifier SystemGesturesPadding() =>
+        Append(curr => ComposeBridges.ModifierSystemGesturesPadding(curr));
+
+    /// <summary>
+    /// <c>Modifier.waterfallPadding()</c> — pads for waterfall display
+    /// insets (the curved edges of waterfall-screen devices). No-op on
+    /// flat-screen phones.
+    /// </summary>
+    public Modifier WaterfallPadding() =>
+        Append(curr => ComposeBridges.ModifierWaterfallPadding(curr));
 
     /// <summary>
     /// <c>Modifier.testTag(tag)</c> — attaches a stable identifier for

--- a/src/ComposeNet.Compose/Orientation.cs
+++ b/src/ComposeNet.Compose/Orientation.cs
@@ -1,0 +1,17 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Drag / scroll orientation. Mirrors Kotlin's
+/// <c>androidx.compose.foundation.gestures.Orientation</c> enum. Passed
+/// to <see cref="Modifier.Draggable(DraggableState, Orientation, bool)"/>
+/// (and to any future orientation-aware modifier helpers) to pick the
+/// axis the gesture operates on.
+/// </summary>
+public enum Orientation
+{
+    /// <summary>Vertical axis — drag amounts are deltas in the Y direction.</summary>
+    Vertical,
+
+    /// <summary>Horizontal axis — drag amounts are deltas in the X direction.</summary>
+    Horizontal,
+}

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -172,6 +172,9 @@ ComposeNet.DropdownMenuItem.LeadingIcon.get -> ComposeNet.ComposableNode?
 ComposeNet.DropdownMenuItem.LeadingIcon.set -> void
 ComposeNet.DropdownMenuItem.TrailingIcon.get -> ComposeNet.ComposableNode?
 ComposeNet.DropdownMenuItem.TrailingIcon.set -> void
+ComposeNet.DraggableState
+ComposeNet.DraggableState.DispatchRawDelta(float delta) -> void
+ComposeNet.DraggableState.DraggableState(System.Action<float>! onDelta) -> void
 ComposeNet.ElevatedAssistChip
 ComposeNet.ElevatedAssistChip.ElevatedAssistChip(System.Action! onClick) -> void
 ComposeNet.ElevatedAssistChip.Label.get -> ComposeNet.ComposableNode?
@@ -437,6 +440,7 @@ ComposeNet.Modifier.Background(long color) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Border(ComposeNet.Dp width, long color, ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Border(ComposeNet.Dp width, long color, ComposeNet.Shape? shape) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Border(ComposeNet.Dp width, long color) -> ComposeNet.Modifier!
+ComposeNet.Modifier.CaptionBarPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.ClearAndSetSemantics(string! contentDescription) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clickable(System.Action! onClick) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
@@ -444,6 +448,7 @@ ComposeNet.Modifier.Clip(ComposeNet.Shape! shape) -> ComposeNet.Modifier!
 ComposeNet.Modifier.CombinedClickable(System.Action! onClick, System.Action? onLongClick = null, System.Action? onDoubleClick = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.DefaultMinSize(ComposeNet.Dp? minWidth = null, ComposeNet.Dp? minHeight = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.DisplayCutoutPadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.Draggable(ComposeNet.DraggableState! state, ComposeNet.Orientation orientation, bool enabled = true) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxHeight(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxSize(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FillMaxWidth(float fraction = 1) -> ComposeNet.Modifier!
@@ -454,6 +459,7 @@ ComposeNet.Modifier.Height(ComposeNet.Dp height) -> ComposeNet.Modifier!
 ComposeNet.Modifier.HeightIn(ComposeNet.Dp? min = null, ComposeNet.Dp? max = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.HorizontalScroll(ComposeNet.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> ComposeNet.Modifier!
 ComposeNet.Modifier.ImePadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.MandatorySystemGesturesPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.MatchParentSize() -> ComposeNet.Modifier!
 ComposeNet.Modifier.NavigationBarsPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.Offset(ComposeNet.Dp? x = null, ComposeNet.Dp? y = null) -> ComposeNet.Modifier!
@@ -466,7 +472,9 @@ ComposeNet.Modifier.RequiredSize(ComposeNet.Dp size) -> ComposeNet.Modifier!
 ComposeNet.Modifier.RequiredSize(ComposeNet.Dp width, ComposeNet.Dp height) -> ComposeNet.Modifier!
 ComposeNet.Modifier.RequiredWidth(ComposeNet.Dp width) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Rotate(float degrees) -> ComposeNet.Modifier!
+ComposeNet.Modifier.SafeContentPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.SafeDrawingPadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.SafeGesturesPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.Scale(float scale) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Scale(float scaleX, float scaleY) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Selectable(bool selected, System.Action! onClick) -> ComposeNet.Modifier!
@@ -478,10 +486,12 @@ ComposeNet.Modifier.Size(ComposeNet.Dp width, ComposeNet.Dp height) -> ComposeNe
 ComposeNet.Modifier.SizeIn(ComposeNet.Dp? minWidth = null, ComposeNet.Dp? minHeight = null, ComposeNet.Dp? maxWidth = null, ComposeNet.Dp? maxHeight = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.StatusBarsPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.SystemBarsPadding() -> ComposeNet.Modifier!
+ComposeNet.Modifier.SystemGesturesPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.TestTag(string! tag) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Then(ComposeNet.Modifier! other) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Toggleable(bool value, System.Action<bool>! onValueChange) -> ComposeNet.Modifier!
 ComposeNet.Modifier.VerticalScroll(ComposeNet.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> ComposeNet.Modifier!
+ComposeNet.Modifier.WaterfallPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.Weight(float weight, bool fill = true) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Width(ComposeNet.Dp width) -> ComposeNet.Modifier!
 ComposeNet.Modifier.WidthIn(ComposeNet.Dp? min = null, ComposeNet.Dp? max = null) -> ComposeNet.Modifier!
@@ -543,6 +553,9 @@ ComposeNet.ObservableList<T>.Remove(T item) -> bool
 ComposeNet.ObservableList<T>.RemoveAt(int index) -> void
 ComposeNet.ObservableList<T>.this[int index].get -> T
 ComposeNet.ObservableList<T>.this[int index].set -> void
+ComposeNet.Orientation
+ComposeNet.Orientation.Horizontal = 1 -> ComposeNet.Orientation
+ComposeNet.Orientation.Vertical = 0 -> ComposeNet.Orientation
 ComposeNet.OutlinedButton
 ComposeNet.OutlinedButton.OutlinedButton(System.Action! onClick) -> void
 ComposeNet.OutlinedCard
@@ -917,6 +930,7 @@ static ComposeNet.Arrangement.SpaceEvenly.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Start.get -> ComposeNet.Arrangement!
 static ComposeNet.Arrangement.Top.get -> ComposeNet.Arrangement!
 static ComposeNet.Compose.Remember<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.RememberDraggableState(System.Action<float>! onDelta, int line = 0, string! file = "") -> ComposeNet.DraggableState!
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(float value) -> ComposeNet.Dp
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(int value) -> ComposeNet.Dp

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -59,6 +59,13 @@ public class MainActivity : ComposeActivity
             var focusStatus63   = Remember(() => new MutableState<string>("not focused"));
             var selectedRow63   = Remember(() => new MutableNumberState<int>(0));
             var taps63          = Remember(() => new MutableNumberState<int>(0));
+            // Issue #63 follow-up: Modifier.Draggable demo state.
+            // dragX63 holds the running offset in pixels; the
+            // RememberDraggableState callback closes over it so the
+            // Java DraggableState identity stays stable across
+            // recompositions while the offset still updates.
+            var dragX63         = Remember(() => new MutableState<float>(0f));
+            var dragState63     = Compose.RememberDraggableState(delta => dragX63.Value += delta);
 
             var checkbox    = Remember(() => new MutableState<bool>(true));
             var switchOn    = Remember(() => new MutableState<bool>(false));
@@ -390,6 +397,79 @@ public class MainActivity : ComposeActivity
                                 new Text("Row 2") { Modifier = Modifier.Companion
                                     .FillMaxWidth().Selectable(selectedRow63.Value == 2, () => selectedRow63.Value = 2).Padding(6) },
                             },
+                            // Issue #63 follow-up — FlowRow scope dispatch:
+                            // chips wrap onto multiple lines once the row
+                            // runs out of horizontal space. Each chip uses
+                            // Modifier.Align(Alignment.Vertical.CenterVertically),
+                            // which is a RowScope-only modifier — proves
+                            // FlowRow forwards the RowScope receiver
+                            // through ScopeKind.Row dispatch.
+                            new Text("FlowRow chips (#63 wraps when wide):"),
+                            new FlowRow
+                            {
+                                Modifier.Companion.FillMaxWidth().Padding(4),
+                                new AssistChip(onClick: () => taps63.Value++)
+                                {
+                                    Label    = new Text("Apple"),
+                                    Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Padding(2),
+                                },
+                                new AssistChip(onClick: () => taps63.Value++)
+                                {
+                                    Label    = new Text("Banana"),
+                                    Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Padding(2),
+                                },
+                                new AssistChip(onClick: () => taps63.Value++)
+                                {
+                                    Label    = new Text("Cherry"),
+                                    Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Padding(2),
+                                },
+                                new AssistChip(onClick: () => taps63.Value++)
+                                {
+                                    Label    = new Text("Durian"),
+                                    Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Padding(2),
+                                },
+                                new AssistChip(onClick: () => taps63.Value++)
+                                {
+                                    Label    = new Text("Elderberry"),
+                                    Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Padding(2),
+                                },
+                                new AssistChip(onClick: () => taps63.Value++)
+                                {
+                                    Label    = new Text("Fig"),
+                                    Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Padding(2),
+                                },
+                                new AssistChip(onClick: () => taps63.Value++)
+                                {
+                                    Label    = new Text("Grape"),
+                                    Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Padding(2),
+                                },
+                            },
+                            // Issue #63 follow-up — Modifier.Draggable:
+                            // touch and drag the purple square left or
+                            // right. The DraggableState's onDelta
+                            // callback accumulates the raw pixel delta
+                            // into dragX63, which Modifier.Offset then
+                            // reads back as a Dp value. Convenience
+                            // inset modifier (.SafeContentPadding) is
+                            // applied to the surrounding container so
+                            // we exercise that bridge too — it's a
+                            // no-op without edge-to-edge but proves
+                            // the JNI call doesn't throw.
+                            new Text($"Drag offset: {dragX63.Value:F0}px") { Modifier = Modifier.Companion.SafeContentPadding() },
+                            new Box
+                            {
+                                Modifier.Companion.FillMaxWidth().Height(72).Padding(4)
+                                    .Border(1, ColorKt.Color(red: 0xB0, green: 0xB0, blue: 0xB0, alpha: 0xFF)),
+                                new Box
+                                {
+                                    Modifier.Companion
+                                        .Offset(x: dragX63.Value)
+                                        .Size(56)
+                                        .Background(ColorKt.Color(red: 0xCE, green: 0x93, blue: 0xD8, alpha: 0xFF))
+                                        .Draggable(dragState63, Orientation.Horizontal),
+                                },
+                            },
+                            new Button(onClick: () => dragX63.Value = 0f) { new Text("Reset drag") },
                                 // Secure text inputs — exercise both
                                 // SecureTextField (filled) and
                                 // OutlinedSecureTextField. The two state

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -60,12 +60,16 @@ public class MainActivity : ComposeActivity
             var selectedRow63   = Remember(() => new MutableNumberState<int>(0));
             var taps63          = Remember(() => new MutableNumberState<int>(0));
             // Issue #63 follow-up: Modifier.Draggable demo state.
-            // dragX63 holds the running offset in pixels; the
-            // RememberDraggableState callback closes over it so the
-            // Java DraggableState identity stays stable across
-            // recompositions while the offset still updates.
+            // The Draggable callback hands us raw pixel deltas; divide
+            // by the screen density so dragX63 accumulates in Dp,
+            // matching what Modifier.Offset(x: Dp) expects. Otherwise
+            // a 3x-density phone moves the box 3x faster than the
+            // finger. The RememberDraggableState callback closes over
+            // dragX63 so the Java DraggableState identity stays stable
+            // across recompositions while the offset still updates.
+            var dragDensity     = Android.Content.Res.Resources.System!.DisplayMetrics!.Density;
             var dragX63         = Remember(() => new MutableState<float>(0f));
-            var dragState63     = Compose.RememberDraggableState(delta => dragX63.Value += delta);
+            var dragState63     = Compose.RememberDraggableState(delta => dragX63.Value += delta / dragDensity);
 
             var checkbox    = Remember(() => new MutableState<bool>(true));
             var switchOn    = Remember(() => new MutableState<bool>(false));
@@ -535,7 +539,7 @@ public class MainActivity : ComposeActivity
                             // that bridge too — it's a no-op without
                             // edge-to-edge but proves the JNI call
                             // doesn't throw.
-                            new Text($"Drag offset: {dragX63.Value:F0}px") { Modifier = Modifier.Companion.SafeContentPadding() },
+                            new Text($"Drag offset: {dragX63.Value:F0}dp") { Modifier = Modifier.Companion.SafeContentPadding() },
                             new Box
                             {
                                 Modifier.Companion.FillMaxWidth().Height(72).Padding(4)

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -131,6 +131,7 @@ public class MainActivity : ComposeActivity
             // that programmatically scroll back to the top.
             var buttonsScroll = Remember(() => new ScrollState());
             var greetingScroll = Remember(() => new ScrollState());
+            var modifiers63Scroll = Remember(() => new ScrollState());
 
             // Compose Navigation demo state (issue #60). The NavController
             // is the externally-driven entry point — Button onClicks call
@@ -208,6 +209,10 @@ public class MainActivity : ComposeActivity
                         {
                             new Text("Custom"),
                             new Text($"count={count}"),
+                        },
+                        new Tab(selected: sub.Value == 4, onClick: () => sub.Value = 4)
+                        {
+                            Text = new Text("#63"),
                         },
                     },
                     sub.Value switch
@@ -320,11 +325,86 @@ public class MainActivity : ComposeActivity
                                     .Clickable(() => count++)
                                     .Padding(horizontal: 16, vertical: 8),
                             },
+                            // Issue #63 demos live in their own sub-tab — see
+                            // sub.Value == 4 below.
+                            new Text("Issue #63 modifiers: see the #63 sub-tab"),
+                            // Secure text inputs — exercise both
+                            // SecureTextField (filled) and
+                            // OutlinedSecureTextField. The two state
+                            // holders are independent; tapping "Sign in"
+                            // snapshots both lengths into signInStatus.
+                            new Text("Secure inputs:"),
+                            new SecureTextField(pwd)
+                            {
+                                Label          = new Text("Password"),
+                                LeadingIcon    = new Text("🔒"),
+                                SupportingText = new Text("Filled"),
+                            },
+                            new OutlinedSecureTextField(pwdConfirm)
+                            {
+                                Label          = new Text("Confirm password"),
+                                LeadingIcon    = new Text("🔒"),
+                                SupportingText = new Text("Outlined"),
+                            },
+                            new Button(onClick: () =>
+                                signInStatus.Value =
+                                    $"len={pwd.Text.Length}/{pwdConfirm.Text.Length}, " +
+                                    $"match={(pwd.Text == pwdConfirm.Text)}")
+                            {
+                                new Text("Sign in"),
+                            },
+                            new Text(string.IsNullOrEmpty(signInStatus.Value)
+                                ? "Tap Sign in to compare"
+                                : signInStatus.Value),
+                        },
+                        1 => new Column
+                        {
+                            new Text($"Count: {count}"),
+                            new Row
+                            {
+                                new Image(Resource.Drawable.ic_star, "Star icon"),
+                                new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
+                                new Column
+                                {
+                                    new Button(onClick: () => count++) { new Text("Tap to increment") },
+                                    new IconButton(onClick: () => count--) { new Text("−") },
+                                },
+                            },
+                        },
+                        2 => (ComposableNode)new Column
+                        {
+                            new ListItem
+                            {
+                                Headline   = new Text("Inbox"),
+                                Supporting = new Text("12 unread messages"),
+                                Leading    = new Text("📥"),
+                                Trailing   = new Badge { new Text("12") },
+                            },
+                            new ListItem
+                            {
+                                Headline   = new Text("Sent"),
+                                Supporting = new Text("Last sent yesterday"),
+                                Leading    = new Text("📤"),
+                            },
+                            new ListItem
+                            {
+                                Headline = new Text("Drafts"),
+                                Leading  = new Text("📝"),
+                                Trailing = new BadgedBox
+                                {
+                                    Badge   = new Badge { new Text("3") },
+                                    Content = new Text("✉"),
+                                },
+                            },
+                        },
+                        4 => (ComposableNode)new Column
+                        {
+                            Modifier.Companion.VerticalScroll(modifiers63Scroll),
                             // Issue #63 modifier demo — scope alignment inside a Box,
                             // Toggleable row with semantic merge, programmatic focus
                             // via FocusRequester + OnFocusChanged + Focusable, and
                             // CombinedClickable + Selectable + Semantics.
-                            new Text("Issue #63 modifiers:"),
+                            new Text("Issue #63 modifiers"),
                             // Box with three corner-aligned labels (TopStart, Center,
                             // BottomEnd). The fourth child is an explicit colored
                             // Box that uses MatchParentSize() to fill the parent —
@@ -404,7 +484,7 @@ public class MainActivity : ComposeActivity
                             // which is a RowScope-only modifier — proves
                             // FlowRow forwards the RowScope receiver
                             // through ScopeKind.Row dispatch.
-                            new Text("FlowRow chips (#63 wraps when wide):"),
+                            new Text("FlowRow chips (wraps when wide):"),
                             new FlowRow
                             {
                                 Modifier.Companion.FillMaxWidth().Padding(4),
@@ -451,10 +531,10 @@ public class MainActivity : ComposeActivity
                             // into dragX63, which Modifier.Offset then
                             // reads back as a Dp value. Convenience
                             // inset modifier (.SafeContentPadding) is
-                            // applied to the surrounding container so
-                            // we exercise that bridge too — it's a
-                            // no-op without edge-to-edge but proves
-                            // the JNI call doesn't throw.
+                            // applied to the offset Text so we exercise
+                            // that bridge too — it's a no-op without
+                            // edge-to-edge but proves the JNI call
+                            // doesn't throw.
                             new Text($"Drag offset: {dragX63.Value:F0}px") { Modifier = Modifier.Companion.SafeContentPadding() },
                             new Box
                             {
@@ -470,74 +550,6 @@ public class MainActivity : ComposeActivity
                                 },
                             },
                             new Button(onClick: () => dragX63.Value = 0f) { new Text("Reset drag") },
-                                // Secure text inputs — exercise both
-                                // SecureTextField (filled) and
-                                // OutlinedSecureTextField. The two state
-                                // holders are independent; tapping "Sign in"
-                                // snapshots both lengths into signInStatus.
-                                new Text("Secure inputs:"),
-                                new SecureTextField(pwd)
-                                {
-                                    Label          = new Text("Password"),
-                                    LeadingIcon    = new Text("🔒"),
-                                    SupportingText = new Text("Filled"),
-                                },
-                                new OutlinedSecureTextField(pwdConfirm)
-                                {
-                                    Label          = new Text("Confirm password"),
-                                    LeadingIcon    = new Text("🔒"),
-                                    SupportingText = new Text("Outlined"),
-                                },
-                                new Button(onClick: () =>
-                                    signInStatus.Value =
-                                        $"len={pwd.Text.Length}/{pwdConfirm.Text.Length}, " +
-                                        $"match={(pwd.Text == pwdConfirm.Text)}")
-                                {
-                                    new Text("Sign in"),
-                                },
-                                new Text(string.IsNullOrEmpty(signInStatus.Value)
-                                    ? "Tap Sign in to compare"
-                                    : signInStatus.Value),
-                            },
-                        1 => new Column
-                        {
-                            new Text($"Count: {count}"),
-                            new Row
-                            {
-                                new Image(Resource.Drawable.ic_star, "Star icon"),
-                                new Spacer { Modifier = Modifier.Companion.FillMaxWidth(0.05f) },
-                                new Column
-                                {
-                                    new Button(onClick: () => count++) { new Text("Tap to increment") },
-                                    new IconButton(onClick: () => count--) { new Text("−") },
-                                },
-                            },
-                        },
-                        2 => (ComposableNode)new Column
-                        {
-                            new ListItem
-                            {
-                                Headline   = new Text("Inbox"),
-                                Supporting = new Text("12 unread messages"),
-                                Leading    = new Text("📥"),
-                                Trailing   = new Badge { new Text("12") },
-                            },
-                            new ListItem
-                            {
-                                Headline   = new Text("Sent"),
-                                Supporting = new Text("Last sent yesterday"),
-                                Leading    = new Text("📤"),
-                            },
-                            new ListItem
-                            {
-                                Headline = new Text("Drafts"),
-                                Leading  = new Text("📝"),
-                                Trailing = new BadgedBox
-                                {
-                                    Badge   = new Badge { new Text("3") },
-                                    Content = new Text("✉"),
-                                },
-                            },
                         },
                         _ => new Column
                         {

--- a/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -735,6 +735,81 @@ public class BridgeGeneratorTests
     }
 
     [Fact]
+    public void ExtensionWithDefault_DraggableShape_AllRequiredBitsSuppressedAndOptionalsDefaulted()
+    {
+        // Mirrors androidx.compose.foundation.gestures.DraggableKt.draggable$default —
+        // Modifier extension with 8 Kotlin params. The C# wrapper supplies
+        // only the first 3 (state, orientation, enabled); the remaining 5
+        // slots stay defaulted in v1 (omitted from the C# signature).
+        var code = """
+            using ComposeNet;
+
+            [assembly: ComposeDefaults("ModifierDraggableDefault",
+                "!state", "!orientation", "!enabled",
+                "interactionSource", "startDragImmediately",
+                "onDragStarted", "onDragStopped", "reverseDirection")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "androidx/compose/foundation/gestures/DraggableKt",
+                        JvmName = "draggable$default",
+                        Signature = "(Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/gestures/DraggableState;Landroidx/compose/foundation/gestures/Orientation;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;ZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ZILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+                        Defaults = typeof(ModifierDraggableDefault))]
+                    internal static partial System.IntPtr ModifierDraggable(
+                        System.IntPtr modifier, System.IntPtr state,
+                        System.IntPtr orientation, bool enabled);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // Receiver, state, orientation, enabled, interactionSource,
+        // startDragImmediately, onDragStarted, onDragStopped,
+        // reverseDirection, $default, marker = 11 slots.
+        Assert.Contains("global::Android.Runtime.JValue[11]", emitted);
+
+        // Supplied params occupy slots 0..3.
+        Assert.Contains("args[0] = new global::Android.Runtime.JValue(modifier)", emitted);
+        Assert.Contains("args[1] = new global::Android.Runtime.JValue(state)", emitted);
+        Assert.Contains("args[2] = new global::Android.Runtime.JValue(orientation)", emitted);
+        Assert.Contains("args[3] = new global::Android.Runtime.JValue(enabled)", emitted);
+
+        // Defaulted-only slots 4..8 fill with IntPtr.Zero / false.
+        Assert.Contains("args[4] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+        Assert.Contains("args[8] = new global::Android.Runtime.JValue(false)", emitted);
+
+        // $default at slot 9, synthetic marker at slot 10.
+        Assert.Contains("args[9] = new global::Android.Runtime.JValue(defaults)", emitted);
+        Assert.Contains("args[10] = new global::Android.Runtime.JValue(global::System.IntPtr.Zero)", emitted);
+
+        // Auto-mask seeded with the full bitmask...
+        Assert.Contains("(int)global::ComposeNet.ModifierDraggableDefault.All", emitted);
+
+        // ...but the !-prefixed required bits are NOT cleared (they stay 0
+        // because the `!` form excludes them from `All`). The mask-clearing
+        // loop skips them entirely.
+        Assert.DoesNotContain("ModifierDraggableDefault.State", emitted);
+        Assert.DoesNotContain("ModifierDraggableDefault.Orientation", emitted);
+        Assert.DoesNotContain("ModifierDraggableDefault.Enabled", emitted);
+
+        // No Composer slot anywhere — non-@Composable extension.
+        Assert.DoesNotContain("Composer", emitted);
+        Assert.DoesNotContain("KeepAlive(composer)", emitted);
+
+        // Non-void return.
+        Assert.Contains("return global::Android.Runtime.JNIEnv.CallStaticObjectMethod(", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void ExtensionWithDefault_CallerProvidesDefaults_SuppressesAutoMask()
     {
         // Same Background shape but the C# stub takes `int defaults` so


### PR DESCRIPTION
Wraps up the remaining items from #63 on top of what shipped in #112 / #116.

## What's new

### 1. `FlowRow` / `FlowColumn` scope dispatch
Adds `Scope = "Row"` / `Scope = "Column"` to the flow facades so `Modifier.Weight` and `Modifier.Align` work inside flow containers. `FlowRowScope extends RowScope` and `FlowColumnScope extends ColumnScope` (verified via `javap` on the upstream AAR), so the existing Java helper calls accept the flow scope handles unchanged.

### 2. Six convenience inset-padding modifiers
- `Modifier.CaptionBarPadding()`
- `Modifier.MandatorySystemGesturesPadding()`
- `Modifier.SafeContentPadding()`
- `Modifier.SafeGesturesPadding()`
- `Modifier.SystemGesturesPadding()`
- `Modifier.WaterfallPadding()`

All wrap the matching `WindowInsetsPadding_androidKt.*` bridge. Same shape as the existing `StatusBarsPadding` / `NavigationBarsPadding` / etc.

### 3. `Modifier.Draggable(...)` + supporting types
- New public `ComposeNet.Orientation` enum (`Vertical`, `Horizontal`).
- New public `ComposeNet.DraggableState` wrapper (mirrors `ScrollState`) with a `(Action<float> onDelta)` ctor that calls the bound `DraggableKt.DraggableState(IFunction1)`.
- New `Compose.RememberDraggableState(onDelta)` helper that wraps `DraggableKt.RememberDraggableState` so the callback identity stays stable across recompositions.
- New `ComposeBridges.ModifierDraggable` bridge for `draggable$default`. The fluent method wires through `state` / `orientation` / `enabled`; the five remaining params (`interactionSource`, `startDragImmediately`, `onDragStarted`, `onDragStopped`, `reverseDirection`) stay defaulted in v1.

### 4. New generator test
`ExtensionWithDefault_DraggableShape_AllRequiredBitsSuppressedAndOptionalsDefaulted` exercises the 11-slot draggable shape: required `!`-prefixed bits stay 0, defaulted reference slots fill with `IntPtr.Zero`, defaulted boolean slots fill with `false`, and no `Composer` is emitted.

## Deferred to follow-up issues
- `GraphicsLayer { ... }` block — 14+ packed-long params; needs a `GraphicsLayerScope` JCW.
- `PointerInput { ... }` — `PointerInputScope` is a suspend coroutine scope; needs the full async-bridge machinery for marginal user-visible improvement over the existing gesture modifiers.
- Generic `Modifier.WindowInsetsPadding(IWindowInsets)` + the `WindowInsets.*` factories — the factories are `@Composable` and the modifier op chain runs without a composer in scope. The six convenience helpers above cover the common cases.

## Verification
- `dotnet test src/ComposeNet.SourceGenerators.Tests` → **94/94 passed** (one new test).
- `dotnet build src/ComposeNet.Compose` → 0 warnings / 0 errors.
- `dotnet build src/ComposeNet.Sample` → succeeded.

Refs #63.