### PR TITLE
Expose ContentScale, Alignment, and Alpha slots on the Image facade

### DIFF
--- a/src/ComposeNet.Compose/Alignment.cs
+++ b/src/ComposeNet.Compose/Alignment.cs
@@ -1,3 +1,4 @@
+using Android.Runtime;
 using AndroidX.Compose.UI;
 
 namespace ComposeNet;
@@ -15,32 +16,48 @@ namespace ComposeNet;
 /// <see cref="Row"/> and the nested <see cref="Horizontal"/> singletons
 /// inside a <see cref="Column"/>.
 /// </summary>
-public sealed class Alignment
+/// <remarks>
+/// Inherits <see cref="Java.Lang.Object"/> so the bridge generator's
+/// reference-type code path
+/// (<c>((Java.Lang.Object)alignment).Handle</c>) can lower an
+/// <see cref="Alignment"/> instance to its underlying Kotlin
+/// <c>Alignment</c> JNI handle — used by facades like
+/// <see cref="Image"/> that take an optional <c>alignment</c> slot.
+/// </remarks>
+public sealed class Alignment : Java.Lang.Object
 {
-    internal IAlignment Java { get; }
+    Alignment(IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer) { }
 
-    Alignment(IAlignment java) => Java = java;
+    // Wrap the bound IAlignment peer's JNI handle in a brand-new
+    // Java.Lang.Object peer so casts to Java.Lang.Object on this
+    // instance return our own (stable) handle. Same approach as Shape.
+    static Alignment From(IAlignment java)
+    {
+        IntPtr handle = ((Java.Lang.Object)java).Handle;
+        return new Alignment(JNIEnv.NewLocalRef(handle), JniHandleOwnership.TransferLocalRef);
+    }
 
     static Alignment? s_topStart, s_topCenter, s_topEnd, s_centerStart, s_center, s_centerEnd, s_bottomStart, s_bottomCenter, s_bottomEnd;
 
     /// <summary><c>Alignment.TopStart</c> — top-left in LTR, top-right in RTL.</summary>
-    public static Alignment TopStart => s_topStart ??= new Alignment(IAlignment.Companion.TopStart);
+    public static Alignment TopStart => s_topStart ??= From(IAlignment.Companion.TopStart);
     /// <summary><c>Alignment.TopCenter</c> — top-center.</summary>
-    public static Alignment TopCenter => s_topCenter ??= new Alignment(IAlignment.Companion.TopCenter);
+    public static Alignment TopCenter => s_topCenter ??= From(IAlignment.Companion.TopCenter);
     /// <summary><c>Alignment.TopEnd</c> — top-right in LTR, top-left in RTL.</summary>
-    public static Alignment TopEnd => s_topEnd ??= new Alignment(IAlignment.Companion.TopEnd);
+    public static Alignment TopEnd => s_topEnd ??= From(IAlignment.Companion.TopEnd);
     /// <summary><c>Alignment.CenterStart</c> — vertically centered, leading edge.</summary>
-    public static Alignment CenterStart => s_centerStart ??= new Alignment(IAlignment.Companion.CenterStart);
+    public static Alignment CenterStart => s_centerStart ??= From(IAlignment.Companion.CenterStart);
     /// <summary><c>Alignment.Center</c> — centered both axes.</summary>
-    public static Alignment Center => s_center ??= new Alignment(IAlignment.Companion.Center);
+    public static Alignment Center => s_center ??= From(IAlignment.Companion.Center);
     /// <summary><c>Alignment.CenterEnd</c> — vertically centered, trailing edge.</summary>
-    public static Alignment CenterEnd => s_centerEnd ??= new Alignment(IAlignment.Companion.CenterEnd);
+    public static Alignment CenterEnd => s_centerEnd ??= From(IAlignment.Companion.CenterEnd);
     /// <summary><c>Alignment.BottomStart</c> — bottom-left in LTR, bottom-right in RTL.</summary>
-    public static Alignment BottomStart => s_bottomStart ??= new Alignment(IAlignment.Companion.BottomStart);
+    public static Alignment BottomStart => s_bottomStart ??= From(IAlignment.Companion.BottomStart);
     /// <summary><c>Alignment.BottomCenter</c> — bottom-center.</summary>
-    public static Alignment BottomCenter => s_bottomCenter ??= new Alignment(IAlignment.Companion.BottomCenter);
+    public static Alignment BottomCenter => s_bottomCenter ??= From(IAlignment.Companion.BottomCenter);
     /// <summary><c>Alignment.BottomEnd</c> — bottom-right in LTR, bottom-left in RTL.</summary>
-    public static Alignment BottomEnd => s_bottomEnd ??= new Alignment(IAlignment.Companion.BottomEnd);
+    public static Alignment BottomEnd => s_bottomEnd ??= From(IAlignment.Companion.BottomEnd);
 
     /// <summary>
     /// Vertical-only alignment singletons (<c>Alignment.Vertical</c>) for

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -587,10 +587,13 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void Image(
         [PainterResource] IntPtr painter,
-        string?    contentDescription,
-        IModifier? modifier,
-        int        defaults,
-        IComposer  composer);
+        string?       contentDescription,
+        IModifier?    modifier,
+        Alignment?    alignment,
+        ContentScale? contentScale,
+        float?        alpha,
+        int           defaults,
+        IComposer     composer);
 
     // androidx.compose.material3.IconKt.Icon-ww6aTOc (Painter overload) —
     // the Painter and ImageBitmap overloads share the mangled JVM name

