### PR TITLE
Add gallery demo for LazyListState scroll-direction properties

### DIFF
--- a/src/ComposeNet.Gallery/Demos/ListsGrids/LazyListScrollStateDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/ListsGrids/LazyListScrollStateDemo.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using AndroidX.Compose.Foundation.Lazy;
+using ComposeNet.Gallery.Registry;
+
+namespace ComposeNet.Gallery.Demos.ListsGrids;
+
+/// <summary>
+/// LazyColumn with a live readout of <see cref="LazyListState"/>'s
+/// scroll-direction and visible-item properties so a reviewer can
+/// scroll the list and watch the snapshot-backed values update on the
+/// device in real time. Exercises #164.
+/// </summary>
+public static class LazyListScrollStateDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "lists-lazy-list-scroll-state",
+        CategoryId:  "lists-grids",
+        Title:       "LazyListState — scroll-direction readout",
+        Description: "1000-row LazyColumn with a live readout of FirstVisibleItemIndex, " +
+                     "FirstVisibleItemScrollOffset, CanScrollBackward/Forward, " +
+                     "LastScrolledBackward/Forward, and IsScrollInProgress.",
+        Build:       () =>
+        {
+            var state = Compose.Remember(() => new LazyListState());
+            return new Column(verticalArrangement: Arrangement.SpacedBy(4))
+            {
+                Modifier.Companion.FillMaxWidth(),
+
+                new Surface
+                {
+                    Modifier.Companion.FillMaxWidth(),
+                    new Column(verticalArrangement: Arrangement.SpacedBy(2))
+                    {
+                        Modifier.Companion.Padding(12),
+                        new Text($"FirstVisibleItemIndex:        {state.FirstVisibleItemIndex}"),
+                        new Text($"FirstVisibleItemScrollOffset: {state.FirstVisibleItemScrollOffset}"),
+                        new Text($"CanScrollBackward:            {state.CanScrollBackward}"),
+                        new Text($"CanScrollForward:             {state.CanScrollForward}"),
+                        new Text($"LastScrolledBackward:         {state.LastScrolledBackward}"),
+                        new Text($"LastScrolledForward:          {state.LastScrolledForward}"),
+                        new Text($"IsScrollInProgress:           {state.IsScrollInProgress}"),
+                    },
+                },
+
+                new Box
+                {
+                    Modifier.Companion.FillMaxWidth().Height(360),
+
+                    new LazyColumn<int>(
+                        items:       Enumerable.Range(0, 1000).ToList(),
+                        itemContent: i => new Text($"Row {i:D4}"))
+                    {
+                        Modifier = Modifier.Companion.FillMaxSize(),
+                        State    = state,
+                    },
+                },
+            };
+        });
+}

--- a/src/ComposeNet.Gallery/Registry/Catalog.cs
+++ b/src/ComposeNet.Gallery/Registry/Catalog.cs
@@ -83,6 +83,7 @@ public static class Catalog
 
         // ---- Lists & grids ----
         D.ListsGrids.LazyColumnLongDemo.Demo,
+        D.ListsGrids.LazyListScrollStateDemo.Demo,
         D.ListsGrids.LazyRowDemo.Demo,
         D.ListsGrids.LazyVerticalGridFixedDemo.Demo,
         D.ListsGrids.LazyVerticalGridAdaptiveDemo.Demo,


### PR DESCRIPTION
Closes #164.

The bound `androidx.compose.foundation.lazy.LazyListState` already exposes all the requested scroll-direction and visible-item properties directly:

- `FirstVisibleItemIndex`
- `FirstVisibleItemScrollOffset`
- `CanScrollBackward` / `CanScrollForward`
- `LastScrolledBackward` / `LastScrolledForward`
- `IsScrollInProgress`

`LazyColumn<T>.State` and `LazyRow<T>.State` are already typed as that binding and already public, so callers can read these properties today — confirmed by reflecting `Xamarin.AndroidX.Compose.Foundation.Android` 1.11.2.1 with `ilspycmd`. The only gap was the lack of a gallery demo to verify the behaviour on-device.

## What's in this PR

A single new gallery demo under **Lists & grids**, `LazyListScrollStateDemo`, that puts a live readout of all seven properties above a 1000-row `LazyColumn` so a reviewer can scroll on-device and watch the snapshot-backed values update in real time.

```csharp
var state = Compose.Remember(() => new LazyListState());
return new Column
{
    new Surface
    {
        new Column
        {
            new Text($"FirstVisibleItemIndex:        {state.FirstVisibleItemIndex}"),
            new Text($"FirstVisibleItemScrollOffset: {state.FirstVisibleItemScrollOffset}"),
            new Text($"CanScrollBackward:            {state.CanScrollBackward}"),
            // …all seven properties…
        },
    },
    new Box
    {
        Modifier.Companion.FillMaxWidth().Height(360),
        new LazyColumn<int>(items: rows, itemContent: i => new Text($"Row {i:D4}"))
        {
            Modifier = Modifier.Companion.FillMaxSize(),
            State    = state,
        },
    },
};
```

```
adb shell am start -n com.companyname.ComposeNet.Gallery/crc64f6e6d73c94e2195e.MainActivity --es route "demo/lists-lazy-list-scroll-state"
```

## What's _not_ in this PR

Wrapping the binding in a `ComposeNet.LazyListState` facade — and the ergonomic improvements that come with it (hiding the `AndroidX.Compose.Foundation.Lazy` namespace from `LazyColumn<T>.State`'s public type, attaching `ScrollToItemAsync` / `AnimateScrollToItemAsync` once the suspend bridges land) — is deferred to #152. That issue is already on the hook for `Compose.RememberLazyListState`, both suspend bridges, and the `JumpToBottom` FAB wiring in Jetchat, so the wrapper class is best landed alongside the rest of that work.

`LazyListLayoutInfo` / `visibleItemsInfo` is also out of scope — separate follow-up if/when a sample needs it.

## Verification

- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet build src/ComposeNet.Gallery` — clean.
- Diff vs merge-base: 2 files (the new demo + 1-line `Catalog.cs` registration); no facade or `PublicAPI` changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>