### PR TITLE
Support MutableState<T?> / CompositionLocal<T?> for nullable primitives

### DIFF
--- a/src/ComposeNet.Compose/CompositionLocal.cs
+++ b/src/ComposeNet.Compose/CompositionLocal.cs
@@ -138,32 +138,47 @@ public sealed class CompositionLocal<T>
     public ProvidedValue Provides(T value) =>
         new(_peer.Provides(ToJava(value)!));
 
-    static Java.Lang.Object? ToJava(T value) => value switch
+    // Cached per-T: when T is Nullable<U> (e.g. long?, int?, bool?), this
+    // is typeof(U) so the primitive dispatch in FromJava/ToJava treats
+    // `long?` the same as `long`. For all other T, it's just typeof(T).
+    static readonly Type s_effectiveType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+    static Java.Lang.Object? ToJava(T value)
     {
-        null               => null,
-        Java.Lang.Object o => o,
-        string s           => new Java.Lang.String(s),
-        bool b             => Java.Lang.Boolean.ValueOf(b),
-        char c             => Java.Lang.Character.ValueOf(c),
-        sbyte sb           => Java.Lang.Byte.ValueOf(sb),
-        byte by            => Java.Lang.Short.ValueOf((short)by),
-        short sh           => Java.Lang.Short.ValueOf(sh),
-        ushort us          => Java.Lang.Integer.ValueOf(us),
-        int i              => Java.Lang.Integer.ValueOf(i),
-        uint ui            => Java.Lang.Long.ValueOf(ui),
-        long l             => Java.Lang.Long.ValueOf(l),
-        ulong ul           => Java.Lang.Long.ValueOf(unchecked((long)ul)),
-        float f            => Java.Lang.Float.ValueOf(f),
-        double d           => Java.Lang.Double.ValueOf(d),
-        _                  => new ManagedBox(value),
-    };
+        if (value is null) return null;
+        // Boxing a non-null Nullable<U> to object yields a boxed U, not a
+        // boxed Nullable<U>, so one switch handles both T == long and
+        // T == long?.
+        object boxed = value!;
+        return boxed switch
+        {
+            Java.Lang.Object o => o,
+            string s           => new Java.Lang.String(s),
+            bool b             => Java.Lang.Boolean.ValueOf(b),
+            char c             => Java.Lang.Character.ValueOf(c),
+            sbyte sb           => Java.Lang.Byte.ValueOf(sb),
+            byte by            => Java.Lang.Short.ValueOf((short)by),
+            short sh           => Java.Lang.Short.ValueOf(sh),
+            ushort us          => Java.Lang.Integer.ValueOf(us),
+            int i              => Java.Lang.Integer.ValueOf(i),
+            uint ui            => Java.Lang.Long.ValueOf(ui),
+            long l             => Java.Lang.Long.ValueOf(l),
+            ulong ul           => Java.Lang.Long.ValueOf(unchecked((long)ul)),
+            float f            => Java.Lang.Float.ValueOf(f),
+            double d           => Java.Lang.Double.ValueOf(d),
+            _                  => new ManagedBox(boxed),
+        };
+    }
 
     static T FromJava(Java.Lang.Object? value)
     {
         if (value is null) return default!;
         if (value is ManagedBox box) return (T)box.Value!;
         if (value is T t) return t;
-        var type = typeof(T);
+        // Use the underlying type when T is Nullable<U> so `long?`
+        // dispatches into the same branch as `long`. `(T)(object)5L`
+        // unboxes directly into Nullable<long> for T == long?.
+        var type = s_effectiveType;
         if (type == typeof(string))  return (T)(object)value.ToString()!;
         if (type == typeof(bool))    return (T)(object)((Java.Lang.Boolean)value).BooleanValue();
         if (type == typeof(char))    return (T)(object)((Java.Lang.Character)value).CharValue();

--- a/src/ComposeNet.Compose/MutableState.cs
+++ b/src/ComposeNet.Compose/MutableState.cs
@@ -1,3 +1,4 @@
+using System;
 using AndroidX.Compose.Runtime;
 
 namespace ComposeNet;
@@ -52,32 +53,52 @@ public class MutableState<T> : IMutableStateWrapper
     /// </summary>
     public override string ToString() => Value?.ToString() ?? "null";
 
-    internal static Java.Lang.Object? ToJava(T value) => value switch
+    // Cached per-T: when T is Nullable<U> (e.g. long?, int?, bool?), this
+    // is typeof(U) so the primitive dispatch in FromJava/ToJava treats
+    // `long?` the same as `long`. For all other T, it's just typeof(T).
+    static readonly Type s_effectiveType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+    internal static Java.Lang.Object? ToJava(T value)
     {
-        null                  => null,
-        Java.Lang.Object o    => o,
-        string s              => new Java.Lang.String(s),
-        bool b                => Java.Lang.Boolean.ValueOf(b),
-        char c                => Java.Lang.Character.ValueOf(c),
-        sbyte sb              => Java.Lang.Byte.ValueOf(sb),
-        byte by               => Java.Lang.Short.ValueOf((short)by),                  // widen 8u -> 16s
-        short sh              => Java.Lang.Short.ValueOf(sh),
-        ushort us             => Java.Lang.Integer.ValueOf(us),                       // widen 16u -> 32s
-        int i                 => Java.Lang.Integer.ValueOf(i),
-        uint ui               => Java.Lang.Long.ValueOf(ui),                          // widen 32u -> 64s
-        long l                => Java.Lang.Long.ValueOf(l),
-        ulong ul              => Java.Lang.Long.ValueOf(unchecked((long)ul)),         // bit-exact round-trip
-        float f               => Java.Lang.Float.ValueOf(f),
-        double d              => Java.Lang.Double.ValueOf(d),
-        _                     => throw new System.NotSupportedException(
-                                    $"MutableState<{typeof(T).Name}>: T must be a Java.Lang.Object subclass, string, bool, char, or a built-in numeric primitive (sbyte/byte/short/ushort/int/uint/long/ulong/float/double). Types like decimal, Half, BigInteger, and IntPtr have no clean Java box and are not supported.")
-    };
+        if (value is null) return null;
+        // Boxing a non-null Nullable<U> to object yields a boxed U, not a
+        // boxed Nullable<U>. That lets one switch handle both T == long and
+        // T == long? without a separate nullable branch.
+        object boxed = value!;
+        return boxed switch
+        {
+            Java.Lang.Object o    => o,
+            string s              => new Java.Lang.String(s),
+            bool b                => Java.Lang.Boolean.ValueOf(b),
+            char c                => Java.Lang.Character.ValueOf(c),
+            sbyte sb              => Java.Lang.Byte.ValueOf(sb),
+            byte by               => Java.Lang.Short.ValueOf((short)by),                  // widen 8u -> 16s
+            short sh              => Java.Lang.Short.ValueOf(sh),
+            ushort us             => Java.Lang.Integer.ValueOf(us),                       // widen 16u -> 32s
+            int i                 => Java.Lang.Integer.ValueOf(i),
+            uint ui               => Java.Lang.Long.ValueOf(ui),                          // widen 32u -> 64s
+            long l                => Java.Lang.Long.ValueOf(l),
+            ulong ul              => Java.Lang.Long.ValueOf(unchecked((long)ul)),         // bit-exact round-trip
+            float f               => Java.Lang.Float.ValueOf(f),
+            double d              => Java.Lang.Double.ValueOf(d),
+            _                     => throw new NotSupportedException(
+                                        $"MutableState<{typeof(T).Name}>: T must be a Java.Lang.Object subclass, string, bool, char, or a built-in numeric primitive (sbyte/byte/short/ushort/int/uint/long/ulong/float/double), or a Nullable<T> of any of those primitives. Types like decimal, Half, BigInteger, and IntPtr have no clean Java box and are not supported.")
+        };
+    }
 
     internal static T FromJava(Java.Lang.Object? value)
     {
+        // For T == Nullable<U> this returns the empty Nullable (HasValue=false);
+        // for reference T it returns null; for non-nullable struct T it's
+        // unreachable in practice because Compose wouldn't store a Java null
+        // there, but `default!` is still the only sane fallback.
         if (value is null) return default!;
         if (value is T t) return t;
-        var type = typeof(T);
+        // Use the underlying type when T is Nullable<U>, so e.g. `long?`
+        // dispatches into the same branch as `long`. The unbox cast
+        // `(T)(object)5L` works for T == long? because boxed-primitive
+        // unboxes directly into Nullable<long>.
+        var type = s_effectiveType;
         if (type == typeof(string))  return (T)(object)value.ToString()!;
         if (type == typeof(bool))    return (T)(object)((Java.Lang.Boolean)value).BooleanValue();
         if (type == typeof(char))    return (T)(object)((Java.Lang.Character)value).CharValue();
@@ -91,7 +112,7 @@ public class MutableState<T> : IMutableStateWrapper
         if (type == typeof(ulong))   return (T)(object)unchecked((ulong)((Java.Lang.Long)value).LongValue());
         if (type == typeof(float))   return (T)(object)((Java.Lang.Float)value).FloatValue();
         if (type == typeof(double))  return (T)(object)((Java.Lang.Double)value).DoubleValue();
-        throw new System.NotSupportedException(
+        throw new NotSupportedException(
             $"MutableState<{typeof(T).Name}>: don't know how to unwrap {value.GetType().Name}");
     }
 }