--- a/src/ComposeNet.Compose/ContentScale.cs
+++ b/src/ComposeNet.Compose/ContentScale.cs
@@ -1,0 +1,101 @@
+using Android.Runtime;
+
+namespace ComposeNet;
+
+/// <summary>
+/// C# wrapper around the <c>androidx.compose.ui.layout.ContentScale</c>
+/// singletons exposed by Kotlin's <c>ContentScale.Companion</c> object.
+/// Compose's <c>ContentScale</c> is a real Kotlin interface (not a
+/// <c>@JvmInline value class</c>) — same plumbing story as
+/// <see cref="TextDecoration"/>. The <c>Xamarin.AndroidX.Compose.UI</c>
+/// binding currently doesn't surface a managed <c>IContentScale</c>
+/// type, so we resolve the companion getters via JNI directly.
+///
+/// Pass instances to facades that accept an optional <c>contentScale</c>
+/// slot (e.g. <see cref="Image"/>) to control how source content is
+/// scaled to fit its destination bounds. Left unset (null) on those
+/// facades, Kotlin's default (<c>ContentScale.Fit</c>) applies.
+/// </summary>
+public sealed class ContentScale : Java.Lang.Object
+{
+    ContentScale(IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer) { }
+
+    static ContentScale Resolve(string getterName)
+    {
+        IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/layout/ContentScale$Companion");
+        IntPtr mid = JNIEnv.GetMethodID(cls, getterName, "()Landroidx/compose/ui/layout/ContentScale;");
+        IntPtr companion = Companion();
+        IntPtr value = JNIEnv.CallObjectMethod(companion, mid);
+        return new ContentScale(value, JniHandleOwnership.TransferLocalRef);
+    }
+
+    // The outer ContentScale interface has a Companion holder object;
+    // the public surface lives on the Companion's getXxx() methods
+    // (the val fields on the outer class are private, same story as
+    // TextDecoration and FontWeight).
+    static IntPtr s_companion;
+    static IntPtr Companion()
+    {
+        if (s_companion == IntPtr.Zero)
+        {
+            IntPtr outerCls = JNIEnv.FindClass("androidx/compose/ui/layout/ContentScale");
+            IntPtr fid = JNIEnv.GetStaticFieldID(outerCls, "Companion", "Landroidx/compose/ui/layout/ContentScale$Companion;");
+            IntPtr local = JNIEnv.GetStaticObjectField(outerCls, fid);
+            s_companion = JNIEnv.NewGlobalRef(local);
+            JNIEnv.DeleteLocalRef(local);
+        }
+        return s_companion;
+    }
+
+    static ContentScale? s_fit, s_crop, s_fillHeight, s_fillWidth, s_fillBounds, s_inside, s_none;
+
+    /// <summary>
+    /// <c>ContentScale.Fit</c> — scale the source uniformly (maintaining
+    /// the aspect ratio) so both dimensions fit within the destination.
+    /// Comparable to <c>ImageView.ScaleType.FIT_CENTER</c>.
+    /// </summary>
+    public static ContentScale Fit => s_fit ??= Resolve("getFit");
+
+    /// <summary>
+    /// <c>ContentScale.Crop</c> — scale the source uniformly so it fully
+    /// fills the destination, cropping any overflow. Comparable to
+    /// <c>ImageView.ScaleType.CENTER_CROP</c>.
+    /// </summary>
+    public static ContentScale Crop => s_crop ??= Resolve("getCrop");
+
+    /// <summary>
+    /// <c>ContentScale.FillHeight</c> — scale the source uniformly to
+    /// match the destination's height; the width may overflow or be
+    /// clipped depending on the parent.
+    /// </summary>
+    public static ContentScale FillHeight => s_fillHeight ??= Resolve("getFillHeight");
+
+    /// <summary>
+    /// <c>ContentScale.FillWidth</c> — scale the source uniformly to
+    /// match the destination's width; the height may overflow or be
+    /// clipped depending on the parent.
+    /// </summary>
+    public static ContentScale FillWidth => s_fillWidth ??= Resolve("getFillWidth");
+
+    /// <summary>
+    /// <c>ContentScale.FillBounds</c> — scale the source non-uniformly
+    /// to exactly match the destination bounds. Distorts the aspect
+    /// ratio. Comparable to <c>ImageView.ScaleType.FIT_XY</c>.
+    /// </summary>
+    public static ContentScale FillBounds => s_fillBounds ??= Resolve("getFillBounds");
+
+    /// <summary>
+    /// <c>ContentScale.Inside</c> — like <see cref="Fit"/> when the
+    /// source is larger than the destination; otherwise the source is
+    /// drawn at its intrinsic size (no upscaling). Comparable to
+    /// <c>ImageView.ScaleType.CENTER_INSIDE</c>.
+    /// </summary>
+    public static ContentScale Inside => s_inside ??= Resolve("getInside");
+
+    /// <summary>
+    /// <c>ContentScale.None</c> — draw the source at its intrinsic size
+    /// (no scaling). Comparable to <c>ImageView.ScaleType.CENTER</c>.
+    /// </summary>
+    public static ContentScale None => s_none ??= Resolve("getNone");
+}

