### PR TITLE
Add SemanticsScope fluent builder for Modifier.Semantics (#167)

### DIFF
--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -2319,6 +2319,44 @@ internal static partial class ComposeBridges
         Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;I)V")]
     internal static partial void SemanticsSetRole(IntPtr receiver, int role);
 
+    // androidx.compose.ui.semantics.SemanticsPropertiesKt.setSelected(
+    //   SemanticsPropertyReceiver, boolean) — toggles the "selected"
+    // state read by TalkBack on grouped selection nodes (tabs, list
+    // items). No mangling — no value class params. No $default.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsPropertiesKt",
+        JvmName   = "setSelected",
+        Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;Z)V")]
+    internal static partial void SemanticsSetSelected(IntPtr receiver, bool selected);
+
+    // androidx.compose.ui.semantics.SemanticsPropertiesKt.setStateDescription(
+    //   SemanticsPropertyReceiver, String) — short state hint TalkBack
+    // reads after the content description ("expanded", "3 of 5"). Same
+    // shape as setContentDescription.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsPropertiesKt",
+        JvmName   = "setStateDescription",
+        Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;" +
+                    "Ljava/lang/String;)V")]
+    internal static partial void SemanticsSetStateDescription(IntPtr receiver, string description);
+
+    // androidx.compose.ui.semantics.SemanticsPropertiesKt.onClick$default(
+    //   SemanticsPropertyReceiver, String?, Function0<Boolean>?,
+    //   int $default, Object marker) — registers a labelled
+    // accessibility click action. Two defaultable Kotlin params:
+    // label (bit 0, may be null = use platform default label) and
+    // action (bit 1, always supplied by the C# wrapper). Auto-mask
+    // shape: `string? label` lowers to the label bit; `IFunction0
+    // action` is suppressed via `!action` in the defaults enum.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsPropertiesKt",
+        JvmName   = "onClick$default",
+        Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;" +
+                    "Ljava/lang/String;Lkotlin/jvm/functions/Function0;" +
+                    "ILjava/lang/Object;)V",
+        Defaults  = typeof(SemanticsOnClickDefault))]
+    internal static partial void SemanticsOnClick(IntPtr receiver, string? label, IFunction0 action);
+
     // Shape factories — additional overloads of RoundedCornerShape /
     // CutCornerShape beyond the existing Dp variant. The Int (percent)
     // overloads aren't mangled because Int isn't an inline class. The

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -539,6 +539,13 @@ using ComposeNet;
 [assembly: ComposeDefaults("ModifierSemanticsDefault",
     "mergeDescendants", "!properties")]
 
+// androidx.compose.ui.semantics.SemanticsPropertiesKt.onClick$default —
+// 2 Kotlin params after the receiver: label (String?, optional — caller
+// may omit to get the platform-default label) and action (Function0,
+// always supplied by the C# wrapper).
+[assembly: ComposeDefaults("SemanticsOnClickDefault",
+    "label", "!action")]
+
 // androidx.compose.foundation.gestures.DraggableKt.draggable$default —
 // non-@Composable Modifier extension. 8 Kotlin params after the
 // receiver: state, orientation, enabled, interactionSource,

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -1091,6 +1091,73 @@ public sealed class Modifier
     }
 
     /// <summary>
