### PR TITLE
Add CancellationToken support to SuspendBridge

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -886,6 +886,16 @@ returns `AndroidUiDispatcher.Main`, which supplies the
 `MonotonicFrameClock` required by animation suspends that use
 `withFrameNanos`.
 
+Both `SuspendBridge.Invoke` overloads accept a trailing optional
+`CancellationToken cancellationToken = default`. When the token fires
+the returned task transitions to **Canceled** (`OperationCanceledException`
+at the awaiter) but the underlying Kotlin suspend body continues to
+its natural completion — there is no `Job` wired into
+`SuspendContinuation.Context` yet, so we cannot ask Kotlin to stop.
+The eventual resume's boxed result is disposed silently. Surface the
+parameter on every new `*Async` facade method and document the
+"awaiter-only" semantics; true Kotlin-side cancel is a follow-up.
+
 ### Adding a new `*Async` method
 
 1. Add a hand-written bridge to `SuspendBridges.cs`. It returns the
@@ -958,21 +968,25 @@ returns `AndroidUiDispatcher.Main`, which supplies the
    ```
 
 2. Add the public facade method and route the bridge through
-   `SuspendBridge.Invoke`:
+   `SuspendBridge.Invoke`. Always surface a trailing
+   `CancellationToken cancellationToken = default` parameter and
+   forward it as the last argument:
    ```csharp
-   public Task<float> DoThingAsync(int value) =>
+   public Task<float> DoThingAsync(int value, CancellationToken cancellationToken = default) =>
        SuspendBridge.Invoke<float>(
            cont => ComposeBridges.MyStateDoThing(
                ((Java.Lang.Object)Jvm).Handle, value, cont),
            static boxed => boxed is Java.Lang.Float f
                ? f.FloatValue()
                : throw new InvalidCastException(
-                   $"Expected java.lang.Float; got '{boxed?.Class?.Name ?? "null"}'"));
+                   $"Expected java.lang.Float; got '{boxed?.Class?.Name ?? "null"}'"),
+           cancellationToken);
 
