### PR TITLE
Bind Compose animation primitives (#56)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,6 +24,10 @@
     <PackageReference Update="Xamarin.AndroidX.Activity.Compose" Version="1.13.0" />
 
     <!-- AndroidX Compose -->
+    <PackageReference Update="Xamarin.AndroidX.Compose.Animation" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Animation.Android" Version="1.11.2.1" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Animation.Core" Version="1.11.2" />
+    <PackageReference Update="Xamarin.AndroidX.Compose.Animation.Core.Android" Version="1.11.2.1" />
     <PackageReference Update="Xamarin.AndroidX.Compose.Foundation" Version="1.11.2.1" />
     <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Android" Version="1.11.2.1" />
     <PackageReference Update="Xamarin.AndroidX.Compose.Foundation.Layout" Version="1.11.2" />

--- a/src/ComposeNet.Compose/AnimatedContent.cs
+++ b/src/ComposeNet.Compose/AnimatedContent.cs
@@ -1,0 +1,95 @@
+using AndroidX.Compose.Animation;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// <c>AnimatedContent</c> — animates between content keyed by
+/// <typeparamref name="T"/>. When <see cref="TargetState"/> changes,
+/// the previous content animates out as the new content animates in,
+/// using Compose's default <c>ContentTransform</c> (a fade + size
+/// animation).
+/// </summary>
+/// <typeparam name="T">
+/// The state type. Same constraints as <see cref="Crossfade{T}"/>:
+/// a primitive boxable to a <see cref="Java.Lang.Object"/> wrapper,
+/// or a <see cref="Java.Lang.Object"/> subclass.
+/// </typeparam>
+/// <remarks>
+/// <para>Mirror of the bound <c>(targetState: T, ...)</c> overload of
+/// <c>androidx.compose.animation.AnimatedContentKt.AnimatedContent</c> —
+/// no JNI bridge needed; every parameter except <c>targetState</c>
+/// and <c>content</c> defaults to Kotlin's value.</para>
+/// <para>The <c>content</c> callback receives the state
+/// value Compose is currently rendering — during a transition both
+/// the previous and new values are rendered simultaneously while one
+/// animates out and the other animates in. The
+/// <c>AnimatedContentScope</c> receiver (which exposes
+/// <c>Modifier.animateEnterExit</c>) is not surfaced in v1.</para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var step = Remember(() => new MutableNumberState&lt;int&gt;(0));
+/// new AnimatedContent&lt;int&gt;(
+///     targetState: step.Value,
+///     content:     i => new Text($"Step {i}"))
+/// </code>
+/// </example>
+public sealed class AnimatedContent<T> : ComposableNode
+{
+    readonly T _targetState;
+    readonly System.Func<T, ComposableNode> _content;
+
+    /// <summary>Build an AnimatedContent keyed on <paramref name="targetState"/> with per-state content.</summary>
+    /// <param name="targetState">The state value that drives the transition.</param>
+    /// <param name="content">Builds the <see cref="ComposableNode"/> to display for a given state value. Invoked once per active state during the transition.</param>
+    public AnimatedContent(T targetState, System.Func<T, ComposableNode> content)
+    {
+        _targetState = targetState;
+        _content     = content ?? throw new System.ArgumentNullException(nameof(content));
+    }
+
+    /// <summary>The state value passed to the underlying <c>AnimatedContent</c>.</summary>
+    public T TargetState => _targetState;
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+        var boxed    = MutableState<T>.ToJava(_targetState);
+
+        // The Function4<AnimatedContentScope, T, Composer, Int, Unit>
+        // content slot delivers (scope, boxedState, composer, $changed).
+        // We discard the scope (animateEnterExit not surfaced in v1)
+        // and unbox the second arg back to T.
+        var content = ComposableLambdas.Wrap4(composer, (scope, p1, c) =>
+        {
+            T value = MutableState<T>.FromJava(p1);
+            _content(value).Render(c);
+        });
+
+        // $default bit positions (Kotlin source order):
+        //   0 = targetState       (always provided → cleared)
+        //   1 = modifier          (cleared when caller set it)
+        //   2 = transitionSpec    (left set → use Compose default)
+        //   3 = contentAlignment  (left set → use Compose default)
+        //   4 = label             (left set → use Compose default)
+        //   5 = contentKey        (left set → use Compose default)
+        //   6 = content           (always provided → cleared)
+        int defaults = (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5);
+        if (modifier is null) defaults |= 1 << 1;
+
+        AnimatedContentKt.AnimatedContent(
+            targetState:      boxed,
+            modifier:         modifier,
+            transitionSpec:   null,
+            contentAlignment: null,
+            label:            null,
+            contentKey:       null,
+            content:          content,
+            _composer:        composer,
+            p8:               0,            // $changed
+            _changed:         defaults);    // $default
+
+        System.GC.KeepAlive(boxed);
+    }
+}