+    /// <c>Modifier.semantics { ... }</c> — fluent builder form that
+    /// exposes all supported semantic properties (selected, role,
+    /// content/state description, onClick label) on
+    /// <see cref="SemanticsScope"/>. Doesn't merge descendant
+    /// semantics; use the overload taking <paramref name="properties"/>
+    /// + <c>mergeDescendants</c> for that.
+    /// </summary>
+    /// <param name="properties">Builder callback. Each chained call on
+    /// the supplied <see cref="SemanticsScope"/> sets one property on
+    /// the underlying Kotlin <c>SemanticsPropertyReceiver</c>.</param>
+    public Modifier Semantics(System.Action<SemanticsScope> properties) =>
+        Semantics(mergeDescendants: false, properties);
+
+    /// <summary>
+    /// <c>Modifier.semantics(mergeDescendants) { ... }</c> — fluent
+    /// builder form. Set <paramref name="mergeDescendants"/> to
+    /// <c>true</c> for a container that should announce itself as a
+    /// single accessibility node instead of exposing its children
+    /// (e.g. a card with a label and a value).
+    /// </summary>
+    /// <param name="mergeDescendants">Whether to merge descendant
+    /// semantics into this node.</param>
+    /// <param name="properties">Builder callback. See
+    /// <see cref="SemanticsScope"/> for available property setters.</param>
+    public Modifier Semantics(bool mergeDescendants, System.Action<SemanticsScope> properties)
+    {
+        System.ArgumentNullException.ThrowIfNull(properties);
+        var lambda = new ComposableLambda1(arg =>
+        {
+            if (arg is Java.Lang.Object obj)
+            {
+                var scope = new SemanticsScope(obj.Handle);
+                try { properties(scope); }
+                finally { scope.Invalidate(); }
+            }
+        });
+        return Append(curr =>
+            ComposeBridges.ModifierSemantics(curr, mergeDescendants, lambda));
+    }
+
+    /// <summary>
+    /// <c>Modifier.clearAndSetSemantics { ... }</c> — fluent builder
+    /// form. Discards the descendant semantics first, then applies
+    /// the properties set in <paramref name="properties"/>. Use when
+    /// a custom composable should appear as a single accessibility
+    /// node with a curated description, hiding implementation
+    /// details.
+    /// </summary>
+    /// <param name="properties">Builder callback. See
+    /// <see cref="SemanticsScope"/> for available property setters.</param>
+    public Modifier ClearAndSetSemantics(System.Action<SemanticsScope> properties)
+    {
+        System.ArgumentNullException.ThrowIfNull(properties);
+        var lambda = new ComposableLambda1(arg =>
+        {
+            if (arg is Java.Lang.Object obj)
+            {
+                var scope = new SemanticsScope(obj.Handle);
+                try { properties(scope); }
+                finally { scope.Invalidate(); }
+            }
+        });
+        return Append(curr =>
+            ComposeBridges.ModifierClearAndSetSemantics(curr, lambda));
+    }
+
+    /// <summary>
     /// Materialize the chain into a managed <c>IModifier</c> wrapper.
     /// Returns <c>null</c> when the chain is empty (no ops appended) so
     /// callers can keep the Kotlin <c>$default</c> bit set and let

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -1118,15 +1118,7 @@ public sealed class Modifier
     public Modifier Semantics(bool mergeDescendants, System.Action<SemanticsScope> properties)
     {
         System.ArgumentNullException.ThrowIfNull(properties);
-        var lambda = new ComposableLambda1(arg =>
-        {
-            if (arg is Java.Lang.Object obj)
-            {
-                var scope = new SemanticsScope(obj.Handle);
-                try { properties(scope); }
-                finally { scope.Invalidate(); }
-            }
-        });
+        var lambda = WrapSemanticsBuilder(properties);
         return Append(curr =>
             ComposeBridges.ModifierSemantics(curr, mergeDescendants, lambda));
     }
@@ -1144,7 +1136,18 @@ public sealed class Modifier
     public Modifier ClearAndSetSemantics(System.Action<SemanticsScope> properties)
     {
         System.ArgumentNullException.ThrowIfNull(properties);
-        var lambda = new ComposableLambda1(arg =>
+        var lambda = WrapSemanticsBuilder(properties);
+        return Append(curr =>
+            ComposeBridges.ModifierClearAndSetSemantics(curr, lambda));
+    }
+
+    // Shared body for the two builder-form overloads above. Each
+    // invocation of the returned ComposableLambda1 gets a fresh
+    // SemanticsScope bound to the JNI handle Compose hands us, and
+    // the scope is Invalidate()d the moment the user callback returns
+    // so leaked references throw a clear error on reuse.
+    static ComposableLambda1 WrapSemanticsBuilder(System.Action<SemanticsScope> properties) =>
+        new(arg =>
         {
             if (arg is Java.Lang.Object obj)
             {
@@ -1153,9 +1156,6 @@ public sealed class Modifier
                 finally { scope.Invalidate(); }
             }
         });
-        return Append(curr =>
-            ComposeBridges.ModifierClearAndSetSemantics(curr, lambda));
-    }
 
     /// <summary>
     /// Materialize the chain into a managed <c>IModifier</c> wrapper.

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -557,6 +557,7 @@ ComposeNet.Modifier.Border(ComposeNet.Dp width, ComposeNet.Color color) -> Compo
 ComposeNet.Modifier.CaptionBarPadding() -> ComposeNet.Modifier!
 ComposeNet.Modifier.ClearAndSetSemantics(string! contentDescription) -> ComposeNet.Modifier!
 ComposeNet.Modifier.ClearAndSetSemantics(string? contentDescription, ComposeNet.SemanticsRole? role) -> ComposeNet.Modifier!
