### PR TITLE
Issue #169: expose NavOptions on NavController.Navigate

### DIFF
--- a/src/ComposeNet.Compose/NavController.cs
+++ b/src/ComposeNet.Compose/NavController.cs
@@ -8,7 +8,7 @@ namespace ComposeNet;
 /// <see cref="NavHost"/> and it will be populated with the underlying
 /// Kotlin controller on first composition (via Kotlin's
 /// <c>rememberNavController()</c>); from then on the navigation methods
-/// — <see cref="Navigate"/>, <c>PopBackStack</c>,
+/// — <see cref="Navigate(string)"/>, <c>PopBackStack</c>,
 /// <see cref="NavigateUp"/> — forward straight to the bound
 /// <see cref="AndroidX.Navigation.NavController"/> binding.
 ///
@@ -44,7 +44,7 @@ public sealed class NavController
     /// <see cref="NavHost.Render"/> on first composition; <c>null</c>
     /// before the host has rendered. Exposed as <c>internal</c> so the
     /// facade can stamp it; user code reaches the controller through
-    /// the <see cref="Navigate"/> / <see cref="PopBackStack()"/> /
+    /// the <see cref="Navigate(string)"/> / <see cref="PopBackStack()"/> /
     /// <see cref="NavigateUp"/> methods.
     /// </summary>
     internal AndroidX.Navigation.NavHostController? Jvm { get; set; }