--- a/src/ComposeNet.Compose/AnimatedContent.cs
+++ b/src/ComposeNet.Compose/AnimatedContent.cs
@@ -89,7 +89,5 @@ public sealed class AnimatedContent<T> : ComposableNode
             _composer:        composer,
             p8:               0,            // $changed
             _changed:         defaults);    // $default
-
-        System.GC.KeepAlive(boxed);
     }
 }

--- a/src/ComposeNet.Compose/AnimatedVisibility.cs
+++ b/src/ComposeNet.Compose/AnimatedVisibility.cs
@@ -1,0 +1,62 @@
+using AndroidX.Compose.Animation;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// <c>AnimatedVisibility</c> — animates the appearance and disappearance
+/// of its content as <see cref="Visible"/> toggles. The default
+/// transitions fade and expand/shrink the content; v1 uses Compose's
+/// defaults rather than exposing the
+/// <c>EnterTransition</c> / <c>ExitTransition</c> factory functions
+/// (<c>fadeIn()</c>, <c>slideInVertically()</c>, etc.) — wire those up
+/// in a follow-up once the animation transition factories are exposed
+/// in the binding.
+/// </summary>
+/// <remarks>
+/// Children are rendered through Compose's <c>AnimatedVisibilityScope</c>
+/// receiver. The scope's helpers (<c>Modifier.animateEnterExit</c>) are
+/// not exposed in v1 — children render with the discarded scope.
+/// Mirror of the bound
+/// <see cref="AnimatedVisibilityKt.AnimatedVisibility(bool, AndroidX.Compose.UI.IModifier?, EnterTransition?, ExitTransition?, string?, Kotlin.Jvm.Functions.IFunction3, IComposer?, int, int)"/>
+/// overload — no JNI bridge, every parameter except <c>visible</c> and
+/// <c>content</c> defaults to Kotlin's value.
+/// </remarks>
+public sealed class AnimatedVisibility : ComposableContainer
+{
+    readonly bool _visible;
+
+    /// <summary>Build an AnimatedVisibility container with the given visibility.</summary>
+    /// <param name="visible">When <see langword="true"/> the content is shown (entering if previously hidden); when <see langword="false"/> the content is hidden (exiting if previously shown).</param>
+    public AnimatedVisibility(bool visible) => _visible = visible;
+
+    /// <summary>Current visibility passed to the underlying Compose <c>AnimatedVisibility</c>.</summary>
+    public bool Visible => _visible;
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier = BuildModifier();
+        var content  = ComposableLambdas.Wrap3(composer, RenderChildren);
+
+        // $default bit positions (Kotlin source order):
+        //   0 = visible        (always provided → cleared)
+        //   1 = modifier       (cleared when caller set it)
+        //   2 = enter          (left set → use Compose default)
+        //   3 = exit           (left set → use Compose default)
+        //   4 = label          (left set → use Compose default)
+        //   5 = content        (always provided → cleared)
+        int defaults = (1 << 2) | (1 << 3) | (1 << 4);
+        if (modifier is null) defaults |= 1 << 1;
+
+        AnimatedVisibilityKt.AnimatedVisibility(
+            visible:   _visible,
+            modifier:  modifier,
+            enter:     null,
+            exit:      null,
+            label:     null,
+            content:   content,
+            _composer: composer,
+            p7:        0,           // $changed
+            _changed:  defaults);   // $default
+    }
+}

