### PR TITLE
Add Semantics(role) and GraphicsLayer modifier support (#63)

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -1911,6 +1911,43 @@ internal static partial class ComposeBridges
         Defaults  = typeof(ModifierShadowDefault))]
     internal static partial IntPtr ModifierShadow(IntPtr modifier, float elevation, IntPtr? shape);
 
+    // androidx.compose.ui.graphics.GraphicsLayerModifierKt.graphicsLayer-sKFY_QE$default —
+    // (Modifier, F scaleX, F scaleY, F alpha, F translationX, F
+    // translationY, F shadowElevation, F rotationX, F rotationY,
+    // F rotationZ, F cameraDistance, J transformOrigin, Shape shape,
+    // Z clip). 13 user params, all defaultable. Mangled because
+    // `transformOrigin` is `@JvmInline value class TransformOrigin`
+    // packed as a `long`. The C# wrapper uses `float?`/`long?`/
+    // `IntPtr?`/`bool?` so the auto-mask clears each bit when a
+    // value is supplied. This is the simplest of the three
+    // graphicsLayer overloads — it omits the `RenderEffect`,
+    // `ambientShadowColor`, `spotShadowColor`, and
+    // `compositingStrategy` parameters introduced in later
+    // versions. Most user code only touches alpha / rotation /
+    // scale, which this overload covers.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/graphics/GraphicsLayerModifierKt",
+        JvmName   = "graphicsLayer-sKFY_QE$default",
+        Signature = "(Landroidx/compose/ui/Modifier;FFFFFFFFFFJ" +
+                    "Landroidx/compose/ui/graphics/Shape;Z" +
+                    "ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierGraphicsLayerDefault))]
+    internal static partial IntPtr ModifierGraphicsLayer(
+        IntPtr modifier,
+        float? scaleX,
+        float? scaleY,
+        float? alpha,
+        float? translationX,
+        float? translationY,
+        float? shadowElevation,
+        float? rotationX,
+        float? rotationY,
+        float? rotationZ,
+        float? cameraDistance,
+        long? transformOrigin,
+        IntPtr? shape,
+        bool? clip);
+
     // androidx.compose.foundation.layout.WindowInsetsPadding_androidKt —
     // additional inset-padding helpers. Same shape as the existing
     // safeDrawingPadding / systemBarsPadding bridges.
@@ -2227,6 +2264,18 @@ internal static partial class ComposeBridges
         Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;" +
                     "Ljava/lang/String;)V")]
     internal static partial void SemanticsSetContentDescription(IntPtr receiver, string description);
+
+    // androidx.compose.ui.semantics.SemanticsPropertiesKt.setRole-kuIjeqM(
+    //   SemanticsPropertyReceiver, int) — JVM-mangled because the
+    // Kotlin source signature takes a `Role` value class whose
+    // underlying type is `int`. Same lambda-receiver invocation shape
+    // as SetContentDescription. The int comes from
+    // <see cref="ComposeNet.SemanticsRole"/>.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsPropertiesKt",
+        JvmName   = "setRole-kuIjeqM",
+        Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;I)V")]
+    internal static partial void SemanticsSetRole(IntPtr receiver, int role);
 
     // Shape factories — additional overloads of RoundedCornerShape /
     // CutCornerShape beyond the existing Dp variant. The Int (percent)

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -572,6 +572,15 @@ using ComposeNet;
 [assembly: ComposeDefaults("ModifierShadowDefault",
     "!elevation", "shape", "clip")]
 
