### PR TITLE
JetNews: render Markup runs via AnnotatedText (closes #141)

### DIFF
--- a/samples/JetNews/Markup.cs
+++ b/samples/JetNews/Markup.cs
@@ -1,0 +1,14 @@
+namespace ComposeNet.Samples.JetNews;
+
+/// <summary>
+/// One inline run inside a <see cref="Paragraph"/>'s text — start/end
+/// offsets into <see cref="Paragraph.Text"/> plus the
+/// <see cref="MarkupType"/> to apply. Mirrors upstream's
+/// <c>Markup</c> data class.
+/// </summary>
+/// <param name="Type">Style applied to the run.</param>
+/// <param name="Start">Inclusive start offset in <see cref="Paragraph.Text"/>.</param>
+/// <param name="End">Exclusive end offset in <see cref="Paragraph.Text"/>.</param>
+/// <param name="Href">URL target for <see cref="MarkupType.Link"/> runs (unused
+/// by upstream's renderer, kept here for future tappable-link wiring).</param>
+public sealed record Markup(MarkupType Type, int Start, int End, string? Href = null);

--- a/samples/JetNews/MarkupType.cs
+++ b/samples/JetNews/MarkupType.cs
@@ -1,0 +1,17 @@
+namespace ComposeNet.Samples.JetNews;
+
+/// <summary>
+/// Inline run style applied to a sub-range of a <see cref="Paragraph"/>.
+/// Mirrors upstream's <c>MarkupType</c> enum.
+/// </summary>
+public enum MarkupType
+{
+    /// <summary>Tappable link target — rendered with an underline.</summary>
+    Link,
+    /// <summary>Inline code span — monospace font over a tinted background.</summary>
+    Code,
+    /// <summary>Italic emphasis.</summary>
+    Italic,
+    /// <summary>Bold emphasis.</summary>
+    Bold,
+}

--- a/samples/JetNews/Paragraph.cs
+++ b/samples/JetNews/Paragraph.cs
@@ -1,11 +1,20 @@
+using System.Collections.Generic;
+
 namespace ComposeNet.Samples.JetNews;
 
 /// <summary>
-/// One paragraph of <see cref="Post"/> body content. The upstream
-/// sample also carries an inline-<c>markups</c> list (Link/Bold/Italic/
-/// Code spans within a paragraph) — that's gated on
-/// <c>AnnotatedString</c> binding work and is omitted here.
+/// One paragraph of <see cref="Post"/> body content. Inline run styling
+/// (Link / Bold / Italic / Code spans within a paragraph) is carried by
+/// the optional <paramref name="Markups"/> list — non-empty paragraphs
+/// render via <see cref="ComposeNet.AnnotatedText"/> using a
+/// <see cref="ComposeNet.AnnotatedStringBuilder"/>.
 /// </summary>
 /// <param name="Type">How to render the text.</param>
 /// <param name="Text">The paragraph content.</param>
-public sealed record Paragraph(ParagraphType Type, string Text);
+/// <param name="Markups">Per-run style overlays applied to sub-ranges
+/// of <paramref name="Text"/>. <see langword="null"/> or empty means
+/// the paragraph renders uniformly.</param>
+public sealed record Paragraph(
+    ParagraphType Type,
+    string Text,
+    IReadOnlyList<Markup>? Markups = null);

--- a/samples/JetNews/PostBody.cs
+++ b/samples/JetNews/PostBody.cs
@@ -1,13 +1,16 @@
+using System;
 using ComposeNet;
 
 namespace ComposeNet.Samples.JetNews;
 
 /// <summary>
 /// Paragraph rendering for the article screen — one factory per
-/// <see cref="ParagraphType"/>. The upstream sample applies inline
-/// run styling (Link / Code / Italic / Bold spans inside a paragraph)
-/// through Compose's <c>AnnotatedString</c>; that's omitted here
-/// because <c>AnnotatedString</c> isn't bound yet.
+/// <see cref="ParagraphType"/>. Inline run styling
+/// (<see cref="MarkupType.Link"/>, <see cref="MarkupType.Code"/>,
+/// <see cref="MarkupType.Italic"/>, <see cref="MarkupType.Bold"/>) is
+/// applied through an <see cref="AnnotatedString"/> built from the
+/// paragraph's <see cref="Paragraph.Markups"/> list, mirroring the
+/// upstream <c>paragraphToAnnotatedString</c> helper.
 /// </summary>
 internal static class PostBody
 {
@@ -18,71 +21,59 @@ internal static class PostBody
 
     public static ComposableNode BuildParagraph(Paragraph p) => p.Type switch
     {
-        ParagraphType.Title     => Title(p.Text),
-        ParagraphType.Caption   => Caption(p.Text),
-        ParagraphType.Header    => Header(p.Text),
-        ParagraphType.Subhead   => Subhead(p.Text),
-        ParagraphType.Text      => Body(p.Text),
-        ParagraphType.CodeBlock => CodeBlock(p.Text),
-        ParagraphType.Quote     => Quote(p.Text),
-        ParagraphType.Bullet    => Bullet(p.Text),
-        _                       => Body(p.Text),
+        ParagraphType.Title     => Title(p),
+        ParagraphType.Caption   => Caption(p),
+        ParagraphType.Header    => Header(p),
+        ParagraphType.Subhead   => Subhead(p),
+        ParagraphType.Text      => Body(p),
+        ParagraphType.CodeBlock => CodeBlock(p),
+        ParagraphType.Quote     => Quote(p),
+        ParagraphType.Bullet    => Bullet(p),
+        _                       => Body(p),
     };
 
-    static Text Title(string text) => new(text)
-    {
-        FontSize   = 22,
-        FontWeight = FontWeight.SemiBold,
-        Modifier   = Modifier.Companion.Padding(horizontal: 16, vertical: 8),
-    };
+    static ComposableNode Title(Paragraph p) => Styled(p,
+        fontSize: 22,
+        fontWeight: FontWeight.SemiBold,
+        modifier:  Modifier.Companion.Padding(horizontal: 16, vertical: 8));
 
-    static Text Caption(string text) => new(text)
-    {
-        FontSize = 13,
-        Color    = Subtle,
-        Modifier = Modifier.Companion.Padding(horizontal: 16, vertical: 4),
-    };
+    static ComposableNode Caption(Paragraph p) => Styled(p,
+        fontSize: 13,
+        color:    Subtle,
+        modifier: Modifier.Companion.Padding(horizontal: 16, vertical: 4));
 
-    static Text Header(string text) => new(text)
-    {
-        FontSize   = 20,
-        FontWeight = FontWeight.SemiBold,
-        Modifier   = Modifier.Companion.Padding(start: 16, top: 16, end: 16, bottom: 4),
-    };
+    static ComposableNode Header(Paragraph p) => Styled(p,
+        fontSize:   20,
+        fontWeight: FontWeight.SemiBold,
+        modifier:   Modifier.Companion.Padding(start: 16, top: 16, end: 16, bottom: 4));
 
-    static Text Subhead(string text) => new(text)
-    {
-        FontSize   = 18,
-        FontWeight = FontWeight.Medium,
-        Modifier   = Modifier.Companion.Padding(start: 16, top: 12, end: 16, bottom: 4),
-    };
+    static ComposableNode Subhead(Paragraph p) => Styled(p,
+        fontSize:   18,
+        fontWeight: FontWeight.Medium,
+        modifier:   Modifier.Companion.Padding(start: 16, top: 12, end: 16, bottom: 4));
 
-    static Text Body(string text) => new(text)
-    {
-        FontSize  = 16,
-        Modifier  = Modifier.Companion.Padding(horizontal: 16, vertical: 4),
-    };
+    static ComposableNode Body(Paragraph p) => Styled(p,
+        fontSize: 16,
+        modifier: Modifier.Companion.Padding(horizontal: 16, vertical: 4));
 
-    static Row CodeBlock(string text) =>
+    static Row CodeBlock(Paragraph p) =>
         new()
         {
             Modifier.Companion
                 .FillMaxWidth()
                 .Padding(horizontal: 16, vertical: 4),
-            new Text(text)
-            {
-                FontSize   = 14,
-                FontFamily = FontFamily.Monospace,
-                Color      = CodeFg,
-                Modifier   = Modifier.Companion
+            Styled(p,
+                fontSize:   14,
+                fontFamily: FontFamily.Monospace,
+                color:      CodeFg,
+                modifier:   Modifier.Companion
                     .FillMaxWidth()
                     .Clip(6)
                     .Background(CodeBg)
-                    .Padding(horizontal: 12, vertical: 8),
-            },
+                    .Padding(horizontal: 12, vertical: 8)),
         };
 
-    static Row Quote(string text) =>
+    static Row Quote(Paragraph p) =>
         new()
         {
             Modifier.Companion
@@ -93,14 +84,12 @@ internal static class PostBody
                 Modifier.Companion.Width(4).Height(40).Background(QuoteBar),
             },
             new Spacer(Modifier.Companion.Width(12)),
-            new Text(text)
-            {
-                FontSize   = 16,
-                FontStyle  = FontStyle.Italic,
-            },
+            Styled(p,
+                fontSize:  16,
+                fontStyle: FontStyle.Italic),
         };
 
-    static Row Bullet(string text) =>
+    static Row Bullet(Paragraph p) =>
         new()
         {
             Modifier.Companion
@@ -111,6 +100,80 @@ internal static class PostBody
                 FontSize = 16,
                 Modifier = Modifier.Companion.Padding(end: 8, top: 0, start: 0, bottom: 0),
             },
-            new Text(text) { FontSize = 16 },
+            Styled(p, fontSize: 16),
         };