--- a/src/ComposeNet.Compose/ComposableLambda3.cs
+++ b/src/ComposeNet.Compose/ComposableLambda3.cs
@@ -9,23 +9,37 @@ namespace ComposeNet;
 /// content. <c>p0</c> is the receiver scope (RowScope/ColumnScope),
 /// <c>p1</c> is the composer, <c>p2</c> is <c>$changed</c>.
 ///
-/// Two ctors: the <c>Action&lt;IComposer&gt;</c> form discards the scope
-/// (used wherever children don't need to know it — Column, Box, Button);
-/// the <c>Action&lt;IntPtr, IComposer&gt;</c> form receives the raw scope
-/// handle, used by container composables whose children are
-/// extension-receiver composables (<c>RowScope.NavigationBarItem</c>).
-/// The scope is published via <see cref="RenderContext"/> so the child
-/// <c>Render</c> can read it.
+/// Three ctors:
+/// <list type="bullet">
+///   <item><description><c>Action&lt;IComposer&gt;</c> discards the scope —
+///     used wherever children don't need to know it (Column, Box,
+///     Button).</description></item>
+///   <item><description><c>Action&lt;IntPtr, IComposer&gt;</c> receives the
+///     raw scope handle, used by container composables whose children
+///     are extension-receiver composables (<c>RowScope.NavigationBarItem</c>).
+///     The scope is published via <see cref="RenderContext"/> so the
+///     child <c>Render</c> can read it.</description></item>
+///   <item><description><c>Action&lt;Java.Lang.Object?, IComposer&gt;</c>
+///     receives the boxed <c>p0</c> as a <see cref="Java.Lang.Object"/>.
+///     Used by value-typed Function3 slots — e.g.
+///     <c>Crossfade</c>'s <c>content: @Composable (T) -&gt; Unit</c>
+///     where <c>p0</c> is the boxed targetState rather than a scope
+///     receiver — so the body can unbox to the user-facing
+///     <c>T</c>.</description></item>
+/// </list>
 /// </summary>
 [Register("composenet/compose/ComposableLambda3")]
 internal sealed class ComposableLambda3 : Java.Lang.Object, IFunction3
 {
-    readonly System.Action<IntPtr, IComposer> _body;
+    readonly System.Action<Java.Lang.Object?, IComposer> _body;
 
     public ComposableLambda3(System.Action<IComposer> body)
-        : this((_, c) => body(c)) { }
+        : this((Java.Lang.Object? _, IComposer c) => body(c)) { }
 
-    public ComposableLambda3(System.Action<IntPtr, IComposer> body) => _body = body;
+    public ComposableLambda3(System.Action<IntPtr, IComposer> body)
+        : this((Java.Lang.Object? p0, IComposer c) => body(p0?.Handle ?? IntPtr.Zero, c)) { }
+
+    public ComposableLambda3(System.Action<Java.Lang.Object?, IComposer> body) => _body = body;
 
     // Kotlin Function3<Scope, Composer, Int, Unit> contractually returns
     // Unit.INSTANCE. See ComposableLambda0 / issue #43 for the rationale.
@@ -34,7 +48,7 @@ internal sealed class ComposableLambda3 : Java.Lang.Object, IFunction3
         System.ArgumentNullException.ThrowIfNull(p1);
         var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p1);
         using var _ = ComposeContext.Push(composer);
-        _body(p0?.Handle ?? IntPtr.Zero, composer);
+        _body(p0, composer);
         return global::Kotlin.Unit.Instance!;
     }
 }

--- a/src/ComposeNet.Compose/ComposableLambdas.cs
+++ b/src/ComposeNet.Compose/ComposableLambdas.cs
@@ -96,6 +96,31 @@ internal static class ComposableLambdas
             block: new ComposableLambda3(body));
 
     /// <summary>
