### PR TITLE
Add query-based DockedSearchBar overload (#165)

### DIFF
--- a/samples/Reply/README.md
+++ b/samples/Reply/README.md
@@ -56,10 +56,10 @@ links back to the tracking issues.
 | `NavigationDrawerItem` rows inside `ModalDrawerSheet` | not used (no drawer in single-pane port) | [#163](https://github.com/jonathanpeppers/compose-net/issues/163) |
 | `BackHandler {}` to collapse multi-select / detail | dropped — system back falls through to the navigator | [#166](https://github.com/jonathanpeppers/compose-net/issues/166) |
 | `NavOptions` with `popUpTo` / `launchSingleTop` / `restoreState` for bottom-nav tab semantics | dropped — re-tapping a tab re-navigates | [#169](https://github.com/jonathanpeppers/compose-net/issues/169) |
-| `DockedSearchBar` (overlay + autocomplete + query state) | replaced with a static "search-shaped" row | [#167](https://github.com/jonathanpeppers/compose-net/issues/167) |
+| `DockedSearchBar` (overlay + autocomplete + query state) | replaced with a static "search-shaped" row | [#165](https://github.com/jonathanpeppers/compose-net/issues/165) |
 | `Modifier.nestedScroll(scrollBehavior)` + `TopAppBarDefaults.exitUntilCollapsedScrollBehavior()` (top-bar collapse on scroll) | dropped | [#142](https://github.com/jonathanpeppers/compose-net/issues/142) |
 | `LazyListState.lastScrolledBackward` / `canScrollBackward` (drives search-bar lift animation) | dropped | [#164](https://github.com/jonathanpeppers/compose-net/issues/164) |
-| `semantics { selected = isSelected }` on email cards (screen reader announces multi-select state) | dropped | [#165](https://github.com/jonathanpeppers/compose-net/issues/165) |
+| `semantics { selected = isSelected }` on email cards (screen reader announces multi-select state) | dropped | [#167](https://github.com/jonathanpeppers/compose-net/issues/167) |
 | `Modifier.windowInsetsPadding(WindowInsets.statusBars)` on bars | dropped | [#69](https://github.com/jonathanpeppers/compose-net/issues/69) |
 | `MaterialTheme.typography.*` per-style reads (titleLarge / bodyMedium / labelMedium / …) | dropped — `FontSize` literals inline | [#61](https://github.com/jonathanpeppers/compose-net/issues/61) |
 | `stringResource(R.string.…)` lookups | dropped — strings inlined | [#146](https://github.com/jonathanpeppers/compose-net/issues/146) |

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -2910,6 +2910,52 @@ internal static partial class ComposeBridges
         IFunction3 content,
         IComposer  composer);
 
+    // androidx.compose.material3.SearchBarKt.DockedSearchBar-eWTbjVg — the
+    // even older query-based docked search bar. Self-contained input field
+    // (no separate inputField slot); the caller drives `query` text and the
+    // `active` boolean directly, with `placeholder` / `leadingIcon` /
+    // `trailingIcon` as composable slots and `content` as the docked
+    // results list. Deprecated in M3 1.2 in favor of the boolean-state
+    // overload above, and again in M3 1.4 in favor of the state-based
+    // `SearchBar` + `ExpandedDockedSearchBar` pair, but still ships in
+    // 1.4.0.3 — and it's what compose-samples/Reply uses for the inbox
+    // search affordance (see issue #165). 16 user params, packed into two
+    // `$changed` ints + one `$default` (trailing `III`). Bits 0/1/2/3/4
+    // (query, onQueryChange, onSearch, active, onActiveChange) and bit 15
+    // (content) are always provided. Bits 10–14 (shape, colors,
+    // tonalElevation, shadowElevation, interactionSource) are unmapped
+    // and stay defaulted by Kotlin; bit 6 (enabled) likewise defaults to
+    // Kotlin's `true`.
+    [ComposeBridge(
+        Class     = "androidx/compose/material3/SearchBarKt",
+        JvmName   = "DockedSearchBar-eWTbjVg",
+        Signature = "(Ljava/lang/String;" +
+                    "Lkotlin/jvm/functions/Function1;" +
+                    "Lkotlin/jvm/functions/Function1;Z" +
+                    "Lkotlin/jvm/functions/Function1;" +
+                    "Landroidx/compose/ui/Modifier;Z" +
+                    "Lkotlin/jvm/functions/Function2;" +
+                    "Lkotlin/jvm/functions/Function2;" +
+                    "Lkotlin/jvm/functions/Function2;" +
+                    "Landroidx/compose/ui/graphics/Shape;" +
+                    "Landroidx/compose/material3/SearchBarColors;FF" +
+                    "Landroidx/compose/foundation/interaction/MutableInteractionSource;" +
+                    "Lkotlin/jvm/functions/Function3;" +
+                    "Landroidx/compose/runtime/Composer;III)V",
+        Defaults  = typeof(DockedSearchBarWithQueryDefault))]
+    public static partial void DockedSearchBarWithQuery(
+        string      query,
+        IFunction1  onQueryChange,
+        IFunction1  onSearch,
+        bool        active,
+        IFunction1  onActiveChange,
+        IModifier?  modifier,
+        IFunction2? placeholder,
+        IFunction2? leadingIcon,
+        IFunction2? trailingIcon,
+        IFunction3  content,
+        IComposer   composer);
+
     // androidx.compose.material3.SearchBarDefaults.InputField — state-based
     // overload. The state-aware InputField is what wires focus/click events
     // to SearchBarState (animateToExpanded/Collapsed), so this is what makes

--- a/src/ComposeNet.Compose/ComposeDefaults.cs
+++ b/src/ComposeNet.Compose/ComposeDefaults.cs
@@ -984,6 +984,18 @@ using ComposeNet;
     "!inputField", "!expanded", "!onExpandedChange", "modifier", "shape",
     "colors", "tonalElevation", "shadowElevation", "!content")]
 
+// androidx.compose.material3.SearchBarKt.DockedSearchBar-eWTbjVg (query-
+// based, even older / deprecated): 16 user params; bits 0–4 (query,
+// onQueryChange, onSearch, active, onActiveChange) and bit 15 (content)
+// always provided. The unmapped slots (enabled, shape, colors,
+// tonalElevation, shadowElevation, interactionSource) are not exposed on
+// the facade and stay defaulted by Kotlin.
+[assembly: ComposeDefaults("DockedSearchBarWithQueryDefault",
+    "!query", "!onQueryChange", "!onSearch", "!active", "!onActiveChange",
+    "modifier", "enabled", "placeholder", "leadingIcon", "trailingIcon",
+    "shape", "colors", "tonalElevation", "shadowElevation", "interactionSource",
+    "!content")]
+
 // androidx.compose.material3.AppBarKt.TopAppBar-cJHQLPU (subtitle overload):
 // 10 user params; bits 0 (title) and 1 (subtitle) always provided.
 // Optional slot bits 3 (NavigationIcon) and 4 (Actions) are toggled

--- a/src/ComposeNet.Compose/DockedSearchBar.cs
+++ b/src/ComposeNet.Compose/DockedSearchBar.cs
@@ -3,37 +3,120 @@ using AndroidX.Compose.Runtime;
 namespace ComposeNet;
 
 /// <summary>
-/// Material 3 <c>DockedSearchBar</c> — the boolean-state docked variant.
-/// The Material 3 1.4 design replaces this with the state-based
-/// <see cref="SearchBar"/> + <see cref="ExpandedDockedSearchBar"/> pair
-/// (sharing a <see cref="SearchBarState"/>); the underlying Kotlin
-/// composable is annotated <c>@Deprecated</c> and only the boolean
-/// variant is exposed by Material 3 1.4.0.3 because the new design has
-/// no standalone "DockedSearchBar" composable.
+/// Material 3 <c>DockedSearchBar</c>. Two deprecated overloads share this
+/// class:
+/// <list type="bullet">
+///   <item><description>
+///     <see cref="DockedSearchBar(bool, System.Action{bool})"/> — the
+///     boolean-state variant (M3 1.2+ form: caller supplies an
+///     <see cref="InputField"/> slot and toggles <c>expanded</c>).
+///   </description></item>
+///   <item><description>
+///     <see cref="DockedSearchBar(string, System.Action{string}, System.Action{string}, bool, System.Action{bool})"/>
+///     — the even older query-based variant (M3 1.0 form: the input
+///     field is built into the composable; caller supplies
+///     <see cref="LeadingIcon"/>, <see cref="TrailingIcon"/>, and
+///     <see cref="Placeholder"/> slots).
+///   </description></item>
+/// </list>
 /// </summary>
 /// <remarks>
-/// <see cref="InputField"/> is required (the Kotlin parameter has no
-/// default) and is rendered at the top of the bar; the
-/// collection-initialized children render as the result list inside the
-/// docked popup (the underlying Kotlin <c>content</c> lambda receives a
-/// <c>ColumnScope</c>).
+/// The Material 3 1.4 design replaces both variants with the state-based
+/// <see cref="SearchBar"/> + <see cref="ExpandedDockedSearchBar"/> pair
+/// (sharing a <see cref="SearchBarState"/>); use that pair for new code.
+/// Both overloads here remain because <c>compose-samples</c> ports (e.g.
+/// the Reply sample) still bind against the deprecated APIs.
+///
+/// Collection-initialized children render as the docked-popup result list
+/// inside the bar's <c>content</c> lambda for both overloads (the
+/// underlying Kotlin lambda receives a <c>ColumnScope</c>).
 /// </remarks>
 [System.Obsolete("Use the state-based SearchBar + ExpandedDockedSearchBar pair instead.")]
 public sealed class DockedSearchBar : ComposableContainer
 {
-    readonly bool _expanded;
-    readonly System.Action<bool> _onExpandedChange;
+    readonly bool _isQueryBased;
 
+    // Boolean-state (M3 1.2+) ctor.
+    readonly bool _expanded;
+    readonly System.Action<bool>? _onExpandedChange;
+
+    // Query-based (M3 1.0) ctor.
+    readonly string? _query;
+    readonly System.Action<string>? _onQueryChange;
+    readonly System.Action<string>? _onSearch;
+    readonly bool _active;
+    readonly System.Action<bool>? _onActiveChange;
+
+    /// <summary>
+    /// Constructs the boolean-state variant. The caller toggles
+    /// <paramref name="expanded"/> in response to
+    /// <paramref name="onExpandedChange"/> and supplies an
+    /// <see cref="InputField"/> slot.
+    /// </summary>
     public DockedSearchBar(bool expanded, System.Action<bool> onExpandedChange)
     {
         _expanded = expanded;
         _onExpandedChange = onExpandedChange;
     }
 
-    /// <summary>Required: composable that renders the search input field at the top of the bar.</summary>
+    /// <summary>
+    /// Constructs the query-based variant. The bar renders its own input
+    /// field driven by <paramref name="query"/> /
+    /// <paramref name="onQueryChange"/>; tapping it toggles
+    /// <paramref name="active"/> via <paramref name="onActiveChange"/>,
+    /// and pressing IME-Search fires <paramref name="onSearch"/>.
+    /// Decorate the field with <see cref="LeadingIcon"/>,
+    /// <see cref="TrailingIcon"/>, and <see cref="Placeholder"/>.
+    /// </summary>
+    public DockedSearchBar(
+        string                query,
+        System.Action<string> onQueryChange,
+        System.Action<string> onSearch,
+        bool                  active,
+        System.Action<bool>   onActiveChange)
+    {
+        _isQueryBased = true;
+        _query = query;
+        _onQueryChange = onQueryChange;
+        _onSearch = onSearch;
+        _active = active;
+        _onActiveChange = onActiveChange;
+    }
+
+    /// <summary>
+    /// Boolean-state variant: required composable that renders the
+    /// search input field at the top of the bar.
+    /// </summary>
     public ComposableNode? InputField { get; set; }
 
+    /// <summary>
+    /// Query-based variant: optional leading-icon slot (e.g. a search
+    /// glyph) shown at the start of the built-in input field.
+    /// </summary>
+    public ComposableNode? LeadingIcon { get; set; }
+
+    /// <summary>
+    /// Query-based variant: optional trailing-icon slot (e.g. a clear
+    /// or close button) shown at the end of the built-in input field.
+    /// </summary>
+    public ComposableNode? TrailingIcon { get; set; }
+
+    /// <summary>
+    /// Query-based variant: optional placeholder shown inside the
+    /// built-in input field while <c>query</c> is empty.
+    /// </summary>
+    public ComposableNode? Placeholder { get; set; }
+
+    /// <inheritdoc />
     public override void Render(IComposer composer)
+    {
+        if (_isQueryBased)
+            RenderQueryBased(composer);
+        else
+            RenderBooleanState(composer);
+    }
+
+    void RenderBooleanState(IComposer composer)
     {
         if (InputField is null)
             throw new System.InvalidOperationException(
@@ -41,7 +124,7 @@ public sealed class DockedSearchBar : ComposableContainer
 
         var inputField       = ComposableLambdas.Wrap2(composer, c => InputField.Render(c));
         var onExpandedChange = new ComposableLambda1(o =>
-            _onExpandedChange(((Java.Lang.Boolean)o!).BooleanValue()));
+            _onExpandedChange!(((Java.Lang.Boolean)o!).BooleanValue()));
         var content          = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
 
         ComposeBridges.DockedSearchBar(
@@ -51,5 +134,33 @@ public sealed class DockedSearchBar : ComposableContainer
             modifier:         BuildModifier(),
             content:          content,
             composer:         composer);
+    }
+
+    void RenderQueryBased(IComposer composer)
+    {
+        var onQueryChange  = new ComposableLambda1(o =>
+            _onQueryChange!(o?.ToString() ?? string.Empty));
+        var onSearch       = new ComposableLambda1(o =>
+            _onSearch!(o?.ToString() ?? string.Empty));
+        var onActiveChange = new ComposableLambda1(o =>
+            _onActiveChange!(((Java.Lang.Boolean)o!).BooleanValue()));
+
+        var placeholder  = Placeholder  is null ? null : ComposableLambdas.Wrap2(composer, c => Placeholder.Render(c));
+        var leadingIcon  = LeadingIcon  is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
+        var trailingIcon = TrailingIcon is null ? null : ComposableLambdas.Wrap2(composer, c => TrailingIcon.Render(c));
+        var content      = ComposableLambdas.Wrap3(composer, c => RenderChildren(c));
+
+        ComposeBridges.DockedSearchBarWithQuery(
+            query:          _query!,
+            onQueryChange:  onQueryChange,
+            onSearch:       onSearch,
+            active:         _active,
+            onActiveChange: onActiveChange,
+            modifier:       BuildModifier(),
+            placeholder:    placeholder,
+            leadingIcon:    leadingIcon,
+            trailingIcon:   trailingIcon,
+            content:        content,
+            composer:       composer);
     }
 }

--- a/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
+++ b/src/ComposeNet.Compose/PublicAPI.Unshipped.txt
@@ -213,8 +213,15 @@ ComposeNet.DisposableEffect.DisposableEffect(object? key1, object? key2, System.
 ComposeNet.DisposableEffect.DisposableEffect(object? key1, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 ComposeNet.DockedSearchBar
 ComposeNet.DockedSearchBar.DockedSearchBar(bool expanded, System.Action<bool>! onExpandedChange) -> void
+ComposeNet.DockedSearchBar.DockedSearchBar(string! query, System.Action<string!>! onQueryChange, System.Action<string!>! onSearch, bool active, System.Action<bool>! onActiveChange) -> void
 ComposeNet.DockedSearchBar.InputField.get -> ComposeNet.ComposableNode?
 ComposeNet.DockedSearchBar.InputField.set -> void
+ComposeNet.DockedSearchBar.LeadingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.DockedSearchBar.LeadingIcon.set -> void
+ComposeNet.DockedSearchBar.Placeholder.get -> ComposeNet.ComposableNode?
+ComposeNet.DockedSearchBar.Placeholder.set -> void
+ComposeNet.DockedSearchBar.TrailingIcon.get -> ComposeNet.ComposableNode?
+ComposeNet.DockedSearchBar.TrailingIcon.set -> void
 ComposeNet.Dp
 ComposeNet.Dp.Dp() -> void
 ComposeNet.Dp.Dp(float value) -> void

--- a/src/ComposeNet.Gallery/Demos/Search/DockedSearchBarQueryDemo.cs
+++ b/src/ComposeNet.Gallery/Demos/Search/DockedSearchBarQueryDemo.cs
@@ -1,0 +1,64 @@
+using ComposeNet.Gallery.Registry;
+
+namespace ComposeNet.Gallery.Demos.Search;
+
+/// <summary>DockedSearchBar — deprecated query-based variant with built-in input field.</summary>
+public static class DockedSearchBarQueryDemo
+{
+    static readonly string[] Fruits =
+    {
+        "Apple", "Banana", "Cherry", "Date", "Elderberry",
+        "Fig", "Grape", "Kiwi", "Lemon", "Mango",
+    };
+
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "search-docked-query",
+        CategoryId:  "search",
+        Title:       "DockedSearchBar (query-based)",
+        Description: "Deprecated query/active overload — the bar renders its own input field.",
+        Build:       () =>
+        {
+            var query  = Compose.Remember(() => new MutableState<string>(""));
+            var active = Compose.Remember(() => new MutableState<bool>(false));
+
+            var matches = System.Array.FindAll(
+                Fruits,
+                f => string.IsNullOrEmpty(query.Value)
+                     || f.Contains(query.Value, System.StringComparison.OrdinalIgnoreCase));
+
+#pragma warning disable CS0618 // DockedSearchBar is intentionally exercised here
+            var docked = new DockedSearchBar(
+                query:          query.Value,
+                onQueryChange:  v => query.Value = v,
+                onSearch:       _ => active.Value = false,
+                active:         active.Value,
+                onActiveChange: v => active.Value = v)
+            {
+                Placeholder  = new Text("Search fruits"),
+                LeadingIcon  = new Text("🔍"),
+                TrailingIcon = active.Value
+                    ? new IconButton(onClick: () =>
+                      {
+                          query.Value  = "";
+                          active.Value = false;
+                      })
+                      {
+                          new Text("✕"),
+                      }
+                    : null,
+            };
+#pragma warning restore CS0618
+
+            foreach (var f in matches)
+                docked.Add(new Text(f) { Modifier = Modifier.Companion.Padding(16, 12) });
+            if (matches.Length == 0)
+                docked.Add(new Text("(no matches)") { Modifier = Modifier.Companion.Padding(16, 12) });
+
+            return new Column
+            {
+                new Text("Tap the field to expand the docked results list."),
+                docked,
+            };
+        });
+}

--- a/src/ComposeNet.Gallery/Registry/Catalog.cs
+++ b/src/ComposeNet.Gallery/Registry/Catalog.cs
@@ -129,6 +129,7 @@ public static class Catalog
         // ---- Search ----
         D.Search.SearchBarPairDemo.Demo,
         D.Search.DockedSearchBarDemo.Demo,
+        D.Search.DockedSearchBarQueryDemo.Demo,
 
         // ---- Modifiers ----
         D.Modifiers.ShapesAndShadowDemo.Demo,


### PR DESCRIPTION
Closes #165.

The Material 3 1.4.0.3 binding exposes two deprecated `DockedSearchBar` overloads sharing the same Kotlin name:

| Kotlin entry point | C# status |
|---|---|
| `DockedSearchBar-EQC0FA8` (M3 1.2+ boolean-state, with `inputField` slot) | Already wrapped in PR #88 |
| `DockedSearchBar-eWTbjVg` (M3 1.0 query-based, with built-in input field) | **This PR** |

Per the issue, the older query-based form is what the `samples/Reply` port needs. Adds it as a **second constructor** on the existing `[Obsolete] DockedSearchBar` class (rather than a new type) — both overloads are deprecated upstream, both share the same Kotlin name, and the class is already marked obsolete.

## What's added

- `ComposeBridges.DockedSearchBarWithQuery` — JNI bridge for `DockedSearchBar-eWTbjVg` (16-slot signature with trailing `III` = `$changed` + `$changed1` + `$default`).
- `[assembly: ComposeDefaults("DockedSearchBarWithQueryDefault", …)]` — declarative-form mask, with required params + content prefixed `!` to suppress enum members.
- New `DockedSearchBar(string query, Action<string> onQueryChange, Action<string> onSearch, bool active, Action<bool> onActiveChange)` ctor.
- New slot properties: `LeadingIcon`, `TrailingIcon`, `Placeholder` (the existing `InputField` slot is reused only by the boolean-state ctor).
- `Render()` branches between the two shapes; an internal `_isQueryBased` flag set by the new ctor picks which `ComposeBridges.*` method to call.
- Gallery demo at `Demos/Search/DockedSearchBarQueryDemo.cs` (id `search-docked-query`) with a fruit-filter autocomplete to exercise the query/active toggling end-to-end.
- Fixes transposed issue numbers in `samples/Reply/README.md` — `DockedSearchBar` is #165, `semantics` is #167.

## Why hand-written, not `[ComposeFacade]`

The query-based shape (`string` + 2× `Action<string>` + `Action<bool>` + three `IFunction2?` slots + `IFunction3` content) could in principle fit the hybrid container + named slots generator shape with `Scope = "Column"` + `[Callback(typeof(string))]`, but the existing hand-written `DockedSearchBar` class hosts the boolean-state ctor — and `[ComposeFacade]` can't produce a class with the same name as a hand-written one. Adding a second ctor to the existing class is the path of least surprise and matches the issue's "matching the existing SearchBar hand-rolled pattern" guidance.

## Build / test

- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 112/112 pass.
- Generator emits the expected bridge body (see `obj/.../ComposeNet.ComposeBridges.DockedSearchBarWithQuery.g.cs`).
- No on-device verification was performed (no device attached). The bridge generator's CN2001-CN2008 static checks all passed, which validates the JNI signature parses correctly and aligns with the `[ComposeDefaults]` slot count.

## Out of scope

- `samples/Reply/ReplySearchBar.cs` remains a placeholder `Box` — wiring the Reply sample's actual search bar against this new ctor is a separate follow-up; the issue only asks to add the facade.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>