### PR TITLE
Migrate drawer family to [ComposeFacade] (#121)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -461,7 +461,7 @@ stay distinct per facade.
 ### When to use it
 
 The generator now supports a wide range of facade shapes (Phases 1,
-2, 3, 4, 6, 7, 8 are implemented):
+2, 3, 4, 6, 7, 8, 9 are implemented):
 
 - **Phase 1** — container with content lambda + ctor primitives
   (`Button`, `Card`, `Text`, `Column`, `Row`, `Box`).
@@ -535,6 +535,47 @@ The generator now supports a wide range of facade shapes (Phases 1,
   required Function2 is a label, not a content slot). Used for
   `BottomAppBar`.
 
+  **Container = true** (issue #121): the wrapper-passthrough variant
+  of the hybrid-container rule, for bridges whose body slot is a
+  non-`@Composable` `IFunction2` rather than a scope-providing
+  `IFunction3`. Set `[ComposeFacade(Container = true)]` to force the
+  facade to derive from `ComposableContainer` (collection-init
+  syntax) and wrap children via `Wrap2(composer, c => RenderChildren(c))`
+  on the bridge's body slot. Required by `ModalWideNavigationRail`,
+  whose Kotlin signature takes a plain `IFunction2` content lambda.
+
+- **Phase 9** — `[ConfirmStateChange(typeof(T))]` on an `IFunction1?`
+  parameter of a `[StateHolder]` Remember bridge. Models the
+  per-instance JNI veto adapter pattern: Kotlin's
+  `rememberDrawerState(confirmStateChange)` (and the rail / sheet
+  equivalents) takes a `(T) -> Boolean` callback that's part of the
+  `remember` cache key, so the JNI reference identity must stay
+  stable across recompositions or the cached state holder is dropped.
+  The generator:
+
+  - allocates a single `readonly` JCW adapter field per facade
+    instance (default name `_<camelCase(PropertyName)>Adapter`);
+  - looks up the adapter class by convention
+    `ComposeNet.<TName>ConfirmStateChange`
+    (e.g. `DrawerValueConfirmStateChange`), or via an explicit
+    `AdapterType = typeof(...)` override;
+  - exposes a `Func<T, bool>? ConfirmStateChange { get; set; }`
+    property (renameable via `PropertyName = "..."`);
+  - in the Render preamble — **before** the Remember call —
+    emits `_<adapter>.Callback = ConfirmStateChange;` so a single
+    JCW instance dispatches to whatever delegate the user wired
+    up this render;
+  - excludes the slot from the main bridge call args and the
+    `$default` auto-mask, since it only ever flows through Remember.
+
+  The adapter class must implement `Kotlin.Jvm.Functions.IFunction1`,
+  have a public parameterless ctor, and declare a writable instance
+  property `public Func<T, bool>? Callback { get; set; }`. Used for
+  `ModalNavigationDrawer`, `DismissibleNavigationDrawer`,
+  `PermanentNavigationDrawer` (no `[ConfirmStateChange]` — drawer
+  is always permanent), `ModalWideNavigationRail` (no veto — rail
+  has no confirmStateChange in Kotlin).
+
 Facades that still stay hand-written are the ones the generator
 can't model:
 
@@ -545,17 +586,6 @@ can't model:
 - Facades that branch between two bridges based on an optional
   slot (`TopAppBar` — Subtitle toggles between `TopAppBar-GHTll3U`
   and `MediumFlexibleTopAppBar-eXZ4JBQ`).
-- Drawer facades with a `confirmStateChange` adapter — the
-  per-`ComposableNode`-instance `DrawerConfirmStateChange` Java peer
-  has to live in a field on the facade (it's part of
-  `rememberDrawerState`'s cache key), and the Remember call also
-  consumes a user-supplied `initialValue` primitive. That combined
-  shape (per-instance `IFunction1` adapter + Phase 4b parameterised
-  Remember) isn't modelled by the generator yet:
-  `ModalNavigationDrawer`, `DismissibleNavigationDrawer`,
-  `PermanentNavigationDrawer`, `ModalWideNavigationRail`. The
-  permanent drawer doesn't actually need a veto adapter, but it
-  shares the hand-written family for consistency.
 - State-holder facades whose `RememberXxxState` bridge takes user
   parameters AND combine that with a per-instance
   `confirmValueChange` veto adapter:
@@ -568,7 +598,11 @@ can't model:
   zero-user-param shape (`DatePicker`, `DateRangePicker`); Phase 4b
   covers parameterised Remember (`TimePicker`); Phase 4c adds
   shared-state caching for sibling facades (`TimePicker` +
-  `TimeInput`).
+  `TimeInput`); Phase 9 (issue #121) added per-instance
+  `confirmStateChange` veto adapters for the drawer / rail family
+  via `[ConfirmStateChange(typeof(T))]` — see Phase 9 above. The
+  remaining bottom-sheet holdouts need Phase 9 *combined* with
+  Phase 4b parameterised Remember, which isn't modelled yet.
 - Scope facades whose bodies do non-trivial work beyond
   `RenderContext.PushScope` (`SegmentedButton`,
   `SingleChoice`/`MultiChoiceSegmentedButtonRow`, the segmented
@@ -581,9 +615,9 @@ can't model:
 Trying to apply `[ComposeFacade]` to an unsupported bridge will
 emit CN3002 (unsupported parameter), CN3003 (scope misuse), CN3005
 (invalid callback type), CN3006 (slot conflict), CN3007 (color
-theme binding failed), CN3008 (painter misuse), or CN3009
-(state-holder misuse) at build time —
-back out the attribute and write the facade by hand.
+theme binding failed), CN3008 (painter misuse), CN3009
+(state-holder misuse), or CN3010 (confirmStateChange misuse) at
+build time — back out the attribute and write the facade by hand.
 
 ### Adding a new generated facade
 
@@ -639,6 +673,7 @@ end-to-end recipe is:
 | CN3007  | `DefaultColorFromTheme` cannot bind to any `long` user param (or `ColorParameter` is ambiguous / missing). |
 | CN3008  | `[PainterResource]` annotates a non-`IntPtr` parameter.            |
 | CN3009  | `[StateHolder]` is invalid: applied to a non-`IntPtr` param, combined with `[PainterResource]`, missing or unidentifier-valued `Remember` / `StateType`, the named `Remember` method is not a static `(IComposer) -> IntPtr` on `ComposeBridges`, or `StateType` has no accessible writable instance field named `Jvm`. |
+| CN3010  | `[ConfirmStateChange(typeof(T))]` is invalid: not on an `IFunction1` param, missing the `typeof(T)` ctor argument, the convention adapter class `ComposeNet.<TName>ConfirmStateChange` is missing (set `AdapterType = typeof(...)` to override), the adapter doesn't implement `Kotlin.Jvm.Functions.IFunction1`, lacks a public parameterless ctor, or has no writable `Callback` property of type `System.Func<T, bool>?`. |
 
 ### Migration rule
 
@@ -755,23 +790,36 @@ has to stay stable across recompositions or the cache is dropped and
 the state holder is rebuilt (the drawer / sheet forgets whether it
 was open).
 
-The pattern (see `DrawerConfirmStateChange` + `ModalNavigationDrawer`
-for the canonical implementation):
+The pattern (see `DrawerValueConfirmStateChange` for the canonical
+adapter implementation):
 
-1. **Expose the hook as a `Func<T, bool>?` property** on the facade
-   type, defaulting to `null` (= "use Kotlin's default — always
-   allow"). Document what `false` means (veto / block transition).
-2. **Allocate the JNI adapter once per node instance** as a
-   `readonly` field. Never `new` it inside `Render` — that recreates
-   the Java peer on every recomposition and invalidates the
-   `remember` key.
-3. **Read the delegate inside the adapter's `Invoke`** (not at
-   adapter construction), so the developer can mutate the property
-   between renders without re-allocating.
-4. **Treat `null` as "always true"** inside the adapter — no
-   separate singleton fallback is needed; the adapter is already
-   allocated, and a single branch in `Invoke` keeps the JNI reference
-   identical whether or not the developer wired up a callback.
+1. **For new facades, prefer the generator path.** Annotate the
+   Remember bridge's `IFunction1?` `confirmStateChange` (or
+   `confirmValueChange`) parameter with
+   `[ConfirmStateChange(typeof(T))]` and stack `[ComposeFacade]` on
+   the facade bridge — Phase 9 above handles the adapter field,
+   property emission, and preamble `Callback` assignment for you.
+   Use this for any facade that fits the supported state-holder
+   shapes (Phase 4 zero-arg Remember, Phase 4b parameterised
+   Remember without combined veto).
+2. **Hand-written holdouts** (`ModalBottomSheet`, `BottomSheetScaffold`)
+   still follow the same conventions, just written by hand:
+   - **Expose the hook as a `Func<T, bool>?` property** on the
+     facade type, defaulting to `null` (= "use Kotlin's default —
+     always allow"). Document what `false` means (veto / block
+     transition).
+   - **Allocate the JNI adapter once per node instance** as a
+     `readonly` field. Never `new` it inside `Render` — that
+     recreates the Java peer on every recomposition and invalidates
+     the `remember` key.
+   - **Read the delegate inside the adapter's `Invoke`** (not at
+     adapter construction), so the developer can mutate the
+     property between renders without re-allocating.
+   - **Treat `null` as "always true"** inside the adapter — no
+     separate singleton fallback is needed; the adapter is already
+     allocated, and a single branch in `Invoke` keeps the JNI
+     reference identical whether or not the developer wired up a
+     callback.
 
 Do **not** use a static singleton for these callbacks: the singleton
 trick is fine for genuinely stateless stubs that the user can't

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1017,6 +1017,47 @@ internal static partial class ComposeBridges
     public static partial IntPtr RememberTimePickerState(int initialHour, int initialMinute,
                                                          bool is24Hour, IComposer composer);
 