+    /// Wrap an <see cref="Action{IComposer}"/> as an identity-stable
+    /// <see cref="IFunction3"/> that receives the boxed <c>p0</c> as a
+    /// <see cref="Java.Lang.Object"/> — the value-typed Function3 shape
+    /// used by <c>Crossfade</c>'s
+    /// <c>content: @Composable (T) -&gt; Unit</c>, where <c>p0</c> is
+    /// the boxed targetState (not a scope receiver). The body unboxes
+    /// it back to <c>T</c>.
+    /// </summary>
+    /// <remarks>
+    /// Distinct method name (rather than a third <c>Wrap3</c>
+    /// overload) so existing call sites that pass
+    /// <c>(_, c) =&gt; ...</c> aren't ambiguous between the
+    /// <c>Action&lt;IntPtr, IComposer&gt;</c> and
+    /// <c>Action&lt;Java.Lang.Object?, IComposer&gt;</c> shapes.
+    /// </remarks>
+    public static IFunction3 Wrap3WithValue(
+        IComposer composer,
+        Action<Java.Lang.Object?, IComposer> body,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => (IFunction3)ComposableLambdaKt.ComposableLambda(
+            composer, SourceLocationKey.Compute(line, file), tracked: true,
+            block: new ComposableLambda3(body));
+
+    /// <summary>
     /// Build an identity-stable <see cref="IFunction4"/> wrapper for the
     /// <c>Function4&lt;LazyItemScope, Int, Composer, Int, Unit&gt;</c>
     /// @Composable shape used by <c>LazyListScope.items</c> and

--- a/src/ComposeNet.Compose/ComposeNet.Compose.csproj
+++ b/src/ComposeNet.Compose/ComposeNet.Compose.csproj
@@ -34,6 +34,10 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Activity" />
     <PackageReference Include="Xamarin.AndroidX.Activity.Compose" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.Animation" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.Animation.Android" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.Animation.Core" />
+    <PackageReference Include="Xamarin.AndroidX.Compose.Animation.Core.Android" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Runtime" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Android" />
     <PackageReference Include="Xamarin.AndroidX.Compose.Runtime.Saveable" />

--- a/src/ComposeNet.Compose/Crossfade.cs
+++ b/src/ComposeNet.Compose/Crossfade.cs
@@ -1,0 +1,103 @@
+using AndroidX.Compose.Animation;
+using AndroidX.Compose.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// <c>Crossfade</c> — fades between content keyed by
+/// <typeparamref name="T"/>. When <see cref="TargetState"/> changes,
+/// the content for the previous and new states are both rendered for
+/// the duration of the crossfade animation while one fades out and
+/// the other fades in.
+/// </summary>
+/// <typeparam name="T">
+/// The state type. Must be one of the <see cref="MutableState{T}"/>-supported
+/// boxable types: a primitive (<c>bool</c>, <c>int</c>, <c>long</c>,
+/// <c>float</c>, <c>double</c>, <c>string</c>, <c>char</c>, the byte
+/// / short / unsigned numeric variants), or a
+/// <see cref="Java.Lang.Object"/> subclass. Other reference types are
+/// not supported because there is no clean Java box for them — wrap
+/// such state in a key type the user controls (e.g. an
+/// <c>int</c> page index) and render the actual content in the
+/// callback.
+/// </typeparam>
+/// <remarks>
+/// <para>Mirror of the bound <c>(targetState: T, ...)</c> overload of
+/// <c>androidx.compose.animation.CrossfadeKt.Crossfade</c> — no JNI
+/// bridge needed; every parameter except <c>targetState</c> and
+/// <c>content</c> defaults to Kotlin's value.</para>
+/// <para>The <c>content</c> callback receives the state
+/// value Compose is currently rendering — typically the
+/// <see cref="TargetState"/> after settling, but during a crossfade
+/// transition it is invoked once per active state (the previous and
+/// the new value). Make sure the callback returns the right node for
+/// the value it receives, not just for the current
+/// <see cref="TargetState"/>.</para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var page = Remember(() => new MutableNumberState&lt;int&gt;(0));
+/// new Crossfade&lt;int&gt;(
+///     targetState: page.Value,
+///     content:     i => new Text($"Page {i}"))
+/// </code>
+/// </example>
+public sealed class Crossfade<T> : ComposableNode
+{
+    readonly T _targetState;
+    readonly System.Func<T, ComposableNode> _content;
+
+    /// <summary>Build a Crossfade keyed on <paramref name="targetState"/> with per-state content.</summary>
+    /// <param name="targetState">The state value that drives the fade.</param>
+    /// <param name="content">Builds the <see cref="ComposableNode"/> to display for a given state value. Invoked once per active state during a crossfade transition.</param>
+    public Crossfade(T targetState, System.Func<T, ComposableNode> content)
+    {
+        _targetState = targetState;
+        _content     = content ?? throw new System.ArgumentNullException(nameof(content));
+    }
+
+    /// <summary>The state value passed to the underlying <c>Crossfade</c>.</summary>
+    public T TargetState => _targetState;
+
+    internal override void Render(IComposer composer)
+    {
+        var modifier  = BuildModifier();
+        var boxed     = MutableState<T>.ToJava(_targetState);
+
+        // p0 carries the boxed state value (Function3<T, Composer, Int, Unit>).
+        // Unbox back to T so the caller's builder receives a typed value
+        // matching whatever Compose is rendering for this pass — could be
+        // the previous OR new target during a crossfade transition.
+        var content = ComposableLambdas.Wrap3WithValue(composer, (p0, c) =>
+        {
+            T value = MutableState<T>.FromJava(p0);
+            _content(value).Render(c);
+        });
+
+        // $default bit positions (Kotlin source order):
+        //   0 = targetState    (always provided → cleared)
+        //   1 = modifier       (cleared when caller set it)
+        //   2 = animationSpec  (left set → use Compose default tween)
+        //   3 = label          (left set → use Compose default)
+        //   4 = content        (always provided → cleared)
+        int defaults = (1 << 2) | (1 << 3);
+        if (modifier is null) defaults |= 1 << 1;
+
+        CrossfadeKt.Crossfade(
+            targetState:   boxed,
+            modifier:      modifier,
+            animationSpec: null,
+            label:         null,
+            content:       content,
+            _composer:     composer,
+            p6:            0,           // $changed
+            _changed:      defaults);   // $default
+
+        // Boxed Java.Lang.Integer/Boolean/etc allocated by ToJava: keep
+        // alive until after the binding call returns. The bound method
+        // already KeepAlive's its `targetState` parameter, but boxed is
+        // a fresh allocation we own — extending its lifetime past the
+        // GC.KeepAlive call below is sufficient.
+        System.GC.KeepAlive(boxed);
+    }
+}

--- a/src/ComposeNet.Compose/Crossfade.cs
+++ b/src/ComposeNet.Compose/Crossfade.cs
@@ -92,12 +92,5 @@ public sealed class Crossfade<T> : ComposableNode
             _composer:     composer,
             p6:            0,           // $changed
             _changed:      defaults);   // $default