--- a/src/ComposeNet.Gallery/Demos/StateEffectsAnimation/NullableMutableStateDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/StateEffectsAnimation/NullableMutableStateDemo.cs
@@ -1,0 +1,68 @@
+using AndroidX.Compose.Runtime;
+using ComposeNet.Gallery.Registry;
+
+namespace ComposeNet.Gallery.Demos.StateEffectsAnimation;
+
+/// <summary>
+/// <see cref="MutableState{T}"/> and <see cref="CompositionLocal{T}"/>
+/// with a nullable value type (<c>long?</c>) — the "nothing selected
+/// yet" sentinel pattern. Toggling between <c>null</c> and a non-null
+/// value round-trips through the JVM box without throwing
+/// <c>NotSupportedException</c> (regression test for issue #173).
+/// </summary>
+public static class NullableMutableStateDemo
+{
+    static readonly CompositionLocal<long?> LocalSelectedId =
+        CompositionLocal.Of<long?>(() => null);
+
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "state-nullable-value-types",
+        CategoryId:  "state-effects",
+        Title:       "MutableState<long?> + nullable Local",
+        Description: "Nullable primitives (long?, int?, bool?) round-trip through MutableState and CompositionLocal without unbox errors. Toggle the selected ID between null and a value.",
+        Build:       () =>
+        {
+            var selectedId = Compose.Remember(() => new MutableState<long?>(null));
+            var taps       = Compose.Remember(() => new MutableNumberState<int>(0));
+
+            return new Column
+            {
+                new Text($"selectedId.Value: {selectedId.Value?.ToString() ?? "<null>"}"),
+                new Text($"taps:             {taps.Value}"),
+                new Row
+                {
+                    new Button(onClick: () =>
+                    {
+                        taps.Value++;
+                        selectedId.Value = 100L + taps.Value;
+                    })
+                    { new Text("Select next") },
+                    new Spacer { Modifier = Modifier.Companion.Padding(4) },
+                    new Button(onClick: () => selectedId.Value = null)
+                        { new Text("Clear") },
+                },
+                new HorizontalDivider { Modifier = Modifier.Companion.Padding(0, 8) },
+                new Text("Below: a CompositionLocal<long?> reads null by default, then a provider supplies the current selectedId:"),
+                new SelectedIdLabel(),
+                new CompositionLocalProvider
+                {
+                    LocalSelectedId.Provides(selectedId.Value),
+                    new Column
+                    {
+                        Modifier.Companion.Padding(8),
+                        new SelectedIdLabel(),
+                    },
+                },
+            };
+        });
+
+    sealed class SelectedIdLabel : ComposableNode
+    {
+        public override void Render(IComposer composer)
+        {
+            var id = LocalSelectedId.GetCurrent(composer);
+            new Text($"  LocalSelectedId.Current: {id?.ToString() ?? "<null>"}").Render(composer);
+        }
+    }
+}