+    // androidx.compose.material3.NavigationDrawerKt.rememberDrawerState.
+    // The Kotlin function is bound natively so we go through it instead
+    // of duplicating the JNI plumbing here. The [ComposeFacade]-generated
+    // facade hands us the per-instance JCW veto adapter as
+    // confirmStateChange (stable JNI identity = stable `remember` key);
+    // initialValue comes from the wrapper's InitialValue property. The
+    // [ConfirmStateChange] attribute is read by the facade generator off
+    // this declaration when resolving the Remember parameter to a
+    // per-instance JCW field instead of a state-wrapper member.
+    public static IntPtr RememberDrawerState(
+        AndroidX.Compose.Material3.DrawerValue initialValue,
+        [ConfirmStateChange(typeof(AndroidX.Compose.Material3.DrawerValue),
+            AdapterType = typeof(DrawerValueConfirmStateChange))]
+        IFunction1 confirmStateChange,
+        IComposer composer)
+    {
+        var state = AndroidX.Compose.Material3.NavigationDrawerKt.RememberDrawerState(
+            initialValue:        initialValue,
+            confirmStateChange:  confirmStateChange,
+            _composer:           composer,
+            p3:                  0,
+            _changed:            0);
+        return ((Java.Lang.Object)state).Handle;
+    }
+
+    // androidx.compose.material3.WideNavigationRailStateKt.rememberWideNavigationRailState.
+    // No confirmStateChange callback; the rail's state is driven entirely
+    // from C# via the wrapper's InitialValue property. Kotlin function is
+    // bound natively — wrapper-passthrough only.
+    public static IntPtr RememberWideNavigationRailState(
+        AndroidX.Compose.Material3.WideNavigationRailValue initialValue,
+        IComposer composer)
+    {
+        var state = AndroidX.Compose.Material3.WideNavigationRailStateKt.RememberWideNavigationRailState(
+            initialValue: initialValue,
+            _composer:    composer,
+            p2:           0,
+            _changed:     0);
+        return ((Java.Lang.Object)state).Handle;
+    }
+
     // androidx.compose.material3.TooltipKt.rememberTooltipState
     [ComposeBridge(
         Class     = "androidx/compose/material3/TooltipKt",
@@ -1446,11 +1487,10 @@ internal static partial class ComposeBridges
     // androidx.compose.material3.WideNavigationRailKt.ModalWideNavigationRail-k3FuEkE.
     // The "-k3FuEkE" hash comes from the @JvmInline value-class Dp param
     // (collapsedShadowElevation). 12 user params + 3 trailing ints
-    // ($changed, $changed1, $default). The facade always supplies
-    // `state` (via the bound RememberWideNavigationRailState),
-    // `hideOnCollapse` (true so the rail unmounts visually on collapse),
-    // and `content`. Shape / colors / elevation / windowInsets /
-    // arrangement / properties remain Kotlin defaults.
+    // ($changed, $changed1, $default). The raw JNI bridge takes the full
+    // surface; the [ComposeFacade]-wrapped partial below hides
+    // `hideOnCollapse` (always true) so the public facade matches the
+    // visibility-toggle pattern documented on the facade class.
     [ComposeBridge(
         Class     = "androidx/compose/material3/WideNavigationRailKt",
         JvmName   = "ModalWideNavigationRail-k3FuEkE",
@@ -1466,7 +1506,7 @@ internal static partial class ComposeBridges
                     "Lkotlin/jvm/functions/Function2;" +
                     "Landroidx/compose/runtime/Composer;III)V",
         Defaults  = typeof(ModalWideNavigationRailDefault))]
-    public static partial void ModalWideNavigationRail(
+    internal static partial void ModalWideNavigationRailRaw(
         IModifier?  modifier,
         IntPtr      state,
         bool        hideOnCollapse,
@@ -1474,6 +1514,135 @@ internal static partial class ComposeBridges
         IFunction2  content,
         int         defaults,
         IComposer   composer);
+
+    // Phase 8 wrapper-passthrough for the public ModalWideNavigationRail
+    // facade. Hides `hideOnCollapse` (always true — the C# visibility-
+    // toggle pattern owns mount/unmount), so the auto-mask never
+    // computes the HideOnCollapse bit. We pre-clear it here before
+    // forwarding, so Kotlin substitutes the body-supplied `true` rather
+    // than its own default.
+    [ComposeFacade(Container = true, Defaults = typeof(ModalWideNavigationRailDefault))]
+    public static partial void ModalWideNavigationRail(
+        IModifier?  modifier,
+        [StateHolder(Remember = nameof(RememberWideNavigationRailState),
+                     StateType = typeof(WideNavigationRailState))] IntPtr state,
+        IFunction2? header,
+        IFunction2  content,
+        int         defaults,
+        IComposer   composer);
+
+    public static partial void ModalWideNavigationRail(
+        IModifier?  modifier,
+        IntPtr      state,
+        IFunction2? header,
+        IFunction2  content,
+        int         defaults,
+        IComposer   composer)
+    {
+        // Clear the HideOnCollapse bit so Kotlin uses our hardcoded
+        // `true` rather than its own default (which is `false`).
+        defaults &= ~(int)ModalWideNavigationRailDefault.HideOnCollapse;
+        ModalWideNavigationRailRaw(
+            modifier:        modifier,
+            state:           state,
+            hideOnCollapse:  true,
+            header:          header,
+            content:         content,
+            defaults:        defaults,
+            composer:        composer);
+    }
+
+    // Phase 8 wrapper-passthroughs for the navigation-drawer family.
+    // Kotlin functions are all bound natively (no hash mangling on the
+    // public overload), so we just forward to `NavigationDrawerKt.*`
+    // and let the bridge generator stay out of it. Each bridge declares
+    // the facade ctor slots the user actually controls (drawer, modifier,
+    // optional state, content) and the bound binding fills in the
+    // hard-coded Kotlin params (gesturesEnabled: true, scrimColor: 0L
+    // — left at the Kotlin default sentinel via the bit mask). The
+    // facade-side $default mask is computed by the [ComposeFacade]
+    // generator from the matching [ComposeDefaults] declaration and
+    // forwarded into _changed.
+
+    [ComposeFacade(Defaults = typeof(ModalNavigationDrawerDefault))]
+    public static partial void ModalNavigationDrawer(
+        [Slot("Drawer")]  IFunction2 drawerContent,
+        IModifier?        modifier,
+        [StateHolder(Remember = nameof(RememberDrawerState),
+                     StateType = typeof(DrawerStateHolder),
+                     SharedState = true)] IntPtr drawerState,
+        [Slot("Content")] IFunction2 content,
+        int               defaults,
+        IComposer         composer);
+
+    public static partial void ModalNavigationDrawer(
+        IFunction2 drawerContent, IModifier? modifier, IntPtr drawerState,
+        IFunction2 content, int defaults, IComposer composer)
+    {
+        // The bound binding takes a typed DrawerState; reconstitute it
+        // from the JNI handle the [StateHolder] handed us.
+        var stateObj = global::Java.Lang.Object.GetObject<AndroidX.Compose.Material3.DrawerState>(
+            drawerState, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;
+        AndroidX.Compose.Material3.NavigationDrawerKt.ModalNavigationDrawer(
+            drawerContent:    drawerContent,
+            modifier:         modifier,
+            drawerState:      stateObj,
+            gesturesEnabled:  true,
+            scrimColor:       0L,
+            content:          content,
+            _composer:        composer,
+            p7:               0,
+            _changed:         defaults);
+    }
+
+    [ComposeFacade(Defaults = typeof(DismissibleNavigationDrawerDefault))]
+    public static partial void DismissibleNavigationDrawer(
+        [Slot("Drawer")]  IFunction2 drawerContent,
+        IModifier?        modifier,
+        [StateHolder(Remember = nameof(RememberDrawerState),
+                     StateType = typeof(DrawerStateHolder),
+                     SharedState = true)] IntPtr drawerState,
+        [Slot("Content")] IFunction2 content,
+        int               defaults,
+        IComposer         composer);
+
+    public static partial void DismissibleNavigationDrawer(
+        IFunction2 drawerContent, IModifier? modifier, IntPtr drawerState,
+        IFunction2 content, int defaults, IComposer composer)
+    {
+        var stateObj = global::Java.Lang.Object.GetObject<AndroidX.Compose.Material3.DrawerState>(
+            drawerState, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;
+        AndroidX.Compose.Material3.NavigationDrawerKt.DismissibleNavigationDrawer(
+            drawerContent:    drawerContent,
+            modifier:         modifier,
+            drawerState:      stateObj,
+            gesturesEnabled:  true,
+            content:          content,
+            _composer:        composer,
+            p6:               0,
+            _changed:         defaults);
+    }
+
+    [ComposeFacade(Defaults = typeof(PermanentNavigationDrawerDefault))]
+    public static partial void PermanentNavigationDrawer(
+        [Slot("Drawer")]  IFunction2 drawerContent,
+        IModifier?        modifier,
+        [Slot("Content")] IFunction2 content,
+        int               defaults,
+        IComposer         composer);
+
+    public static partial void PermanentNavigationDrawer(
+        IFunction2 drawerContent, IModifier? modifier,
+        IFunction2 content, int defaults, IComposer composer)
+    {
+        AndroidX.Compose.Material3.NavigationDrawerKt.PermanentNavigationDrawer(
+            drawerContent: drawerContent,
+            modifier:      modifier,
+            content:       content,
+            _composer:     composer,
+            p4:            0,
+            _changed:      defaults);
+    }
 
     // Modifier-chain extensions. These are non-@Composable Kotlin
     // extension functions on Modifier; their JNI signatures end in

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -343,6 +343,30 @@ using ComposeNet;
     "modifier", "shape", "drawerContainerColor", "drawerContentColor",
     "tonalElevation", "windowInsets", "!content")]
 
+// androidx.compose.material3.NavigationDrawerKt.ModalNavigationDrawer.
+// 6 Kotlin user params. The facade ALWAYS supplies drawerContent (Drawer
+// slot), drawerState (Phase 4b StateHolder auto-creates a wrapper), and
+// content (Content slot); modifier is the only auto-mask-controlled bit.
+// gesturesEnabled and scrimColor stay set so Kotlin substitutes its
+// defaults (true / DrawerDefaults.scrimColor); the wrapper-passthrough
+// body passes dummy values that Kotlin ignores when the bit is set.
+[assembly: ComposeDefaults("ModalNavigationDrawerDefault",
+    "!drawerContent", "modifier", "!drawerState", "gesturesEnabled",
+    "scrimColor", "!content")]
+
+// androidx.compose.material3.NavigationDrawerKt.DismissibleNavigationDrawer.
+// 5 Kotlin user params (same as ModalNavigationDrawer minus scrimColor —
+// the dismissible drawer has no scrim).
+[assembly: ComposeDefaults("DismissibleNavigationDrawerDefault",
+    "!drawerContent", "modifier", "!drawerState", "gesturesEnabled",
+    "!content")]
+
+// androidx.compose.material3.NavigationDrawerKt.PermanentNavigationDrawer.
+// 3 Kotlin user params — no state holder (drawer is always visible), no
+// gesturesEnabled (can't be swiped closed), no scrimColor (no scrim).
+[assembly: ComposeDefaults("PermanentNavigationDrawerDefault",
+    "!drawerContent", "modifier", "!content")]
+
 // androidx.compose.material3.ChipKt.AssistChip: 11 user params,
 // bit 0 = onClick, bit 1 = label (both always provided).
 // Optional slot bits 4 (LeadingIcon) and 5 (TrailingIcon) are toggled

--- a/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
@@ -1,79 +1,11 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>DismissibleNavigationDrawer</c> — a drawer that
-/// pushes the main content aside when open (no scrim). The
-/// <see cref="Drawer"/> slot typically holds a
-/// <see cref="DismissibleDrawerSheet"/>. Toggle by horizontal swipe.
+/// pushes the main content aside when open (no scrim, no overlay).
+/// The <c>Drawer</c> slot typically holds a
+/// <see cref="DismissibleDrawerSheet"/>. Drag horizontally to toggle.
+/// Behavior mirrors <see cref="ModalNavigationDrawer"/> for the state
+/// holder and <c>ConfirmStateChange</c> veto.
 /// </summary>
-/// <remarks>
-/// Calls the bound C# entry point directly — the wrapper is bound
-/// natively. See <see cref="ModalNavigationDrawer"/> for the
-/// suspend-function caveat that forces gesture-only interaction.
-/// </remarks>
-public sealed class DismissibleNavigationDrawer : ComposableNode
-{
-    /// <summary>Required: the slide-in drawer panel.</summary>
-    public ComposableNode? Drawer { get; set; }
-
-    /// <summary>Required: the main content shown next to the drawer.</summary>
-    public ComposableNode? Content { get; set; }
-
-    /// <summary>
-    /// Initial drawer state on first composition. Defaults to closed.
-    /// </summary>
-    public bool InitiallyOpen { get; set; }
-
-    /// <summary>
-    /// Optional veto invoked before the drawer transitions between
-    /// <c>Open</c> and <c>Closed</c> (Compose Kotlin
-    /// <c>confirmStateChange</c>). Return <c>true</c> to allow the
-    /// change, <c>false</c> to block it. When <c>null</c> all
-    /// transitions are allowed.
-    /// </summary>
-    public System.Func<DrawerValue, bool>? ConfirmStateChange { get; set; }
-
-    // Allocate once per node and reuse across recompositions — the
-    // Java peer is part of `rememberDrawerState`'s cache key, so a
-    // fresh adapter each pass would drop the cached DrawerState.
-    readonly DrawerConfirmStateChange _confirm = new();
-
-    internal override void Render(IComposer composer)
-    {
-        if (Drawer is null)
-            throw new System.InvalidOperationException(
-                "DismissibleNavigationDrawer.Drawer is required.");
-        if (Content is null)
-            throw new System.InvalidOperationException(
-                "DismissibleNavigationDrawer.Content is required.");
-
-        var initial = InitiallyOpen ? DrawerValue.Open! : DrawerValue.Closed!;
-
-        _confirm.Callback = ConfirmStateChange;
-
-        var state = NavigationDrawerKt.RememberDrawerState(
-            initialValue:        initial,
-            confirmStateChange:  _confirm,
-            _composer:           composer,
-            p3:                  0,
-            _changed:            0);
-
-        var drawer  = ComposableLambdas.Wrap2(composer, c => Drawer.Render(c));
-        var content = ComposableLambdas.Wrap2(composer, c => Content.Render(c));
-        // Param order: drawerContent (0, provided), modifier (1, def),
-        // drawerState (2, provided), gesturesEnabled (3, provided),
-        // content (4, provided). $default = 0b00010 = 2.
-        NavigationDrawerKt.DismissibleNavigationDrawer(
-            drawerContent:    drawer,
-            modifier:         null,
-            drawerState:      state,
-            gesturesEnabled:  true,
-            content:          content,
-            _composer:        composer,
-            p6:               0,
-            _changed:         0b00010);
-    }
-}
+public sealed partial class DismissibleNavigationDrawer;

--- a/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
@@ -8,4 +8,27 @@ namespace ComposeNet;
 /// Behavior mirrors <see cref="ModalNavigationDrawer"/> for the state
 /// holder and <c>ConfirmStateChange</c> veto.
 /// </summary>
-public sealed partial class DismissibleNavigationDrawer;
+public sealed partial class DismissibleNavigationDrawer
+{
+    /// <summary>
+    /// Convenience: when <c>true</c>, the drawer starts in the
+    /// <see cref="AndroidX.Compose.Material3.DrawerValue.Open"/> state
+    /// on first composition. Mirrors Kotlin
+    /// <c>rememberDrawerState(initialValue = DrawerValue.Open)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Setting this constructs a default <see cref="DrawerStateHolder"/>
+    /// with the requested initial value. If the caller also passes an
+    /// explicit holder to the constructor, the init setter overwrites
+    /// it — pass the holder directly (with the desired
+    /// <c>InitialValue</c>) when you need to share state across
+    /// recompositions.
+    /// </remarks>
+    public bool InitiallyOpen
+    {
+        get => _drawerState?.InitialValue == AndroidX.Compose.Material3.DrawerValue.Open;
+        init => _drawerState = new DrawerStateHolder(
+            value ? AndroidX.Compose.Material3.DrawerValue.Open!
+                  : AndroidX.Compose.Material3.DrawerValue.Closed!);
+    }
+}

--- a/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/DismissibleNavigationDrawer.cs
@@ -11,8 +11,7 @@ namespace ComposeNet;
 public sealed partial class DismissibleNavigationDrawer
 {
     /// <summary>
-    /// Convenience: when <c>true</c>, the drawer starts in the
-    /// <see cref="AndroidX.Compose.Material3.DrawerValue.Open"/> state
+    /// Convenience: starting <see cref="AndroidX.Compose.Material3.DrawerValue"/>
     /// on first composition. Mirrors Kotlin
     /// <c>rememberDrawerState(initialValue = DrawerValue.Open)</c>.
     /// </summary>
@@ -24,11 +23,9 @@ public sealed partial class DismissibleNavigationDrawer
     /// <c>InitialValue</c>) when you need to share state across
     /// recompositions.
     /// </remarks>
-    public bool InitiallyOpen
+    public AndroidX.Compose.Material3.DrawerValue? InitialValue
     {
-        get => _drawerState?.InitialValue == AndroidX.Compose.Material3.DrawerValue.Open;
-        init => _drawerState = new DrawerStateHolder(
-            value ? AndroidX.Compose.Material3.DrawerValue.Open!
-                  : AndroidX.Compose.Material3.DrawerValue.Closed!);
+        get => _drawerState?.InitialValue;
+        init => _drawerState = new DrawerStateHolder(value);
     }
 }

--- a/src/ComposeNet.Compose/DrawerStateHolder.cs
+++ b/src/ComposeNet.Compose/DrawerStateHolder.cs
@@ -1,0 +1,76 @@
+using AndroidX.Compose.Material3;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Caller-supplied state holder for <see cref="ModalNavigationDrawer"/>
+/// and <see cref="DismissibleNavigationDrawer"/>. Wraps Kotlin's
+/// <c>DrawerState</c> (created via <c>rememberDrawerState</c>) so a
+/// facade can carry an initial <see cref="DrawerValue"/> across
+/// recompositions and expose the live drawer position back to C#.
+/// </summary>
+/// <remarks>
+/// <para>This type is named with a <c>Holder</c> suffix to avoid
+/// colliding with the binding's
+/// <see cref="AndroidX.Compose.Material3.DrawerState"/> class — both
+/// would otherwise resolve to <c>DrawerState</c> when a user imports
+/// <c>using AndroidX.Compose.Material3;</c> and
+/// <c>using ComposeNet;</c> at the same time.</para>
+/// <para>Construct one inside <c>Remember</c> so the same instance
+/// survives recomposition:</para>
+/// <code>
+/// var drawer = Remember(() =&gt; new DrawerStateHolder(DrawerValue.Closed));
+///
+/// new ModalNavigationDrawer(state: drawer)
+/// {
+///     Drawer  = new ModalDrawerSheet { … },
+///     Content = new Column { … },
+///     ConfirmStateChange = v =&gt; !formIsDirty || v != DrawerValue.Closed,
+/// };
+/// </code>
+/// </remarks>
+public sealed class DrawerStateHolder
+{
+    internal DrawerState? Jvm;
+
+    /// <summary>
+    /// Initial <see cref="DrawerValue"/> the drawer remembers on first
+    /// composition. Defaults to <see cref="DrawerValue.Closed"/>.
+    /// </summary>
+    public DrawerValue InitialValue { get; }
+
+    /// <summary>
+    /// Construct a holder with the given <paramref name="initialValue"/>
+    /// (or <see cref="DrawerValue.Closed"/> when omitted).
+    /// </summary>
+    public DrawerStateHolder(DrawerValue? initialValue = null)
+    {
+        InitialValue = initialValue ?? DrawerValue.Closed!;
+    }
+
+    /// <summary>
+    /// The drawer's current visual state. Falls back to
+    /// <see cref="InitialValue"/> until the holder is bound to a live
+    /// peer (i.e. the first render has happened).
+    /// </summary>
+    public DrawerValue CurrentValue => Jvm?.CurrentValue ?? InitialValue;
+
+    /// <summary>
+    /// The drawer's target state during animation, or the resting
+    /// state otherwise. Falls back to <see cref="InitialValue"/> until
+    /// bound.
+    /// </summary>
+    public DrawerValue TargetValue => Jvm?.TargetValue ?? InitialValue;
+
+    /// <summary>
+    /// <c>true</c> when the drawer is fully open. Equivalent to
+    /// <c>CurrentValue == DrawerValue.Open</c>.
+    /// </summary>
+    public bool IsOpen => Jvm?.IsOpen ?? (InitialValue == DrawerValue.Open);
+
+    /// <summary>
+    /// <c>true</c> when the drawer is fully closed. Equivalent to
+    /// <c>CurrentValue == DrawerValue.Closed</c>.
+    /// </summary>
+    public bool IsClosed => Jvm?.IsClosed ?? (InitialValue == DrawerValue.Closed);
+}

--- a/src/ComposeNet.Compose/DrawerValueConfirmStateChange.cs
+++ b/src/ComposeNet.Compose/DrawerValueConfirmStateChange.cs
@@ -17,11 +17,33 @@ namespace ComposeNet;
 /// When <see cref="Callback"/> is <c>null</c> the adapter behaves as
 /// the Kotlin default <c>{ true }</c> — every transition is allowed.
 /// </summary>
-[Register("composenet/compose/DrawerConfirmStateChange")]
-internal sealed class DrawerConfirmStateChange : Java.Lang.Object, IFunction1
+/// <remarks>
+/// The name follows the source generator's convention
+/// <c>&lt;TName&gt;ConfirmStateChange</c> so a
+/// <c>[ConfirmStateChange(typeof(DrawerValue))]</c> attribute on a
+/// Remember bridge parameter resolves to this adapter automatically.
+/// Public so generated facade classes (which live alongside this type
+/// in <c>ComposeNet</c>) can declare it as a <c>readonly</c> field;
+/// it is not part of the developer-facing API and should not be
+/// constructed directly.
+/// </remarks>
+[Register("composenet/compose/DrawerValueConfirmStateChange")]
+public sealed class DrawerValueConfirmStateChange : Java.Lang.Object, IFunction1
 {
+    /// <summary>
+    /// Developer-supplied veto delegate, assigned by the generator-
+    /// emitted facade in its <c>Render</c> preamble from the facade's
+    /// <c>ConfirmStateChange</c> property. Treated as
+    /// <c>{ true }</c> when <c>null</c>.
+    /// </summary>
     public System.Func<DrawerValue, bool>? Callback { get; set; }
 
+    /// <summary>
+    /// Kotlin <c>Function1.invoke</c> entry point. Marshals the JNI
+    /// argument to <see cref="DrawerValue"/>, invokes
+    /// <see cref="Callback"/>, and returns a boxed
+    /// <see cref="Java.Lang.Boolean"/>.
+    /// </summary>
     public Java.Lang.Object? Invoke(Java.Lang.Object? p0)
     {
         var cb = Callback;

--- a/src/ComposeNet.Compose/ModalNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/ModalNavigationDrawer.cs
@@ -10,4 +10,27 @@ namespace ComposeNet;
 /// <c>ConfirmStateChange</c> to veto a transition (return
 /// <c>false</c>) — e.g. block close while a form is dirty.
 /// </summary>
-public sealed partial class ModalNavigationDrawer;
+public sealed partial class ModalNavigationDrawer
+{
+    /// <summary>
+    /// Convenience: when <c>true</c>, the drawer starts in the
+    /// <see cref="AndroidX.Compose.Material3.DrawerValue.Open"/> state
+    /// on first composition. Mirrors Kotlin
+    /// <c>rememberDrawerState(initialValue = DrawerValue.Open)</c>.
+    /// </summary>
+    /// <remarks>
+    /// Setting this constructs a default <see cref="DrawerStateHolder"/>
+    /// with the requested initial value. If the caller also passes an
+    /// explicit holder to the constructor, the init setter overwrites
+    /// it — pass the holder directly (with the desired
+    /// <c>InitialValue</c>) when you need to share state across
+    /// recompositions.
+    /// </remarks>
+    public bool InitiallyOpen
+    {
+        get => _drawerState?.InitialValue == AndroidX.Compose.Material3.DrawerValue.Open;
+        init => _drawerState = new DrawerStateHolder(
+            value ? AndroidX.Compose.Material3.DrawerValue.Open!
+                  : AndroidX.Compose.Material3.DrawerValue.Closed!);
+    }
+}

--- a/src/ComposeNet.Compose/ModalNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/ModalNavigationDrawer.cs
@@ -1,89 +1,13 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>ModalNavigationDrawer</c> — a phone-sized drawer that
-/// slides over the content with a scrim. The <see cref="Drawer"/>
-/// slot typically holds a <see cref="ModalDrawerSheet"/>. The drawer
-/// is opened by edge-swipe or programmatically via the underlying
-/// <c>DrawerState</c>; tap the scrim to close.
+/// slides over the content with a scrim. The <c>Drawer</c> slot
+/// typically holds a <see cref="ModalDrawerSheet"/>; the <c>Content</c>
+/// slot holds the screen the drawer overlays. Drag from the left edge
+/// or tap the scrim to toggle; pass a <see cref="DrawerStateHolder"/>
+/// to programmatically inspect the drawer position. Set
+/// <c>ConfirmStateChange</c> to veto a transition (return
+/// <c>false</c>) — e.g. block close while a form is dirty.
 /// </summary>
-/// <remarks>
-/// Calls the bound C# entry point directly — the wrapper is bound
-/// natively. Driving open/close from C# requires Kotlin
-/// <c>suspend</c> calls (<c>DrawerState.open()</c> /
-/// <c>close()</c>), so this facade exposes only swipe-to-toggle
-/// behavior using a <c>rememberDrawerState</c>-backed state.
-/// </remarks>
-public sealed class ModalNavigationDrawer : ComposableNode
-{
-    /// <summary>Required: the slide-in drawer panel.</summary>
-    public ComposableNode? Drawer { get; set; }
-
-    /// <summary>Required: the main content shown beneath the drawer.</summary>
-    public ComposableNode? Content { get; set; }
-
-    /// <summary>
-    /// Initial drawer state on first composition. Defaults to closed.
-    /// </summary>
-    public bool InitiallyOpen { get; set; }
-
-    /// <summary>
-    /// Optional veto invoked before the drawer transitions between
-    /// <c>Open</c> and <c>Closed</c> (Compose Kotlin
-    /// <c>confirmStateChange</c>). Return <c>true</c> to allow the
-    /// change, <c>false</c> to block it (e.g. don't let the user close
-    /// the drawer while a form is dirty). When <c>null</c> all
-    /// transitions are allowed.
-    /// </summary>
-    public System.Func<DrawerValue, bool>? ConfirmStateChange { get; set; }
-
-    // Allocate once per node and reuse across recompositions — the
-    // Java peer is part of `rememberDrawerState`'s cache key, so a
-    // fresh adapter each pass would drop the cached DrawerState.
-    readonly DrawerConfirmStateChange _confirm = new();
-
-    internal override void Render(IComposer composer)
-    {
-        if (Drawer is null)
-            throw new System.InvalidOperationException(
-                "ModalNavigationDrawer.Drawer is required.");
-        if (Content is null)
-            throw new System.InvalidOperationException(
-                "ModalNavigationDrawer.Content is required.");
-
-        var initial = InitiallyOpen ? DrawerValue.Open! : DrawerValue.Closed!;
-
-        _confirm.Callback = ConfirmStateChange;
-
-        // Param order: initialValue (bit 0, provided), confirmStateChange
-        // (bit 1, provided — passing a real non-null adapter avoids
-        // Kotlin's $default substitution misfiring for the lambda
-        // parameter). $default = 0.
-        var state = NavigationDrawerKt.RememberDrawerState(
-            initialValue:        initial,
-            confirmStateChange:  _confirm,
-            _composer:           composer,
-            p3:                  0,
-            _changed:            0);
-
-        var drawer  = ComposableLambdas.Wrap2(composer, c => Drawer.Render(c));
-        var content = ComposableLambdas.Wrap2(composer, c => Content.Render(c));
-        // Param order: drawerContent (0, provided), modifier (1, def),
-        // drawerState (2, provided), gesturesEnabled (3, provided),
-        // scrimColor (4, def — 0L is not a valid color sentinel),
-        // content (5, provided). $default = 0b010010 = 18.
-        NavigationDrawerKt.ModalNavigationDrawer(
-            drawerContent:    drawer,
-            modifier:         null,
-            drawerState:      state,
-            gesturesEnabled:  true,
-            scrimColor:       0L,
-            content:          content,
-            _composer:        composer,
-            p7:               0,
-            _changed:         0b010010);
-    }
-}
+public sealed partial class ModalNavigationDrawer;

--- a/src/ComposeNet.Compose/ModalNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/ModalNavigationDrawer.cs
@@ -13,8 +13,7 @@ namespace ComposeNet;
 public sealed partial class ModalNavigationDrawer
 {
     /// <summary>
-    /// Convenience: when <c>true</c>, the drawer starts in the
-    /// <see cref="AndroidX.Compose.Material3.DrawerValue.Open"/> state
+    /// Convenience: starting <see cref="AndroidX.Compose.Material3.DrawerValue"/>
     /// on first composition. Mirrors Kotlin
     /// <c>rememberDrawerState(initialValue = DrawerValue.Open)</c>.
     /// </summary>
@@ -26,11 +25,9 @@ public sealed partial class ModalNavigationDrawer
     /// <c>InitialValue</c>) when you need to share state across
     /// recompositions.
     /// </remarks>
-    public bool InitiallyOpen
+    public AndroidX.Compose.Material3.DrawerValue? InitialValue
     {
-        get => _drawerState?.InitialValue == AndroidX.Compose.Material3.DrawerValue.Open;
-        init => _drawerState = new DrawerStateHolder(
-            value ? AndroidX.Compose.Material3.DrawerValue.Open!
-                  : AndroidX.Compose.Material3.DrawerValue.Closed!);
+        get => _drawerState?.InitialValue;
+        init => _drawerState = new DrawerStateHolder(value);
     }
 }

--- a/src/ComposeNet.Compose/ModalWideNavigationRail.cs
+++ b/src/ComposeNet.Compose/ModalWideNavigationRail.cs
@@ -1,36 +1,23 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>ModalWideNavigationRail</c> — the modal-overlay variant
-/// of <see cref="WideNavigationRail"/>. Drawn on top of the host screen
-/// with a scrim, suitable for narrow-width adaptive layouts. Stripped
-/// from the binding because <c>collapsedShadowElevation</c> is a
-/// <c>Dp</c> <c>@JvmInline value class</c> (hashed JVM name
-/// <c>-k3FuEkE</c>); reached via <see cref="ComposeBridges"/>.
-///
+/// Material 3 <c>ModalWideNavigationRail</c> — the modal-overlay
+/// variant of <see cref="WideNavigationRail"/>. Drawn on top of the
+/// host screen with a scrim, suitable for narrow-width adaptive
+/// layouts. Children flow into the rail body; <c>Header</c> is an
+/// optional slot drawn above them.
+/// </summary>
+/// <remarks>
 /// <para>The Kotlin signature has no <c>onDismissRequest</c> callback —
 /// dismissal is driven internally by the rail's
-/// <c>WideNavigationRailState</c>. Because that state's
-/// <c>expand</c>/<c>collapse</c>/<c>snapTo</c> methods are Kotlin
-/// suspend functions, and the facade does not have a
-/// <c>LaunchedEffect</c>/coroutine-scope story yet, this facade ships
-/// with two practical limitations callers should know about:</para>
-/// <list type="bullet">
-///   <item>The rail always remembers its state with
-///   <c>WideNavigationRailValue.Expanded</c>, so it opens immediately
-///   when mounted.</item>
-///   <item>When the user dismisses by tapping the scrim, the rail
-///   visually disappears (because <c>hideOnCollapse=true</c>) but the
-///   C# facade has no way to observe the collapse. Drive close gestures
-///   from your own <see cref="MutableState{T}"/>-of-<see cref="bool"/>
-///   gate by mirroring the <see cref="ModalBottomSheet"/> pattern:
-///   wrap the instance in a ternary and add a button inside the rail
-///   content that flips the gate.</item>
-/// </list>
-///
+/// <see cref="WideNavigationRailState"/>. Because the live
+/// <c>expand</c>/<c>collapse</c>/<c>snapTo</c> operations are Kotlin
+/// suspend functions and the facade does not yet have a coroutine-scope
+/// story, the rail is wired with <c>hideOnCollapse = true</c> (its
+/// content visually unmounts on collapse) and the C# facade has no
+/// way to observe the collapse. Drive open/close from a separate
+/// <see cref="MutableState{T}"/>-of-<see cref="bool"/> gate by mirroring
+/// the <see cref="ModalBottomSheet"/> pattern.</para>
 /// <code>
 /// var show = Remember(() =&gt; new MutableState&lt;bool&gt;(false));
 /// var tab  = Remember(() =&gt; new MutableNumberState&lt;int&gt;(0));
@@ -41,7 +28,8 @@ namespace ComposeNet;
 ///         ? new ModalWideNavigationRail
 ///         {
 ///             Header = new Text("Sections"),
-///             new WideNavigationRailItem(selected: tab.Value == 0, onClick: () =&gt; { tab.Value = 0; show.Value = false; })
+///             new WideNavigationRailItem(selected: tab.Value == 0,
+///                 onClick: () =&gt; { tab.Value = 0; show.Value = false; })
 ///             {
 ///                 Icon  = new Text("🏠"),
 ///                 Label = new Text("Home"),
@@ -50,52 +38,5 @@ namespace ComposeNet;
 ///         : null,
 /// };
 /// </code>
-/// </summary>
-public sealed class ModalWideNavigationRail : ComposableContainer
-{
-    /// <summary>Optional header slot drawn at the top of the rail (e.g. a logo or menu button).</summary>
-    public ComposableNode? Header { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Children.Count == 0)
-            throw new System.InvalidOperationException(
-                "ModalWideNavigationRail requires at least one child (the content slot has no Kotlin default).");
-
-        // Bound C# call — RememberWideNavigationRailState is NOT stripped.
-        // initialValue=Expanded so the rail opens immediately on mount;
-        // the visibility-toggle pattern (see XML doc) controls mount/unmount.
-        // _changed=0 because we provide initialValue.
-        var stateObj = WideNavigationRailStateKt.RememberWideNavigationRailState(
-            initialValue: WideNavigationRailValue.Expanded,
-            _composer:    composer,
-            p2:           0,
-            _changed:     0);
-        var stateHandle = ((Java.Lang.Object)stateObj).Handle;
-
-        var content = ComposableLambdas.Wrap2(composer, c => RenderChildren(c));
-        var headerNode = Header;
-        var header = headerNode is null ? null
-            : ComposableLambdas.Wrap2(composer, c => headerNode.Render(c));
-
-        // Start from "default everything" and clear the bit for each
-        // optional slot the user actually supplied. `state` and `content`
-        // are not enum members (always provided), so they're not in `All`.
-        // `hideOnCollapse` IS an enum member and we always pass true, so
-        // we always clear its bit.
-        int defaults = (int)ModalWideNavigationRailDefault.All;
-        var modifier = BuildModifier();
-        if (modifier is not null) defaults &= ~(int)ModalWideNavigationRailDefault.Modifier;
-        defaults &= ~(int)ModalWideNavigationRailDefault.HideOnCollapse;
-        if (header   is not null) defaults &= ~(int)ModalWideNavigationRailDefault.Header;
-
-        ComposeBridges.ModalWideNavigationRail(
-            modifier:        modifier,
-            state:           stateHandle,
-            hideOnCollapse:  true,
-            header:          header,
-            content:         content,
-            defaults:        defaults,
-            composer:        composer);
-    }
-}
+/// </remarks>
+public sealed partial class ModalWideNavigationRail;

--- a/src/ComposeNet.Compose/PermanentNavigationDrawer.cs
+++ b/src/ComposeNet.Compose/PermanentNavigationDrawer.cs
@@ -1,47 +1,10 @@
-using AndroidX.Compose.Material3;
-using AndroidX.Compose.Runtime;
-
 namespace ComposeNet;
 
 /// <summary>
 /// Material 3 <c>PermanentNavigationDrawer</c> — always-visible side
-/// drawer, intended for tablets / large screens. The
-/// <see cref="Drawer"/> slot typically holds a
-/// <see cref="PermanentDrawerSheet"/>.
+/// drawer, intended for tablets and large screens. The <c>Drawer</c>
+/// slot typically holds a <see cref="PermanentDrawerSheet"/>. No
+/// state holder needed (the drawer is always rendered) and no
+/// gestures or scrim.
 /// </summary>
-/// <remarks>
-/// Calls the bound C# entry point directly — the wrapper isn't
-/// hash-mangled so no JNI bridge is needed. Only the inner
-/// <c>PermanentDrawerSheet-afqeVBk</c> overload is stripped (see
-/// <see cref="PermanentDrawerSheet"/>).
-/// </remarks>
-public sealed class PermanentNavigationDrawer : ComposableNode
-{
-    /// <summary>Required: the always-visible drawer panel.</summary>
-    public ComposableNode? Drawer { get; set; }
-
-    /// <summary>Required: the main content shown next to the drawer.</summary>
-    public ComposableNode? Content { get; set; }
-
-    internal override void Render(IComposer composer)
-    {
-        if (Drawer is null)
-            throw new System.InvalidOperationException(
-                "PermanentNavigationDrawer.Drawer is required.");
-        if (Content is null)
-            throw new System.InvalidOperationException(
-                "PermanentNavigationDrawer.Content is required.");
-
-        var drawer  = ComposableLambdas.Wrap2(composer, c => Drawer.Render(c));
-        var content = ComposableLambdas.Wrap2(composer, c => Content.Render(c));
-        // Param order: drawerContent (bit 0, provided), modifier (bit 1,
-        // defaulted), content (bit 2, provided). $default = 0b010 = 2.
-        NavigationDrawerKt.PermanentNavigationDrawer(
-            drawerContent: drawer,
-            modifier:      null,
-            content:       content,
-            _composer:     composer,
-            p4:            0,
-            _changed:      0b010);
-    }
-}
+public sealed partial class PermanentNavigationDrawer;

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -148,11 +148,9 @@ ComposeNet.DismissibleNavigationDrawer.ConfirmStateChange.get -> System.Func<And
 ComposeNet.DismissibleNavigationDrawer.ConfirmStateChange.set -> void
 ComposeNet.DismissibleNavigationDrawer.Content.get -> ComposeNet.ComposableNode?
 ComposeNet.DismissibleNavigationDrawer.Content.set -> void
-ComposeNet.DismissibleNavigationDrawer.DismissibleNavigationDrawer() -> void
+ComposeNet.DismissibleNavigationDrawer.DismissibleNavigationDrawer(ComposeNet.DrawerStateHolder? drawerState = null) -> void
 ComposeNet.DismissibleNavigationDrawer.Drawer.get -> ComposeNet.ComposableNode?
 ComposeNet.DismissibleNavigationDrawer.Drawer.set -> void
-ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.get -> bool
-ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.set -> void
 ComposeNet.DockedSearchBar
 ComposeNet.DockedSearchBar.DockedSearchBar(bool expanded, System.Action<bool>! onExpandedChange) -> void
 ComposeNet.DockedSearchBar.InputField.get -> ComposeNet.ComposableNode?
@@ -162,6 +160,18 @@ ComposeNet.Dp.Dp() -> void
 ComposeNet.Dp.Dp(float value) -> void
 ComposeNet.Dp.Equals(ComposeNet.Dp other) -> bool
 ComposeNet.Dp.Value.get -> float
+ComposeNet.DrawerStateHolder
+ComposeNet.DrawerStateHolder.CurrentValue.get -> AndroidX.Compose.Material3.DrawerValue!
+ComposeNet.DrawerStateHolder.DrawerStateHolder(AndroidX.Compose.Material3.DrawerValue? initialValue = null) -> void
+ComposeNet.DrawerStateHolder.InitialValue.get -> AndroidX.Compose.Material3.DrawerValue!
+ComposeNet.DrawerStateHolder.IsClosed.get -> bool
+ComposeNet.DrawerStateHolder.IsOpen.get -> bool
+ComposeNet.DrawerStateHolder.TargetValue.get -> AndroidX.Compose.Material3.DrawerValue!
+ComposeNet.DrawerValueConfirmStateChange
+ComposeNet.DrawerValueConfirmStateChange.Callback.get -> System.Func<AndroidX.Compose.Material3.DrawerValue!, bool>?
+ComposeNet.DrawerValueConfirmStateChange.Callback.set -> void
+ComposeNet.DrawerValueConfirmStateChange.DrawerValueConfirmStateChange() -> void
+ComposeNet.DrawerValueConfirmStateChange.Invoke(Java.Lang.Object? p0) -> Java.Lang.Object?
 ComposeNet.DropdownMenu
 ComposeNet.DropdownMenu.DropdownMenu(bool expanded, System.Action! onDismissRequest) -> void
 ComposeNet.DropdownMenuItem
@@ -418,13 +428,11 @@ ComposeNet.ModalNavigationDrawer.Content.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalNavigationDrawer.Content.set -> void
 ComposeNet.ModalNavigationDrawer.Drawer.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalNavigationDrawer.Drawer.set -> void
-ComposeNet.ModalNavigationDrawer.InitiallyOpen.get -> bool
-ComposeNet.ModalNavigationDrawer.InitiallyOpen.set -> void
-ComposeNet.ModalNavigationDrawer.ModalNavigationDrawer() -> void
+ComposeNet.ModalNavigationDrawer.ModalNavigationDrawer(ComposeNet.DrawerStateHolder? drawerState = null) -> void
 ComposeNet.ModalWideNavigationRail
 ComposeNet.ModalWideNavigationRail.Header.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalWideNavigationRail.Header.set -> void
-ComposeNet.ModalWideNavigationRail.ModalWideNavigationRail() -> void
+ComposeNet.ModalWideNavigationRail.ModalWideNavigationRail(ComposeNet.WideNavigationRailState? state = null) -> void
 ComposeNet.Modifier
 ComposeNet.Modifier.AbsoluteOffset(ComposeNet.Dp? x = null, ComposeNet.Dp? y = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Align(ComposeNet.Alignment! alignment) -> ComposeNet.Modifier!
@@ -881,6 +889,11 @@ ComposeNet.WideNavigationRailItem.Icon.set -> void
 ComposeNet.WideNavigationRailItem.Label.get -> ComposeNet.ComposableNode?
 ComposeNet.WideNavigationRailItem.Label.set -> void
 ComposeNet.WideNavigationRailItem.WideNavigationRailItem(bool selected, System.Action! onClick) -> void
+ComposeNet.WideNavigationRailState
+ComposeNet.WideNavigationRailState.CurrentValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!
+ComposeNet.WideNavigationRailState.InitialValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!
+ComposeNet.WideNavigationRailState.TargetValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!
+ComposeNet.WideNavigationRailState.WideNavigationRailState(AndroidX.Compose.Material3.WideNavigationRailValue? initialValue = null) -> void
 override ComposeNet.ComposeActivity.OnCreate(Android.OS.Bundle? savedInstanceState) -> void
 override ComposeNet.Dp.Equals(object? obj) -> bool
 override ComposeNet.Dp.GetHashCode() -> int

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -161,6 +161,8 @@ ComposeNet.DismissibleNavigationDrawer.Content.set -> void
 ComposeNet.DismissibleNavigationDrawer.DismissibleNavigationDrawer(ComposeNet.DrawerStateHolder? drawerState = null) -> void
 ComposeNet.DismissibleNavigationDrawer.Drawer.get -> ComposeNet.ComposableNode?
 ComposeNet.DismissibleNavigationDrawer.Drawer.set -> void
+ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.get -> bool
+ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.init -> void
 ComposeNet.DisposableEffect
 ComposeNet.DisposableEffect.DisposableEffect(object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 ComposeNet.DisposableEffect.DisposableEffect(object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
@@ -450,6 +452,8 @@ ComposeNet.ModalNavigationDrawer.Content.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalNavigationDrawer.Content.set -> void
 ComposeNet.ModalNavigationDrawer.Drawer.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalNavigationDrawer.Drawer.set -> void
+ComposeNet.ModalNavigationDrawer.InitiallyOpen.get -> bool
+ComposeNet.ModalNavigationDrawer.InitiallyOpen.init -> void
 ComposeNet.ModalNavigationDrawer.ModalNavigationDrawer(ComposeNet.DrawerStateHolder? drawerState = null) -> void
 ComposeNet.ModalWideNavigationRail
 ComposeNet.ModalWideNavigationRail.Header.get -> ComposeNet.ComposableNode?

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -161,8 +161,8 @@ ComposeNet.DismissibleNavigationDrawer.Content.set -> void
 ComposeNet.DismissibleNavigationDrawer.DismissibleNavigationDrawer(ComposeNet.DrawerStateHolder? drawerState = null) -> void
 ComposeNet.DismissibleNavigationDrawer.Drawer.get -> ComposeNet.ComposableNode?
 ComposeNet.DismissibleNavigationDrawer.Drawer.set -> void
-ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.get -> bool
-ComposeNet.DismissibleNavigationDrawer.InitiallyOpen.init -> void
+ComposeNet.DismissibleNavigationDrawer.InitialValue.get -> AndroidX.Compose.Material3.DrawerValue?
+ComposeNet.DismissibleNavigationDrawer.InitialValue.init -> void
 ComposeNet.DisposableEffect
 ComposeNet.DisposableEffect.DisposableEffect(object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 ComposeNet.DisposableEffect.DisposableEffect(object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
@@ -452,8 +452,8 @@ ComposeNet.ModalNavigationDrawer.Content.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalNavigationDrawer.Content.set -> void
 ComposeNet.ModalNavigationDrawer.Drawer.get -> ComposeNet.ComposableNode?
 ComposeNet.ModalNavigationDrawer.Drawer.set -> void
-ComposeNet.ModalNavigationDrawer.InitiallyOpen.get -> bool
-ComposeNet.ModalNavigationDrawer.InitiallyOpen.init -> void
+ComposeNet.ModalNavigationDrawer.InitialValue.get -> AndroidX.Compose.Material3.DrawerValue?
+ComposeNet.ModalNavigationDrawer.InitialValue.init -> void
 ComposeNet.ModalNavigationDrawer.ModalNavigationDrawer(ComposeNet.DrawerStateHolder? drawerState = null) -> void
 ComposeNet.ModalWideNavigationRail
 ComposeNet.ModalWideNavigationRail.Header.get -> ComposeNet.ComposableNode?

--- a/src/ComposeNet.Compose/WideNavigationRailState.cs
+++ b/src/ComposeNet.Compose/WideNavigationRailState.cs
@@ -1,0 +1,55 @@
+using AndroidX.Compose.Material3;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Caller-supplied state holder for <see cref="ModalWideNavigationRail"/>.
+/// Wraps Kotlin's <c>WideNavigationRailState</c> (created via
+/// <c>rememberWideNavigationRailState</c>) so a facade can carry an
+/// initial <see cref="WideNavigationRailValue"/> across recompositions.
+/// </summary>
+/// <remarks>
+/// Construct inside <c>Remember</c> so the same instance survives
+/// recomposition:
+/// <code>
+/// var rail = Remember(() =&gt; new WideNavigationRailState(WideNavigationRailValue.Expanded));
+/// new ModalWideNavigationRail(state: rail) { … };
+/// </code>
+/// </remarks>
+public sealed class WideNavigationRailState
+{
+    internal IWideNavigationRailState? Jvm;
+
+    /// <summary>
+    /// Initial <see cref="WideNavigationRailValue"/> the rail
+    /// remembers on first composition. Defaults to
+    /// <see cref="WideNavigationRailValue.Expanded"/> so the rail
+    /// pops open as soon as it mounts (matches the modal-overlay
+    /// pattern documented on <see cref="ModalWideNavigationRail"/>).
+    /// </summary>
+    public WideNavigationRailValue InitialValue { get; }
+
+    /// <summary>
+    /// Construct a holder with the given <paramref name="initialValue"/>
+    /// (or <see cref="WideNavigationRailValue.Expanded"/> when omitted).
+    /// </summary>
+    public WideNavigationRailState(WideNavigationRailValue? initialValue = null)
+    {
+        InitialValue = initialValue ?? WideNavigationRailValue.Expanded!;
+    }
+
+    /// <summary>
+    /// The rail's current visual state. Falls back to
+    /// <see cref="InitialValue"/> until the holder is bound to a live
+    /// peer (i.e. the first render has happened).
+    /// </summary>
+    public WideNavigationRailValue CurrentValue =>
+        Jvm?.CurrentValue ?? InitialValue;
+
+    /// <summary>
+    /// The rail's target state during animation, or the resting state
+    /// otherwise. Falls back to <see cref="InitialValue"/> until bound.
+    /// </summary>
+    public WideNavigationRailValue TargetValue =>
+        Jvm?.TargetValue ?? InitialValue;
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -714,6 +714,7 @@ public class MainActivity : ComposeActivity
                         },
                         1 => new DismissibleNavigationDrawer
                         {
+                            InitiallyOpen = true,
                             Drawer = new DismissibleDrawerSheet
                             {
                                 new Text("Dismissible drawer"),
@@ -724,7 +725,8 @@ public class MainActivity : ComposeActivity
                             Content = new Column
                             {
                                 new Text("Main content"),
-                                new Text("Swipe right to open →"),
+                                new Text("Drawer opens initially via InitiallyOpen = true"),
+                                new Text("Swipe horizontally to toggle"),
                                 new Text($"Count: {count}"),
                                 new Button(onClick: () => count++) { new Text("+1") },
                             },

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -714,7 +714,7 @@ public class MainActivity : ComposeActivity
                         },
                         1 => new DismissibleNavigationDrawer
                         {
-                            InitiallyOpen = true,
+                            InitialValue = DrawerValue.Open!,
                             Drawer = new DismissibleDrawerSheet
                             {
                                 new Text("Dismissible drawer"),
@@ -725,7 +725,7 @@ public class MainActivity : ComposeActivity
                             Content = new Column
                             {
                                 new Text("Main content"),
-                                new Text("Drawer opens initially via InitiallyOpen = true"),
+                                new Text("Drawer opens initially via InitialValue = DrawerValue.Open"),
                                 new Text("Swipe horizontally to toggle"),
                                 new Text($"Count: {count}"),
                                 new Button(onClick: () => count++) { new Text("+1") },

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -1435,8 +1435,11 @@ public class FacadeGeneratorTests
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
 
-        // Ctor: state slot LAST, with default = null.
-        Assert.Contains("readonly global::ComposeNet.DatePickerState? _state;", emitted);
+        // Ctor: state slot LAST, with default = null. The field is
+        // emitted writable (no `readonly`) so partials can override
+        // it via init-only convenience setters.
+        Assert.Contains("global::ComposeNet.DatePickerState? _state;", emitted);
+        Assert.DoesNotContain("readonly global::ComposeNet.DatePickerState? _state;", emitted);
         Assert.Contains("public DatePicker(global::ComposeNet.DatePickerState? state = null)", emitted);
 
         // Render: Remember + .Jvm population.
@@ -1671,8 +1674,11 @@ public class FacadeGeneratorTests
 
         // Ctor: parameterised StateHolder auto-creates the wrapper when
         // the caller passes null, so the field is guaranteed non-null
-        // even though the ctor param keeps its = null default.
-        Assert.Contains("readonly global::ComposeNet.TimePickerState? _state;", emitted);
+        // even though the ctor param keeps its = null default. The
+        // field is emitted writable (no `readonly`) so partials can
+        // override it via init-only convenience setters.
+        Assert.Contains("global::ComposeNet.TimePickerState? _state;", emitted);
+        Assert.DoesNotContain("readonly global::ComposeNet.TimePickerState? _state;", emitted);
         Assert.Contains("public TimePicker(global::ComposeNet.TimePickerState? state = null)", emitted);
         Assert.Contains("_state = state ?? new global::ComposeNet.TimePickerState();", emitted);
 
@@ -1827,8 +1833,11 @@ public class FacadeGeneratorTests
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
 
-        // Phase 4 field stays nullable (no auto-create in ctor).
-        Assert.Contains("readonly global::ComposeNet.DatePickerState? _state;", emitted);
+        // Phase 4 field stays nullable (no auto-create in ctor). The
+        // field is emitted writable (no `readonly`) so partials can
+        // override it via init-only convenience setters.
+        Assert.Contains("global::ComposeNet.DatePickerState? _state;", emitted);
+        Assert.DoesNotContain("readonly global::ComposeNet.DatePickerState? _state;", emitted);
         Assert.DoesNotContain("_state = state ?? new global::ComposeNet.DatePickerState();", emitted);
 
         // Cache-hit branch — guarded with explicit null check on _state.

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -2299,4 +2299,229 @@ public class FacadeGeneratorTests
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
     }
+
+    // ─── [ConfirmStateChange] — per-instance JNI veto adapter ─────────
+
+    /// <summary>Shared snippet stubbing a DrawerState-style state class
+    /// plus the convention-named JCW adapter
+    /// (<c>&lt;TName&gt;ConfirmStateChange</c>) the generator looks up
+    /// from a <c>[ConfirmStateChange(typeof(T))]</c> attribute.</summary>
+    const string DrawerStateStubs = """
+        namespace AndroidX.Compose.Material3
+        {
+            public enum DrawerValue { Closed, Open }
+            public interface IDrawerState { }
+        }
+        namespace ComposeNet
+        {
+            public sealed class DrawerStateHolder
+            {
+                internal AndroidX.Compose.Material3.IDrawerState? Jvm;
+                public AndroidX.Compose.Material3.DrawerValue InitialValue { get; }
+                public DrawerStateHolder() { }
+            }
+            public sealed class DrawerValueConfirmStateChange : Kotlin.Jvm.Functions.IFunction1
+            {
+                public System.Func<AndroidX.Compose.Material3.DrawerValue, bool>? Callback { get; set; }
+            }
+        }
+        """;
+
+    const string DrawerSig =
+        "(Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Landroidx/compose/material3/DrawerState;ZJLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V";
+
+    [Fact]
+    public void ConfirmStateChange_GeneratesAdapterFieldPropertyAndPreamble()
+    {
+        // Happy path: a Remember bridge takes an IFunction1?
+        // `confirmStateChange` param annotated with
+        // [ConfirmStateChange(typeof(DrawerValue))]. The facade should:
+        //   - allocate a single readonly adapter field
+        //   - expose a Func<DrawerValue, bool>? ConfirmStateChange prop
+        //   - assign Callback = ConfirmStateChange in the Render
+        //     preamble BEFORE calling Remember
+        //   - forward _confirmStateChangeAdapter to the Remember bridge
+        //     as the IFunction1? slot
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DrawerDefault",
+                "!drawerContent", "modifier", "!drawerState", "gesturesEnabled", "scrimColor", "!content")]
+
+            {{DrawerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/NavigationDrawerKt",
+                                   JvmName="ModalNavigationDrawer",
+                                   Signature="{{DrawerSig}}",
+                                   Defaults=typeof(DrawerDefault))]
+                    [ComposeFacade]
+                    public static partial void Drawer(
+                        IFunction2 drawerContent,
+                        IModifier? modifier,
+                        [StateHolder(Remember = nameof(RememberDrawerState),
+                                     StateType = typeof(DrawerStateHolder))]
+                        IntPtr drawerState,
+                        IFunction2 content,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDrawerState(
+                        AndroidX.Compose.Material3.DrawerValue initialValue,
+                        [ConfirmStateChange(typeof(AndroidX.Compose.Material3.DrawerValue))]
+                        IFunction1? confirmStateChange,
+                        IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "Drawer");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // (a) adapter field allocated once.
+        Assert.Contains(
+            "readonly global::ComposeNet.DrawerValueConfirmStateChange _confirmStateChangeAdapter = new global::ComposeNet.DrawerValueConfirmStateChange();",
+            emitted);
+        // (b) ConfirmStateChange property surfaces with the right type.
+        Assert.Contains(
+            "public global::System.Func<global::AndroidX.Compose.Material3.DrawerValue, bool>? ConfirmStateChange { get; set; }",
+            emitted);
+        // (c) Render preamble assigns the user delegate into the adapter.
+        Assert.Contains(
+            "_confirmStateChangeAdapter.Callback = ConfirmStateChange;",
+            emitted);
+        // (d) Remember call forwards the adapter into the IFunction1? slot.
+        Assert.Contains(
+            "global::ComposeNet.ComposeBridges.RememberDrawerState(_drawerState!.InitialValue, _confirmStateChangeAdapter, composer)",
+            emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ConfirmStateChange_OnNonIFunction1_FailsCN3010()
+    {
+        // Put [ConfirmStateChange] on a primitive param — generator
+        // must reject with CN3010 because the slot is meant for an
+        // IFunction1 veto adapter.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DrawerDefault",
+                "!drawerContent", "modifier", "!drawerState", "gesturesEnabled", "scrimColor", "!content")]
+
+            {{DrawerStateStubs}}
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/NavigationDrawerKt",
+                                   JvmName="ModalNavigationDrawer",
+                                   Signature="{{DrawerSig}}",
+                                   Defaults=typeof(DrawerDefault))]
+                    [ComposeFacade]
+                    public static partial void Drawer(
+                        IFunction2 drawerContent,
+                        IModifier? modifier,
+                        [StateHolder(Remember = nameof(RememberDrawerState),
+                                     StateType = typeof(DrawerStateHolder))]
+                        IntPtr drawerState,
+                        IFunction2 content,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDrawerState(
+                        AndroidX.Compose.Material3.DrawerValue initialValue,
+                        [ConfirmStateChange(typeof(AndroidX.Compose.Material3.DrawerValue))]
+                        bool confirmStateChange,
+                        IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "Drawer");
+        Assert.Null(emitted);
+        Assert.Contains(diags, d => d.Id == "CN3010"
+            && d.GetMessage().Contains("requires a Kotlin.Jvm.Functions.IFunction1"));
+    }
+
+    [Fact]
+    public void ConfirmStateChange_MissingConventionAdapter_FailsCN3010()
+    {
+        // No `ComposeNet.<TName>ConfirmStateChange` class in scope and
+        // no explicit AdapterType — generator must report CN3010 with
+        // a message naming the missing convention class.
+        var code = $$"""
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+            using System;
+
+            [assembly: ComposeDefaults("DrawerDefault",
+                "!drawerContent", "modifier", "!drawerState", "gesturesEnabled", "scrimColor", "!content")]
+
+            namespace AndroidX.Compose.Material3
+            {
+                public enum DrawerValue { Closed, Open }
+                public interface IDrawerState { }
+            }
+            namespace ComposeNet
+            {
+                public sealed class DrawerStateHolder
+                {
+                    internal AndroidX.Compose.Material3.IDrawerState? Jvm;
+                    public AndroidX.Compose.Material3.DrawerValue InitialValue { get; }
+                    public DrawerStateHolder() { }
+                }
+                // NOTE: no `DrawerValueConfirmStateChange` class declared.
+            }
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="androidx/compose/material3/NavigationDrawerKt",
+                                   JvmName="ModalNavigationDrawer",
+                                   Signature="{{DrawerSig}}",
+                                   Defaults=typeof(DrawerDefault))]
+                    [ComposeFacade]
+                    public static partial void Drawer(
+                        IFunction2 drawerContent,
+                        IModifier? modifier,
+                        [StateHolder(Remember = nameof(RememberDrawerState),
+                                     StateType = typeof(DrawerStateHolder))]
+                        IntPtr drawerState,
+                        IFunction2 content,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberDrawerState(
+                        AndroidX.Compose.Material3.DrawerValue initialValue,
+                        [ConfirmStateChange(typeof(AndroidX.Compose.Material3.DrawerValue))]
+                        IFunction1? confirmStateChange,
+                        IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "Drawer");
+        Assert.Null(emitted);
+        Assert.Contains(diags, d => d.Id == "CN3010"
+            && d.GetMessage().Contains("ComposeNet.DrawerValueConfirmStateChange"));
+    }
 }

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -432,6 +432,57 @@ public class FacadeGeneratorTests
     }
 
     [Fact]
+    public void HybridContainer_ContainerTrueWithFn2Body_EmitsContainerWithNamedSlot()
+    {
+        // Mirrors the ModalWideNavigationRail shape (issue #121): a
+        // non-`@Composable` IFunction2 body slot + a nullable IFunction2?
+        // header slot. Container = true is required because there's no
+        // IFunction3 body for the Scope path to latch onto. The facade
+        // must still derive from ComposableContainer (collection-init
+        // syntax), wrap children via Wrap2, and surface the nullable
+        // Fn2 slot as a named property.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("RailDefault",
+                "modifier", "header", "!content")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/RailKt", JvmName="Rail",
+                                   Signature="(Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(RailDefault))]
+                    [ComposeFacade(Container = true)]
+                    public static partial void Rail(
+                        IModifier? modifier, IFunction2? header, IFunction2 content, IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "Rail");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        // Derives from ComposableContainer so collection-init syntax works
+        // ("new Rail { new WideNavigationRailItem(...), ... }").
+        Assert.Contains(": global::ComposeNet.ComposableContainer", emitted);
+        // Non-nullable IFunction2 body wraps children via Wrap2 (no
+        // Fn3 / no PushScope — Container=true uses the Fn2 path).
+        Assert.Contains("Wrap2(composer, c => RenderChildren(c))", emitted);
+        Assert.DoesNotContain("PushScope", emitted);
+        // Nullable IFunction2? slot surfaces as a named property, not a
+        // ctor primitive.
+        Assert.Contains("public global::ComposeNet.ComposableNode? Header { get; set; }", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
     public void JavaEnumPrimitive_SurfacedAsCtorParam()
     {
         // Simulates ToggleableState — a class derived from Java.Lang.Enum.

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -186,6 +186,22 @@ internal static class Attributes
                 /// instead — this property is ignored in that case.
                 /// </summary>
                 public global::System.Type? Defaults { get; set; }
+
+                /// <summary>
+                /// Opt in to hybrid container shape: bridge has exactly
+                /// one non-nullable <c>IFunction2</c> or <c>IFunction3</c>
+                /// body slot plus one or more nullable <c>IFunction2?</c> /
+                /// <c>IFunction3?</c> slots. The non-nullable body slot
+                /// becomes <c>RenderChildren</c> and the facade derives
+                /// from <see cref="ComposableContainer"/>; the nullable
+                /// slots surface as named <see cref="ComposableNode"/>?
+                /// properties (Phase 3 style). For an <c>IFunction3</c>
+                /// body, set <see cref="Scope"/> too if children need
+                /// the published <c>RowScope</c>/<c>ColumnScope</c>. For
+                /// an <c>IFunction2</c> body, <see cref="Scope"/> has no
+                /// effect.
+                /// </summary>
+                public bool Container { get; set; }
             }
 
             /// <summary>
@@ -301,6 +317,44 @@ internal static class Attributes
                 public string Remember { get; set; } = "";
                 public global::System.Type StateType { get; set; } = null!;
                 public bool SharedState { get; set; }
+            }
+
+            /// <summary>
+            /// Annotates an <c>IFunction1</c> parameter on a
+            /// <c>Remember*State(…)</c> helper on <c>ComposeBridges</c>
+            /// to tell <c>ComposeFacadeGenerator</c> that the value is
+            /// a per-instance JNI veto adapter — Kotlin's
+            /// <c>confirmStateChange</c> / <c>confirmValueChange</c>
+            /// callback. The facade allocates the JCW once per node
+            /// (<c>readonly</c> field) and exposes a
+            /// <c>System.Func&lt;T, bool&gt;?</c> property the user
+            /// can mutate freely without invalidating Kotlin's
+            /// <c>remember</c> cache key (which is part of the
+            /// Java identity of the adapter, not the C# delegate).
+            /// </summary>
+            /// <remarks>
+            /// <para>The value type <c>T</c> is what the Kotlin
+            /// callback receives (e.g. <c>DrawerValue</c>,
+            /// <c>SheetValue</c>) and what the developer-facing
+            /// <c>Func&lt;T, bool&gt;</c> takes.</para>
+            /// <para><b>AdapterType</b> — JCW class implementing
+            /// <c>Kotlin.Jvm.Functions.IFunction1</c> with a writable
+            /// <c>System.Func&lt;T, bool&gt;? Callback</c> property the
+            /// generator assigns from the facade's
+            /// <see cref="PropertyName"/>. Must be registered with
+            /// Mono.Android (<c>[Register]</c>) so its Java peer
+            /// identity is stable. Defaults to convention
+            /// <c>ComposeNet.&lt;TName&gt;ConfirmStateChange</c>.</para>
+            /// <para><b>PropertyName</b> — name of the property the
+            /// facade exposes. Defaults to <c>ConfirmStateChange</c>.</para>
+            /// </remarks>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class ConfirmStateChangeAttribute : global::System.Attribute
+            {
+                public ConfirmStateChangeAttribute(global::System.Type valueType) { }
+                public global::System.Type? AdapterType { get; set; }
+                public string? PropertyName { get; set; }
             }
         }
         """;

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -911,11 +911,17 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         sb.Append("    public sealed partial class ").Append(className).Append(" : ").AppendLine(baseClass);
         sb.AppendLine("    {");
 
-        // Backing fields for ctor slots.
+        // Backing fields for ctor slots. StateHolder fields are
+        // emitted writable (no `readonly`) so that hand-written
+        // partial declarations of the same facade can pre-populate
+        // them via `init`-only properties — useful for thin
+        // convenience accessors like `InitiallyOpen = true` over the
+        // state holder's constructor argument.
         foreach (var s in ctorSlots)
         {
             var typeRef = CtorFieldType(s);
-            sb.Append("        readonly ").Append(typeRef).Append(" _").Append(CtorIdentifier(s)).AppendLine(";");
+            var modifier = s.Kind == FacadeSlotKind.StateHolder ? "" : "readonly ";
+            sb.Append("        ").Append(modifier).Append(typeRef).Append(" _").Append(CtorIdentifier(s)).AppendLine(";");
         }
 
         // Phase 10 — per-instance JCW veto adapter fields. One per

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -48,6 +48,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     const string CallbackAttributeMetadataName = "ComposeNet.CallbackAttribute";
     const string PainterResourceAttributeMetadataName = "ComposeNet.PainterResourceAttribute";
     const string StateHolderAttributeMetadataName = "ComposeNet.StateHolderAttribute";
+    const string ConfirmStateChangeAttributeMetadataName = "ComposeNet.ConfirmStateChangeAttribute";
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -72,6 +73,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             var callbackAttr = compilation.GetTypeByMetadataName(CallbackAttributeMetadataName);
             var painterAttr = compilation.GetTypeByMetadataName(PainterResourceAttributeMetadataName);
             var stateHolderAttr = compilation.GetTypeByMetadataName(StateHolderAttributeMetadataName);
+            var confirmAttr = compilation.GetTypeByMetadataName(ConfirmStateChangeAttributeMetadataName);
             if (facadeAttr is null) return;
 
             var method = (IMethodSymbol)ctx.SemanticModel.GetDeclaredSymbol((MethodDeclarationSyntax)ctx.Node)!;
@@ -79,7 +81,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 .FirstOrDefault(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, facadeAttr));
             if (attr is null) return;
 
-            var ctxObj = new Context(method, attr, bridgeAttr, declarativeAttr, slotAttr, callbackAttr, painterAttr, stateHolderAttr, compilation);
+            var ctxObj = new Context(method, attr, bridgeAttr, declarativeAttr, slotAttr, callbackAttr, painterAttr, stateHolderAttr, confirmAttr, compilation);
             var result = Build(ctxObj);
             foreach (var diag in result.Diagnostics)
                 spc.ReportDiagnostic(diag);
@@ -98,11 +100,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         public INamedTypeSymbol? CallbackAttr { get; }
         public INamedTypeSymbol? PainterAttr { get; }
         public INamedTypeSymbol? StateHolderAttr { get; }
+        public INamedTypeSymbol? ConfirmStateChangeAttr { get; }
         public Compilation Compilation { get; }
 
         public Context(IMethodSymbol method, AttributeData attr, INamedTypeSymbol? bridgeAttr,
             INamedTypeSymbol? declarativeAttr, INamedTypeSymbol? slotAttr, INamedTypeSymbol? callbackAttr,
-            INamedTypeSymbol? painterAttr, INamedTypeSymbol? stateHolderAttr, Compilation compilation)
+            INamedTypeSymbol? painterAttr, INamedTypeSymbol? stateHolderAttr,
+            INamedTypeSymbol? confirmStateChangeAttr, Compilation compilation)
         {
             Method = method;
             Attr = attr;
@@ -112,6 +116,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             CallbackAttr = callbackAttr;
             PainterAttr = painterAttr;
             StateHolderAttr = stateHolderAttr;
+            ConfirmStateChangeAttr = confirmStateChangeAttr;
             Compilation = compilation;
         }
     }
@@ -150,6 +155,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         string? scope = ReadString(attr, "Scope");
         string? themeColor = ReadString(attr, "DefaultColorFromTheme");
         string? colorParameter = ReadString(attr, "ColorParameter");
+        bool containerOptIn = ReadBool(attr, "Container");
 
         // Composer is the trailing param for @Composable bridges (the only
         // shape facade generation supports).
@@ -215,39 +221,59 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         // an explicit [Slot], OR there's >1 Fn2/3 slot, treat the facade
         // as a multi-slot LEAF (named properties). Otherwise stick with
         // the Phase 1 "container with children" shape.
-        // Hybrid container exception: exactly 1 non-nullable Fn3 (+ no
-        // [Slot]) PLUS 1+ nullable Fn2/3 slots AND `[ComposeFacade(Scope = "...")]`
-        // explicitly set — the non-nullable Fn3 stays as the container
-        // body (RenderChildren) and the nullable slots become named
-        // properties. The Scope opt-in disambiguates from leafs that
-        // happen to have a required Fn2 label slot (e.g. AssistChip).
+        // Hybrid container exception: exactly 1 non-nullable Fn2/Fn3
+        // (without [Slot]) PLUS 1+ nullable Fn2/3 slots, AND either:
+        //   (a) `[ComposeFacade(Scope = "...")]` is set — disambiguates
+        //       from leafs that happen to have a required Fn2 label
+        //       slot (e.g. AssistChip). Only valid when the body slot
+        //       is Fn3 (Fn2 has no scope receiver to publish). OR
+        //   (b) `[ComposeFacade(Container = true)]` is set explicitly —
+        //       allows Fn2 body without a scope (e.g.
+        //       ModalWideNavigationRail's `content: @Composable () -> Unit`).
         bool hasMultiSlot = slots.Any(s => s.IsNullableSlot || s.HasSlotAttribute) || fnContentCount > 1;
         bool isHybridContainer = false;
-        if (hasMultiSlot && !string.IsNullOrEmpty(scope))
+        if (hasMultiSlot && (!string.IsNullOrEmpty(scope) || containerOptIn))
         {
             var nonNullableFn3 = slots.Where(s =>
                 s.Kind == FacadeSlotKind.Content3 &&
                 s.Param.NullableAnnotation != NullableAnnotation.Annotated &&
                 !s.HasSlotAttribute).ToArray();
+            var nonNullableFn2 = slots.Where(s =>
+                s.Kind == FacadeSlotKind.Content2 &&
+                s.Param.NullableAnnotation != NullableAnnotation.Annotated &&
+                !s.HasSlotAttribute).ToArray();
             var nullableContent = slots.Where(s =>
                 s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3 &&
                 s.Param.NullableAnnotation == NullableAnnotation.Annotated).ToArray();
-            isHybridContainer =
-                nonNullableFn3.Length == 1 &&
-                nullableContent.Length >= 1 &&
-                !slots.Any(s => s.HasSlotAttribute);
+            // Scope path: Fn3 body only.
+            if (!string.IsNullOrEmpty(scope))
+            {
+                isHybridContainer =
+                    nonNullableFn3.Length == 1 &&
+                    nullableContent.Length >= 1 &&
+                    !slots.Any(s => s.HasSlotAttribute);
+            }
+            // Container=true path: accept either Fn2 or Fn3 body.
+            else if (containerOptIn)
+            {
+                int totalBodies = nonNullableFn3.Length + nonNullableFn2.Length;
+                isHybridContainer =
+                    totalBodies == 1 &&
+                    nullableContent.Length >= 1 &&
+                    !slots.Any(s => s.HasSlotAttribute);
+            }
         }
         if (hasMultiSlot)
         {
             // Re-classify the Fn2/Fn3 slots into property slots (the
             // generator picks one shape per bridge; mixing is invalid).
-            // Hybrid container: leave the sole non-nullable Fn3 as
-            // Content3 so it renders the container body.
+            // Hybrid container: leave the sole non-nullable body slot
+            // (Fn2 or Fn3) as Content2/3 so it renders as RenderChildren.
             for (int i = 0; i < slots.Count; i++)
             {
                 var s = slots[i];
                 bool isContainerBody = isHybridContainer
-                    && s.Kind == FacadeSlotKind.Content3
+                    && s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3
                     && s.Param.NullableAnnotation != NullableAnnotation.Annotated
                     && !s.HasSlotAttribute;
                 if (s.Kind is FacadeSlotKind.Content2 && !isContainerBody)
@@ -445,17 +471,22 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             }
 
             // Phase 4b — Remember has N user params before composer. Each
-            // user param must resolve to a readable instance member on
-            // the StateType (case-insensitive PascalCase match; fall back
-            // to `Initial<PascalCase>` for the Kotlin "initialX → live X"
-            // wrapper convention). Phase 4b also requires an accessible
-            // parameterless construction path on the StateType so the
-            // ctor can auto-create a default wrapper when the caller
-            // passes null.
+            // user param must either:
+            //   (a) carry [ConfirmStateChange] — surface as a per-instance
+            //       JCW veto adapter (CN3010 if the configuration is
+            //       invalid); OR
+            //   (b) resolve to a readable instance member on the
+            //       StateType (case-insensitive PascalCase match; fall
+            //       back to `Initial<PascalCase>` for the Kotlin
+            //       "initialX → live X" wrapper convention).
+            // Phase 4b also requires an accessible parameterless
+            // construction path on the StateType so the ctor can
+            // auto-create a default wrapper when the caller passes null.
             var rememberUserParams = rememberFit.Parameters
                 .Take(rememberFit.Parameters.Length - 1)
                 .ToArray();
             string[] rememberArgExpressions = System.Array.Empty<string>();
+            var confirmInfos = new List<ConfirmStateChangeInfo>();
             if (rememberUserParams.Length > 0)
             {
                 if (!HasAccessibleParameterlessConstructor(stateType))
@@ -469,6 +500,23 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 for (int i = 0; i < rememberUserParams.Length; i++)
                 {
                     var up = rememberUserParams[i];
+
+                    // [ConfirmStateChange] — per-instance JCW veto adapter.
+                    AttributeData? confirmAttr = null;
+                    if (c.ConfirmStateChangeAttr is not null)
+                    {
+                        confirmAttr = up.GetAttributes().FirstOrDefault(a =>
+                            SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.ConfirmStateChangeAttr));
+                    }
+                    if (confirmAttr is not null)
+                    {
+                        var info = ResolveConfirmStateChange(c, up, confirmAttr, methodName, loc, diags);
+                        if (info is null) return null;
+                        confirmInfos.Add(info.Value);
+                        rememberArgExpressions[i] = "_" + info.Value.FieldIdentifier;
+                        continue;
+                    }
+
                     var resolved = ResolveStateMember(stateType, up.Name);
                     if (resolved is null)
                     {
@@ -476,7 +524,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                             $"[StateHolder] on '{p.Name}': cannot resolve Remember parameter '{up.Name}' on StateType '{stateType.ToDisplayString()}'; expected a readable instance member named '{Pascal(up.Name)}' or 'Initial{Pascal(up.Name)}'"));
                         return null;
                     }
-                    rememberArgExpressions[i] = "_state!." + resolved;
+                    rememberArgExpressions[i] = "_" + p.Name + "!." + resolved;
                 }
             }
 
@@ -485,7 +533,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 stateWrapperType: stateType,
                 stateJvmType: jvmMember.Type,
                 rememberArgExpressions: rememberArgExpressions,
-                sharedState: ReadBool(stateAttr, "SharedState"));
+                sharedState: ReadBool(stateAttr, "SharedState"),
+                confirmStateChanges: confirmInfos.ToArray());
         }
 
         // [PainterResource] — annotates the IntPtr bridge param that
@@ -620,6 +669,20 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             sb.Append("        readonly ").Append(typeRef).Append(" _").Append(CtorIdentifier(s)).AppendLine(";");
         }
 
+        // Phase 4b — per-instance JCW veto adapter fields. One per
+        // [ConfirmStateChange] across all StateHolder slots. Stable
+        // JNI identity for Kotlin's `remember` cache key.
+        foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.StateHolder))
+        {
+            foreach (var info in s.ConfirmStateChanges)
+            {
+                var adapterFqn = info.AdapterType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                    .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+                sb.Append("        readonly ").Append(adapterFqn).Append(" _").Append(info.FieldIdentifier)
+                  .Append(" = new ").Append(adapterFqn).AppendLine("();");
+            }
+        }
+
         // Phase 6 — ContainerColor property + (no theme fallback here; happens in Render).
         if (themeColor is not null && colorSlot is not null)
         {
@@ -642,6 +705,20 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         {
             sb.Append("        public ").Append(OptionalValueDisplay(s)).Append(' ')
               .Append(PropertyName(s)).AppendLine(" { get; set; }");
+        }
+
+        // Phase 4b — public `Func<T, bool>?` properties for each
+        // [ConfirmStateChange] adapter. Null = "always allow"; the
+        // adapter's Invoke reads this property each call.
+        foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.StateHolder))
+        {
+            foreach (var info in s.ConfirmStateChanges)
+            {
+                var valueFqn = info.ValueType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                    .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+                sb.Append("        public global::System.Func<").Append(valueFqn).Append(", bool>? ")
+                  .Append(info.PropertyName).AppendLine(" { get; set; }");
+            }
         }
 
         // Constructor.