+ComposeNet.Modifier.ClearAndSetSemantics(System.Action<ComposeNet.SemanticsScope!>! properties) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clickable(System.Action! onClick) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Dp cornerRadius) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Clip(ComposeNet.Shape! shape) -> ComposeNet.Modifier!
@@ -597,9 +598,11 @@ ComposeNet.Modifier.Scale(float scaleX, float scaleY) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Selectable(bool selected, System.Action! onClick) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Semantics(bool mergeDescendants, string! contentDescription) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Semantics(bool mergeDescendants, string? contentDescription, ComposeNet.SemanticsRole? role) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Semantics(bool mergeDescendants, System.Action<ComposeNet.SemanticsScope!>! properties) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Semantics(ComposeNet.SemanticsRole role) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Semantics(string! contentDescription) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Semantics(string? contentDescription, ComposeNet.SemanticsRole? role) -> ComposeNet.Modifier!
+ComposeNet.Modifier.Semantics(System.Action<ComposeNet.SemanticsScope!>! properties) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Shadow(ComposeNet.Dp elevation, ComposeNet.Shape? shape = null) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp size) -> ComposeNet.Modifier!
 ComposeNet.Modifier.Size(ComposeNet.Dp width, ComposeNet.Dp height) -> ComposeNet.Modifier!
@@ -877,6 +880,15 @@ ComposeNet.SemanticsRole.RadioButton = 3 -> ComposeNet.SemanticsRole
 ComposeNet.SemanticsRole.Switch = 2 -> ComposeNet.SemanticsRole
 ComposeNet.SemanticsRole.Tab = 4 -> ComposeNet.SemanticsRole
 ComposeNet.SemanticsRole.ValuePicker = 7 -> ComposeNet.SemanticsRole
+ComposeNet.SemanticsScope
+ComposeNet.SemanticsScope.ContentDescription(string! description) -> ComposeNet.SemanticsScope!
+ComposeNet.SemanticsScope.OnClick(string? label, System.Action! action) -> ComposeNet.SemanticsScope!
+ComposeNet.SemanticsScope.OnClick(string? label, System.Func<bool>! action) -> ComposeNet.SemanticsScope!
+ComposeNet.SemanticsScope.OnClick(System.Action! action) -> ComposeNet.SemanticsScope!
+ComposeNet.SemanticsScope.OnClick(System.Func<bool>! action) -> ComposeNet.SemanticsScope!
+ComposeNet.SemanticsScope.Role(ComposeNet.SemanticsRole role) -> ComposeNet.SemanticsScope!
+ComposeNet.SemanticsScope.Selected(bool isSelected) -> ComposeNet.SemanticsScope!
+ComposeNet.SemanticsScope.StateDescription(string! description) -> ComposeNet.SemanticsScope!
 ComposeNet.Shape
 ComposeNet.SideEffect
 ComposeNet.SideEffect.SideEffect(System.Action! effect) -> void