+
+    /// <summary>
+    /// Render <paramref name="p"/> with shared paragraph-level styling.
+    /// Routes to <see cref="Text"/> when no inline markups are present
+    /// and to <see cref="AnnotatedText"/> otherwise; both facades share
+    /// the same styling surface so the call site doesn't branch.
+    /// </summary>
+    static ComposableNode Styled(
+        Paragraph p,
+        Sp? fontSize = null,
+        FontWeight? fontWeight = null,
+        FontStyle? fontStyle = null,
+        Color? color = null,
+        FontFamily? fontFamily = null,
+        Modifier? modifier = null)
+    {
+        if (p.Markups is null || p.Markups.Count == 0)
+        {
+            return new Text(p.Text)
+            {
+                FontSize   = fontSize,
+                FontWeight = fontWeight,
+                FontStyle  = fontStyle,
+                Color      = color,
+                FontFamily = fontFamily,
+                Modifier   = modifier,
+            };
+        }
+        return new AnnotatedText(BuildAnnotated(p))
+        {
+            FontSize   = fontSize,
+            FontWeight = fontWeight,
+            FontStyle  = fontStyle,
+            Color      = color,
+            FontFamily = fontFamily,
+            Modifier   = modifier,
+        };
+    }
+
+    static AnnotatedString BuildAnnotated(Paragraph p)
+    {
+        var b = new AnnotatedStringBuilder();
+        b.Append(p.Text);
+        var len = p.Text.Length;
+        foreach (var m in p.Markups!)
+        {
+            // Clamp to the paragraph's actual length so a malformed
+            // (start, end) range can't blow up the AnnotatedString
+            // builder — upstream silently truncates the same way.
+            var start = Math.Clamp(m.Start, 0, len);
+            var end   = Math.Clamp(m.End,   start, len);
+            if (end == start)
+                continue;
+            b.AddStyle(StyleFor(m.Type), start, end);
+        }
+        return b.ToAnnotatedString();
+    }
+
+    static SpanStyle StyleFor(MarkupType type) => type switch
+    {
+        MarkupType.Italic => new SpanStyle { FontStyle  = FontStyle.Italic   },
+        MarkupType.Bold   => new SpanStyle { FontWeight = FontWeight.Bold    },
+        MarkupType.Link   => new SpanStyle { Decoration = TextDecoration.Underline },
+        MarkupType.Code   => new SpanStyle
+        {
+            FontFamily = FontFamily.Monospace,
+            // CodeFg is forced for legibility against the fixed-light
+            // CodeBg, mirroring the same dark-mode workaround the
+            // CodeBlock paragraph type already applies (commit b69af97).
+            Color      = CodeFg,
+            Background = CodeBg,
+        },
+        _ => new SpanStyle(),
+    };
 }