@@ -711,6 +788,21 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             var id = CtorIdentifier(s);
             var jvmFqn = s.StateJvmType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                 .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+
+            // Phase 4b — assign the developer-supplied delegate onto each
+            // per-instance JCW adapter BEFORE the Remember call so the
+            // adapter is wired up by the time Kotlin invokes it. Skip on
+            // SharedState cache-hit paths because the assignment is
+            // identity-stable (same `_<id>Adapter` field) regardless of
+            // whether Remember runs; doing it unconditionally also avoids
+            // a missed assignment when the developer mutates the property
+            // between renders without a re-Remember.
+            foreach (var info in s.ConfirmStateChanges)
+            {
+                sb.Append("            _").Append(info.FieldIdentifier).Append(".Callback = ")
+                  .Append(info.PropertyName).AppendLine(";");
+            }
+
             if (s.SharedState)
             {
                 EmitStateHolderPreambleShared(sb, s, id, jvmFqn, composerName);
@@ -1229,6 +1321,99 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         SyntaxFacts.GetKeywordKind(name) == SyntaxKind.None ? name : "@" + name;
 
     /// <summary>
+    /// Phase 4b — validate a <c>[ConfirmStateChange]</c> attribute on a
+    /// Remember-bridge user param and produce its emission metadata.
+    /// Reports CN3010 on any failure and returns <c>null</c>.
+    /// </summary>
+    static ConfirmStateChangeInfo? ResolveConfirmStateChange(Context c, IParameterSymbol up,
+        AttributeData attr, string methodName, Location loc, List<Diagnostic> diags)
+    {
+        // (a) IFunction1 / IFunction1? param required.
+        if (KotlinFunctionArity(up.Type) != 1)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                $"[ConfirmStateChange] on Remember parameter '{up.Name}' requires a Kotlin.Jvm.Functions.IFunction1 parameter type; was '{up.Type.ToDisplayString()}'"));
+            return null;
+        }
+
+        // (b) Value type — typeof(T) ctor arg.
+        if (attr.ConstructorArguments.Length == 0 ||
+            attr.ConstructorArguments[0].Value is not INamedTypeSymbol valueType)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                $"[ConfirmStateChange] on Remember parameter '{up.Name}' is missing its required typeof(T) constructor argument"));
+            return null;
+        }
+
+        // (c) Adapter type — explicit AdapterType or convention lookup.
+        INamedTypeSymbol? adapterType = ReadType(attr, "AdapterType");
+        if (adapterType is null)
+        {
+            var conventionName = "ComposeNet." + valueType.Name + "ConfirmStateChange";
+            adapterType = c.Compilation.GetTypeByMetadataName(conventionName);
+            if (adapterType is null)
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                    $"[ConfirmStateChange] on Remember parameter '{up.Name}': cannot resolve adapter type '{conventionName}' by convention; set AdapterType = typeof(...) explicitly"));
+                return null;
+            }
+        }
+
+        // (d) AdapterType must implement Kotlin.Jvm.Functions.IFunction1.
+        bool implementsIFunction1 = adapterType.AllInterfaces.Any(i =>
+            i.Name == "IFunction1" &&
+            i.ContainingNamespace?.ToDisplayString() == "Kotlin.Jvm.Functions");
+        if (!implementsIFunction1)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                $"[ConfirmStateChange] on Remember parameter '{up.Name}': AdapterType '{adapterType.ToDisplayString()}' must implement Kotlin.Jvm.Functions.IFunction1"));
+            return null;
+        }
+
+        // (e) AdapterType must have a public parameterless ctor.
+        bool hasParameterlessCtor = adapterType.InstanceConstructors.Any(ic =>
+            ic.DeclaredAccessibility == Accessibility.Public &&
+            (ic.Parameters.Length == 0 || ic.Parameters.All(pp => pp.HasExplicitDefaultValue)));
+        if (adapterType.InstanceConstructors.Length > 0 && !hasParameterlessCtor)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                $"[ConfirmStateChange] on Remember parameter '{up.Name}': AdapterType '{adapterType.ToDisplayString()}' must declare a public parameterless constructor"));
+            return null;
+        }
+
+        // (f) AdapterType must have an accessible writable `Callback`
+        // property of type Func<T, bool> or Func<T, bool>?.
+        var callbackProp = adapterType.GetMembers("Callback").OfType<IPropertySymbol>().FirstOrDefault();
+        if (callbackProp is null || callbackProp.SetMethod is null)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                $"[ConfirmStateChange] on Remember parameter '{up.Name}': AdapterType '{adapterType.ToDisplayString()}' must declare a writable instance property 'Callback'"));
+            return null;
+        }
+        if (callbackProp.Type is not INamedTypeSymbol ct ||
+            ct.Name != "Func" || ct.ContainingNamespace?.ToDisplayString() != "System" ||
+            ct.TypeArguments.Length != 2 ||
+            !SymbolEqualityComparer.Default.Equals(ct.TypeArguments[0], valueType) ||
+            ct.TypeArguments[1].SpecialType != SpecialType.System_Boolean)
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                $"[ConfirmStateChange] on Remember parameter '{up.Name}': AdapterType '{adapterType.ToDisplayString()}'.Callback must be 'System.Func<{valueType.ToDisplayString()}, bool>?'"));
+            return null;
+        }
+
+        // (g) Optional property name override; default = "ConfirmStateChange".
+        string propertyName = ReadString(attr, "PropertyName") ?? "ConfirmStateChange";
+        if (!SyntaxFacts.IsValidIdentifier(propertyName))
+        {
+            diags.Add(Diagnostic.Create(Diagnostics.FacadeConfirmStateChangeInvalid, loc, methodName,
+                $"[ConfirmStateChange] on Remember parameter '{up.Name}': PropertyName '{propertyName}' is not a valid C# identifier"));
+            return null;
+        }
+
+        return new ConfirmStateChangeInfo(up, adapterType, valueType, propertyName);
+    }
+
+    /// <summary>
     /// Phase 4b — resolve the wrapper-side member name for a Remember
     /// bridge user parameter. Tries an exact <see cref="Pascal"/> match
     /// first, then falls back to <c>Initial&lt;Pascal&gt;</c> for the