-   public Task AnimateAsync(int value) =>
+   public Task AnimateAsync(int value, CancellationToken cancellationToken = default) =>
        SuspendBridge.Invoke(cont =>
            ComposeBridges.MyStateAnimate(
-               ((Java.Lang.Object)Jvm).Handle, value, cont));
+               ((Java.Lang.Object)Jvm).Handle, value, cont),
+           cancellationToken);
    ```
 3. Add the new public member(s) to `PublicAPI.Unshipped.txt`.
 

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -746,13 +746,13 @@ ComposeNet.Scaffold.TopBar.set -> void
 ComposeNet.ScrollableTabRow
 ComposeNet.ScrollableTabRow.ScrollableTabRow(int selectedTabIndex) -> void
 ComposeNet.ScrollState
-ComposeNet.ScrollState.AnimateScrollToAsync(int value) -> System.Threading.Tasks.Task!
+ComposeNet.ScrollState.AnimateScrollToAsync(int value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 ComposeNet.ScrollState.CanScrollBackward.get -> bool
 ComposeNet.ScrollState.CanScrollForward.get -> bool
 ComposeNet.ScrollState.IsScrollInProgress.get -> bool
 ComposeNet.ScrollState.MaxValue.get -> int
 ComposeNet.ScrollState.ScrollState(int initial = 0) -> void
-ComposeNet.ScrollState.ScrollToAsync(int value) -> System.Threading.Tasks.Task<float>!
+ComposeNet.ScrollState.ScrollToAsync(int value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<float>!
 ComposeNet.ScrollState.Value.get -> int
 ComposeNet.ScrollState.ViewportSize.get -> int
 ComposeNet.SearchBar

--- a/src/ComposeNet.Compose/ScrollState.cs
+++ b/src/ComposeNet.Compose/ScrollState.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace ComposeNet;
@@ -100,20 +101,28 @@ public sealed class ScrollState
     /// (clamped to <c>[0, MaxValue]</c>). Mirrors Kotlin's
     /// <c>ScrollState.scrollTo(value)</c>.
     /// </summary>
+    /// <param name="value">Target pixel offset.</param>
+    /// <param name="cancellationToken">
+    /// Cancels the returned task with
+    /// <see cref="System.OperationCanceledException"/>. See
+    /// <see cref="SuspendBridge"/> remarks for the current (C#-only)
+    /// cancellation semantics.
+    /// </param>
     /// <returns>
     /// A task whose result is the actual delta the scroll covered (the
     /// Kotlin return) — useful when the requested value was clamped.
     /// Faulted with the wrapped <c>Throwable</c> if Kotlin reports
     /// <c>Result.Failure</c>.
     /// </returns>
-    public Task<float> ScrollToAsync(int value) =>
+    public Task<float> ScrollToAsync(int value, CancellationToken cancellationToken = default) =>
         SuspendBridge.Invoke<float>(
             cont => ComposeBridges.ScrollStateScrollTo(
                 ((Java.Lang.Object)Jvm).Handle, value, cont),
             static boxed => boxed is Java.Lang.Float f
                 ? f.FloatValue()
                 : throw new System.InvalidCastException(
-                    $"Expected java.lang.Float from ScrollState.scrollTo; got '{boxed?.Class?.Name ?? "null"}'"));
+                    $"Expected java.lang.Float from ScrollState.scrollTo; got '{boxed?.Class?.Name ?? "null"}'"),
+            cancellationToken);
 
     /// <summary>
     /// Animate to the given pixel <paramref name="value"/> using the
@@ -121,8 +130,17 @@ public sealed class ScrollState
     /// <c>ScrollState.animateScrollTo(value)</c>; the returned task
     /// completes when the animation lands.
     /// </summary>
-    public Task AnimateScrollToAsync(int value) =>
+    /// <param name="value">Target pixel offset.</param>
+    /// <param name="cancellationToken">
+    /// Cancels the returned task with
+    /// <see cref="System.OperationCanceledException"/>. Note that
+    /// the underlying Kotlin animation keeps running to its natural
+    /// completion — see <see cref="SuspendBridge"/> remarks for the
+    /// current (C#-only) cancellation semantics.
+    /// </param>
+    public Task AnimateScrollToAsync(int value, CancellationToken cancellationToken = default) =>
         SuspendBridge.Invoke(cont =>
             ComposeBridges.ScrollStateAnimateScrollTo(
-                ((Java.Lang.Object)Jvm).Handle, value, cont));
+                ((Java.Lang.Object)Jvm).Handle, value, cont),
+            cancellationToken);
 }

--- a/src/ComposeNet.Compose/SuspendBridge.cs
+++ b/src/ComposeNet.Compose/SuspendBridge.cs
@@ -33,9 +33,10 @@ namespace ComposeNet;
 /// <c>await</c> captured.
 /// </para>
 /// <para>
-/// Cancellation: an optional <see cref="CancellationToken"/> faults
-/// the returned <see cref="Task"/> with
-/// <see cref="System.OperationCanceledException"/> as soon as the
+/// Cancellation: an optional <see cref="CancellationToken"/> cancels
+/// the returned <see cref="Task"/> (transitioning it to
+/// <see cref="TaskStatus.Canceled"/>, so the <c>await</c> throws
+/// <see cref="System.OperationCanceledException"/>) as soon as the
 /// token fires. The Kotlin suspend body keeps running to its natural
 /// completion — we don't yet plumb a <c>Job</c> into
 /// <see cref="SuspendContinuation.Context"/>, so there is no

--- a/src/ComposeNet.Compose/SuspendBridge.cs
+++ b/src/ComposeNet.Compose/SuspendBridge.cs
@@ -96,7 +96,6 @@ internal static class SuspendBridge
         // start a (visible) scroll/animation we'd then have to wait on.
         if (cancellationToken.IsCancellationRequested)
         {
-            cont.ReleaseLifetime();
             cont.Dispose();
             return Task.FromCanceled<T>(cancellationToken);
         }
@@ -112,7 +111,6 @@ internal static class SuspendBridge
             // (e.g. JNI lookup failures, Kotlin throwing inline before
             // creating a Result.Failure) shouldn't surface as
             // synchronous throws from an async-style API.
-            cont.ReleaseLifetime();
             cont.Dispose();
             return Task.FromException<T>(ex);
         }
@@ -132,8 +130,8 @@ internal static class SuspendBridge
                 // Kotlin will resume cont later. Free the local ref to
                 // the sentinel; the cached global lives in
                 // s_suspendedHandle for future comparisons. Leave the
-                // lifetime intact — ReleaseLifetime fires from
-                // ResumeWith when Kotlin actually resumes.
+                // continuation alive — ResumeWith disposes it when
+                // Kotlin actually resumes.
                 JNIEnv.DeleteLocalRef(syncHandle);
             }
             else
@@ -141,10 +139,10 @@ internal static class SuspendBridge
                 // Synchronous completion — funnel through the same
                 // promote-to-global + TCS path as the Kotlin-async
                 // callback (SuspendContinuation.ResumeWith), then
-                // release the lifetime ourselves since Kotlin will
-                // never call ResumeWith on this path.
+                // dispose ourselves since Kotlin will never call
+                // ResumeWith on this path.
                 cont.CompleteWithLocalHandle(syncHandle);
-                cont.ReleaseLifetime();
+                cont.Dispose();
             }
         }
         else
@@ -153,7 +151,7 @@ internal static class SuspendBridge
             // result (rare in practice; most suspends either suspend or
             // return a boxed Unit / boxed primitive).
             cont.CompleteWithLocalHandle(IntPtr.Zero);
-            cont.ReleaseLifetime();
+            cont.Dispose();
         }
 
         return AwaitAndUnbox(cont, unbox);
@@ -184,7 +182,7 @@ internal static class SuspendBridge
         {
             // Belt-and-suspenders: the state machine already roots cont
             // across the await, but this also covers the synchronous-
-            // completion path where ReleaseLifetime already ran (the
+            // completion path where Dispose already ran (the
             // pin is gone, so only the state-machine field keeps cont
             // alive while we touch its TCS).
             GC.KeepAlive(cont);

--- a/src/ComposeNet.Compose/SuspendBridge.cs
+++ b/src/ComposeNet.Compose/SuspendBridge.cs
@@ -33,9 +33,16 @@ namespace ComposeNet;
 /// <c>await</c> captured.
 /// </para>
 /// <para>
-/// v1 does not honour <see cref="CancellationToken"/>. Cancellation
-/// support needs a <c>Job</c>-bearing <see cref="Kotlin.Coroutines.ICoroutineContext"/>
-/// (~50 LOC); deferred to a follow-up issue.
+/// Cancellation: an optional <see cref="CancellationToken"/> faults
+/// the returned <see cref="Task"/> with
+/// <see cref="System.OperationCanceledException"/> as soon as the
+/// token fires. The Kotlin suspend body keeps running to its natural
+/// completion — we don't yet plumb a <c>Job</c> into
+/// <see cref="SuspendContinuation.Context"/>, so there is no
+/// Kotlin-side cancel. The boxed result of the eventual resume is
+/// disposed silently. True Kotlin-side cancel (calling
+/// <c>job.cancel()</c> so animation/scroll bodies stop at the next
+/// suspend point) is tracked as a follow-up.
 /// </para>
 /// </remarks>
 internal static class SuspendBridge
@@ -61,16 +68,39 @@ internal static class SuspendBridge
     /// <param name="unbox">
     /// Converts the success-value box (e.g. <c>java.lang.Float</c>) to
     /// the target C# type. May be passed <c>null</c> for suspend
-    /// functions that return <c>Unit</c>.
+    /// functions that return <c>Unit</c>. The supplied box is owned
+    /// by <see cref="Invoke{T}"/> and disposed after this delegate
+    /// returns; do not capture or return the box itself.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancels the returned task. See the type-level remarks for the
+    /// (current) semantics: only the C# awaiter sees the cancel; the
+    /// Kotlin suspend body keeps running.
     /// </param>
     public static Task<T> Invoke<T>(
         Func<SuspendContinuation, IntPtr> call,
-        Func<Java.Lang.Object?, T> unbox)
+        Func<Java.Lang.Object?, T> unbox,
+        CancellationToken cancellationToken = default)
     {
         if (call is null) throw new ArgumentNullException(nameof(call));
         if (unbox is null) throw new ArgumentNullException(nameof(unbox));
 
-        var cont = new SuspendContinuation();
+        if (cancellationToken.IsCancellationRequested)
+            return Task.FromCanceled<T>(cancellationToken);
+
+        var cont = new SuspendContinuation(cancellationToken);
+
+        // The ctor's Register call invokes the cancellation callback
+        // synchronously if the token fires between the pre-check above
+        // and registration. Re-check before invoking Kotlin so we don't
+        // start a (visible) scroll/animation we'd then have to wait on.
+        if (cancellationToken.IsCancellationRequested)
+        {
+            cont.ReleaseLifetime();
+            cont.Dispose();
+            return Task.FromCanceled<T>(cancellationToken);
+        }
+
         IntPtr syncHandle;
         try
         {
@@ -82,7 +112,7 @@ internal static class SuspendBridge
             // (e.g. JNI lookup failures, Kotlin throwing inline before
             // creating a Result.Failure) shouldn't surface as
             // synchronous throws from an async-style API.
-            cont.AbandonPin();
+            cont.ReleaseLifetime();
             cont.Dispose();
             return Task.FromException<T>(ex);
         }
@@ -101,15 +131,20 @@ internal static class SuspendBridge
             {
                 // Kotlin will resume cont later. Free the local ref to
                 // the sentinel; the cached global lives in
-                // s_suspendedHandle for future comparisons.
+                // s_suspendedHandle for future comparisons. Leave the
+                // lifetime intact — ReleaseLifetime fires from
+                // ResumeWith when Kotlin actually resumes.
                 JNIEnv.DeleteLocalRef(syncHandle);
             }
             else
             {
                 // Synchronous completion — funnel through the same
                 // promote-to-global + TCS path as the Kotlin-async
-                // callback (SuspendContinuation.ResumeWith).
+                // callback (SuspendContinuation.ResumeWith), then
+                // release the lifetime ourselves since Kotlin will
+                // never call ResumeWith on this path.
                 cont.CompleteWithLocalHandle(syncHandle);
+                cont.ReleaseLifetime();
             }
         }
         else
@@ -118,43 +153,54 @@ internal static class SuspendBridge
             // result (rare in practice; most suspends either suspend or
             // return a boxed Unit / boxed primitive).
             cont.CompleteWithLocalHandle(IntPtr.Zero);
+            cont.ReleaseLifetime();
         }
 
-        return cont.Tcs.Task.ContinueWith(static (t, state) =>
-        {
-            var (unboxFn, cont) = ((Func<Java.Lang.Object?, T>, SuspendContinuation))state!;
-            // Belt-and-suspenders: keep the JCW alive until completion.
-            GC.KeepAlive(cont);
-
-            // GetAwaiter().GetResult() rather than t.Result so a faulted
-            // TCS surfaces the original exception instead of an
-            // AggregateException wrapper.
-            var boxed = t.GetAwaiter().GetResult();
-            try
-            {
-                if (boxed is not null && KotlinResult.IsFailure(boxed.Handle))
-                    throw KotlinResult.ExtractException(boxed);
-                return unboxFn(boxed);
-            }
-            finally
-            {
-                // Release the global ref the JNI callback promoted in
-                // SuspendContinuation.ResumeWith.
-                boxed?.Dispose();
-            }
-        },
-        (unbox, cont),
-        CancellationToken.None,
-        TaskContinuationOptions.ExecuteSynchronously,
-        TaskScheduler.Default);
+        return AwaitAndUnbox(cont, unbox);
     }
 
     /// <summary>
     /// Non-generic overload for suspend functions that return Kotlin
     /// <c>Unit</c> (e.g. <c>ScrollState.animateScrollTo</c>).
     /// </summary>
-    public static Task Invoke(Func<SuspendContinuation, IntPtr> call) =>
-        Invoke<object?>(call, static _ => null);
+    public static Task Invoke(
+        Func<SuspendContinuation, IntPtr> call,
+        CancellationToken cancellationToken = default) =>
+        Invoke<object?>(call, static _ => null, cancellationToken);
+
+    // Awaits the TCS, runs the failure-vs-success split, and disposes
+    // the boxed result. Lives in its own async method so a cancelled
+    // TCS surfaces as a Canceled (not Faulted) Task — the async state
+    // machine routes an uncaught OperationCanceledException straight
+    // into AsyncTaskMethodBuilder.SetCanceled.
+    static async Task<T> AwaitAndUnbox<T>(SuspendContinuation cont, Func<Java.Lang.Object?, T> unbox)
+    {
+        Java.Lang.Object? boxed;
+        try
+        {
+            boxed = await cont.Tcs.Task.ConfigureAwait(false);
+        }
+        finally
+        {
+            // Belt-and-suspenders: the state machine already roots cont
+            // across the await, but this also covers the synchronous-
+            // completion path where ReleaseLifetime already ran (the
+            // pin is gone, so only the state-machine field keeps cont
+            // alive while we touch its TCS).
+            GC.KeepAlive(cont);
+        }
+
+        try
+        {
+            if (boxed is not null && KotlinResult.IsFailure(boxed.Handle))
+                throw KotlinResult.ExtractException(boxed);
+            return unbox(boxed);
+        }
+        finally
+        {
+            boxed?.Dispose();
+        }
+    }
 
     static bool IsCoroutineSuspended(IntPtr handle)
     {

--- a/src/ComposeNet.Compose/SuspendContinuation.cs
+++ b/src/ComposeNet.Compose/SuspendContinuation.cs
@@ -27,11 +27,9 @@ namespace ComposeNet;
 /// <see cref="ResumeWith(Java.Lang.Object)"/> — fire-and-forget callers
 /// (no one holding the returned <see cref="Task"/>) would otherwise
 /// race the GC. The handle is a normal strong reference, not pinned
-/// in memory. <see cref="ReleaseLifetime(bool)"/> is the single
-/// cleanup entry point: it frees the pin, disposes the
-/// <see cref="CancellationTokenRegistration"/>, and is idempotent
-/// (guarded by an interlocked flag) so the overlapping
-/// completion / cancel / dispose paths can't double-free.
+/// in memory. <see cref="Dispose(bool)"/> is the single, idempotent
+/// cleanup entry point: it releases the pin, the
+/// <see cref="CancellationTokenRegistration"/>, and the JNI peer.
 /// </para>
 /// <para>
 /// Cancellation: when a non-default <see cref="CancellationToken"/>
@@ -50,7 +48,7 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
 {
     GCHandle _selfPin;
     CancellationTokenRegistration _ctr;
-    int _lifetimeReleased;
+    int _disposed;
 
     /// <summary>
     /// Backing TCS exposed for <see cref="SuspendBridge"/>.
@@ -68,10 +66,10 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
         {
             // Allocation-free (state, token) overload: no closure per
             // suspend call. Disposing the registration in
-            // ReleaseLifetime blocks until any in-flight invocation of
+            // Dispose blocks until any in-flight invocation of
             // this callback completes; the callback only touches the
             // (thread-safe) TCS, so there's no deadlock path back into
-            // ReleaseLifetime.
+            // Dispose.
             _ctr = cancellationToken.Register(
                 static (state, token) =>
                 {
@@ -137,7 +135,10 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
         }
         finally
         {
-            ReleaseLifetime();
+            // Continuations are single-resume; Kotlin is done with the
+            // JCW now. Standard IDisposable cleanup releases the pin,
+            // the CTR, and the JNI peer all in one shot.
+            Dispose();
         }
     }
 
@@ -176,34 +177,32 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
     }
 
     /// <summary>
-    /// Single, idempotent cleanup entry point: frees the GCHandle
-    /// self-pin and disposes the <see cref="CancellationTokenRegistration"/>.
-    /// Called from every completion path (Kotlin resume in
-    /// <see cref="ResumeWith"/>, the sync-completion and sync-throw
-    /// paths in <see cref="SuspendBridge.Invoke{T}"/>, and
-    /// <see cref="Dispose(bool)"/>).
+    /// Releases the GCHandle self-pin, disposes the
+    /// <see cref="CancellationTokenRegistration"/>, and lets
+    /// <see cref="Java.Lang.Object.Dispose(bool)"/> release the JNI
+    /// peer. Idempotent and safe to call from any completion path
+    /// (Kotlin resume in <see cref="ResumeWith"/>, the sync paths in
+    /// <see cref="SuspendBridge.Invoke{T}"/>, the finalizer).
     /// </summary>
-    /// <param name="disposing">
-    /// <see langword="false"/> when called from the finalizer thread
-    /// (via <see cref="Java.Lang.Object.Dispose(bool)"/>): the CTR
-    /// dispose is skipped to avoid blocking the finalizer thread, but
-    /// the GCHandle (which is the thing that prevented finalization in
-    /// the first place) is still released for symmetry. In practice
-    /// every call site uses the default <see langword="true"/>.
-    /// </param>
-    internal void ReleaseLifetime(bool disposing = true)
-    {
-        if (Interlocked.Exchange(ref _lifetimeReleased, 1) != 0)
-            return;
-        if (disposing)
-            _ctr.Dispose();
-        if (_selfPin.IsAllocated)
-            _selfPin.Free();
-    }
-
+    /// <remarks>
+    /// Disposing the JNI peer here is safe because in every code
+    /// path that reaches Dispose, Kotlin is already done with this
+    /// continuation: it either never received it (sync-throw before
+    /// the JNI call), already returned a synchronous result
+    /// (sync-completion), or already invoked <c>resumeWith</c>
+    /// (continuations are single-resume). Calling <c>Dispose</c>
+    /// before the suspend resumes would race Kotlin's JNI hold on
+    /// the JCW — this method is not for that.
+    /// </remarks>
     protected override void Dispose(bool disposing)
     {
-        ReleaseLifetime(disposing);
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        {
+            if (disposing)
+                _ctr.Dispose();
+            if (_selfPin.IsAllocated)
+                _selfPin.Free();
+        }
         base.Dispose(disposing);
     }
 }

--- a/src/ComposeNet.Compose/SuspendContinuation.cs
+++ b/src/ComposeNet.Compose/SuspendContinuation.cs
@@ -48,7 +48,7 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
 {
     GCHandle _selfPin;
     CancellationTokenRegistration _ctr;
-    int _disposed;
+    bool _disposed;
 
     /// <summary>
     /// Backing TCS exposed for <see cref="SuspendBridge"/>.
@@ -196,7 +196,7 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
     /// </remarks>
     protected override void Dispose(bool disposing)
     {
-        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        if (!Interlocked.Exchange(ref _disposed, true))
         {
             if (disposing)
                 _ctr.Dispose();

--- a/src/ComposeNet.Compose/SuspendContinuation.cs
+++ b/src/ComposeNet.Compose/SuspendContinuation.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Android.Runtime;
 using Kotlin.Coroutines;
@@ -17,7 +18,7 @@ namespace ComposeNet;
 /// <para>
 /// Allocate one instance per suspend call (continuations cannot be
 /// reused). The class is internal — call sites should go through
-/// <see cref="SuspendBridge.Invoke{T}(System.Func{SuspendContinuation, System.IntPtr}, System.Func{Java.Lang.Object?, T})"/>
+/// <see cref="SuspendBridge.Invoke{T}(System.Func{SuspendContinuation, System.IntPtr}, System.Func{Java.Lang.Object?, T}, CancellationToken)"/>
 /// instead of constructing one directly.
 /// </para>
 /// <para>
@@ -26,15 +27,30 @@ namespace ComposeNet;
 /// <see cref="ResumeWith(Java.Lang.Object)"/> — fire-and-forget callers
 /// (no one holding the returned <see cref="Task"/>) would otherwise
 /// race the GC. The handle is a normal strong reference, not pinned
-/// in memory. It is released in <see cref="ResumeWith"/>'s finally,
-/// or by <see cref="Dispose(bool)"/> if the suspend call throws
-/// before suspension.
+/// in memory. <see cref="ReleaseLifetime(bool)"/> is the single
+/// cleanup entry point: it frees the pin, disposes the
+/// <see cref="CancellationTokenRegistration"/>, and is idempotent
+/// (guarded by an interlocked flag) so the overlapping
+/// completion / cancel / dispose paths can't double-free.
+/// </para>
+/// <para>
+/// Cancellation: when a non-default <see cref="CancellationToken"/>
+/// is supplied, a registration on the token cancels the backing TCS.
+/// That propagates to the caller's <c>await</c> as
+/// <see cref="System.OperationCanceledException"/> immediately, but
+/// the Kotlin suspend function keeps running to its natural
+/// completion — we don't wire a <c>Job</c> into <see cref="Context"/>
+/// yet. When Kotlin eventually resumes,
+/// <see cref="CompleteWithLocalHandle"/> sees the TCS is already
+/// completed and disposes the boxed result without surfacing it.
 /// </para>
 /// </remarks>
 [Register("composenet/compose/SuspendContinuation")]
 internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
 {
     GCHandle _selfPin;
+    CancellationTokenRegistration _ctr;
+    int _lifetimeReleased;
 
     /// <summary>
     /// Backing TCS exposed for <see cref="SuspendBridge"/>.
@@ -45,9 +61,25 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
     public TaskCompletionSource<Java.Lang.Object?> Tcs { get; } =
         new TaskCompletionSource<Java.Lang.Object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    public SuspendContinuation()
+    public SuspendContinuation(CancellationToken cancellationToken = default)
     {
         _selfPin = GCHandle.Alloc(this);
+        if (cancellationToken.CanBeCanceled)
+        {
+            // Allocation-free (state, token) overload: no closure per
+            // suspend call. Disposing the registration in
+            // ReleaseLifetime blocks until any in-flight invocation of
+            // this callback completes; the callback only touches the
+            // (thread-safe) TCS, so there's no deadlock path back into
+            // ReleaseLifetime.
+            _ctr = cancellationToken.Register(
+                static (state, token) =>
+                {
+                    var self = (SuspendContinuation)state!;
+                    self.Tcs.TrySetCanceled(token);
+                },
+                this);
+        }
     }
 
     /// <summary>
@@ -105,8 +137,7 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
         }
         finally
         {
-            if (_selfPin.IsAllocated)
-                _selfPin.Free();
+            ReleaseLifetime();
         }
     }
 
@@ -145,21 +176,34 @@ internal sealed class SuspendContinuation : Java.Lang.Object, IContinuation
     }
 
     /// <summary>
-    /// Release the self-pin when the suspend call fails before
-    /// suspension (the Kotlin runtime will never invoke
-    /// <see cref="ResumeWith"/>). Called from <see cref="SuspendBridge"/>
-    /// on the sync-throw path.
+    /// Single, idempotent cleanup entry point: frees the GCHandle
+    /// self-pin and disposes the <see cref="CancellationTokenRegistration"/>.
+    /// Called from every completion path (Kotlin resume in
+    /// <see cref="ResumeWith"/>, the sync-completion and sync-throw
+    /// paths in <see cref="SuspendBridge.Invoke{T}"/>, and
+    /// <see cref="Dispose(bool)"/>).
     /// </summary>
-    internal void AbandonPin()
+    /// <param name="disposing">
+    /// <see langword="false"/> when called from the finalizer thread
+    /// (via <see cref="Java.Lang.Object.Dispose(bool)"/>): the CTR
+    /// dispose is skipped to avoid blocking the finalizer thread, but
+    /// the GCHandle (which is the thing that prevented finalization in
+    /// the first place) is still released for symmetry. In practice
+    /// every call site uses the default <see langword="true"/>.
+    /// </param>
+    internal void ReleaseLifetime(bool disposing = true)
     {
+        if (Interlocked.Exchange(ref _lifetimeReleased, 1) != 0)
+            return;
+        if (disposing)
+            _ctr.Dispose();
         if (_selfPin.IsAllocated)
             _selfPin.Free();
     }
 
     protected override void Dispose(bool disposing)
     {
-        if (_selfPin.IsAllocated)
-            _selfPin.Free();
+        ReleaseLifetime(disposing);
         base.Dispose(disposing);
     }
 }


### PR DESCRIPTION
Compared our hand-rolled Kotlin-suspend → Task plumbing against the workaround in [dotnet/android-libraries#1456](https://github.com/dotnet/android-libraries/issues/1456) and noticed our one real gap: no `CancellationToken`. This wires it through.

## What changes

`SuspendBridge.Invoke` (both overloads) and the two `ScrollState` async facades (`ScrollToAsync`, `AnimateScrollToAsync`) now take a trailing `CancellationToken cancellationToken = default`. When the token fires, the returned task transitions to **Canceled** (`OperationCanceledException` at the awaiter) via the allocation-free `CancellationToken.Register((state, token) => ...)` overload calling `Tcs.TrySetCanceled(token)`.

Three secondary cleanups fell out of this:

- **Consolidated lifecycle into `IDisposable`.** `Java.Lang.Object` already implements `IDisposable`, and in every code path Kotlin is done with the continuation by the time we clean up (sync-throw, sync-completion, post-`ResumeWith` single-resume contract). The previous `AbandonPin()` method is gone; `Dispose(bool)` is now the single, idempotent cleanup point that releases the `GCHandle` self-pin, disposes the `CancellationTokenRegistration`, and lets the base call release the JNI peer. Guarded by `Interlocked.Exchange(ref _disposed, true)`.
- **Replaced the `ContinueWith` tail with a small `async Task<T> AwaitAndUnbox(...)` helper.** A cancelled TCS now surfaces as a *Canceled* (not Faulted) task because the async state machine routes the uncaught `OperationCanceledException` straight into `AsyncTaskMethodBuilder.SetCanceled`.
- **Fixed a pre-existing leak.** The sync-completion path used to set the TCS without ever freeing the `GCHandle` self-pin. The new `cont.Dispose()` call on that path closes it.

## Cancellation semantics (intentional, documented)

This is the "simple" / `#1456`-shaped cancel: the awaiter sees `OperationCanceledException` immediately, but the Kotlin suspend body continues to its natural completion. We don't yet wire a `Job` into `SuspendContinuation.Context`, so there is no Kotlin-side cancel. When Kotlin eventually resumes, `CompleteWithLocalHandle` sees the TCS is already completed and disposes the boxed result silently.

True Kotlin-side cancel (calling `job.cancel()` so animation/scroll bodies stop at the next suspend point) needs JNI bridges for `JobKt.Job()` + `CoroutineContext.plus()` + `Job.cancel()` plus `Result.Failure(CancellationException)` routing. Left as a follow-up; called out in the `SuspendBridge` XML doc and in the suspend section of `.github/copilot-instructions.md` (which also has the updated facade template).

## Verification

- `ComposeNet.Compose` and `ComposeNet.Sample` build clean (0 warnings, 0 errors).
- `ComposeNet.SourceGenerators.Tests`: 105/105 passing.
- A post-`Register` re-check of `IsCancellationRequested` covers the rare race where the token fires between the pre-check and the registration callback firing synchronously inside the ctor, so we don't start a visible scroll/animation we'd then have to wait on.