@@ -63,6 +63,32 @@ public sealed class NavController
     {
         ArgumentNullException.ThrowIfNull(route);
         EnsureJvm().Navigate(route);
+    }
+
+    /// <summary>
+    /// Navigate to <paramref name="route"/> with the back-stack
+    /// behaviour described by <paramref name="options"/> — the
+    /// C# equivalent of Kotlin's
+    /// <c>navController.navigate(route, navOptions { ... })</c>.
+    /// Used to implement the standard Material 3 bottom-navigation
+    /// pattern (<c>popUpTo(startDestinationRoute) { saveState = true }</c>
+    /// + <c>launchSingleTop = true</c> + <c>restoreState = true</c>):
+    ///
+    /// <code>
+    /// nav.Navigate("search", new NavOptions
+    /// {
+    ///     PopUpToRoute     = "home",
+    ///     PopUpToSaveState = true,
+    ///     LaunchSingleTop  = true,
+    ///     RestoreState     = true,
+    /// });
+    /// </code>
+    /// </summary>
+    public void Navigate(string route, NavOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+        ArgumentNullException.ThrowIfNull(options);
+        EnsureJvm().Navigate(route, options.BuildJvm());
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/NavOptions.cs
+++ b/src/ComposeNet.Compose/NavOptions.cs
@@ -1,0 +1,119 @@
+using System;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Mutable property bag that mirrors the subset of Kotlin's
+/// <c>androidx.navigation.NavOptions.Builder</c> needed by the
+/// classic Material 3 bottom-navigation pattern. Pass to
+/// <see cref="NavController.Navigate(string, NavOptions)"/> to
+/// pop-and-restore back-stack state when switching between top-level
+/// tabs:
+///
+/// <code>
+/// nav.Navigate("search", new NavOptions
+/// {
+///     PopUpToRoute     = "home",   // = startDestinationRoute
+///     PopUpToSaveState = true,
+///     LaunchSingleTop  = true,
+///     RestoreState     = true,
+/// });
+/// </code>
+///
+/// <para>
+/// Construct with object-initializer syntax — every property is
+/// optional and defaults to "behave like the parameterless
+/// <see cref="NavController.Navigate(string)"/> overload". Reuse one
+/// <see cref="NavOptions"/> instance across navigate calls; the C#
+/// peer is built on each call so subsequent mutations are observed.
+/// </para>
+///
+/// <para>
+/// Not modelled (yet): <c>Navigator.Extras</c>, integer-id
+/// <c>popUpTo</c>, custom enter/exit animations. File an issue if
+/// you need them.
+/// </para>
+/// </summary>
+public sealed class NavOptions
+{
+    /// <summary>
+    /// Route at which to apply <c>popUpTo</c> before navigating; pops
+    /// every entry above this one off the back stack. Leave
+    /// <see langword="null"/> (the default) to skip <c>popUpTo</c>
+    /// entirely. The route must already exist on the back stack —
+    /// typically the <see cref="NavHost.StartDestination"/>.
+    /// </summary>
+    public string? PopUpToRoute { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the destination named by
+    /// <see cref="PopUpToRoute"/> is itself popped off the back
+    /// stack too. Ignored when <see cref="PopUpToRoute"/> is
+    /// <see langword="null"/>. Mirrors Kotlin's
+    /// <c>popUpTo(route) { inclusive = true }</c>.
+    /// </summary>
+    public bool PopUpToInclusive { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, the popped destinations'
+    /// saved state — <c>rememberSaveable</c>, <c>ViewModel</c>s —
+    /// is preserved and can be restored later by a navigate call
+    /// that also sets <see cref="RestoreState"/>. Standard
+    /// bottom-nav pattern: <c>PopUpToSaveState = true</c>. Ignored
+    /// when <see cref="PopUpToRoute"/> is <see langword="null"/>.
+    /// Mirrors Kotlin's <c>popUpTo(route) { saveState = true }</c>.
+    /// </summary>
+    public bool PopUpToSaveState { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, navigating to a destination
+    /// already on top of the back stack is a no-op — preventing a
+    /// duplicate entry from being pushed. Mirrors Kotlin's
+    /// <c>launchSingleTop = true</c>.
+    /// </summary>
+    public bool LaunchSingleTop { get; set; }
+
+    /// <summary>
+    /// When <see langword="true"/>, any state previously saved for
+    /// the target destination (via an earlier
+    /// <see cref="PopUpToSaveState"/> pop) is restored when the
+    /// destination is re-entered. Mirrors Kotlin's
+    /// <c>restoreState = true</c>.
+    /// </summary>
+    public bool RestoreState { get; set; }
+
+    /// <summary>
+    /// Build the Kotlin <c>NavOptions</c> peer by applying every
+    /// configured flag to a fresh
+    /// <c>androidx.navigation.NavOptions.Builder</c>. Called from
+    /// <see cref="NavController.Navigate(string, NavOptions)"/> on
+    /// every navigate so mutations to the wrapper between calls are
+    /// observed by the next navigate.
+    /// </summary>
+    internal AndroidX.Navigation.NavOptions BuildJvm()
+    {
+        // Catch caller bugs early: the route-dependent flags are
+        // silently ignored by Kotlin when no popUpTo is set, which
+        // is exactly the surprise that bites people writing the
+        // bottom-nav pattern (they forget to set PopUpToRoute and
+        // wonder why state isn't being saved).
+        if (PopUpToRoute is null && (PopUpToInclusive || PopUpToSaveState))
+        {
+            throw new InvalidOperationException(
+                "NavOptions.PopUpToInclusive / PopUpToSaveState require PopUpToRoute to be set; otherwise the popUpTo clause is dropped and the flags have no effect.");
+        }
+
+        var builder = new AndroidX.Navigation.NavOptions.Builder();
+
+        if (PopUpToRoute is not null)
+            builder.SetPopUpTo(PopUpToRoute, PopUpToInclusive, PopUpToSaveState);
+
+        if (LaunchSingleTop)
+            builder.SetLaunchSingleTop(true);
+
+        if (RestoreState)
+            builder.SetRestoreState(true);
+
+        return builder.Build();
+    }
+}

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -670,6 +670,7 @@ ComposeNet.NavController
 ComposeNet.NavController.CurrentBackStackEntry.get -> ComposeNet.NavBackStackEntry?
 ComposeNet.NavController.NavController() -> void
 ComposeNet.NavController.Navigate(string! route) -> void
+ComposeNet.NavController.Navigate(string! route, ComposeNet.NavOptions! options) -> void
 ComposeNet.NavController.NavigateUp() -> bool
 ComposeNet.NavController.PopBackStack() -> bool
 ComposeNet.NavController.PopBackStack(string! route, bool inclusive) -> bool
@@ -679,6 +680,18 @@ ComposeNet.NavHost.Add(ComposeNet.Modifier! modifier) -> void
 ComposeNet.NavHost.NavController.get -> ComposeNet.NavController!
 ComposeNet.NavHost.NavHost(string! startDestination, ComposeNet.NavController? navController = null) -> void
 ComposeNet.NavHost.StartDestination.get -> string!
+ComposeNet.NavOptions
+ComposeNet.NavOptions.LaunchSingleTop.get -> bool
+ComposeNet.NavOptions.LaunchSingleTop.set -> void
+ComposeNet.NavOptions.NavOptions() -> void
+ComposeNet.NavOptions.PopUpToInclusive.get -> bool
+ComposeNet.NavOptions.PopUpToInclusive.set -> void
+ComposeNet.NavOptions.PopUpToRoute.get -> string?
+ComposeNet.NavOptions.PopUpToRoute.set -> void
+ComposeNet.NavOptions.PopUpToSaveState.get -> bool
+ComposeNet.NavOptions.PopUpToSaveState.set -> void
+ComposeNet.NavOptions.RestoreState.get -> bool
+ComposeNet.NavOptions.RestoreState.set -> void
 ComposeNet.NavigationBar
 ComposeNet.NavigationBar.NavigationBar() -> void
 ComposeNet.NavigationBarItem

--- a/src/ComposeNet.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
@@ -1,0 +1,124 @@
+using AndroidX.Compose.Runtime;
+using ComposeNet.Gallery.Registry;
+
+namespace ComposeNet.Gallery.Demos.Navigation;
+
+/// <summary>
+/// Bottom-navigation demo that exercises the
+/// <see cref="ComposeNet.NavOptions"/> overload of
+/// <see cref="NavController.Navigate(string, ComposeNet.NavOptions)"/>.
+/// Three top-level tabs — Home, Search, Profile — share a single
+/// <see cref="NavController"/>; each tab tap pops back to the start
+/// destination with <c>saveState = true</c>, launches single-top, and
+/// restores any state previously saved for the target tab.
+///
+/// <para>
+/// Per-tab counters use <see cref="Compose.RememberSaveable{T}(System.Func{T}, int, string)"/>
+/// so a reviewer can prove the saved-state round-trip: tap Increment
+/// a few times, switch tabs, come back — the count should still be
+/// there.
+/// </para>
+/// </summary>
+public static class BottomNavOptionsDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "navigation-bottom-nav-options",
+        CategoryId:  "navigation",
+        Title:       "NavOptions — bottom nav (popUpTo + saveState)",
+        Description: "Three tabs share one NavController; tapping pops to start with saveState/restoreState so per-tab counters survive switches.",
+        Build:       () =>
+        {
+            const string startRoute = "home";
+
+            var nav      = Compose.Remember(() => new NavController());
+            var selected = Compose.Remember(() => new MutableState<string>(startRoute));
+
+            return new Column
+            {
+                Modifier.Companion.FillMaxWidth(),
+
+                new Text("Tap Search or Profile, hit Increment a few times, switch to another tab and come back — the counter survives via popUpTo(saveState) + restoreState. (Selection follows taps; back-stack changes via the system Back button don't update the highlight in this v1 demo.)"),
+
+                // Bounded NavHost so the inner subcomposition has a
+                // finite slot to lay out into; the NavigationBar below
+                // it picks up its natural M3 height.
+                new Box
+                {
+                    Modifier.Companion.FillMaxWidth().Height(260),
+                    new NavHost(startDestination: startRoute, navController: nav)
+                    {
+                        new Composable(startRoute,    _ => new CounterPane("🏠 Home")),
+                        new Composable("search",      _ => new CounterPane("🔍 Search")),
+                        new Composable("profile",     _ => new CounterPane("👤 Profile")),
+                    },
+                },
+
+                new NavigationBar
+                {
+                    new NavigationBarItem(
+                        selected: selected.Value == startRoute,
+                        onClick:  () => GoToTab(nav, selected, startRoute, startRoute))
+                    {
+                        Icon  = new Text("🏠"),
+                        Label = new Text("Home"),
+                    },
+                    new NavigationBarItem(
+                        selected: selected.Value == "search",
+                        onClick:  () => GoToTab(nav, selected, "search", startRoute))
+                    {
+                        Icon  = new Text("🔍"),
+                        Label = new Text("Search"),
+                    },
+                    new NavigationBarItem(
+                        selected: selected.Value == "profile",
+                        onClick:  () => GoToTab(nav, selected, "profile", startRoute))
+                    {
+                        Icon  = new Text("👤"),
+                        Label = new Text("Profile"),
+                    },
+                },
+            };
+        });
+
+    static void GoToTab(NavController nav, MutableState<string> selected, string route, string startRoute)
+    {
+        selected.Value = route;
+        nav.Navigate(route, new NavOptions
+        {
+            PopUpToRoute     = startRoute,
+            PopUpToSaveState = true,
+            LaunchSingleTop  = true,
+            RestoreState     = true,
+        });
+    }
+
+    // Private per-destination node — needs to be a ComposableNode (not
+    // an inline tree built in the demo's Build lambda) so the
+    // RememberSaveable call happens INSIDE the destination's own
+    // subcomposition. That's what scopes the saved counter to the
+    // NavBackStackEntry rather than the outer demo screen, so the
+    // saveState/restoreState round-trip actually has work to do.
+    sealed class CounterPane : ComposableNode
+    {
+        readonly string _title;
+
+        public CounterPane(string title) => _title = title;
+
+        public override void Render(IComposer composer)
+        {
+            var count = Compose.RememberSaveable(() => new MutableNumberState<int>(0));
+
+            new Column(verticalArrangement: Arrangement.SpacedBy(8))
+            {
+                Modifier.Companion.Padding(16),
+                new Text(_title),
+                new Text($"Tapped {count.Value} times"),
+                new Button(onClick: () => count++)
+                {
+                    new Text("Increment"),
+                },
+            }.Render(composer);
+        }
+    }
+}

--- a/src/ComposeNet.Gallery/Registry/Catalog.cs
+++ b/src/ComposeNet.Gallery/Registry/Catalog.cs
@@ -107,6 +107,7 @@ public static class Catalog
 
         // ---- Navigation ----
         D.Navigation.NavHostRouteArgsDemo.Demo,
+        D.Navigation.BottomNavOptionsDemo.Demo,
         D.Navigation.BackHandlerDemo.Demo,
         D.Navigation.NavigationDrawerItemDemo.Demo,
         D.Navigation.ModalDrawerDemo.Demo,


### PR DESCRIPTION
Closes #169.

Adds a `ComposeNet.NavOptions` POCO and a
`NavController.Navigate(string, NavOptions)` overload so callers can
wire up the standard Material 3 bottom-navigation pattern without
needing a raw `androidx.navigation.NavOptions.Builder` JNI call:

```csharp
nav.Navigate("search", new NavOptions
{
    PopUpToRoute     = "home",   // = startDestinationRoute
    PopUpToSaveState = true,
    LaunchSingleTop  = true,
    RestoreState     = true,
});
```

The parameterless `Navigate(string)` overload is unchanged.

## Surface

- **`ComposeNet.NavOptions`** — mutable property bag with
  `PopUpToRoute` (string?), `PopUpToInclusive`, `PopUpToSaveState`,
  `LaunchSingleTop`, `RestoreState`. Internal `BuildJvm()` instantiates
  `new AndroidX.Navigation.NavOptions.Builder()`, applies the
  configured flags, and returns the built peer on every navigate.
- **`NavController.Navigate(string route, NavOptions options)`** —
  forwards to the bound `NavController.Navigate(string, NavOptions)`
  binding overload.

`NavOptions.BuildJvm` throws `InvalidOperationException` if
`PopUpToInclusive` or `PopUpToSaveState` is set without
`PopUpToRoute` — catches the most common bottom-nav footgun (forgetting
to set the route causes Kotlin to silently drop the whole `popUpTo`
clause).

## Demo

`src/ComposeNet.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs` —
three-tab Home / Search / Profile bottom nav. Each route hosts a
`Compose.RememberSaveable`-backed counter inside a per-destination
`ComposableNode` so the saveable scope is the `NavBackStackEntry`
(not the outer demo screen). To verify the round-trip on-device:
tap Search → Increment a few times → tap Profile → tap Search again
— the counter is still there.

## Out of scope

- `Navigator.Extras` overload — follow-up.
- Integer-id `popUpTo` overload — Compose routes are strings.
- `NavigationBarItem.Selected` syncing with the system Back button —
  the demo's selected-tab highlight is one-way (taps only). A proper
  fix needs a `CurrentBackStackEntryAsState`-style API; called out in
  the demo's description text.

## Verification

- `dotnet build src/ComposeNet.Compose` — 0 errors, 0 warnings.
- `dotnet build src/ComposeNet.Gallery` — 0 errors, 0 warnings.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 112/112 passed.

Public-API analyzer (`RS0016`/`RS0017`) is clean — `NavOptions` and the
new `Navigate` overload are listed in `PublicAPI.Unshipped.txt`.