--- a/samples/JetNews/PostsRepo.cs
+++ b/samples/JetNews/PostsRepo.cs
@@ -22,25 +22,50 @@ public static class PostsRepo
         {
             new(ParagraphType.Title,   "Hello, ComposeNet"),
             new(ParagraphType.Caption, "An idiomatic-C# facade over the real Jetpack Compose runtime."),
+            // "ComposeNet" → Bold, "Kotlin" → Italic, "compiler interceptors" → Code.
             new(ParagraphType.Text,
                 "ComposeNet hosts Jetpack Compose UI from a .NET-for-Android app. " +
                 "There is no Kotlin in the project, no custom bindings, and no " +
                 "compiler interceptors — every C# composable either calls a " +
-                "generated AndroidX binding method or a tiny JNI bridge."),
+                "generated AndroidX binding method or a tiny JNI bridge.",
+                new Markup[]
+                {
+                    new(MarkupType.Bold,   0,  10),  // ComposeNet
+                    new(MarkupType.Italic, 77, 83),  // Kotlin
+                    new(MarkupType.Code,   127, 148),  // compiler interceptors
+                }),
             new(ParagraphType.Subhead, "How it works"),
+            // "Column", "Text", "Card" all surfaced as Code spans, plus
+            // "[ComposeBridge]" and "@JvmInline".
             new(ParagraphType.Text,
                 "Public facades like Column, Text, and Card derive from " +
                 "ComposableNode and translate their Render(IComposer) body " +
                 "into a chain of bound binding calls. Where Kotlin's @JvmInline " +
                 "value classes confuse the binder, source-generated " +
                 "[ComposeBridge] partial methods drop down to raw JNI for one " +
-                "stripped overload at a time."),
+                "stripped overload at a time.",
+                new Markup[]
+                {
+                    new(MarkupType.Code, 20, 26),    // Column
+                    new(MarkupType.Code, 28, 32),    // Text
+                    new(MarkupType.Code, 38, 42),    // Card
+                    new(MarkupType.Code, 55, 69),    // ComposableNode
+                    new(MarkupType.Code, 90, 112),   // Render(IComposer) body
+                    new(MarkupType.Code, 165, 175),  // @JvmInline
+                    new(MarkupType.Code, 227, 242),  // [ComposeBridge]
+                }),
             new(ParagraphType.Quote,
                 "Compose, but with C# 12 records, nullable refs, and the " +
                 "rest of the .NET tooling you already use."),