--- a/src/ComposeNet.Gallery/Registry/Catalog.cs
+++ b/src/ComposeNet.Gallery/Registry/Catalog.cs
@@ -140,6 +140,7 @@ public static class Catalog
         D.StateEffectsAnimation.RememberSaveableDemo.Demo,
         D.StateEffectsAnimation.ProduceStateTickerDemo.Demo,
         D.StateEffectsAnimation.MutableStateCollectionsDemo.Demo,
+        D.StateEffectsAnimation.NullableMutableStateDemo.Demo,
         D.StateEffectsAnimation.DerivedStateDemo.Demo,
         D.StateEffectsAnimation.LaunchedEffectDemo.Demo,
         D.StateEffectsAnimation.DisposableEffectDemo.Demo,


### PR DESCRIPTION
Closes #173.

## Problem

`MutableState<long?>(null)` (and every other `Nullable<U>` of a built-in primitive — `int?`, `bool?`, `float?`, `double?`, `char?`, `byte?`, `short?`, `ushort?`, `uint?`, `ulong?`, `sbyte?`) crashed in `FromJava`:

```
System.NotSupportedException:
    MutableState<Nullable`1>: don't know how to unwrap Long
    at ComposeNet.MutableState`1[Nullable`1[Int64]].FromJava
    at ComposeNet.MutableState`1[Nullable`1[Int64]].get_Value
