### PR TITLE
[Jetchat] Real EmojiSelector panel (Emojis/Stickers tabs, tappable grid)

### DIFF
--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -9,8 +9,8 @@ namespace ComposeNet.Samples.Jetchat;
 /// Builds the Jetchat conversation tree. C# port of upstream's
 /// <c>ConversationContent</c> + <c>UserInput</c> +
 /// <c>JetchatDrawerContent</c>. See <c>README.md</c> for the remaining
-/// gaps vs the Kotlin original (jump-to-bottom, message formatter,
-/// voice record, profile screen, real emoji table).
+/// gaps vs the Kotlin original (drag-and-drop image target,
+/// voice-record swipe-to-cancel gesture, profile screen).
 /// </summary>
 public static class Conversation
 {
@@ -309,7 +309,7 @@ public static class Conversation
                 Modifier.Companion.FillMaxWidth(),
                 BuildTextFieldRow(ui, input),
                 BuildSelectorRow(ui, input, scheme, selectedSelector, messagesScroll),
-                BuildSelectorPanel(scheme, selectedSelector),
+                BuildSelectorPanel(input, scheme, selectedSelector),
             },
         };
 
@@ -375,10 +375,14 @@ public static class Conversation
         return button;
     }
 
-    static ComposableNode BuildSelectorPanel(ColorScheme scheme, MutableState<int> selectedSelector)
+    static ComposableNode BuildSelectorPanel(
+        MutableState<string> input,
+        ColorScheme          scheme,
+        MutableState<int>    selectedSelector)
     {
         int sel = selectedSelector.Value;
         if (sel == 0) return new Spacer(Modifier.Companion.Width(0));
+        if (sel == SelEmoji) return EmojiSelector.Build(input, scheme);
         string title    = "Functionality currently not available";
         string subtitle = "Grab a beverage and check back later!";
         return new Column

--- a/samples/Jetchat/EmojiSelector.cs
+++ b/samples/Jetchat/EmojiSelector.cs
@@ -1,0 +1,144 @@
+using AndroidX.Compose.Material3;
+using ComposeNet;
+
+namespace ComposeNet.Samples.Jetchat;
+
+/// <summary>
+/// Two-tab emoji / sticker panel that opens below the input row when
+/// the <c>ic_mood</c> selector button is toggled. C# port of upstream
+/// Jetchat's <c>EmojiSelector</c> composable + supporting
+/// <c>ExtendedSelectorInnerButton</c> / <c>EmojiTable</c> helpers.
+/// </summary>
+/// <remarks>
+/// Tapping a glyph in the Emojis tab appends it to the shared input
+/// state — same behaviour as upstream's <c>onTextAdded</c> callback
+/// that does <c>textState.addText(it)</c>. The Stickers tab renders a
+/// "not implemented" placeholder, matching upstream's intent (the real
+/// app's Stickers tab pops a "not available" dialog).
+/// </remarks>
+public static class EmojiSelector
+{
+    /// <summary>Columns per grid row — matches upstream's <c>EMOJI_COLUMNS</c>.</summary>
+    public const int EmojiColumns = 10;
+
+    /// <summary>Rows rendered in the grid — matches upstream's hard-coded <c>repeat(4)</c>.</summary>
+    public const int EmojiRows = 4;
+
+    // Verbatim from upstream's `private val emojis = listOf(...)`. We
+    // expose the first EmojiColumns * EmojiRows entries via the grid;
+    // the rest are kept available for parity with the Kotlin source.
+    static readonly string[] Emojis = new[]
+    {
+        "\U0001F600", // Grinning Face
+        "\U0001F601", // Grinning Face With Smiling Eyes
+        "\U0001F602", // Face With Tears of Joy
+        "\U0001F603", // Smiling Face With Open Mouth
+        "\U0001F604", // Smiling Face With Open Mouth and Smiling Eyes
+        "\U0001F605", // Smiling Face With Open Mouth and Cold Sweat
+        "\U0001F606", // Smiling Face With Open Mouth and Tightly-Closed Eyes
+        "\U0001F609", // Winking Face
+        "\U0001F60A", // Smiling Face With Smiling Eyes
+        "\U0001F60B", // Face Savouring Delicious Food
+        "\U0001F60E", // Smiling Face With Sunglasses
+        "\U0001F60D", // Smiling Face With Heart-Shaped Eyes
+        "\U0001F618", // Face Throwing a Kiss
+        "\U0001F617", // Kissing Face
+        "\U0001F619", // Kissing Face With Smiling Eyes
+        "\U0001F61A", // Kissing Face With Closed Eyes
+        "\u263A",     // White Smiling Face
+        "\U0001F642", // Slightly Smiling Face
+        "\U0001F917", // Hugging Face
+        "\U0001F607", // Smiling Face With Halo
+        "\U0001F913", // Nerd Face
+        "\U0001F914", // Thinking Face
+        "\U0001F610", // Neutral Face
+        "\U0001F611", // Expressionless Face
+        "\U0001F636", // Face Without Mouth
+        "\U0001F644", // Face With Rolling Eyes
+        "\U0001F60F", // Smirking Face
+        "\U0001F623", // Persevering Face
+        "\U0001F625", // Disappointed but Relieved Face
+        "\U0001F62E", // Face With Open Mouth
+        "\U0001F910", // Zipper-Mouth Face
+        "\U0001F62F", // Hushed Face
+        "\U0001F62A", // Sleepy Face
+        "\U0001F62B", // Tired Face
+        "\U0001F634", // Sleeping Face
+        "\U0001F60C", // Relieved Face
+        "\U0001F61B", // Face With Stuck-Out Tongue
+        "\U0001F61C", // Face With Stuck-Out Tongue and Winking Eye
+        "\U0001F61D", // Face With Stuck-Out Tongue and Tightly-Closed Eyes
+        "\U0001F612", // Unamused Face
+    };
+
+    /// <summary>Build the emoji selector panel.</summary>
+    /// <param name="input">Shared text-field state; tapped emojis are appended to <c>input.Value</c>.</param>
+    /// <param name="scheme">Active Material 3 color scheme — used for the panel background + tab colors.</param>
+    public static ComposableNode Build(MutableState<string> input, ColorScheme scheme) =>
+        new Composed(c =>
+        {
+            var selected = Compose.Remember(() => new MutableState<int>(0));
+            return new Column
+            {
+                Modifier.Companion
+                    .FillMaxWidth()
+                    .Height(320)
+                    .Background(new Color(scheme.SurfaceVariant)),
+                new PrimaryTabRow(selectedTabIndex: selected.Value)
+                {
+                    new Tab(selected: selected.Value == 0, onClick: () => selected.Value = 0)
+                    {
+                        Text = new Text("Emojis"),
+                    },
+                    new Tab(selected: selected.Value == 1, onClick: () => selected.Value = 1)
+                    {
+                        Text = new Text("Stickers"),
+                    },
+                },
+                selected.Value == 0
+                    ? BuildEmojiGrid(input, scheme)
+                    : BuildStickerPlaceholder(scheme),
+            };
+        });
+
+    static Column BuildEmojiGrid(MutableState<string> input, ColorScheme scheme)
+    {
+        var grid = new Column
+        {
+            Modifier.Companion.FillMaxWidth().Padding(8),
+        };
+        for (int row = 0; row < EmojiRows; row++)
+        {
+            var rowNode = new Row(Arrangement.SpaceEvenly)
+            {
+                Modifier.Companion.FillMaxWidth(),
+            };
+            for (int col = 0; col < EmojiColumns; col++)
+            {
+                string emoji = Emojis[row * EmojiColumns + col];
+                rowNode.Add(new Text(emoji)
+                {
+                    FontSize = 18,
+                    Color    = new Color(scheme.OnSurface),
+                    Modifier = Modifier.Companion
+                        .Clickable(() => input.Value = (input.Value ?? string.Empty) + emoji)
+                        .SizeIn(minWidth: 42, minHeight: 42)
+                        .Padding(8),
+                });
+            }
+            grid.Add(rowNode);
+        }
+        return grid;
+    }
+
+    static Column BuildStickerPlaceholder(ColorScheme scheme) =>
+        new()
+        {
+            Modifier.Companion.FillMaxWidth().Padding(horizontal: 16, vertical: 48),
+            new Text("Stickers not yet implemented in this port.")
+            {
+                FontSize = 14,
+                Color    = new Color(scheme.OnSurfaceVariant),
+            },
+        };
+}

--- a/samples/Jetchat/EmojiSelector.cs
+++ b/samples/Jetchat/EmojiSelector.cs
@@ -18,15 +18,12 @@ namespace ComposeNet.Samples.Jetchat;
 /// </remarks>
 public static class EmojiSelector
 {
-    /// <summary>Columns per grid row — matches upstream's <c>EMOJI_COLUMNS</c>.</summary>
+    /// <summary>Columns per grid row.</summary>
     public const int EmojiColumns = 10;
 
-    /// <summary>Rows rendered in the grid — matches upstream's hard-coded <c>repeat(4)</c>.</summary>
+    /// <summary>Rows rendered in the grid.</summary>
     public const int EmojiRows = 4;
 
-    // Verbatim from upstream's `private val emojis = listOf(...)`. We
-    // expose the first EmojiColumns * EmojiRows entries via the grid;
-    // the rest are kept available for parity with the Kotlin source.
     static readonly string[] Emojis = new[]
     {
         "\U0001F600", // Grinning Face

--- a/samples/Jetchat/EmojiSelector.cs
+++ b/samples/Jetchat/EmojiSelector.cs
@@ -79,7 +79,6 @@ public static class EmojiSelector
             {
                 Modifier.Companion
                     .FillMaxWidth()
-                    .Height(320)
                     .Background(new Color(scheme.SurfaceVariant)),
                 new PrimaryTabRow(selectedTabIndex: selected.Value)
                 {

--- a/samples/Jetchat/EmojiSelector.cs
+++ b/samples/Jetchat/EmojiSelector.cs
@@ -1,4 +1,4 @@
-using AndroidX.Compose.Material3;
+﻿using AndroidX.Compose.Material3;
 using ComposeNet;
 
 namespace ComposeNet.Samples.Jetchat;
@@ -26,46 +26,46 @@ public static class EmojiSelector
 
     static readonly string[] Emojis = new[]
     {
-        "\U0001F600", // Grinning Face
-        "\U0001F601", // Grinning Face With Smiling Eyes
-        "\U0001F602", // Face With Tears of Joy
-        "\U0001F603", // Smiling Face With Open Mouth
-        "\U0001F604", // Smiling Face With Open Mouth and Smiling Eyes
-        "\U0001F605", // Smiling Face With Open Mouth and Cold Sweat
-        "\U0001F606", // Smiling Face With Open Mouth and Tightly-Closed Eyes
-        "\U0001F609", // Winking Face
-        "\U0001F60A", // Smiling Face With Smiling Eyes
-        "\U0001F60B", // Face Savouring Delicious Food
-        "\U0001F60E", // Smiling Face With Sunglasses
-        "\U0001F60D", // Smiling Face With Heart-Shaped Eyes
-        "\U0001F618", // Face Throwing a Kiss
-        "\U0001F617", // Kissing Face
-        "\U0001F619", // Kissing Face With Smiling Eyes
-        "\U0001F61A", // Kissing Face With Closed Eyes
-        "\u263A",     // White Smiling Face
-        "\U0001F642", // Slightly Smiling Face
-        "\U0001F917", // Hugging Face
-        "\U0001F607", // Smiling Face With Halo
-        "\U0001F913", // Nerd Face
-        "\U0001F914", // Thinking Face
-        "\U0001F610", // Neutral Face
-        "\U0001F611", // Expressionless Face
-        "\U0001F636", // Face Without Mouth
-        "\U0001F644", // Face With Rolling Eyes
-        "\U0001F60F", // Smirking Face
-        "\U0001F623", // Persevering Face
-        "\U0001F625", // Disappointed but Relieved Face
-        "\U0001F62E", // Face With Open Mouth
-        "\U0001F910", // Zipper-Mouth Face
-        "\U0001F62F", // Hushed Face
-        "\U0001F62A", // Sleepy Face
-        "\U0001F62B", // Tired Face
-        "\U0001F634", // Sleeping Face
-        "\U0001F60C", // Relieved Face
-        "\U0001F61B", // Face With Stuck-Out Tongue
-        "\U0001F61C", // Face With Stuck-Out Tongue and Winking Eye
-        "\U0001F61D", // Face With Stuck-Out Tongue and Tightly-Closed Eyes
-        "\U0001F612", // Unamused Face
+        "😀", // Grinning Face
+        "😁", // Grinning Face With Smiling Eyes
+        "😂", // Face With Tears of Joy
+        "😃", // Smiling Face With Open Mouth
+        "😄", // Smiling Face With Open Mouth and Smiling Eyes
+        "😅", // Smiling Face With Open Mouth and Cold Sweat
+        "😆", // Smiling Face With Open Mouth and Tightly-Closed Eyes
+        "😉", // Winking Face
+        "😊", // Smiling Face With Smiling Eyes
+        "😋", // Face Savouring Delicious Food
+        "😎", // Smiling Face With Sunglasses
+        "😍", // Smiling Face With Heart-Shaped Eyes
+        "😘", // Face Throwing a Kiss
+        "😗", // Kissing Face
+        "😙", // Kissing Face With Smiling Eyes
+        "😚", // Kissing Face With Closed Eyes
+        "☺",     // White Smiling Face
+        "🙂", // Slightly Smiling Face
+        "🤗", // Hugging Face
+        "😇", // Smiling Face With Halo
+        "🤓", // Nerd Face
+        "🤔", // Thinking Face
+        "😐", // Neutral Face
+        "😑", // Expressionless Face
+        "😶", // Face Without Mouth
+        "🙄", // Face With Rolling Eyes
+        "😏", // Smirking Face
+        "😣", // Persevering Face
+        "😥", // Disappointed but Relieved Face
+        "😮", // Face With Open Mouth
+        "🤐", // Zipper-Mouth Face
+        "😯", // Hushed Face
+        "😪", // Sleepy Face
+        "😫", // Tired Face
+        "😴", // Sleeping Face
+        "😌", // Relieved Face
+        "😛", // Face With Stuck-Out Tongue
+        "😜", // Face With Stuck-Out Tongue and Winking Eye
+        "😝", // Face With Stuck-Out Tongue and Tightly-Closed Eyes
+        "😒", // Unamused Face
     };
 
     /// <summary>Build the emoji selector panel.</summary>

--- a/samples/Jetchat/MainActivity.cs
+++ b/samples/Jetchat/MainActivity.cs
@@ -1,4 +1,5 @@
 using Android.OS;
+using Android.Views;
 using AndroidX.Compose.Material3;
 using ComposeNet;
 
@@ -7,7 +8,8 @@ namespace ComposeNet.Samples.Jetchat;
 [Activity(
     Label = "@string/app_name",
     MainLauncher = true,
-    Theme = "@android:style/Theme.Material.Light.NoActionBar")]
+    Theme = "@android:style/Theme.Material.Light.NoActionBar",
+    WindowSoftInputMode = SoftInput.AdjustResize)]
 public class MainActivity : ComposeActivity
 {
     protected override void OnCreate(Bundle? savedInstanceState)

--- a/samples/Jetchat/README.md
+++ b/samples/Jetchat/README.md
@@ -109,8 +109,11 @@ dotnet build samples/Jetchat -t:Run
   image / location / video opens a `FunctionalityNotAvailable` panel —
   the same fallback upstream uses for the unbound selector pages.
 - **IME + navigation-bar safe insets** on the input area via
-  `Modifier.NavigationBarsPadding().ImePadding()` so the keyboard
-  pushes the input row up without obscuring it.
+  `Modifier.NavigationBarsPadding().ImePadding()` plus
+  `WindowSoftInputMode = SoftInput.AdjustResize` on the activity, so
+  the keyboard pushes the input row up without obscuring it (and
+  without the system's default `adjustUnspecified` behaviour
+  double-shifting the content under edge-to-edge).
 - Reactive message list via `MutableStateList<Message>` — tapping
   send appends to the active channel and the UI recomposes.
 - Reactive channel selection via `MutableState<string>` — drawer
@@ -137,6 +140,7 @@ feature, a new package reference, or simply more sample plumbing:
 | `Sp(float)` for exact M3 letter-spacing (0.5 / 0.1 sp values) | `Sp` is integer-only; `labelSmall` rounds 0.5 → 1, `titleSmall` rounds 0.1 → 0 (dropped). |
 | `FocusRequester` programmatic focus into the emoji panel | the panel opens correctly but doesn't grab focus on expand. |
 | Full ~80-glyph emoji table | `EmojiSelector.cs` exposes the first 40 glyphs from upstream's `private val emojis = listOf(...)` — the same `EMOJI_COLUMNS × 4` grid Kotlin's `EmojiTable` actually renders. The remaining upstream entries are unused on screen and were dropped. |
+| Emoji-tap places cursor at end of input   | Upstream uses `TextFieldValue` with explicit `selection = TextRange(newText.length)` so each emoji append moves the cursor past the appended glyph. This port's `TextField` facade is bound to `MutableState<string>` (Compose's `String`-overload), which preserves the existing cursor position across external value updates. Tapping an emoji appends the glyph to the buffer but the cursor stays where it was — a `TextFieldValue` / `TextRange` binding is needed for parity. |
 
 ## Facade features added for this port
 

--- a/samples/Jetchat/README.md
+++ b/samples/Jetchat/README.md
@@ -140,7 +140,7 @@ feature, a new package reference, or simply more sample plumbing:
 | `Sp(float)` for exact M3 letter-spacing (0.5 / 0.1 sp values) | `Sp` is integer-only; `labelSmall` rounds 0.5 → 1, `titleSmall` rounds 0.1 → 0 (dropped). |
 | `FocusRequester` programmatic focus into the emoji panel | the panel opens correctly but doesn't grab focus on expand. |
 | Full ~80-glyph emoji table | `EmojiSelector.cs` exposes the first 40 glyphs from upstream's `private val emojis = listOf(...)` — the same `EMOJI_COLUMNS × 4` grid Kotlin's `EmojiTable` actually renders. The remaining upstream entries are unused on screen and were dropped. |
-| Emoji-tap places cursor at end of input   | Upstream uses `TextFieldValue` with explicit `selection = TextRange(newText.length)` so each emoji append moves the cursor past the appended glyph. This port's `TextField` facade is bound to `MutableState<string>` (Compose's `String`-overload), which preserves the existing cursor position across external value updates. Tapping an emoji appends the glyph to the buffer but the cursor stays where it was — a `TextFieldValue` / `TextRange` binding is needed for parity. |
+| Emoji-tap places cursor at end of input   | Upstream uses `TextFieldValue` with explicit `selection = TextRange(newText.length)` so each emoji append moves the cursor past the appended glyph. This port's `TextField` facade is bound to `MutableState<string>` (Compose's `String`-overload), which preserves the existing cursor position across external value updates. Tapping an emoji appends the glyph to the buffer but the cursor stays where it was — a `TextFieldValue` / `TextRange` binding is needed for parity. Tracked in #204. |
 
 ## Facade features added for this port
 

--- a/samples/Jetchat/README.md
+++ b/samples/Jetchat/README.md
@@ -104,10 +104,10 @@ dotnet build samples/Jetchat -t:Run
   Each is a toggleable `IconButton` whose background fills with
   `secondaryContainer` and whose tint flips to `onSecondaryContainer`
   when selected, matching upstream's selection visual. Selecting the
-  emoji button opens a placeholder panel below the input area;
-  selecting @ / image / location / video opens a
-  `FunctionalityNotAvailable` panel — the same fallback upstream
-  uses for the unbound selector pages.
+  emoji button opens the real two-tab emoji panel (Emojis/Stickers,
+  10-column tappable grid — see `EmojiSelector.cs`); selecting @ /
+  image / location / video opens a `FunctionalityNotAvailable` panel —
+  the same fallback upstream uses for the unbound selector pages.
 - **IME + navigation-bar safe insets** on the input area via
   `Modifier.NavigationBarsPadding().ImePadding()` so the keyboard
   pushes the input row up without obscuring it.

--- a/samples/Jetchat/README.md
+++ b/samples/Jetchat/README.md
@@ -136,6 +136,7 @@ feature, a new package reference, or simply more sample plumbing:
 | Sticky day-headers spanning multiple dates (e.g. "20 Aug" alongside "Today") | needs the `LazyListScope.item { … }` DSL exposed on the `LazyColumn` facade so a per-day header can be emitted between message groups. Only "Today" is rendered. |
 | `Sp(float)` for exact M3 letter-spacing (0.5 / 0.1 sp values) | `Sp` is integer-only; `labelSmall` rounds 0.5 → 1, `titleSmall` rounds 0.1 → 0 (dropped). |
 | `FocusRequester` programmatic focus into the emoji panel | the panel opens correctly but doesn't grab focus on expand. |
+| Full ~80-glyph emoji table | `EmojiSelector.cs` exposes the first 40 glyphs from upstream's `private val emojis = listOf(...)` — the same `EMOJI_COLUMNS × 4` grid Kotlin's `EmojiTable` actually renders. The remaining upstream entries are unused on screen and were dropped. |
 
 ## Facade features added for this port
 


### PR DESCRIPTION
Closes #150.

Replaces the static "Functionality currently not available" text in the `SelEmoji` branch of `BuildSelectorPanel` with a real two-tab emoji panel mirroring upstream Jetchat's [`EmojiSelector.kt`](https://github.com/android/compose-samples/blob/main/Jetchat/app/src/main/java/com/example/compose/jetchat/conversation/UserInput.kt#L361).

## What

New `samples/Jetchat/EmojiSelector.cs`:

- **`PrimaryTabRow`** with two `Tab`s — "Emojis" / "Stickers" — driven by a local `MutableState<int>` created via `Compose.Remember` inside a `Composed` wrapper.
- **Emoji grid** rendered as a `Column` of `Row`s (4 rows × 10 columns = 40 glyphs) — matches upstream's `EmojiTable` `repeat(4) { repeat(EMOJI_COLUMNS) { ... } }` shape. Each `Text` wraps in `Modifier.Clickable(() => input.Value += emoji).SizeIn(minWidth: 42, minHeight: 42).Padding(8)`, mirroring upstream's `clickable(...).sizeIn(...).padding(8.dp)`.
- **Stickers tab** renders a `Stickers not yet implemented in this port.` placeholder — same intent as upstream's `NotAvailablePopup`.
- Emoji codepoints are copied verbatim from upstream's `private val emojis = listOf(...)` (kept as the first 40 entries since the upstream `EmojiTable` only renders that many).

`Conversation.cs`:

- `BuildSelectorPanel` now takes `MutableState<string> input` and routes `SelEmoji` to `EmojiSelector.Build(input, scheme)` while keeping the existing "not available" fallback for DM / Picture / Map / Phone.
- Header doc-comment updated (no longer lists "real emoji table" as a known gap).

`samples/Jetchat/README.md`:

- "5 input-selector icons" bullet rewritten to say the emoji button now opens the real grid.

## Out of scope (consistent with the issue's "v1 compromise" notes)

- `FocusRequester` integration — left in the gaps table (the panel opens correctly, but doesn't grab focus on expand). No facade for `FocusRequester` exists yet.
- `LazyVerticalGrid` — used the hand-built `Column { Row { ... } }` fallback the issue suggested.

## Verification

```
dotnet test src/ComposeNet.SourceGenerators.Tests   # 112 passed
dotnet build samples/Jetchat                         # 0 errors, only pre-existing BG8605/BG8606 warnings
```