+            // "JetNews" → Link (decorative underline), "Jetchat" → Link too.
             new(ParagraphType.Text,
                 "JetNews is the second sample in the repo — see Jetchat for the " +
-                "navigation-drawer baseline and the per-author message bubbles."),
+                "navigation-drawer baseline and the per-author message bubbles.",
+                new Markup[]
+                {
+                    new(MarkupType.Link, 0,  7,  Href: "https://github.com/android/compose-samples/tree/main/JetNews"),
+                    new(MarkupType.Link, 47, 54, Href: "https://github.com/android/compose-samples/tree/main/Jetchat"),
+                }),
         });
 
     static readonly Post _kotlinFreeBindings = new(
@@ -58,7 +83,14 @@ public static class PostsRepo
                 "When an overload is stripped by the binder, the project files an " +
                 "issue against dotnet/android-libraries and works around the gap " +
                 "with a [ComposeBridge]-decorated partial method until the upstream " +
-                "binder fix ships."),
+                "binder fix ships.",
+                new Markup[]
+                {
+                    new(MarkupType.Bold, 0,  10),                                              // ComposeNet
+                    new(MarkupType.Code, 29, 55),                                              // Xamarin.AndroidX.Compose.*
+                    new(MarkupType.Link, 143, 167, Href: "https://github.com/dotnet/android-libraries"),
+                    new(MarkupType.Code, 200, 215),                                            // [ComposeBridge]
+                }),
             new(ParagraphType.Subhead, "The cost of forking bindings"),
             new(ParagraphType.Text,
                 "Forking the bindings would mean carrying a parallel set of " +
@@ -110,7 +142,13 @@ public static class PostsRepo
                 "(composer) read the active theme inside any Render body. On " +
                 "Android 12 and later the default scheme is dynamic — derived from " +
                 "the device wallpaper — so your app picks up Material You without " +
-                "extra plumbing."),
+                "extra plumbing.",
+                new Markup[]
+                {
+                    new(MarkupType.Code,   0,   42),  // MaterialTheme.CurrentColorScheme(composer)
+                    new(MarkupType.Code,   47,  64),  // CurrentTypography
+                    new(MarkupType.Italic, 235, 247), // Material You
+                }),
             new(ParagraphType.Header,  "Custom palettes"),
             new(ParagraphType.Text,
                 "Pass MaterialTheme.LightColorScheme() / DarkColorScheme() with " +


### PR DESCRIPTION
JetNews's article paragraphs were silently dropping the inline run styling that upstream's Kotlin `Markup` model carries. The bindings for `AnnotatedString` / `SpanStyle` / `LinkAnnotation` / `AnnotatedText` were already in place — they just weren't wired into the JetNews sample yet.

This PR finishes the job:

- Adds `Markup` (`Type`, `Start`, `End`, `Href?`) and `MarkupType` (`Link`, `Code`, `Italic`, `Bold`) — same shape as upstream's `Markup.kt`.
- Extends `Paragraph` with an optional `IReadOnlyList<Markup>? Markups` slot. Existing call sites keep working unchanged.
- Routes every paragraph factory in `PostBody` through one `Styled(...)` helper that picks `Text` for plain paragraphs and `AnnotatedText` (built via `AnnotatedStringBuilder`) when markups are present. `StyleFor(MarkupType)` mirrors upstream's `paragraphToAnnotatedString`:
    - Italic → `FontStyle.Italic`
    - Bold → `FontWeight.Bold`
    - Link → `TextDecoration.Underline`
    - Code → `FontFamily.Monospace` + `CodeBg` background + forced `CodeFg` foreground (so dark-mode users can read the run; matches the dark-mode workaround the `CodeBlock` paragraph type already applies in b69af97).
- Adds markups to a few representative paragraphs in `PostsRepo` so all four run styles render in the seed feed.

### Verified on device

Opening the highlighted *"Hello, ComposeNet"* post shows mixed-style runs inside single paragraphs:

- **Bold** *"ComposeNet"*, italic *"Kotlin"*, and code-styled `compiler interceptors` in the lead paragraph.
- Code-styled `Column`, `Text`, `Card`, `ComposableNode`, `Render(IComposer) body`, `@JvmInline`, `[ComposeBridge]` in the *"How it works"* section.
- Underlined link runs on `JetNews` and `Jetchat` at the bottom of the article.

Closes #141