@@ -1309,6 +1494,42 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         return false;
     }
 
+    /// <summary>
+    /// Phase 4b — metadata for a <c>[ConfirmStateChange(typeof(T))]</c>
+    /// Remember-bridge parameter. The facade allocates one JCW
+    /// instance per node (<c>readonly</c> field
+    /// <c>_&lt;FieldIdentifier&gt;</c>), exposes a developer-mutable
+    /// <c>Func&lt;T, bool&gt;? &lt;PropertyName&gt;</c> property, and
+    /// assigns <c>_&lt;FieldIdentifier&gt;.Callback = &lt;PropertyName&gt;</c>
+    /// in the Render preamble before the <c>RememberXxxState</c> call.
+    /// The Remember bridge sees a stable JNI reference (the JCW), so
+    /// Kotlin's <c>remember</c> cache key is unaffected when the
+    /// developer rewires the C# delegate.
+    /// </summary>
+    internal readonly struct ConfirmStateChangeInfo
+    {
+        public ConfirmStateChangeInfo(IParameterSymbol rememberParam,
+            INamedTypeSymbol adapterType, INamedTypeSymbol valueType, string propertyName)
+        {
+            RememberParam = rememberParam;
+            AdapterType = adapterType;
+            ValueType = valueType;
+            PropertyName = propertyName;
+        }
+        public IParameterSymbol RememberParam { get; }
+        public INamedTypeSymbol AdapterType { get; }
+        public INamedTypeSymbol ValueType { get; }
+        public string PropertyName { get; }
+        /// <summary>
+        /// Backing-field identifier (no leading underscore). Conventional
+        /// form: lowercased first char of <see cref="PropertyName"/> plus
+        /// <c>"Adapter"</c>. Two different <see cref="PropertyName"/>s
+        /// produce two different fields.
+        /// </summary>
+        public string FieldIdentifier =>
+            char.ToLowerInvariant(PropertyName[0]) + PropertyName.Substring(1) + "Adapter";
+    }
+
     internal enum FacadeSlotKind
     {
         Modifier,
@@ -1334,7 +1555,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             ITypeSymbol? callbackType = null, string? slotPropertyName = null,
             string? rememberMethodName = null, INamedTypeSymbol? stateWrapperType = null,
             ITypeSymbol? stateJvmType = null, string[]? rememberArgExpressions = null,
-            bool sharedState = false)
+            bool sharedState = false, ConfirmStateChangeInfo[]? confirmStateChanges = null)
         {
             Param = param;
             Kind = kind;
@@ -1345,6 +1566,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             StateJvmType = stateJvmType;
             RememberArgExpressions = rememberArgExpressions ?? System.Array.Empty<string>();
             SharedState = sharedState;
+            ConfirmStateChanges = confirmStateChanges ?? System.Array.Empty<ConfirmStateChangeInfo>();
         }
         public IParameterSymbol Param { get; }
         public FacadeSlotKind Kind { get; }