--- a/src/ComposeNet.Compose/SemanticsScope.cs
+++ b/src/ComposeNet.Compose/SemanticsScope.cs
@@ -1,0 +1,187 @@
+namespace ComposeNet;
+
+/// <summary>
+/// Fluent receiver passed to
+/// <see cref="Modifier.Semantics(System.Action{SemanticsScope})"/> and
+/// its overloads. Mirrors Kotlin's
+/// <c>androidx.compose.ui.semantics.SemanticsPropertyReceiver</c> —
+/// the lambda-receiver type Kotlin code sees as
+/// <c>Modifier.semantics { selected = true; role = Role.Tab; ... }</c>.
+///
+/// Each method invokes the corresponding
+/// <c>SemanticsPropertiesKt</c> setter against the underlying
+/// JNI <c>SemanticsPropertyReceiver</c> handle and returns
+/// <c>this</c>, so a single call can chain several properties:
+///
+/// <code>
+/// Modifier.Companion.Semantics(s =&gt; s
+///     .Selected(isSelected)
+///     .Role(SemanticsRole.Tab)
+///     .ContentDescription("Email from " + sender)
+///     .OnClick("Open email", () =&gt; { open(); return true; }));
+/// </code>
+///
+/// The scope is short-lived — Compose may invoke the configuration
+/// lambda multiple times (e.g. when semantics are re-applied), and
+/// each invocation gets a fresh <see cref="SemanticsScope"/> bound to
+/// the JNI handle that's live for that call. After the user's
+/// <c>Action&lt;SemanticsScope&gt;</c> returns the scope is
+/// invalidated; capturing it and calling a method later throws
+/// <see cref="System.ObjectDisposedException"/>.
+/// </summary>
+public sealed class SemanticsScope
+{
+    System.IntPtr _receiver;
+    readonly int _threadId;
+    bool _active;
+
+    internal SemanticsScope(System.IntPtr receiver)
+    {
+        _receiver = receiver;
+        _threadId = System.Environment.CurrentManagedThreadId;
+        _active = true;
+    }
+
+    internal void Invalidate()
+    {
+        _active = false;
+        _receiver = System.IntPtr.Zero;
+    }
+
+    System.IntPtr Handle
+    {
+        get
+        {
+            if (!_active)
+                throw new System.ObjectDisposedException(nameof(SemanticsScope),
+                    "SemanticsScope can only be used inside the Action<SemanticsScope> " +
+                    "callback passed to Modifier.Semantics(...) / ClearAndSetSemantics(...). " +
+                    "Capturing the scope and calling a method later is not supported.");
+            if (System.Environment.CurrentManagedThreadId != _threadId)
+                throw new System.InvalidOperationException(
+                    "SemanticsScope must be used on the same managed thread that received it. " +
+                    "Compose invokes the builder callback synchronously on the composition thread; " +
+                    "do not dispatch SemanticsScope calls to a Task / Thread / Dispatcher.");
+            return _receiver;
+        }
+    }
+
+    /// <summary>
+    /// <c>selected = isSelected</c> — marks the node as part of a
+    /// selectable group (tab, list item, chip). TalkBack announces
+    /// "selected" / "not selected" alongside the node's content
+    /// description.
+    /// </summary>
+    /// <param name="isSelected">Whether this node is currently selected.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope Selected(bool isSelected)
+    {
+        ComposeBridges.SemanticsSetSelected(Handle, isSelected);
+        return this;
+    }
+
+    /// <summary>
+    /// <c>role = role</c> — tags the node with an accessibility
+    /// <see cref="SemanticsRole"/> (e.g.
+    /// <see cref="SemanticsRole.Tab"/>) so TalkBack announces the
+    /// element class. Useful when wrapping a custom composable that
+    /// behaves like a button/tab/etc. but isn't the real
+    /// <see cref="Button"/> / <see cref="Tab"/> control.
+    /// </summary>
+    /// <param name="role">The accessibility role to advertise.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope Role(SemanticsRole role)
+    {
+        ComposeBridges.SemanticsSetRole(Handle, (int)role);
+        return this;
+    }
+
+    /// <summary>
+    /// <c>contentDescription = description</c> — the human-readable
+    /// label TalkBack reads aloud when the node is focused. For
+    /// graphical elements (icons, images) this is the only way the
+    /// user knows what the node is.
+    /// </summary>
+    /// <param name="description">Non-null description text.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope ContentDescription(string description)
+    {
+        System.ArgumentNullException.ThrowIfNull(description);
+        ComposeBridges.SemanticsSetContentDescription(Handle, description);
+        return this;
+    }
+
+    /// <summary>
+    /// <c>stateDescription = description</c> — a short string
+    /// describing the node's current state, read after the content
+    /// description (e.g. "expanded", "3 of 5"). Use for nodes whose
+    /// announced label changes with state but whose identity does
+    /// not.
+    /// </summary>
+    /// <param name="description">Non-null state description text.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope StateDescription(string description)
+    {
+        System.ArgumentNullException.ThrowIfNull(description);
+        ComposeBridges.SemanticsSetStateDescription(Handle, description);
+        return this;
+    }
+
+    /// <summary>
+    /// <c>onClick(label = label) { action() }</c> — registers a
+    /// custom accessibility click action with a label TalkBack
+    /// announces in the actions menu (e.g. "Open email"). The
+    /// <paramref name="action"/> returns <c>true</c> if the action
+    /// was handled, <c>false</c> to let the system fall back to the
+    /// node's default click behavior.
+    /// </summary>
+    /// <param name="label">Action label, or <c>null</c> to use the
+    /// platform-default label ("activate").</param>
+    /// <param name="action">Callback invoked when the user triggers
+    /// the action from the a11y menu. Must return whether the action
+    /// was handled.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope OnClick(string? label, System.Func<bool> action)
+    {
+        System.ArgumentNullException.ThrowIfNull(action);
+        var f0 = new ObjectFunction0(() => action()
+            ? (Java.Lang.Object)Java.Lang.Boolean.True!
+            : Java.Lang.Boolean.False!);
+        ComposeBridges.SemanticsOnClick(Handle, label, f0);
+        return this;
+    }
+
+    /// <summary>
+    /// Convenience overload of
+    /// <see cref="OnClick(string?, System.Func{bool})"/> that always
+    /// reports the action as handled (returns <c>true</c>). Use when
+    /// you don't need to defer back to the system's default click.
+    /// </summary>
+    /// <param name="label">Action label, or <c>null</c> for default.</param>
+    /// <param name="action">Callback invoked when the user triggers
+    /// the action.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope OnClick(string? label, System.Action action)
+    {
+        System.ArgumentNullException.ThrowIfNull(action);
+        return OnClick(label, () => { action(); return true; });
+    }
+
+    /// <summary>
+    /// Label-less overload of
+    /// <see cref="OnClick(string?, System.Func{bool})"/> — registers
+    /// the action with the platform-default label ("activate").
+    /// </summary>
+    /// <param name="action">Callback returning whether the action was handled.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope OnClick(System.Func<bool> action) => OnClick(label: null, action);
+
+    /// <summary>
+    /// Label-less <see cref="System.Action"/> overload of
+    /// <see cref="OnClick(string?, System.Func{bool})"/> — always
+    /// reports the action as handled.
+    /// </summary>
+    /// <param name="action">Callback invoked when the user triggers the action.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope OnClick(System.Action action) => OnClick(label: null, action);
+}