--- a/src/ComposeNet.Compose/ContentScale.cs
+++ b/src/ComposeNet.Compose/ContentScale.cs
@@ -21,10 +21,10 @@ public sealed class ContentScale : Java.Lang.Object
     ContentScale(IntPtr handle, JniHandleOwnership transfer)
         : base(handle, transfer) { }
 
-    static ContentScale Resolve(string getterName)
+    static ContentScale Resolve(string getterName, string returnSig = "Landroidx/compose/ui/layout/ContentScale;")
     {
         IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/layout/ContentScale$Companion");
-        IntPtr mid = JNIEnv.GetMethodID(cls, getterName, "()Landroidx/compose/ui/layout/ContentScale;");
+        IntPtr mid = JNIEnv.GetMethodID(cls, getterName, $"(){returnSig}");
         IntPtr companion = Companion();
         IntPtr value = JNIEnv.CallObjectMethod(companion, mid);
         return new ContentScale(value, JniHandleOwnership.TransferLocalRef);
@@ -97,5 +97,5 @@ public sealed class ContentScale : Java.Lang.Object
     /// <c>ContentScale.None</c> — draw the source at its intrinsic size
     /// (no scaling). Comparable to <c>ImageView.ScaleType.CENTER</c>.
     /// </summary>
-    public static ContentScale None => s_none ??= Resolve("getNone");
+    public static ContentScale None => s_none ??= Resolve("getNone", "Landroidx/compose/ui/layout/FixedScale;");
 }

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -810,7 +810,7 @@ public sealed class Modifier
                 throw new System.InvalidOperationException(
                     "Modifier.Align(Alignment) is only valid inside a Box. " +
                     $"Current scope kind: {RenderContext.CurrentScopeKind}.");