@@ -1357,8 +1579,10 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         /// Phase 4b — one C# expression per user parameter of the
         /// <c>Remember*State</c> bridge (composer excluded). Each expression
         /// reads a member of the caller-supplied state wrapper, e.g.
-        /// <c>_state!.InitialHour</c>. Empty when the Remember bridge has
-        /// zero user params (Phase 4).
+        /// <c>_state!.InitialHour</c>. For Remember params marked with
+        /// <c>[ConfirmStateChange]</c>, the expression instead reads the
+        /// per-instance JCW field (e.g. <c>_confirmStateChangeAdapter</c>).
+        /// Empty when the Remember bridge has zero user params (Phase 4).
         /// </summary>
         public string[] RememberArgExpressions { get; }
         /// <summary>
@@ -1368,6 +1592,12 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         /// call in that case, reusing the cached JNI handle.
         /// </summary>
         public bool SharedState { get; }
+        /// <summary>
+        /// Phase 4b — zero or more <c>[ConfirmStateChange]</c> Remember
+        /// params hoisted to per-node JCW adapter fields with stable
+        /// JNI identity.
+        /// </summary>
+        public ConfirmStateChangeInfo[] ConfirmStateChanges { get; }
         public bool HasSlotAttribute => SlotPropertyName is not null;
         public bool IsNullableSlot => Param.NullableAnnotation == NullableAnnotation.Annotated
             && KindIsFnSlot(Kind);