--- a/src/ComposeNet.Gallery/Demos/Modifiers/SemanticsBuilderDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/Modifiers/SemanticsBuilderDemo.cs
@@ -1,0 +1,100 @@
+using AndroidX.Compose.UI.Graphics;
+using ComposeNet.Gallery.Registry;
+
+namespace ComposeNet.Gallery.Demos.Modifiers;
+
+/// <summary>
+/// Fluent <see cref="Modifier.Semantics(System.Action{ComposeNet.SemanticsScope})"/>
+/// builder demo — exposes Selected, Role, ContentDescription,
+/// StateDescription, and OnClick(label, action) on a single chain.
+/// Models a multi-select email row from the upstream Reply sample.
+/// </summary>
+public static class SemanticsBuilderDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "modifiers-semantics-builder",
+        CategoryId:  "modifiers",
+        Title:       "Semantics builder (Selected/Role/OnClick)",
+        Description: "Modifier.Semantics(s => s.Selected(..).Role(..).ContentDescription(..).OnClick(\"Open\", ..)). Enable TalkBack to hear the announcements.",
+        Build:       () =>
+        {
+            var selected = Compose.Remember(() => new MutableState<bool>(false));
+            var opens    = Compose.Remember(() => new MutableNumberState<int>(0));
+
+            // The card has TWO accessibility actions:
+            //   1. The standard click — toggles selection.
+            //   2. A labelled OnClick — "Open email" in TalkBack's
+            //      actions menu, increments a counter.
+            // With TalkBack on, double-tap fires the labelled action.
+            // Without TalkBack, the physical tap toggles selection
+            // (only the Clickable handler runs in that case).
+            return new Column
+            {
+                new Text("Tap the email card to toggle selection."),
+                new Text("With TalkBack on, the same card announces "
+                       + "'Tab, selected/not selected, Email from Alice...' "
+                       + "and exposes an 'Open email' action you can "
+                       + "trigger from the actions menu."),
+                new Text("Settings → Accessibility → TalkBack to enable "
+                       + "the screen reader."),
+
+                new Card
+                {
+                    Modifier.Companion
+                        .FillMaxWidth()
+                        .Padding(8)
+                        .Clickable(() => selected.Value = !selected.Value)
+                        .Semantics(mergeDescendants: true, s => s
+                            .Selected(selected.Value)
+                            .Role(SemanticsRole.Tab)
+                            .ContentDescription("Email from Alice — Reply samples PR review")
+                            .StateDescription(selected.Value ? "Selected" : "Not selected")
+                            .OnClick("Open email", () =>
+                            {
+                                opens.Value++;
+                                return true;
+                            })),
+                    new Column
+                    {
+                        Modifier.Companion.Padding(12),
+                        new Text(selected.Value ? "✓ Alice" : "Alice")
+                        {
+                            Color = selected.Value
+                                ? Color.FromRgb(0x1B, 0x5E, 0x20)
+                                : Color.Black,
+                        },
+                        new Text("Reply samples PR review")
+                        {
+                            Color = Color.Black,
+                        },
+                        new Text($"'Open email' triggered {opens} time(s) "
+                               + "via TalkBack actions menu.")
+                        {
+                            Color = Color.Black,
+                        },
+                    },
+                },
+
+                // ClearAndSet variant — masks all descendant semantics
+                // and replaces them with our curated description, so
+                // TalkBack reads a single "Three new messages" instead
+                // of walking into each child Text.
+                new Card
+                {
+                    Modifier.Companion
+                        .FillMaxWidth()
+                        .Padding(8)
+                        .ClearAndSetSemantics(s => s
+                            .Role(SemanticsRole.Button)
+                            .ContentDescription("Three new messages, double-tap to open inbox")),
+                    new Column
+                    {
+                        Modifier.Companion.Padding(12),
+                        new Text("📬 3 new") { Color = Color.Black },
+                        new Text("Alice, Bob, Carol") { Color = Color.Black },
+                    },
+                },
+            };
+        });
+}