-
-        // Boxed Java.Lang.Integer/Boolean/etc allocated by ToJava: keep
-        // alive until after the binding call returns. The bound method
-        // already KeepAlive's its `targetState` parameter, but boxed is
-        // a fresh allocation we own — extending its lifetime past the
-        // GC.KeepAlive call below is sufficient.
-        System.GC.KeepAlive(boxed);
     }
 }

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -16,6 +16,12 @@ ComposeNet.AlertDialog.Title.set -> void
 ComposeNet.Alignment
 ComposeNet.Alignment.Horizontal
 ComposeNet.Alignment.Vertical
+ComposeNet.AnimatedContent<T>
+ComposeNet.AnimatedContent<T>.AnimatedContent(T targetState, System.Func<T, ComposeNet.ComposableNode!>! content) -> void
+ComposeNet.AnimatedContent<T>.TargetState.get -> T
+ComposeNet.AnimatedVisibility
+ComposeNet.AnimatedVisibility.AnimatedVisibility(bool visible) -> void
+ComposeNet.AnimatedVisibility.Visible.get -> bool
 ComposeNet.Arrangement
 ComposeNet.AssistChip
 ComposeNet.AssistChip.AssistChip(System.Action! onClick) -> void
@@ -110,6 +116,9 @@ ComposeNet.ComposeActivity.RememberSaveable<T>(System.Func<T>! factory, object? 
 ComposeNet.ComposeActivity.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
 ComposeNet.ComposeActivity.RememberSaveableKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 ComposeNet.ComposeActivity.SetContent(System.Func<ComposeNet.ComposableNode!>! content) -> void
+ComposeNet.Crossfade<T>
+ComposeNet.Crossfade<T>.Crossfade(T targetState, System.Func<T, ComposeNet.ComposableNode!>! content) -> void
+ComposeNet.Crossfade<T>.TargetState.get -> T
 ComposeNet.CustomTab
 ComposeNet.CustomTab.CustomTab(bool selected, System.Action! onClick) -> void
 ComposeNet.DatePicker

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -170,7 +170,13 @@ public class MainActivity : ComposeActivity
             var effectKey   = Remember(() => new MutableNumberState<int>(0));
             var disposeCount = Remember(() => new MutableNumberState<int>(0));
 
-            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy", "Carousels", "Pager", "Nav", "State", "Effects" };
+            // Animation tab (issue #56): drive AnimatedVisibility with a bool,
+            // and Crossfade<int> / AnimatedContent<int> with the same step
+            // counter so the two transitions can be compared side-by-side.
+            var animVisible = Remember(() => new MutableState<bool>(true));
+            var animStep    = Remember(() => new MutableNumberState<int>(0));
+
+            string[] tabNames = { "Basics", "Buttons", "Cards", "Drawer", "Selection", "Pickers", "Misc", "App bars", "Lazy", "Carousels", "Pager", "Nav", "State", "Effects", "Animation" };
 
             // Per-tab content. Only the current tab's column is added to
             // the screen — keeps the sample short enough to fit on one
@@ -1260,6 +1266,62 @@ public class MainActivity : ComposeActivity
                         new Text("Reset counters"),
                     },
                 },