@@ -1379,6 +1609,6 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
               or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3;
         public FacadeSlot WithKind(FacadeSlotKind newKind) =>
             new(Param, newKind, CallbackType, SlotPropertyName, RememberMethodName,
-                StateWrapperType, StateJvmType, RememberArgExpressions, SharedState);
+                StateWrapperType, StateJvmType, RememberArgExpressions, SharedState, ConfirmStateChanges);
     }
 }

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -669,7 +669,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             sb.Append("        readonly ").Append(typeRef).Append(" _").Append(CtorIdentifier(s)).AppendLine(";");
         }
 
-        // Phase 4b — per-instance JCW veto adapter fields. One per
+        // Phase 9 — per-instance JCW veto adapter fields. One per
         // [ConfirmStateChange] across all StateHolder slots. Stable
         // JNI identity for Kotlin's `remember` cache key.
         foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.StateHolder))
@@ -707,7 +707,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
               .Append(PropertyName(s)).AppendLine(" { get; set; }");
         }
 
-        // Phase 4b — public `Func<T, bool>?` properties for each
+        // Phase 9 — public `Func<T, bool>?` properties for each
         // [ConfirmStateChange] adapter. Null = "always allow"; the
         // adapter's Invoke reads this property each call.
         foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.StateHolder))
