### PR TITLE
Add Compose.SnapshotFlow<T> runtime primitive

### DIFF
--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -701,4 +701,78 @@ public static class Compose
             composer.EndReplaceableGroup();
         }
     }
+
+    /// <summary>
+    /// Bridges Compose's <c>snapshotFlow { producer() }</c> into an
+    /// <see cref="System.Collections.Generic.IAsyncEnumerable{T}"/>.
+    /// Every time any <see cref="MutableState{T}"/> /
+    /// <see cref="MutableNumberState{T}"/> read inside
+    /// <paramref name="producer"/> is written to and the surrounding
+    /// snapshot is applied, the producer re-runs on Compose's main
+    /// dispatcher and the new value flows through the returned
+    /// async sequence. Duplicate consecutive values (compared via
+    /// Java <c>equals</c>) are suppressed by Kotlin's
+    /// <c>snapshotFlow</c> — the C# consumer only sees genuine
+    /// changes.
+    /// </summary>
+    /// <typeparam name="T">
+    /// Value type produced. Must round-trip through
+    /// <see cref="MutableState{T}"/>'s boxing helpers — the
+    /// supported set is .NET primitives (<see cref="byte"/>,
+    /// <see cref="sbyte"/>, <see cref="short"/>, <see cref="ushort"/>,
+    /// <see cref="int"/>, <see cref="uint"/>, <see cref="long"/>,
+    /// <see cref="ulong"/>, <see cref="float"/>, <see cref="double"/>,
+    /// <see cref="bool"/>, <see cref="char"/>), <see cref="string"/>,
+    /// <see cref="Java.Lang.Object"/> peers, and
+    /// <see cref="System.Nullable{T}"/> of any of those primitives.
+    /// Tuples / value tuples / arbitrary CLR structs are not
+    /// supported.
+    /// </typeparam>
+    /// <param name="producer">
+    /// Lambda that reads one or more Compose state values and
+    /// returns a derived value. <strong>Not</strong>
+    /// <c>@Composable</c> — do not call <c>Compose.Remember</c> or
+    /// any other Compose-runtime helper from inside. Reads do not
+    /// have to be wrapped in <see cref="DerivedStateOf{T}"/>;
+    /// <c>snapshotFlow</c> records dependencies automatically via
+    /// snapshot tracking.
+    /// </param>
+    /// <returns>
+    /// An async sequence that yields each new producer value on the
+    /// Compose main thread until the consumer disposes the
+    /// enumerator or cancels the <see cref="System.Threading.CancellationToken"/>
+    /// passed to <c>WithCancellation</c>. Disposing or cancelling
+    /// tears down the underlying Kotlin coroutine and unregisters
+    /// the snapshot-apply observer.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// <strong>Back-pressure:</strong> values are buffered through a
+    /// bounded(1) channel with <c>DropOldest</c> conflation. A slow
+    /// consumer naturally sees only the latest value between reads —
+    /// matching the behaviour of Kotlin's own <c>collect</c> when
+    /// the collector can't keep up. <c>emit</c> never blocks
+    /// Kotlin's dispatcher, so there's no risk of deadlock against a
+    /// C# awaiter resuming on the same main thread.
+    /// </para>
+    /// <para>
+    /// <strong>Canonical use case:</strong> reacting to
+    /// <c>LazyListState</c> scroll position, e.g.
+    /// <c>Compose.SnapshotFlow(() => listState.FirstVisibleItemIndex)</c>,
+    /// to fire analytics or fetch more data when the user scrolls
+    /// past a threshold. Pair with <c>Compose.LaunchedEffect</c> so
+    /// the collection's lifetime is tied to the composition that
+    /// started it.
+    /// </para>
+    /// <para>
+    /// Each call to <see cref="System.Collections.Generic.IAsyncEnumerable{T}.GetAsyncEnumerator"/>
+    /// starts a fresh Kotlin coroutine — the returned enumerable is
+    /// not multicast.
+    /// </para>
+    /// </remarks>
+    public static System.Collections.Generic.IAsyncEnumerable<T> SnapshotFlow<T>(System.Func<T> producer)
+    {
+        System.ArgumentNullException.ThrowIfNull(producer);
+        return new SnapshotFlowEnumerable<T>(producer);
+    }
 }

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -1303,6 +1303,7 @@ static ComposeNet.Compose.RememberDraggableState(System.Action<float>! onDelta, 
 static ComposeNet.Compose.RememberKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
+static ComposeNet.Compose.SnapshotFlow<T>(System.Func<T>! producer) -> System.Collections.Generic.IAsyncEnumerable<T>!
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveableKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -1303,11 +1303,11 @@ static ComposeNet.Compose.RememberDraggableState(System.Action<float>! onDelta, 
 static ComposeNet.Compose.RememberKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
-static ComposeNet.Compose.SnapshotFlow<T>(System.Func<T>! producer) -> System.Collections.Generic.IAsyncEnumerable<T>!
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveable<T>(System.Func<T>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.RememberSaveableKeyed<T>(System.Func<T>! factory, object?[]! keys, int line = 0, string! file = "") -> T
 static ComposeNet.Compose.SideEffect(System.Action! effect) -> void
+static ComposeNet.Compose.SnapshotFlow<T>(System.Func<T>! producer) -> System.Collections.Generic.IAsyncEnumerable<T>!
 static ComposeNet.CompositionLocal.Of<T>(System.Func<T>! defaultFactory) -> ComposeNet.CompositionLocal<T>!
 static ComposeNet.CompositionLocal.StaticOf<T>(System.Func<T>! defaultFactory) -> ComposeNet.CompositionLocal<T>!
 static ComposeNet.CompositionLocal<T>.Of(System.Func<T>! defaultFactory) -> ComposeNet.CompositionLocal<T>!

--- a/src/ComposeNet.Compose/SnapshotFlowCollectorAdapter.cs
+++ b/src/ComposeNet.Compose/SnapshotFlowCollectorAdapter.cs
@@ -1,0 +1,64 @@
+using System.Threading.Channels;
+using Android.Runtime;
+using Kotlin.Coroutines;
+using Xamarin.KotlinX.Coroutines.Flow;
+
+namespace ComposeNet;
+
+/// <summary>
+/// JCW implementing Kotlin's <c>kotlinx.coroutines.flow.FlowCollector</c>
+/// for <see cref="Compose.SnapshotFlow{T}(System.Func{T})"/>. Each
+/// <c>emit(value, continuation)</c> call from Kotlin unboxes the
+/// value, pushes it onto a single-slot bounded
+/// <see cref="System.Threading.Channels.Channel{T}"/>, and returns
+/// <c>Unit.INSTANCE</c> synchronously — i.e. <c>emit</c> never
+/// suspends Kotlin's continuation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The channel is <see cref="BoundedChannelFullMode.DropOldest"/> with
+/// capacity 1 so a slow C# consumer naturally conflates to the
+/// latest value. This matches Compose's own behaviour: between
+/// snapshot applies, only the most recent producer result matters.
+/// It also makes <c>emit</c> non-blocking, which is critical when
+/// the Kotlin coroutine ends up dispatched onto the same main
+/// thread the C# <c>await foreach</c> resumes on (blocking
+/// <c>emit</c> there would deadlock).
+/// </para>
+/// </remarks>
+[Register("composenet/compose/SnapshotFlowCollectorAdapter")]
+internal sealed class SnapshotFlowCollectorAdapter<T> : Java.Lang.Object, IFlowCollector
+{
+    readonly ChannelWriter<T> _writer;
+
+    public SnapshotFlowCollectorAdapter(ChannelWriter<T> writer)
+    {
+        _writer = writer;
+    }
+
+    public Java.Lang.Object Emit(Java.Lang.Object? value, IContinuation p1)
+    {
+        try
+        {
+            var unboxed = MutableState<T>.FromJava(value);
+            // BoundedChannelFullMode.DropOldest guarantees TryWrite
+            // succeeds — the channel always has room because the
+            // oldest entry is silently discarded when full.
+            _writer.TryWrite(unboxed);
+        }
+        catch (System.Exception ex)
+        {
+            // A faulting Emit would otherwise propagate into the
+            // Kotlin flow as a CancellationException-shaped exit,
+            // but the C# consumer would never see the underlying
+            // cause. Surface it through channel completion so the
+            // awaiter's await foreach throws it directly.
+            _writer.TryComplete(ex);
+        }
+        // Synchronous completion: returning a non-suspended value
+        // tells Kotlin's flow machinery that emit finished without
+        // needing to park the continuation. snapshotFlow then loops
+        // back to its next snapshot-apply wait.
+        return global::Kotlin.Unit.Instance!;
+    }
+}

--- a/src/ComposeNet.Compose/SnapshotFlowContinuation.cs
+++ b/src/ComposeNet.Compose/SnapshotFlowContinuation.cs
@@ -1,0 +1,137 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Android.Runtime;
+using Kotlin.Coroutines;
+using Xamarin.KotlinX.Coroutines;
+
+namespace ComposeNet;
+
+/// <summary>
+/// JCW implementing Kotlin's <see cref="IContinuation"/> for the
+/// long-running <c>Flow.collect</c> call that drives
+/// <see cref="Compose.SnapshotFlow{T}(System.Func{T})"/>. Unlike
+/// <see cref="SuspendContinuation"/>, which models a one-shot suspend
+/// resumed back into a <see cref="TaskCompletionSource{TResult}"/>,
+/// this continuation:
+/// <list type="bullet">
+/// <item><description>Exposes a <see cref="Context"/> combining
+/// <c>AndroidUiDispatcher.Main</c> with a Kotlin <see cref="IJob"/>
+/// so that cancelling the job tears down the flow's
+/// <c>snapshotFlow</c> internals (its apply observer registration,
+/// its internal changes channel, etc.).</description></item>
+/// <item><description>On <see cref="ResumeWith(Java.Lang.Object)"/>
+/// — fired once when Kotlin's collect coroutine finishes for any
+/// reason — completes the consumer's channel writer so the
+/// <c>await foreach</c> exits cleanly (with the underlying exception
+/// if the flow faulted with anything other than a normal
+/// cancellation).</description></item>
+/// </list>
+/// </summary>
+[Register("composenet/compose/SnapshotFlowContinuation")]
+internal sealed class SnapshotFlowContinuation : Java.Lang.Object, IContinuation
+{
+    readonly IJob _job;
+    readonly TaskCompletionSource<object?> _tcs;
+
+    /// <summary>
+    /// Task that completes when Kotlin's collect coroutine has fully
+    /// resumed (i.e. <see cref="ResumeWith(Java.Lang.Object)"/> has
+    /// fired). The result is irrelevant — callers <c>await</c> it just
+    /// to know the Kotlin side has unwound (used by
+    /// <see cref="SnapshotFlowEnumerator{T}.DisposeAsync"/>).
+    /// </summary>
+    public Task Completion => _tcs.Task;
+
+    public SnapshotFlowContinuation(IJob job)
+    {
+        _job = job;
+        _tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    /// <summary>
+    /// Coroutine context = <c>AndroidUiDispatcher.Main</c> combined
+    /// with our <see cref="IJob"/>. The Main dispatcher provides the
+    /// <c>MonotonicFrameClock</c> Compose needs internally; the Job
+    /// is what lets us cancel from C#.
+    /// </summary>
+    public ICoroutineContext Context
+    {
+        get
+        {
+            var mainHandle = ComposeBridges.AndroidUiDispatcherMain();
+            var main = global::Java.Lang.Object.GetObject<ICoroutineContext>(
+                mainHandle, JniHandleOwnership.DoNotTransfer)!;
+            return main.Plus(_job);
+        }
+    }
+
+    /// <summary>
+    /// Callback invoked once when Kotlin's collect coroutine
+    /// resumes. Receives <c>null</c> for normal completion /
+    /// cancellation, or the underlying <see cref="System.Exception"/>
+    /// when the flow faulted with anything other than a
+    /// <c>CancellationException</c>.
+    /// </summary>
+    /// <remarks>
+    /// Set this exactly once before the Kotlin coroutine can ever
+    /// reach a resume point (i.e. immediately after constructing the
+    /// continuation, before passing it to <c>flow.Collect</c>). It's
+    /// read once on the resume path and isn't expected to change.
+    /// </remarks>
+    internal System.Action<System.Exception?>? OnResumed { get; set; }
+
+    /// <summary>
+    /// Forces <see cref="Completion"/> to complete without going
+    /// through Kotlin's <see cref="ResumeWith(Java.Lang.Object)"/>
+    /// path. Use this only when the caller knows the suspend
+    /// function completed synchronously (returned a non-suspended
+    /// value before ever scheduling a resume), since Kotlin then
+    /// never invokes the continuation and we'd otherwise wait
+    /// forever for the resume that's never coming.
+    /// </summary>
+    internal void MarkSynchronouslyCompleted()
+    {
+        try { OnResumed?.Invoke(null); }
+        catch (System.Exception ex) { _tcs.TrySetException(ex); return; }
+        _tcs.TrySetResult(null);
+    }
+
+    public void ResumeWith(Java.Lang.Object p0)
+    {
+        System.Exception? error = null;
+        try
+        {
+            if (p0 is not null && KotlinResult.IsFailure(p0.Handle))
+            {
+                var ex = KotlinResult.ExtractException(p0);
+                // CancellationException is the normal "we were told
+                // to stop" signal — surface as a clean stream close,
+                // not as an exception on the awaiter.
+                if (ex is not Java.Util.Concurrent.CancellationException)
+                    error = ex;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            // KotlinResult helpers can throw on malformed boxes.
+            // Surface the diagnostic to the awaiter rather than
+            // swallowing it.
+            error = ex;
+        }
+
+        try
+        {
+            OnResumed?.Invoke(error);
+        }
+        catch (System.Exception ex)
+        {
+            // The enumerator's completion handler should be
+            // exception-free, but if it ever isn't we still need to
+            // unblock awaiters of Completion.
+            _tcs.TrySetException(ex);
+            return;
+        }
+
+        _tcs.TrySetResult(null);
+    }
+}

--- a/src/ComposeNet.Compose/SnapshotFlowEnumerable.cs
+++ b/src/ComposeNet.Compose/SnapshotFlowEnumerable.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Backing implementation for
+/// <see cref="Compose.SnapshotFlow{T}(System.Func{T})"/>. Each call to
+/// <see cref="GetAsyncEnumerator(CancellationToken)"/> spins up a
+/// fresh Kotlin <c>snapshotFlow</c> collection so multiple consumers
+/// of the same producer don't share state.
+/// </summary>
+internal sealed class SnapshotFlowEnumerable<T> : IAsyncEnumerable<T>
+{
+    readonly System.Func<T> _producer;
+
+    public SnapshotFlowEnumerable(System.Func<T> producer)
+    {
+        _producer = producer;
+    }
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) =>
+        new SnapshotFlowEnumerator<T>(_producer, cancellationToken);
+}

--- a/src/ComposeNet.Compose/SnapshotFlowEnumerator.cs
+++ b/src/ComposeNet.Compose/SnapshotFlowEnumerator.cs
@@ -3,9 +3,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Android.Runtime;
 using AndroidX.Compose.Runtime;
-using Kotlin.Coroutines.Intrinsics;
 using Xamarin.KotlinX.Coroutines;
 using Xamarin.KotlinX.Coroutines.Flow;
 
@@ -217,7 +215,7 @@ internal sealed class SnapshotFlowEnumerator<T> : IAsyncEnumerator<T>
         {
             var boxed = flow.Collect(_collectorJcw, _continuation);
             var handle = boxed?.Handle ?? IntPtr.Zero;
-            if (handle != IntPtr.Zero && !IsCoroutineSuspended(handle))
+            if (handle != IntPtr.Zero && !SuspendBridge.IsCoroutineSuspended(handle))
             {
                 synchronouslyCompleted = true;
                 // Only dispose the non-sentinel wrapper. The
@@ -259,26 +257,5 @@ internal sealed class SnapshotFlowEnumerator<T> : IAsyncEnumerator<T>
             return;
         if (_pin.IsAllocated)
             _pin.Free();
-    }
-
-    // Cached global ref to the COROUTINE_SUSPENDED sentinel — same
-    // pattern as SuspendBridge. snapshotFlow's collect always
-    // suspends on first call (it has to register an apply observer
-    // first), so this branch is essentially dead in practice; we
-    // still need it to be correct for the synchronous-fault edge
-    // case where Kotlin throws inline.
-    static IntPtr s_suspendedHandle;
-    static bool IsCoroutineSuspended(IntPtr handle)
-    {
-        if (handle == IntPtr.Zero) return false;
-        if (s_suspendedHandle == IntPtr.Zero)
-        {
-            var inst = IntrinsicsKt.COROUTINE_SUSPENDED;
-            var gref = JNIEnv.NewGlobalRef(inst.Handle);
-            if (Interlocked.CompareExchange(ref s_suspendedHandle, gref, IntPtr.Zero) != IntPtr.Zero)
-                JNIEnv.DeleteGlobalRef(gref);
-            System.GC.KeepAlive(inst);
-        }
-        return JNIEnv.IsSameObject(handle, s_suspendedHandle);
     }
 }

--- a/src/ComposeNet.Compose/SnapshotFlowEnumerator.cs
+++ b/src/ComposeNet.Compose/SnapshotFlowEnumerator.cs
@@ -1,0 +1,284 @@
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Android.Runtime;
+using AndroidX.Compose.Runtime;
+using Kotlin.Coroutines.Intrinsics;
+using Xamarin.KotlinX.Coroutines;
+using Xamarin.KotlinX.Coroutines.Flow;
+
+namespace ComposeNet;
+
+/// <summary>
+/// Async iterator for <see cref="Compose.SnapshotFlow{T}(System.Func{T})"/>.
+/// On first <see cref="MoveNextAsync"/> it starts a Kotlin
+/// <c>snapshotFlow(producer).collect(...)</c> coroutine on the
+/// Compose main dispatcher, with a Kotlin <see cref="IJob"/> in the
+/// continuation context so the consumer's
+/// <see cref="CancellationToken"/> (or
+/// <see cref="DisposeAsync"/>) can tear the flow down for real.
+/// </summary>
+internal sealed class SnapshotFlowEnumerator<T> : IAsyncEnumerator<T>
+{
+    readonly System.Func<T> _producer;
+    readonly CancellationToken _userToken;
+    readonly Channel<T> _channel;
+
+    // JCWs we have to keep rooted for the lifetime of the Kotlin
+    // coroutine: dropping any of these while Kotlin is still holding
+    // its JNI ref would leave the runtime pointing at a freed peer.
+    ObjectFunction0? _producerJcw;
+    SnapshotFlowCollectorAdapter<T>? _collectorJcw;
+    SnapshotFlowContinuation? _continuation;
+    ICompletableJob? _job;
+    GCHandle _pin;
+    int _pinReleased;
+
+    CancellationTokenRegistration _ctr;
+    bool _started;
+    bool _disposed;
+    T? _current;
+
+    public SnapshotFlowEnumerator(System.Func<T> producer, CancellationToken userToken)
+    {
+        _producer = producer;
+        _userToken = userToken;
+        // SingleWriter intentionally false: Emit (Kotlin dispatcher
+        // thread), OnResumed (resume thread), and DisposeAsync
+        // (caller thread) can each call TryComplete / TryWrite.
+        _channel = Channel.CreateBounded<T>(new BoundedChannelOptions(1)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+    }
+
+    public T Current => _current!;
+
+    public async ValueTask<bool> MoveNextAsync()
+    {
+        if (!_started)
+        {
+            _started = true;
+            try
+            {
+                StartCollection();
+            }
+            catch (System.Exception ex)
+            {
+                // Setup failure — surface to the awaiter and stop
+                // the iteration. Mark started so a subsequent call
+                // sees the now-completed channel instead of trying
+                // again.
+                _channel.Writer.TryComplete(ex);
+            }
+        }
+
+        try
+        {
+            if (await _channel.Reader.WaitToReadAsync(_userToken).ConfigureAwait(false))
+            {
+                if (_channel.Reader.TryRead(out var value))
+                {
+                    _current = value;
+                    return true;
+                }
+            }
+        }
+        catch (ChannelClosedException ex) when (ex.InnerException is not null)
+        {
+            // WaitToReadAsync surfaces the completion exception as
+            // its own ChannelClosedException wrapper; unwrap so the
+            // awaiter sees the original error from the producer or
+            // collector.
+            throw ex.InnerException;
+        }
+
+        return false;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _ctr.Dispose();
+
+        // Cancel Kotlin-side so snapshotFlow's apply observer
+        // unregisters and its internal channel closes. If Kotlin
+        // never started, _job is null and there's nothing to cancel.
+        try { _job?.Cancel(null); } catch { }
+
+        // Close the channel from our side too in case Kotlin never
+        // got far enough to drive ResumeWith (e.g. setup failure).
+        _channel.Writer.TryComplete();
+
+        if (_continuation is { } cont)
+        {
+            try
+            {
+                // Wait — bounded — for Kotlin to actually unwind.
+                // Without this, the JCWs (and their JNI peers) could
+                // be GC'd while Kotlin still holds references, which
+                // tends to crash with "expected Local but found ..."
+                // from CheckJNI.
+                var completedFirst = await Task.WhenAny(
+                    cont.Completion,
+                    Task.Delay(System.TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+                if (completedFirst != cont.Completion)
+                {
+                    // Kotlin didn't acknowledge cancellation within the
+                    // grace window. Log and keep going; the JCWs stay
+                    // rooted via _pin until the resume eventually
+                    // fires, which is leak-not-crash.
+                    Android.Util.Log.Warn(
+                        "ComposeNet",
+                        "SnapshotFlow: Kotlin coroutine didn't unwind within 2s after cancellation; JCWs will stay rooted until the eventual resume.");
+                    return;
+                }
+            }
+            catch
+            {
+                // Completion task can fault if ResumeWith fails;
+                // we've already cancelled and best-effort cleaned up.
+            }
+        }
+
+        ReleasePin();
+    }
+
+    void StartCollection()
+    {
+        // 1. Fresh Kotlin Job so we can cancel the coroutine for
+        //    real (vs. just abandoning the C# awaiter).
+        _job = JobKt.Job(null);
+
+        // 2. JCWs. Allocate them once and root via _pin so neither
+        //    Kotlin nor we drop them while collect is running.
+        _producerJcw = new ObjectFunction0(() => MutableState<T>.ToJava(_producer()));
+        _collectorJcw = new SnapshotFlowCollectorAdapter<T>(_channel.Writer);
+        _continuation = new SnapshotFlowContinuation(_job);
+
+        // Self-pin so fire-and-forget consumers (no one holding the
+        // enumerator) can't have GC reclaim the JCWs while the
+        // coroutine is still emitting.
+        _pin = GCHandle.Alloc(this);
+
+        // 3. Hook channel completion to the continuation's resume.
+        //    Closing the writer wakes the awaiter; passing the
+        //    optional exception faults the await foreach.
+        //    Also release the self-pin once Kotlin has actually
+        //    unwound — if the consumer disposed first and
+        //    DisposeAsync timed out, this is the only place the
+        //    GCHandle gets freed.
+        _continuation.OnResumed = error =>
+        {
+            if (error is not null)
+                _channel.Writer.TryComplete(error);
+            else
+                _channel.Writer.TryComplete();
+            ReleasePin();
+        };
+
+        // 4. User cancellation → Kotlin job cancel. The job's
+        //    cancellation propagates into the flow's snapshot-apply
+        //    waiter, which throws CancellationException, which
+        //    surfaces via the continuation's ResumeWith path.
+        if (_userToken.CanBeCanceled)
+        {
+            _ctr = _userToken.Register(static state =>
+            {
+                var self = (SnapshotFlowEnumerator<T>)state!;
+                try { self._job?.Cancel(null); } catch { }
+            }, this);
+
+            if (_userToken.IsCancellationRequested)
+            {
+                _job.Cancel(null);
+                _channel.Writer.TryComplete();
+                _continuation.MarkSynchronouslyCompleted();
+                return;
+            }
+        }
+
+        // 5. Drive the collect. snapshotFlow().collect() suspends
+        //    immediately — the first frame's snapshot tracking work
+        //    runs on the dispatcher we hand it via _continuation's
+        //    context, and emit fires from there on each apply.
+        //    Returning anything other than COROUTINE_SUSPENDED would
+        //    be the synchronous-completion path (only happens if
+        //    Kotlin throws inline before the first suspend).
+        var flow = SnapshotStateKt.SnapshotFlow(_producerJcw);
+        bool synchronouslyCompleted = false;
+        try
+        {
+            var boxed = flow.Collect(_collectorJcw, _continuation);
+            var handle = boxed?.Handle ?? IntPtr.Zero;
+            if (handle != IntPtr.Zero && !IsCoroutineSuspended(handle))
+            {
+                synchronouslyCompleted = true;
+                // Only dispose the non-sentinel wrapper. The
+                // COROUTINE_SUSPENDED sentinel is a Kotlin singleton
+                // whose Java.Lang.Object peer in Mono's cache holds
+                // a *global* ref; calling Dispose on it would
+                // DeleteLocalRef a global handle and CheckJNI would
+                // abort. The cached wrapper outlives every call to
+                // collect by design, so leaking the local ref isn't
+                // a concern here. (See SuspendBridge for the same
+                // pattern.)
+                boxed!.Dispose();
+            }
+        }
+        catch (System.Exception ex)
+        {
+            _channel.Writer.TryComplete(ex);
+            _continuation.MarkSynchronouslyCompleted();
+            return;
+        }
+
+        if (synchronouslyCompleted)
+        {
+            // Synchronous completion (rare for snapshotFlow — it's
+            // designed to be infinite). Treat as immediate end-of-
+            // stream. Kotlin won't invoke our continuation in this
+            // case, so manually drive OnResumed so DisposeAsync's
+            // wait on Completion can finish.
+            _continuation.MarkSynchronouslyCompleted();
+        }
+    }
+
+    void ReleasePin()
+    {
+        // Idempotent: DisposeAsync and OnResumed can race to be
+        // first; whichever loses sees _pinReleased already non-zero
+        // and skips the Free.
+        if (Interlocked.Exchange(ref _pinReleased, 1) != 0)
+            return;
+        if (_pin.IsAllocated)
+            _pin.Free();
+    }
+
+    // Cached global ref to the COROUTINE_SUSPENDED sentinel — same
+    // pattern as SuspendBridge. snapshotFlow's collect always
+    // suspends on first call (it has to register an apply observer
+    // first), so this branch is essentially dead in practice; we
+    // still need it to be correct for the synchronous-fault edge
+    // case where Kotlin throws inline.
+    static IntPtr s_suspendedHandle;
+    static bool IsCoroutineSuspended(IntPtr handle)
+    {
+        if (handle == IntPtr.Zero) return false;
+        if (s_suspendedHandle == IntPtr.Zero)
+        {
+            var inst = IntrinsicsKt.COROUTINE_SUSPENDED;
+            var gref = JNIEnv.NewGlobalRef(inst.Handle);
+            if (Interlocked.CompareExchange(ref s_suspendedHandle, gref, IntPtr.Zero) != IntPtr.Zero)
+                JNIEnv.DeleteGlobalRef(gref);
+            System.GC.KeepAlive(inst);
+        }
+        return JNIEnv.IsSameObject(handle, s_suspendedHandle);
+    }
+}

--- a/src/ComposeNet.Compose/SuspendBridge.cs
+++ b/src/ComposeNet.Compose/SuspendBridge.cs
@@ -201,14 +201,14 @@ internal static class SuspendBridge
         }
     }
 
-    static bool IsCoroutineSuspended(IntPtr handle)
+    internal static bool IsCoroutineSuspended(IntPtr handle)
     {
         if (handle == IntPtr.Zero) return false;
         EnsureSuspendedHandle();
         return JNIEnv.IsSameObject(handle, s_suspendedHandle);
     }
 
-    static void EnsureSuspendedHandle()
+    internal static void EnsureSuspendedHandle()
     {
         if (s_suspendedHandle != IntPtr.Zero) return;
         var inst = IntrinsicsKt.COROUTINE_SUSPENDED;

--- a/src/ComposeNet.Gallery/Demos/StateEffectsAnimation/SnapshotFlowDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/StateEffectsAnimation/SnapshotFlowDemo.cs
@@ -1,0 +1,53 @@
+using ComposeNet.Gallery.Registry;
+
+namespace ComposeNet.Gallery.Demos.StateEffectsAnimation;
+
+/// <summary>SnapshotFlow — bridge Compose state reads into a C# IAsyncEnumerable.</summary>
+public static class SnapshotFlowDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "state-snapshotflow",
+        CategoryId:  "state-effects",
+        Title:       "SnapshotFlow",
+        Description: "Compose.SnapshotFlow(producer) yields a new value on every snapshot apply. Tap +1 a few times — 'observed' tracks live. Tap Burst x10 — Kotlin's snapshot conflation means you usually only see the final value, demonstrating the bounded(1) DropOldest semantics.",
+        Build:       () =>
+        {
+            var counter  = Compose.Remember(() => new MutableNumberState<int>(0));
+            var observed = Compose.Remember(() => new MutableNumberState<int>(0));
+            var seen     = Compose.Remember(() => new MutableNumberState<int>(0));
+
+            return new Column
+            {
+                new Text($"Counter:  {counter}"),
+                new Text($"Observed: {observed}"),
+                new Text($"Emissions seen by flow: {seen}"),
+
+                new LaunchedEffect(key1: null, async ct =>
+                {
+                    try
+                    {
+                        await foreach (var value in
+                            Compose.SnapshotFlow(() => counter.Value).WithCancellation(ct))
+                        {
+                            observed.Value = value;
+                            seen.Value++;
+                        }
+                    }
+                    catch (System.OperationCanceledException) { }
+                }),
+
+                new Button(onClick: () => counter++) { new Text("+1") },
+                new Button(onClick: () =>
+                {
+                    for (int i = 0; i < 10; i++)
+                        counter++;
+                }) { new Text("Burst x10 (conflates)") },
+                new Button(onClick: () =>
+                {
+                    counter.Value = 0;
+                    seen.Value = 0;
+                }) { new Text("Reset") },
+            };
+        });
+}

--- a/src/ComposeNet.Gallery/Registry/Catalog.cs
+++ b/src/ComposeNet.Gallery/Registry/Catalog.cs
@@ -142,6 +142,7 @@ public static class Catalog
         // ---- State, effects, animation ----
         D.StateEffectsAnimation.RememberSaveableDemo.Demo,
         D.StateEffectsAnimation.ProduceStateTickerDemo.Demo,
+        D.StateEffectsAnimation.SnapshotFlowDemo.Demo,
         D.StateEffectsAnimation.MutableStateCollectionsDemo.Demo,
         D.StateEffectsAnimation.NullableMutableStateDemo.Demo,
         D.StateEffectsAnimation.DerivedStateDemo.Demo,


### PR DESCRIPTION
Closes #161

Bridges Compose's `snapshotFlow { producer() }` into a C# `IAsyncEnumerable<T>` so consumers can `await foreach` over Compose state changes from a `LaunchedEffect` body. Canonical use case: reacting to `LazyListState.FirstVisibleItemIndex` to fire analytics or fetch more data when the user scrolls past a threshold.

## Public surface

```csharp
public static IAsyncEnumerable<T> SnapshotFlow<T>(Func<T> producer);
```

Typical use from a `LaunchedEffect`:

```csharp
new LaunchedEffect(key1: null, async ct =>
{
    await foreach (var idx in
        Compose.SnapshotFlow(() => listState.FirstVisibleItemIndex).WithCancellation(ct))
    {
        // react to scroll
    }
});
```

## Architecture

- `Compose.SnapshotFlow<T>(producer)` returns a fresh `IAsyncEnumerable<T>`; each `GetAsyncEnumerator` call spins up its own Kotlin coroutine.
- `SnapshotFlowEnumerator<T>` lazily starts the collect on first `MoveNextAsync`:
  - Wraps the producer in an `ObjectFunction0` JCW. The producer is **not** `@Composable` — deliberately not wrapped with `ComposableLambda*`, which would inject `startRestartGroup` machinery into code that runs outside composition.
  - Builds a fresh Kotlin `IJob` so the user's `CancellationToken` (or `DisposeAsync`) can call `job.Cancel(null)` and tear down snapshotFlow's apply-observer registration for real — not just abandon the C# awaiter.
  - Continuation context = `AndroidUiDispatcher.Main + Job` so the coroutine resumes on the Compose main thread.
  - `IFlowCollector` JCW pushes each emit into a bounded(1) `DropOldest` channel — slow consumers naturally conflate to the latest value (matching snapshotFlow's own conflation when the collector can't keep up) and `emit` never blocks Kotlin's dispatcher, avoiding any deadlock if the consumer's awaiter resumes on the same main thread.
- The enumerator self-pins via `GCHandle.Alloc(this)` for the duration of the collect so the JCWs (and their JNI peers) stay rooted even if the consumer drops the enumerator reference.
- Pin release is idempotent: `DisposeAsync` releases on the happy path; `OnResumed` releases when Kotlin's coroutine eventually unwinds. This covers the `DisposeAsync` 2s-timeout scenario where Kotlin doesn't acknowledge cancellation immediately — the pin stays alive until the eventual resume, then is released.
- Sync-completion paths (token already cancelled, `flow.Collect` throws inline, returns non-suspended Unit) call `SnapshotFlowContinuation.MarkSynchronouslyCompleted` so Kotlin's "never going to resume you" contract doesn't leave `DisposeAsync` waiting on a completion that won't come.
- `COROUTINE_SUSPENDED` sentinel handling matches `SuspendBridge`: the boxed wrapper is **not** disposed because Mono's peer cache backs the singleton with a global JNI ref, and `Dispose` would `DeleteLocalRef` a global handle and abort under CheckJNI.

## Files

New:
- `src/ComposeNet.Compose/SnapshotFlowEnumerable.cs`
- `src/ComposeNet.Compose/SnapshotFlowEnumerator.cs`
- `src/ComposeNet.Compose/SnapshotFlowCollectorAdapter.cs`
- `src/ComposeNet.Compose/SnapshotFlowContinuation.cs`
- `src/ComposeNet.Gallery/Demos/StateEffectsAnimation/SnapshotFlowDemo.cs`

Modified:
- `src/ComposeNet.Compose/Compose.cs` — added `SnapshotFlow<T>` factory
- `src/ComposeNet.Compose/PublicAPI.Unshipped.txt` — added the new public method
- `src/ComposeNet.Gallery/Registry/Catalog.cs` — registered the demo

## Gallery demo

`SnapshotFlowDemo` under the State, effects, animation category shows a counter wired through `Compose.SnapshotFlow + LaunchedEffect`; a "Burst x10" button demonstrates the conflation — Kotlin's snapshot-apply dedup plus the bounded(1) channel mean the consumer typically only observes the final value.

## Tested

- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 112/112 pass.
- `dotnet build src/ComposeNet.Compose` — 0 warnings, 0 errors.
- `dotnet build src/ComposeNet.Gallery` — 0 warnings, 0 errors.

## Reviewer notes

- **Initial dispatch:** `flow.Collect` runs inline on the caller's thread until first suspension. In the documented usage (calling `await foreach` from a `LaunchedEffect` body), that caller is already on the Compose main thread, so the first producer invocation lands on Main. Off-main `await foreach` callers would invoke the producer once on their thread before the apply-observer registration takes over; Compose state reads are thread-safe so this is benign, but documented for completeness. Implementing proper `BuildersKt.Launch` dispatching is a follow-up if a real use case demands it.
- **Collector error → Kotlin keeps running until disposal:** If `Emit` faults (e.g. an unboxing failure) we complete the C# channel with the exception. The consumer then sees the throw via `await foreach`, the state machine calls `DisposeAsync`, and Kotlin tears down. Window is typically sub-millisecond. Not pursuing a more aggressive "throw from the JCW back into Kotlin" path in v1.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;