-            return ComposeBridges.BoxScopeAlign(scope, curr, ((Java.Lang.Object)alignment.Java).Handle);
+            return ComposeBridges.BoxScopeAlign(scope, curr, ((Java.Lang.Object)alignment).Handle);
         });
     }
 

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -144,6 +144,7 @@ ComposeNet.CompositionLocal<T>.Provides(T value) -> ComposeNet.ProvidedValue!
 ComposeNet.CompositionLocalProvider
 ComposeNet.CompositionLocalProvider.Add(ComposeNet.ProvidedValue! value) -> void
 ComposeNet.CompositionLocalProvider.CompositionLocalProvider() -> void
+ComposeNet.ContentScale
 ComposeNet.Crossfade<T>
 ComposeNet.Crossfade<T>.Crossfade(T targetState, System.Func<T, ComposeNet.ComposableNode!>! content) -> void
 ComposeNet.Crossfade<T>.TargetState.get -> T
@@ -374,6 +375,12 @@ ComposeNet.IconButton.IconButton(System.Action! onClick) -> void
 ComposeNet.IconToggleButton
 ComposeNet.IconToggleButton.IconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 ComposeNet.Image
+ComposeNet.Image.Alignment.get -> ComposeNet.Alignment?
+ComposeNet.Image.Alignment.set -> void
+ComposeNet.Image.Alpha.get -> float?
+ComposeNet.Image.Alpha.set -> void
+ComposeNet.Image.ContentScale.get -> ComposeNet.ContentScale?
+ComposeNet.Image.ContentScale.set -> void
 ComposeNet.Image.Image(AndroidX.Compose.UI.Graphics.Painter.Painter! painter, string? contentDescription) -> void
 ComposeNet.Image.Image(int drawableResourceId, string? contentDescription) -> void
 ComposeNet.Image.Image(int drawableResourceId) -> void
@@ -1268,6 +1275,13 @@ static ComposeNet.CompositionLocal.Of<T>(System.Func<T>! defaultFactory) -> Comp
 static ComposeNet.CompositionLocal.StaticOf<T>(System.Func<T>! defaultFactory) -> ComposeNet.CompositionLocal<T>!
 static ComposeNet.CompositionLocal<T>.Of(System.Func<T>! defaultFactory) -> ComposeNet.CompositionLocal<T>!
 static ComposeNet.CompositionLocal<T>.StaticOf(System.Func<T>! defaultFactory) -> ComposeNet.CompositionLocal<T>!
+static ComposeNet.ContentScale.Crop.get -> ComposeNet.ContentScale!
+static ComposeNet.ContentScale.FillBounds.get -> ComposeNet.ContentScale!
+static ComposeNet.ContentScale.FillHeight.get -> ComposeNet.ContentScale!
+static ComposeNet.ContentScale.FillWidth.get -> ComposeNet.ContentScale!
+static ComposeNet.ContentScale.Fit.get -> ComposeNet.ContentScale!
+static ComposeNet.ContentScale.Inside.get -> ComposeNet.ContentScale!
+static ComposeNet.ContentScale.None.get -> ComposeNet.ContentScale!
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(float value) -> ComposeNet.Dp
 static ComposeNet.Dp.implicit operator ComposeNet.Dp(int value) -> ComposeNet.Dp
 static ComposeNet.Dp.operator !=(ComposeNet.Dp left, ComposeNet.Dp right) -> bool