@@ -789,7 +789,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             var jvmFqn = s.StateJvmType!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                 .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
 
-            // Phase 4b — assign the developer-supplied delegate onto each
+            // Phase 9 — assign the developer-supplied delegate onto each
             // per-instance JCW adapter BEFORE the Remember call so the
             // adapter is wired up by the time Kotlin invokes it. Skip on
             // SharedState cache-hit paths because the assignment is
@@ -1321,7 +1321,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         SyntaxFacts.GetKeywordKind(name) == SyntaxKind.None ? name : "@" + name;
 
     /// <summary>
-    /// Phase 4b — validate a <c>[ConfirmStateChange]</c> attribute on a
+    /// Phase 9 — validate a <c>[ConfirmStateChange]</c> attribute on a
     /// Remember-bridge user param and produce its emission metadata.
     /// Reports CN3010 on any failure and returns <c>null</c>.
     /// </summary>
@@ -1495,7 +1495,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     }
 
     /// <summary>
-    /// Phase 4b — metadata for a <c>[ConfirmStateChange(typeof(T))]</c>
+    /// Phase 9 — metadata for a <c>[ConfirmStateChange(typeof(T))]</c>
     /// Remember-bridge parameter. The facade allocates one JCW
     /// instance per node (<c>readonly</c> field
     /// <c>_&lt;FieldIdentifier&gt;</c>), exposes a developer-mutable