+// androidx.compose.ui.graphics.GraphicsLayerModifierKt.graphicsLayer-sKFY_QE$default —
+// 13 user params, all defaultable. Caller passes null to skip,
+// non-null to override.
+[assembly: ComposeDefaults("ModifierGraphicsLayerDefault",
+    "scaleX", "scaleY", "alpha",
+    "translationX", "translationY", "shadowElevation",
+    "rotationX", "rotationY", "rotationZ",
+    "cameraDistance", "transformOrigin", "shape", "clip")]
+
 // androidx.compose.material3.NavigationRailKt.NavigationRail-qi6gXK8:
 // 6 user params, bit 5 = content provided.
 [assembly: ComposeDefaults("NavigationRailDefault",

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -650,6 +650,59 @@ public sealed class Modifier
     }
 
     /// <summary>
+    /// <c>Modifier.graphicsLayer(...)</c> — applies a draw-time
+    /// graphics layer to the composable. All parameters default to
+    /// <c>null</c>, which lets Compose substitute its own
+    /// per-property defaults (identity for transforms, full opacity
+    /// for <paramref name="alpha"/>, etc.). Supply only the
+    /// properties you want to override.
+    /// </summary>
+    /// <param name="scaleX">Horizontal scale (1.0 = no scaling).</param>
+    /// <param name="scaleY">Vertical scale (1.0 = no scaling).</param>
+    /// <param name="alpha">Opacity in [0, 1].</param>
+    /// <param name="translationX">Horizontal translation in pixels.</param>
+    /// <param name="translationY">Vertical translation in pixels.</param>
+    /// <param name="shadowElevation">Elevation in pixels (use <see cref="Shadow"/> to specify in Dp).</param>
+    /// <param name="rotationX">Rotation around the X axis in degrees.</param>
+    /// <param name="rotationY">Rotation around the Y axis in degrees.</param>
+    /// <param name="rotationZ">Rotation around the Z axis in degrees (clockwise).</param>
+    /// <param name="cameraDistance">Distance of the camera from the rotation pivot, in pixels.</param>
+    /// <param name="transformOrigin">Packed <c>TransformOrigin</c> value (use <see cref="ComposeNet.TransformOrigin.Pack(float, float)"/>); the default is the center (0.5, 0.5).</param>
+    /// <param name="shape">Clip / shadow outline shape (default = rectangle).</param>
+    /// <param name="clip">Whether to clip content to <paramref name="shape"/>.</param>
+    public Modifier GraphicsLayer(
+        float? scaleX = null,
+        float? scaleY = null,
+        float? alpha = null,
+        float? translationX = null,
+        float? translationY = null,
+        float? shadowElevation = null,
+        float? rotationX = null,
+        float? rotationY = null,
+        float? rotationZ = null,
+        float? cameraDistance = null,
+        long? transformOrigin = null,
+        Shape? shape = null,
+        bool? clip = null)
+    {
+        return Append(curr => ComposeBridges.ModifierGraphicsLayer(
+            curr,
+            scaleX,
+            scaleY,
+            alpha,
+            translationX,
+            translationY,
+            shadowElevation,
+            rotationX,
+            rotationY,
+            rotationZ,
+            cameraDistance,
+            transformOrigin,
+            shape?.Handle,
+            clip));
+    }
+
+    /// <summary>
     /// <c>Modifier.imePadding()</c> — pads the composable so it sits
     /// above the soft keyboard (IME) when it's visible. Use under
     /// edge-to-edge to keep input controls visible.
@@ -923,7 +976,7 @@ public sealed class Modifier
     /// that.
     /// </summary>
     public Modifier Semantics(string contentDescription) =>
-        Semantics(mergeDescendants: false, contentDescription);
+        Semantics(mergeDescendants: false, contentDescription, role: null);
 
     /// <summary>
     /// <c>Modifier.semantics(mergeDescendants) { contentDescription = ... }</c> —
@@ -931,13 +984,50 @@ public sealed class Modifier
     /// container that should announce itself instead of its children
     /// (e.g. a card with a label and a value).
     /// </summary>
-    public Modifier Semantics(bool mergeDescendants, string contentDescription)
+    public Modifier Semantics(bool mergeDescendants, string contentDescription) =>
+        Semantics(mergeDescendants, contentDescription, role: null);
+
+    /// <summary>
+    /// <c>Modifier.semantics { role = ... }</c> — tags the node with
+    /// an accessibility <see cref="SemanticsRole"/> (e.g.
+    /// <see cref="SemanticsRole.Button"/>). Useful when wrapping a
+    /// custom composable that's clickable but isn't a real
+    /// <see cref="Button"/>, so TalkBack announces "button" instead
+    /// of just the content description.
+    /// </summary>
+    public Modifier Semantics(SemanticsRole role) =>
+        Semantics(mergeDescendants: false, contentDescription: null, role: role);
+
+    /// <summary>
+    /// <c>Modifier.semantics { contentDescription = ...; role = ... }</c> —
+    /// combine a content description with a role in a single
+    /// semantics block. Either argument may be omitted by passing
+    /// <c>null</c>.
+    /// </summary>
+    public Modifier Semantics(string? contentDescription, SemanticsRole? role) =>
+        Semantics(mergeDescendants: false, contentDescription, role);
+
+    /// <summary>
+    /// <c>Modifier.semantics(mergeDescendants) { contentDescription = ...; role = ... }</c> —
+    /// full form. Pass <c>null</c> for either property to skip it.
+    /// At least one of <paramref name="contentDescription"/> or
+    /// <paramref name="role"/> must be supplied.
+    /// </summary>
+    public Modifier Semantics(bool mergeDescendants, string? contentDescription, SemanticsRole? role)
     {
-        System.ArgumentNullException.ThrowIfNull(contentDescription);
+        if (contentDescription is null && role is null)
+            throw new System.ArgumentException(
+                "At least one of contentDescription or role must be supplied.",
+                nameof(contentDescription));
         var properties = new ComposableLambda1(arg =>
         {
             if (arg is Java.Lang.Object obj)
-                ComposeBridges.SemanticsSetContentDescription(obj.Handle, contentDescription);
+            {
+                if (contentDescription is not null)
+                    ComposeBridges.SemanticsSetContentDescription(obj.Handle, contentDescription);
+                if (role is not null)
+                    ComposeBridges.SemanticsSetRole(obj.Handle, (int)role.Value);
+            }
         });
         return Append(curr =>
             ComposeBridges.ModifierSemantics(curr, mergeDescendants, properties));
@@ -950,13 +1040,31 @@ public sealed class Modifier
     /// should appear as a single accessibility node with a curated
     /// description, hiding implementation details.
     /// </summary>
-    public Modifier ClearAndSetSemantics(string contentDescription)
+    public Modifier ClearAndSetSemantics(string contentDescription) =>
+        ClearAndSetSemantics(contentDescription, role: null);
+
+    /// <summary>
+    /// <c>Modifier.clearAndSetSemantics { contentDescription = ...; role = ... }</c> —
+    /// combine a content description with a <see cref="SemanticsRole"/>
+    /// in a single clear-and-set block. At least one of
+    /// <paramref name="contentDescription"/> or <paramref name="role"/>
+    /// must be supplied.
+    /// </summary>
+    public Modifier ClearAndSetSemantics(string? contentDescription, SemanticsRole? role)
     {
-        System.ArgumentNullException.ThrowIfNull(contentDescription);
+        if (contentDescription is null && role is null)
+            throw new System.ArgumentException(
+                "At least one of contentDescription or role must be supplied.",
+                nameof(contentDescription));
         var properties = new ComposableLambda1(arg =>
         {
             if (arg is Java.Lang.Object obj)
-                ComposeBridges.SemanticsSetContentDescription(obj.Handle, contentDescription);
+            {
+                if (contentDescription is not null)
+                    ComposeBridges.SemanticsSetContentDescription(obj.Handle, contentDescription);
+                if (role is not null)
+                    ComposeBridges.SemanticsSetRole(obj.Handle, (int)role.Value);
+            }
         });
         return Append(curr =>
             ComposeBridges.ModifierClearAndSetSemantics(curr, properties));

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -509,6 +509,7 @@ ComposeNet.Modifier.Border(ComposeNet.Dp width, ComposeNet.Color color, ComposeN
 ComposeNet.Modifier.Border(ComposeNet.Dp width, ComposeNet.Color color) -> ComposeNet.Modifier!
 ComposeNet.Modifier.CaptionBarPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.ClearAndSetSemantics(string! contentDescription) -> ComposeNet.Modifier!
+ComposeNet.Modifier.ClearAndSetSemantics(string? contentDescription, ComposeNet.SemanticsRole? role) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clickable(System.Action! onClick) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Shape! shape) -> ComposeNet.Modifier!
@@ -522,6 +523,7 @@ ComposeNet.Modifier.FillMaxWidth(float fraction = 1) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Focusable(bool enabled = true) -> ComposeNet.Modifier!
 ComposeNet.Modifier.FocusGroup() -> ComposeNet.Modifier!
 ComposeNet.Modifier.FocusRequester(ComposeNet.FocusRequester! requester) -> ComposeNet.Modifier!
+ComposeNet.Modifier.GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, long? transformOrigin = null, ComposeNet.Shape? shape = null, bool? clip = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Height(ComposeNet.Dp height) -> ComposeNet.Modifier!
 ComposeNet.Modifier.HeightIn(ComposeNet.Dp? min = null, ComposeNet.Dp? max = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.HorizontalScroll(ComposeNet.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> ComposeNet.Modifier!
@@ -546,7 +548,10 @@ ComposeNet.Modifier.Scale(float scale) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Scale(float scaleX, float scaleY) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Selectable(bool selected, System.Action! onClick) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Semantics(bool mergeDescendants, string! contentDescription) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Semantics(bool mergeDescendants, string? contentDescription, ComposeNet.SemanticsRole? role) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Semantics(ComposeNet.SemanticsRole role) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Semantics(string! contentDescription) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Semantics(string? contentDescription, ComposeNet.SemanticsRole? role) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Shadow(ComposeNet.Dp elevation, ComposeNet.Shape? shape = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp size) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp width, ComposeNet.Dp height) -> ComposeNet.Modifier!
@@ -802,6 +807,16 @@ ComposeNet.SegmentedButton.Icon.get -> ComposeNet.ComposableNode?
 ComposeNet.SegmentedButton.Icon.set -> void
 ComposeNet.SegmentedButton.SegmentedButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 ComposeNet.SegmentedButton.SegmentedButton(bool selected, System.Action! onClick) -> void
+ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.Button = 0 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.Carousel = 8 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.Checkbox = 1 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.DropdownList = 6 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.Image = 5 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.RadioButton = 3 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.Switch = 2 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.Tab = 4 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsRole.ValuePicker = 7 -> ComposeNet.SemanticsRole
 ComposeNet.Shape
 ComposeNet.SideEffect
 ComposeNet.SideEffect.SideEffect(System.Action! effect) -> void
@@ -958,6 +973,9 @@ ComposeNet.TopAppBar.Subtitle.set -> void
 ComposeNet.TopAppBar.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.TopAppBar.Title.set -> void
 ComposeNet.TopAppBar.TopAppBar() -> void
+ComposeNet.TransformOrigin
+static ComposeNet.TransformOrigin.Center.get -> long
+static ComposeNet.TransformOrigin.Pack(float pivotFractionX, float pivotFractionY) -> long
 ComposeNet.TopSearchBar
 ComposeNet.TopSearchBar.InputField.get -> ComposeNet.ComposableNode?
 ComposeNet.TopSearchBar.InputField.set -> void

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -973,13 +973,13 @@ ComposeNet.TopAppBar.Subtitle.set -> void
 ComposeNet.TopAppBar.Title.get -> ComposeNet.ComposableNode?
 ComposeNet.TopAppBar.Title.set -> void
 ComposeNet.TopAppBar.TopAppBar() -> void
-ComposeNet.TransformOrigin
-static ComposeNet.TransformOrigin.Center.get -> long
-static ComposeNet.TransformOrigin.Pack(float pivotFractionX, float pivotFractionY) -> long
 ComposeNet.TopSearchBar
 ComposeNet.TopSearchBar.InputField.get -> ComposeNet.ComposableNode?
 ComposeNet.TopSearchBar.InputField.set -> void
 ComposeNet.TopSearchBar.TopSearchBar(ComposeNet.SearchBarState! state) -> void
+ComposeNet.TransformOrigin
+static ComposeNet.TransformOrigin.Center.get -> long
+static ComposeNet.TransformOrigin.Pack(float pivotFractionX, float pivotFractionY) -> long
 ComposeNet.TriStateCheckbox
 ComposeNet.TriStateCheckbox.TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState! state, System.Action! onClick) -> void
 ComposeNet.VerticalDivider

--- a/src/ComposeNet.Compose/SemanticsRole.cs
+++ b/src/ComposeNet.Compose/SemanticsRole.cs
@@ -6,7 +6,7 @@ namespace ComposeNet;
 /// <c>Modifier.semantics { role = ... }</c>. Compose defines
 /// <c>Role</c> as a <c>@JvmInline value class</c> over an <see cref="int"/>;
 /// the underlying values match Kotlin's source order
-/// (<see cref="Button"/> = 0 … <see cref="ValuePicker"/> = 8) and have
+/// (<see cref="Button"/> = 0 … <see cref="Carousel"/> = 8) and have
 /// been stable since the feature was introduced.
 ///
 /// Use with <see cref="Modifier.Semantics(SemanticsRole)"/> or

--- a/src/ComposeNet.Compose/SemanticsRole.cs
+++ b/src/ComposeNet.Compose/SemanticsRole.cs
@@ -1,0 +1,37 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Mirror of Kotlin's <c>androidx.compose.ui.semantics.Role</c> — the
+/// accessibility role advertised to TalkBack via
+/// <c>Modifier.semantics { role = ... }</c>. Compose defines
+/// <c>Role</c> as a <c>@JvmInline value class</c> over an <see cref="int"/>;
+/// the underlying values match Kotlin's source order
+/// (<see cref="Button"/> = 0 … <see cref="ValuePicker"/> = 8) and have
+/// been stable since the feature was introduced.
+///
+/// Use with <see cref="Modifier.Semantics(SemanticsRole)"/> or
+/// <see cref="Modifier.Semantics(string?, SemanticsRole?)"/> to attach a
+/// role to any composable that the framework didn't already classify
+/// (e.g. tagging a custom <see cref="Box"/> as <see cref="Button"/>).
+/// </summary>
+public enum SemanticsRole
+{
+    /// <summary>An element that triggers an action when clicked.</summary>
+    Button = 0,
+    /// <summary>An on/off two-state checkbox.</summary>
+    Checkbox = 1,
+    /// <summary>An on/off two-state switch.</summary>
+    Switch = 2,
+    /// <summary>A radio button that is part of a mutually-exclusive group.</summary>
+    RadioButton = 3,
+    /// <summary>A selectable tab in a tab strip.</summary>
+    Tab = 4,
+    /// <summary>A static image (announced as "image" by TalkBack).</summary>
+    Image = 5,
+    /// <summary>An element that opens a dropdown / popup menu of choices.</summary>
+    DropdownList = 6,
+    /// <summary>An incremental value picker (e.g. date/time spinner).</summary>
+    ValuePicker = 7,
+    /// <summary>A horizontally swipeable carousel of items.</summary>
+    Carousel = 8,
+}

--- a/src/ComposeNet.Compose/TransformOrigin.cs
+++ b/src/ComposeNet.Compose/TransformOrigin.cs
@@ -1,0 +1,41 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Mirror of Kotlin's <c>androidx.compose.ui.graphics.TransformOrigin</c> —
+/// the pivot point used by transform-aware modifiers such as
+/// <see cref="Modifier.GraphicsLayer"/> for scale and rotation. Compose
+/// defines it as a <c>@JvmInline value class TransformOrigin(val packedValue: Long)</c>
+/// that packs two <see cref="float"/>s (fractions in <c>[0, 1]</c>)
+/// into a single <see cref="long"/>: <c>x</c> in the upper 32 bits,
+/// <c>y</c> in the lower 32 bits. Because the binding generator
+/// strips inline value-class types, the <see cref="Modifier.GraphicsLayer"/>
+/// API takes the raw packed <see cref="long"/>; <see cref="Pack"/>
+/// builds one from a <c>(x, y)</c> pair and <see cref="Center"/>
+/// supplies the common (0.5, 0.5) default.
+/// </summary>
+public static class TransformOrigin
+{
+    /// <summary>
+    /// Packed <see cref="long"/> equivalent to Compose's
+    /// <c>TransformOrigin.Center</c> — pivot (0.5, 0.5), i.e. the
+    /// geometric center of the composable. This is the default
+    /// pivot Compose uses when none is supplied.
+    /// </summary>
+    public static long Center { get; } = Pack(0.5f, 0.5f);
+
+    /// <summary>
+    /// Pack a (<paramref name="pivotFractionX"/>,
+    /// <paramref name="pivotFractionY"/>) pair into the
+    /// <c>TransformOrigin</c> bit layout expected by
+    /// <see cref="Modifier.GraphicsLayer"/>. Both fractions are
+    /// typically in <c>[0, 1]</c>: <c>0</c> = left/top,
+    /// <c>0.5</c> = center, <c>1</c> = right/bottom. Values outside
+    /// that range are allowed but rarely useful.
+    /// </summary>
+    public static long Pack(float pivotFractionX, float pivotFractionY)
+    {
+        long x = unchecked((uint)System.BitConverter.SingleToInt32Bits(pivotFractionX));
+        long y = unchecked((uint)System.BitConverter.SingleToInt32Bits(pivotFractionY));
+        return (x << 32) | y;
+    }
+}

--- a/src/ComposeNet.Sample/MainActivity.cs
+++ b/src/ComposeNet.Sample/MainActivity.cs
@@ -560,6 +560,59 @@ public class MainActivity : ComposeActivity
                                 },
                             },
                             new Button(onClick: () => dragX63.Value = 0f) { new Text("Reset drag") },
+                            // Semantics(role) — TalkBack announces the
+                            // custom Box as a "button" thanks to the
+                            // SemanticsRole tag, even though it's not a
+                            // real Button. The combined overload also
+                            // sets a content description.
+                            new Text("Semantics(role) — custom 'button':"),
+                            new Box
+                            {
+                                Modifier.Companion
+                                    .FillMaxWidth()
+                                    .Height(48)
+                                    .Background(Color.FromRgb(0xB3, 0xE5, 0xFC))
+                                    .Clickable(() => taps63.Value++)
+                                    .Semantics("Custom tap target", SemanticsRole.Button)
+                                    .Padding(12),
+                                new Text("Tap me — announced as 'button'"),
+                            },
+                            // GraphicsLayer — drag-driven rotation, with
+                            // a non-default TransformOrigin so the tile
+                            // rotates around its top-left corner instead
+                            // of its center. Drag the purple square
+                            // above (or tap reset) to change dragX63.
+                            new Text($"GraphicsLayer (rotation = drag offset, pivot = top-left):"),
+                            new Row
+                            {
+                                Modifier.Companion.FillMaxWidth().Height(96).Padding(4),
+                                new Box
+                                {
+                                    Modifier.Companion
+                                        .Size(64)
+                                        .GraphicsLayer(
+                                            rotationZ:       dragX63.Value,
+                                            alpha:           0.6f + 0.4f * System.MathF.Min(1f, System.MathF.Abs(dragX63.Value) / 90f),
+                                            transformOrigin: TransformOrigin.Pack(0f, 0f))
+                                        .Background(Color.FromRgb(0xAB, 0x47, 0xBC)),
+                                    new Text("⟲") { Modifier = Modifier.Companion.Padding(20) },
+                                },
+                                new Spacer { Modifier = Modifier.Companion.WidthIn(16, null) },
+                                // Same source value, but the second tile
+                                // pivots around its center (the default)
+                                // and scales asymmetrically.
+                                new Box
+                                {
+                                    Modifier.Companion
+                                        .Size(64)
+                                        .GraphicsLayer(
+                                            rotationZ: -dragX63.Value,
+                                            scaleX:    1.0f + dragX63.Value / 200f,
+                                            scaleY:    1.0f - dragX63.Value / 400f)
+                                        .Background(Color.FromRgb(0x66, 0xBB, 0x6A)),
+                                    new Text("↔") { Modifier = Modifier.Companion.Padding(20) },
+                                },
+                            },
                         },
                         _ => new Column
                         {


### PR DESCRIPTION
Fills two of the remaining gaps in the Modifier surface tracked by #63.

### `Semantics(role: …)`

- New `SemanticsRole` enum mirrors Kotlin's `androidx.compose.ui.semantics.Role` `@JvmInline value class`. Values **0..8** match Kotlin's static-init order — `Button..Image`, `DropdownList=6`, `ValuePicker=7`, `Carousel=8` (verified against the 1.11.x bytecode `<clinit>`).
- New JNI bridge `SemanticsSetRole` calling the mangled `setRole-kuIjeqM(SemanticsPropertyReceiver, int)V`.
- `Modifier` gains:
  - `Semantics(SemanticsRole)`
  - `Semantics(string?, SemanticsRole?)`
  - `Semantics(bool, string?, SemanticsRole?)`
  - `ClearAndSetSemantics(string?, SemanticsRole?)`
- Existing overloads still compile and behave identically; the new combined body builds one `ComposableLambda1` that conditionally sets `contentDescription` and/or `role` on the lambda's `SemanticsPropertyReceiver`.

### `GraphicsLayer(…)`

- New JNI bridge `ModifierGraphicsLayer` wraps `graphicsLayer-sKFY_QE$default` (13 user params: scale, alpha, translation, shadow elevation, rotation, camera distance, transform origin, shape, clip). All params are nullable so the auto-mask emits the correct Kotlin `$default` bits — pass only what you want to override.
- Matching declarative `[assembly: ComposeDefaults(…)]` entry.
- New `Modifier.GraphicsLayer(…)` exposes all 13 params as optional `float?` / `long?` / `Shape?` / `bool?`.
- New `TransformOrigin` helper packs `(x, y)` fractions into the `long` bit layout Compose expects (`SingleToInt32Bits(x) << 32 | SingleToInt32Bits(y) & 0xFFFFFFFF`); `TransformOrigin.Center` matches the `(0.5, 0.5)` default pivot.

This is the `sKFY_QE` overload — the simplest one (no `RenderEffect`, no per-color shadows, no compositing strategy). The other graphicsLayer overloads can be added on demand.

### Out of scope

- **`Modifier.WindowInsetsPadding(WindowInsets)` generic form** — all `WindowInsets.Companion.systemBars`/`ime`/etc. accessors are `@Composable` and need an `IComposer`, but the Modifier chain's `Append` delegate is `Func<IntPtr, IntPtr>` with no composer access. The named padding variants (`SystemBarsPadding`, `ImePadding`, `NavigationBarsPadding`, …) already cover the common cases; the generic form needs a chain refactor that's larger than this PR. Tracked by #63.
- **`Modifier.PointerInput { … }`** — needs a suspend-DSL design effort. Tracked by #63.

### Verification

- `dotnet build src/ComposeNet.Compose` — clean
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 105 passed
- `dotnet build src/ComposeNet.Sample` — Android build succeeded
- JVM signatures (`setRole-kuIjeqM`, `graphicsLayer-sKFY_QE$default`) and Role static-init values verified directly via `javap` on the 1.11.x AAR bytecode.

`PublicAPI.Unshipped.txt` updated for all new public surface.