--- a/src/ComposeNet.Gallery/Demos/Modifiers/SemanticsBuilderDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/Modifiers/SemanticsBuilderDemo.cs
@@ -1,4 +1,3 @@
-using AndroidX.Compose.UI.Graphics;
 using ComposeNet.Gallery.Registry;
 
 namespace ComposeNet.Gallery.Demos.Modifiers;
@@ -58,21 +57,10 @@ public static class SemanticsBuilderDemo
                     new Column
                     {
                         Modifier.Companion.Padding(12),
-                        new Text(selected.Value ? "✓ Alice" : "Alice")
-                        {
-                            Color = selected.Value
-                                ? Color.FromRgb(0x1B, 0x5E, 0x20)
-                                : Color.Black,
-                        },
-                        new Text("Reply samples PR review")
-                        {
-                            Color = Color.Black,
-                        },
+                        new Text(selected.Value ? "✓ Alice" : "Alice"),
+                        new Text("Reply samples PR review"),
                         new Text($"'Open email' triggered {opens} time(s) "
-                               + "via TalkBack actions menu.")
-                        {
-                            Color = Color.Black,
-                        },
+                               + "via TalkBack actions menu."),
                     },
                 },
 
@@ -91,8 +79,8 @@ public static class SemanticsBuilderDemo
                     new Column
                     {
                         Modifier.Companion.Padding(12),
-                        new Text("📬 3 new") { Color = Color.Black },
-                        new Text("Alice, Bob, Carol") { Color = Color.Black },
+                        new Text("📬 3 new"),
+                        new Text("Alice, Bob, Carol"),
                     },
                 },
             };