@@ -1593,7 +1593,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         /// </summary>
         public bool SharedState { get; }
         /// <summary>
-        /// Phase 4b — zero or more <c>[ConfirmStateChange]</c> Remember
+        /// Phase 9 — zero or more <c>[ConfirmStateChange]</c> Remember
         /// params hoisted to per-node JCW adapter fields with stable
         /// JNI identity.
         /// </summary>

--- a/src/ComposeNet.SourceGenerators/Diagnostics.cs
+++ b/src/ComposeNet.SourceGenerators/Diagnostics.cs
@@ -163,4 +163,12 @@ internal static class Diagnostics
         category: "ComposeNet",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor FacadeConfirmStateChangeInvalid = new(
+        id: "CN3010",
+        title: "[ConfirmStateChange] configuration is invalid",
+        messageFormat: "Facade for bridge '{0}': {1}",
+        category: "ComposeNet",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }


### PR DESCRIPTION
Fixes #121.

Introduces **Phase 9** of the facade generator: `[ConfirmStateChange(typeof(T))]` on a Remember bridge's `IFunction1?` parameter, which models the per-instance JNI veto adapter pattern (Kotlin's `rememberDrawerState(confirmStateChange)`, `rememberSheetState(confirmValueChange)`) with stable JNI identity across recompositions. The generator allocates a single `readonly` adapter field, exposes `Func<T, bool>? ConfirmStateChange { get; set; }`, and assigns `adapter.Callback = ConfirmStateChange` in the Render preamble before the Remember call.

Also adds **`[ComposeFacade(Container = true)]`** for hybrid-container facades whose body slot is a non-`@Composable` `IFunction2` (rather than a scope-providing `IFunction3`). Required by `ModalWideNavigationRail`.

## Migrated facades

| Facade | Veto adapter | Container = true |
|---|---|---|
| `ModalNavigationDrawer` | ✅ `[ConfirmStateChange(typeof(DrawerValue))]` | |
| `DismissibleNavigationDrawer` | ✅ | |
| `PermanentNavigationDrawer` | (drawer always open — no veto) | |
| `ModalWideNavigationRail` | (rail has no veto in Kotlin) | ✅ |

Net **355 lines of hand-written facade code removed**.

## Other changes

- Adds `DrawerStateHolder` and `WideNavigationRailState` Phase 4b state wrappers (the `Holder` suffix avoids a name clash with the bound `AndroidX.Compose.Material3.DrawerState` class).
- Renames `DrawerConfirmStateChange` → `DrawerValueConfirmStateChange` to match the generator's convention lookup `<TName>ConfirmStateChange`, and promotes it to `public sealed`.
- Adds wrapper-passthrough `RememberDrawerState` / `RememberWideNavigationRailState` helpers to `ComposeBridges` that delegate to the bound `NavigationDrawerKt.*` methods.
- Fixes a Phase 4b bug where the StateHolder field name was hardcoded as `_state` instead of derived from the param name; existing `TimePicker` passed by coincidence (its param is literally `state`). Now correctly emits `_drawerState!.InitialValue` etc.
- New diagnostic **CN3010** for invalid `[ConfirmStateChange]` configurations (wrong arity, missing adapter class, adapter doesn't implement `IFunction1`, missing `Callback` property of right type, etc.).
- 3 new generator tests (happy path + 2 CN3010 cases). All **96/96 tests pass**.
- `.github/copilot-instructions.md` updated: documents Phase 9 + `Container = true`, removes drawer family from the "stay hand-written" list, adds CN3010 to the diagnostics table.

## Verification

- `dotnet test src/ComposeNet.SourceGenerators.Tests` → 96/96 ✅
- `dotnet build src/ComposeNet.Compose` → 0 errors ✅
- `dotnet build src/ComposeNet.Sample` → 0 errors ✅
- The drawer page in the sample is unchanged — the new ctors all accept defaulted `state = null`, so existing collection-init call sites keep working.