+                14 => new Column
+                {
+                    // Animation tab (issue #56): demonstrate the three Compose
+                    // animation primitives bound by ComposeNet.
+                    //   - AnimatedVisibility: fade/expand a child in and out
+                    //     as a bool toggles.
+                    //   - Crossfade<T>: cross-dissolve between content keyed
+                    //     on a value (here: an int step counter).
+                    //   - AnimatedContent<T>: fade + slight size animation
+                    //     between content for the same key — Material 3's
+                    //     richer counterpart to Crossfade.
+                    new Text("AnimatedVisibility — toggle a child"),
+                    new Button(onClick: () => animVisible.Value = !animVisible.Value)
+                    {
+                        new Text(animVisible.Value ? "Hide" : "Show"),
+                    },
+                    new AnimatedVisibility(animVisible.Value)
+                    {
+                        new Card
+                        {
+                            Modifier.Companion.Padding(8),
+                            new Text("👋 I fade in and out"),
+                        },
+                    },
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+
+                    new Text("Crossfade<int> — cross-dissolve between values"),
+                    new Row(horizontalArrangement: Arrangement.SpacedBy(8))
+                    {
+                        new Button(onClick: () => animStep.Value--)
+                        {
+                            new Text("−"),
+                        },
+                        new Button(onClick: () => animStep.Value++)
+                        {
+                            new Text("+"),
+                        },
+                    },
+                    new Crossfade<int>(
+                        targetState: animStep.Value,
+                        content:     i => new Card
+                        {
+                            Modifier.Companion.Padding(8),
+                            new Text($"Step {i}"),
+                        }),
+                    new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+
+                    new Text("AnimatedContent<int> — same counter, richer transition"),
+                    new AnimatedContent<int>(
+                        targetState: animStep.Value,
+                        content:     i => new Card
+                        {
+                            Modifier.Companion.Padding(8),
+                            new Text($"Frame {i}"),
+                        }),
+                },
                 _ => new Column
                 {
                     // Lazy lists — bound through LazyDslKt / LazyGridDslKt.
@@ -1579,6 +1641,11 @@ public class MainActivity : ComposeActivity
                                 {
                                     Text = new Text("Effects"),
                                     Icon = new Text("⚡"),
+                                },
+                                new Tab(selected: tab.Value == 14, onClick: () => tab.Value = 14)
+                                {
+                                    Text = new Text("Animation"),
+                                    Icon = new Text("🎞"),
                                 },
                             },
                             tabContent,