--- a/src/ComposeNet.Gallery/Demos/LocalsMisc/ImageContentScaleDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/LocalsMisc/ImageContentScaleDemo.cs
@@ -1,0 +1,96 @@
+using ComposeNet.Gallery.Registry;
+
+namespace ComposeNet.Gallery.Demos.LocalsMisc;
+
+/// <summary>
+/// Image — ContentScale, Alignment, and Alpha slots. Renders the same
+/// drawable in a rectangular tile under each ContentScale value so the
+/// scaling behaviour is visible side-by-side, plus a row of alignment
+/// presets and an alpha-fade ladder.
+/// </summary>
+public static class ImageContentScaleDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "misc-image-content-scale",
+        CategoryId:  "locals-misc",
+        Title:       "Image — ContentScale / Alignment / Alpha",
+        Description: "Exercises the optional ContentScale, Alignment, and Alpha slots on the Image facade — one tile per ContentScale value, plus alignment and alpha rows.",
+        Build:       () => new Column
+        {
+            new Text("ContentScale (24×24 star, 160×80 tile):"),
+            ContentScaleTile("Fit", ContentScale.Fit),
+            ContentScaleTile("Crop", ContentScale.Crop),
+            ContentScaleTile("FillHeight", ContentScale.FillHeight),
+            ContentScaleTile("FillWidth", ContentScale.FillWidth),
+            ContentScaleTile("FillBounds", ContentScale.FillBounds),
+            ContentScaleTile("Inside", ContentScale.Inside),
+            ContentScaleTile("None", ContentScale.None),
+
+            new Text("Alignment inside a 160×80 tile (ContentScale.None):"),
+            AlignmentTile("TopStart", Alignment.TopStart),
+            AlignmentTile("Center", Alignment.Center),
+            AlignmentTile("BottomEnd", Alignment.BottomEnd),
+
+            new Text("Alpha (100% → 25%):"),
+            AlphaTile("Alpha 1.0", 1.0f),
+            AlphaTile("Alpha 0.5", 0.5f),
+            AlphaTile("Alpha 0.25", 0.25f),
+        });
+
+    static ComposableNode ContentScaleTile(string label, ContentScale scale) => new Column
+    {
+        new Text(label) { Color = Color.Black },
+        new Box
+        {
+            Modifier.Companion
+                .Border(1, Color.Gray)
+                .Background(Color.LightGray)
+                .Width(160)
+                .Height(80),
+            new Image(Resource.Drawable.ic_star, $"Star — {label}")
+            {
+                Modifier      = Modifier.Companion.FillMaxSize(),
+                ContentScale  = scale,
+            },
+        },
+    };
+
+    static ComposableNode AlignmentTile(string label, Alignment alignment) => new Column
+    {
+        new Text(label) { Color = Color.Black },
+        new Box
+        {
+            Modifier.Companion
+                .Border(1, Color.Gray)
+                .Background(Color.LightGray)
+                .Width(160)
+                .Height(80),
+            new Image(Resource.Drawable.ic_star, $"Star — {label}")
+            {
+                Modifier      = Modifier.Companion.FillMaxSize(),
+                ContentScale  = ContentScale.None,
+                Alignment     = alignment,
+            },
+        },
+    };
+
+    static ComposableNode AlphaTile(string label, float alpha) => new Column
+    {
+        new Text(label) { Color = Color.Black },
+        new Box
+        {
+            Modifier.Companion
+                .Border(1, Color.Gray)
+                .Background(Color.LightGray)
+                .Width(160)
+                .Height(80),
+            new Image(Resource.Drawable.ic_star, $"Star — {label}")
+            {
+                Modifier      = Modifier.Companion.FillMaxSize(),
+                ContentScale  = ContentScale.Fit,
+                Alpha         = alpha,
+            },
+        },
+    };
+}