--- a/src/ComposeNet.Gallery/Registry/Catalog.cs
+++ b/src/ComposeNet.Gallery/Registry/Catalog.cs
@@ -131,6 +131,7 @@ public static class Catalog
         D.Modifiers.ShapesAndShadowDemo.Demo,
         D.Modifiers.RotateScaleAlphaDemo.Demo,
         D.Modifiers.ToggleableSelectableSemanticsDemo.Demo,
+        D.Modifiers.SemanticsBuilderDemo.Demo,
         D.Modifiers.FocusRequesterDemo.Demo,
         D.Modifiers.CombinedClickableDemo.Demo,
         D.Modifiers.DraggableOffsetDemo.Demo,


### PR DESCRIPTION
Closes #167.

Adds a fluent `SemanticsScope` builder receiver for `Modifier.Semantics(...)` and `Modifier.ClearAndSetSemantics(...)`. The previous flat-args overloads only covered `contentDescription` + `role`; porting upstream samples (compose-samples/Reply) needed `selected`, `stateDescription`, and a labelled `onClick` action. The builder mirrors Kotlin's lambda-receiver shape:

```csharp
Modifier.Companion.Semantics(s => s
    .Selected(isSelected)
    .Role(SemanticsRole.Tab)
    .ContentDescription("Email from " + sender)
    .OnClick("Open email", () => { /* ... */ return true; }));
```

### What changed

- New public sealed `SemanticsScope` (`src/ComposeNet.Compose/SemanticsScope.cs`). Internal ctor; fluent instance methods `Selected`, `Role`, `ContentDescription`, `StateDescription`, `OnClick` (four overloads — `string? label` + `Func<bool>` / `Action`, plus label-less convenience overloads). Lifetime-guarded with an `_active` flag and managed-thread-ID check so capturing the scope and using it after the callback returns or from another thread throws `ObjectDisposedException` / `InvalidOperationException` with a clear message.
- Three new `Modifier` overloads: `Semantics(Action<SemanticsScope>)`, `Semantics(bool mergeDescendants, Action<SemanticsScope>)`, `ClearAndSetSemantics(Action<SemanticsScope>)`. Existing flat-args overloads kept — they remain convenient for the simplest single-property case.
- Three new `[ComposeBridge]` declarations in `ComposeBridges.cs`: `SemanticsSetSelected` (`setSelected;Z`), `SemanticsSetStateDescription` (`setStateDescription;String`), and `SemanticsOnClick` (`onClick$default` with `Defaults = typeof(SemanticsOnClickDefault)` — auto-mask: label bit cleared when caller supplies non-null, action bit suppressed via `!action`).
- New `[assembly: ComposeDefaults("SemanticsOnClickDefault", "label", "!action")]` in `ComposeDefaults.cs`.
- `OnClick` reuses the existing `ObjectFunction0` JCW to box the `() -> Boolean` action — `Java.Lang.Boolean.True`/`False` is returned per call.
- Gallery demo at `src/ComposeNet.Gallery/Demos/Modifiers/SemanticsBuilderDemo.cs` renders an email-card mock with `Selected + Role.Tab + ContentDescription + StateDescription + OnClick("Open email", …)`, plus a `ClearAndSetSemantics` card. Comment explains how to enable TalkBack to verify on-device.
- `PublicAPI.Unshipped.txt` updated with the new public entries.

### Verification

- `dotnet build src/ComposeNet.Compose` — clean, 0 warnings (no RS0016).
- `dotnet build src/ComposeNet.Gallery` — clean.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 112/112 passing.
- Inspected the emitted `ComposeNet.ComposeBridges.SemanticsOnClick.g.cs` to confirm: defaults starts at `All` (Label bit set), is cleared when the caller supplies a non-null label, never sets the Action bit, and passes 5 JNI args (receiver, label string, action handle, mask, marker = `IntPtr.Zero`) matching the `onClick$default` JVM signature.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>