```

The type-comparison switch in `FromJava` was keyed off `typeof(T)`. When `T = long?`, `typeof(T) == typeof(Nullable<long>)`, which doesn't match `typeof(long)`, so the boxed `java.lang.Long` fell through the primitive arms to the final `throw`.

## Fix

Per generic specialization, cache:

```csharp
static readonly Type s_effectiveType =
    Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
```

and dispatch off it in `FromJava`. The existing primitive arms work as-is — `(T)(object)5L` unboxes correctly into `Nullable<long>` for `T = long?` thanks to the CLR's unbox-any semantics.

`ToJava` was also reshaped to box the incoming `T` to `object` before switching. A non-null `Nullable<U>` boxes to `U` (not to `Nullable<U>`), so one switch handles both `T == long` and `T == long?` without a separate nullable branch — and the behaviour is now self-evident at the call site instead of relying on lifted pattern-matching semantics.

The same fix is mirrored in `CompositionLocal<T>` — its `ToJava` / `FromJava` had the same shape and the same bug. The `ManagedBox` branch stays ahead of the primitive switch so arbitrary POCO types still flow through unchanged.

## Demo

New gallery demo `state-nullable-value-types` exercises the round-trip on-device:

- `MutableState<long?>` starts `null`
- "Select next" assigns `100L + taps`
- "Clear" resets to `null`
- A sibling `CompositionLocal<long?>` reader inside a `CompositionLocalProvider` verifies the local side end-to-end (default factory returns `null`, then a provider supplies the current `selectedId.Value`)

Wired into the "State, effects, animation" category in `Catalog.cs`.

## Verification

- `dotnet build src/ComposeNet.Compose` — 0 warnings, 0 errors
- `dotnet build src/ComposeNet.Gallery` — 0 warnings, 0 errors
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 105/105 pass

No public API surface added; `PublicAPI.Unshipped.txt` unchanged.