### PR DESCRIPTION
Closes #56.

Binds `AnimatedVisibility`, `Crossfade<T>` and `AnimatedContent<T>` from `androidx.compose.animation` to the C# facade. All three Kotlin functions are directly bindable from `Xamarin.AndroidX.Compose.Animation.Android` 1.11.2.1, so each facade is hand-written and calls the bound `*Kt` method directly — no JNI bridge needed.

## Public surface

- **`AnimatedVisibility(bool visible)`** — derives from `ComposableContainer` so children can be supplied via collection-init syntax. `enter`/`exit` transitions stay defaulted in v1 (the `EnterTransition` / `ExitTransition` factory functions haven't been surfaced yet — follow-up).
- **`Crossfade<T>(T targetState, Func<T, ComposableNode> content)`** — cross-dissolves between content keyed by `targetState`. `T` inherits `MutableState<T>`'s boxable-types support: primitives plus `Java.Lang.Object` subclasses.
- **`AnimatedContent<T>(T targetState, Func<T, ComposableNode> content)`** — same shape as `Crossfade<T>`; uses Compose's default `ContentTransform`.

## Implementation notes

- Boxing for `Crossfade<T>` / `AnimatedContent<T>` reuses the internal `MutableState<T>.ToJava` / `FromJava` helpers.
- New `ComposableLambdas.Wrap3WithValue` helper exposes the `Function3` slot used by `Crossfade`'s `(T) -> Unit` content lambda — `p0` carries the boxed targetState rather than a scope receiver, so the body unboxes back to `T` before invoking the user callback.
- `ComposableLambda3` gains a third `Action<Java.Lang.Object?, IComposer>` ctor and routes its existing two ctors through it.
- `$default` masks are computed from each Kotlin user param in source order. Always-provided params (`targetState`/`visible`, `content`) clear their bits; always-defaulted params (`animationSpec`, `label`, `transitionSpec`, `contentAlignment`, `enter`, `exit`, `contentKey`) keep their bits set; the modifier bit is cleared only when the caller actually wired one up.

## Sample

Adds an **Animation** (🎞) tab to `MainActivity` driving all three primitives off two state holders (`MutableState<bool>` for `AnimatedVisibility`, `MutableNumberState<int>` for the two value-keyed transitions). Toggle a card in/out and step a counter up/down to compare `Crossfade` vs `AnimatedContent`.

## Build

- Centralised package versions: `Xamarin.AndroidX.Compose.Animation` + `…Animation.Core` (`.Android` variants pinned at 1.11.2.1; non-`.Android` companions at 1.11.2 since 1.11.2.1 wasn't published for those).
- `dotnet build src/ComposeNet.Compose` ✅
- `dotnet build src/ComposeNet.Sample` ✅
- `dotnet test src/ComposeNet.SourceGenerators.Tests` ✅ (93/93)
- `PublicAPI.Unshipped.txt` updated.

## Follow-ups (not in this PR)

- Expose `EnterTransition`/`ExitTransition` factory functions (`fadeIn`, `slideInVertically`, etc.) once their bindings are confirmed clean.
- Surface the `AnimatedVisibilityScope` / `AnimatedContentScope` receivers so children can call `Modifier.animateEnterExit`.
- Consider also binding the `Transition`-based and `MutableTransitionState`-based overloads.