--- a/src/ComposeNet.Gallery/Demos/LocalsMisc/ImageContentScaleDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/LocalsMisc/ImageContentScaleDemo.cs
@@ -40,7 +40,7 @@ public static class ImageContentScaleDemo
 
     static ComposableNode ContentScaleTile(string label, ContentScale scale) => new Column
     {
-        new Text(label) { Color = Color.Black },
+        new Text(label),
         new Box
         {
             Modifier.Companion
@@ -58,7 +58,7 @@ public static class ImageContentScaleDemo
 
     static ComposableNode AlignmentTile(string label, Alignment alignment) => new Column
     {
-        new Text(label) { Color = Color.Black },
+        new Text(label),
         new Box
         {
             Modifier.Companion
@@ -77,7 +77,7 @@ public static class ImageContentScaleDemo
 
     static ComposableNode AlphaTile(string label, float alpha) => new Column
     {
-        new Text(label) { Color = Color.Black },
+        new Text(label),
         new Box
         {
             Modifier.Companion

--- a/src/ComposeNet.Gallery/Registry/Catalog.cs
+++ b/src/ComposeNet.Gallery/Registry/Catalog.cs
@@ -154,6 +154,7 @@ public static class Catalog
         D.LocalsMisc.CircularProgressIndicatorDemo.Demo,
         D.LocalsMisc.LinearProgressIndicatorDemo.Demo,
         D.LocalsMisc.ImageDemo.Demo,
+        D.LocalsMisc.ImageContentScaleDemo.Demo,
         D.LocalsMisc.IconDemo.Demo,
     ];
 

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -131,6 +131,8 @@ public class FacadeGeneratorTests
             public class TextAlign : Java.Lang.Object { }
             public class TextDecoration : Java.Lang.Object { }
             public class Shape : Java.Lang.Object { }
+            public class Alignment : Java.Lang.Object { }
+            public class ContentScale : Java.Lang.Object { }
             public abstract class ComposableNode
             {
                 public abstract void Render(AndroidX.Compose.Runtime.IComposer composer);
@@ -2996,5 +2998,67 @@ public class FacadeGeneratorTests
 
         var (_, diags, _) = Run(code, "Bar");
         Assert.Contains(diags, d => d.Id == "CN3010" && d.GetMessage().Contains("'int defaults'"));
+    }
+
+    [Fact]
+    public void Image_OptionalAlignmentContentScaleAlphaEmitProperties()
+    {
+        // Issue #145: ContentScale, Alignment, and Alpha should surface
+        // as OptionalValue properties (nullable = "use Kotlin default"),
+        // not ctor params, and the auto-mask should clear each bit only
+        // when the corresponding property is supplied.
+        var code = """
+            using AndroidX.Compose.Runtime;
+            using AndroidX.Compose.UI;
+            using ComposeNet;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("ImageDefault",
+                "!painter", "contentDescription", "modifier",
+                "alignment", "contentScale", "alpha", "colorFilter")]
+
+            namespace ComposeNet
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class="androidx/compose/foundation/ImageKt",
+                        JvmName="Image",
+                        Signature="(Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;Landroidx/compose/runtime/Composer;II)V",
+                        Defaults=typeof(ImageDefault))]
+                    [ComposeFacade]
+                    public static partial void Image(
+                        [PainterResource] System.IntPtr painter,
+                        string? contentDescription,
+                        IModifier? modifier,
+                        Alignment? alignment,
+                        ContentScale? contentScale,
+                        float? alpha,
+                        int defaults,
+                        IComposer composer);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "Image");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+
+        // The three new slots surface as nullable auto-properties, not ctor params.
+        Assert.Contains("public global::ComposeNet.Alignment? Alignment { get; set; }", emitted);
+        Assert.Contains("public global::ComposeNet.ContentScale? ContentScale { get; set; }", emitted);
+        Assert.Contains("public float? Alpha { get; set; }", emitted);
+
+        // Auto-mask clears each bit only when the property is non-null.
+        Assert.Contains("if (Alignment is not null) __defaults &= ~(int)global::ComposeNet.ImageDefault.Alignment;", emitted);
+        Assert.Contains("if (ContentScale is not null) __defaults &= ~(int)global::ComposeNet.ImageDefault.ContentScale;", emitted);
+        Assert.Contains("if (Alpha is not null) __defaults &= ~(int)global::ComposeNet.ImageDefault.Alpha;", emitted);
+
+        // Bridge call forwards each property directly.
+        Assert.Contains("global::ComposeNet.ComposeBridges.Image(", emitted);
+        Assert.Contains(", Alignment, ContentScale, Alpha, __defaults, composer);", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
     }
 }

--- a/src/ComposeNet.SourceGenerators/ComposeReferenceTypes.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeReferenceTypes.cs
@@ -36,6 +36,8 @@ internal static class ComposeReferenceTypes
         "ComposeNet.TextAlign",
         "ComposeNet.TextDecoration",
         "ComposeNet.Shape",
+        "ComposeNet.Alignment",
+        "ComposeNet.ContentScale",
     };
 
     /// <summary>


### PR DESCRIPTION
Closes #145.

The Kotlin `androidx.compose.foundation.Image(Painter, …)` overload already accepts `alignment`, `contentScale`, and `alpha` — our facade was just passing the Kotlin defaults for all three. This PR surfaces them as optional properties so callers can render an image cropped to fill, aligned to a corner, or faded.

### What changed

- **`ComposeBridges.Image`** — three new parameters added between `modifier` and the caller-managed `defaults` mask: `Alignment? alignment, ContentScale? contentScale, float? alpha`. The JNI signature already had slots for them; only the C# user-param list grew.
- **New `ContentScale` wrapper** (`src/ComposeNet.Compose/ContentScale.cs`) — one-file class with seven static singletons (`Fit`, `Crop`, `FillHeight`, `FillWidth`, `FillBounds`, `Inside`, `None`) obtained via JNI Companion getters. Pattern mirrors `TextDecoration`.
- **`Alignment` refactor** — outer wrapper now inherits `Java.Lang.Object` using the `Shape`-style `From(IAlignment)` factory + `NewLocalRef` + `TransferLocalRef`. Nested `Vertical`/`Horizontal` (used by `Modifier.Align`) are unchanged.
- **`ComposeReferenceTypes`** — registered `ComposeNet.Alignment` and `ComposeNet.ContentScale` so the bridge generator's `null → IntPtr.Zero` reference-type path picks them up and the facade generator emits them as nullable `OptionalValue` properties. No new slot kind or generator extension needed — the existing classification handles this shape.
- **`Image` facade** — generator now emits `Alignment`, `ContentScale`, `Alpha` properties on the existing `[ComposeFacade]`-generated class. Followed the "do not demote a generated facade" rule.
- **Gallery demo** — new `Image — ContentScale / Alignment / Alpha` demo under `Demos/LocalsMisc`, wired into `Catalog.cs`. Renders `Resource.Drawable.ic_star` in 160×80 bordered tiles for each `ContentScale` value, plus a 3-tile alignment row and a 3-tile alpha-fade row.
- **Generator test** — `Image_OptionalAlignmentContentScaleAlphaEmitProperties` pins the expected facade shape for nullable reference-type slots on a caller-managed-defaults bridge.
- **`PublicAPI.Unshipped.txt`** — 15 new entries.

### Verification

- `dotnet build src/ComposeNet.Compose` — clean, 0 warnings (no `RS0016`).
- `dotnet build src/ComposeNet.Gallery` — clean.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 106/106 passing.
- Inspected the emitted `ComposeNet.ComposeBridges.Image.g.cs` and `ComposeNet.Facade.Image.g.cs` to confirm the new slots land at the right JNI positions and the auto-mask clears the correct bits.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>