### PR TITLE
JetNews: pull-to-refresh, snackbar feedback, share dialog (and friends) — chips at #159

### DIFF
--- a/samples/JetNews/BookmarkButton.cs
+++ b/samples/JetNews/BookmarkButton.cs
@@ -1,3 +1,4 @@
+using System;
 using ComposeNet;
 
 namespace ComposeNet.Samples.JetNews;
@@ -5,14 +6,22 @@ namespace ComposeNet.Samples.JetNews;
 /// <summary>
 /// Bookmark toggle. Reads the <see cref="BookmarksViewModel"/> and
 /// renders <c>ic_bookmark</c> (outline) or <c>ic_bookmark_filled</c>
-/// based on membership. Tapping flips the bit.
+/// based on membership. Tapping flips the bit and fires the optional
+/// <c>onToggled</c> callback so screens can show snackbar feedback.
 /// </summary>
 internal static class BookmarkButton
 {
-    public static IconToggleButton Build(string postId, BookmarksViewModel bookmarks) =>
+    public static IconToggleButton Build(
+        string postId,
+        BookmarksViewModel bookmarks,
+        Action<bool>? onToggled = null) =>
         new(
             @checked:         bookmarks.Contains(postId),
-            onCheckedChange:  isChecked => bookmarks.Set(postId, isChecked))
+            onCheckedChange:  isChecked =>
+            {
+                bookmarks.Set(postId, isChecked);
+                onToggled?.Invoke(isChecked);
+            })
         {
             new Icon(
                 bookmarks.Contains(postId)

--- a/samples/JetNews/HomeCards.cs
+++ b/samples/JetNews/HomeCards.cs
@@ -48,7 +48,8 @@ internal static class HomeCards
 
     public static Row BuildSimple(Post post,
                                   BookmarksViewModel bookmarks,
-                                  Action<string> onSelectPost) =>
+                                  Action<string> onSelectPost,
+                                  SnackbarController? snackbars = null) =>
         new()
         {
             Modifier.Companion
@@ -72,7 +73,14 @@ internal static class HomeCards
                     FontSize = 14,
                 },
             },
-            BookmarkButton.Build(post.Id, bookmarks),
+            BookmarkButton.Build(
+                post.Id,
+                bookmarks,
+                onToggled: snackbars is null
+                    ? null
+                    : isChecked => snackbars.Show(isChecked
+                        ? "Added to bookmarks"
+                        : "Removed from bookmarks")),
         };
 
     public static Card BuildPopular(Post post, Action<string> onSelectPost) =>

--- a/samples/JetNews/HomeScreen.cs
+++ b/samples/JetNews/HomeScreen.cs
@@ -27,40 +27,82 @@ public static class HomeScreen
         BookmarksViewModel bookmarks,
         DrawerStateHolder drawerState,
         Action<string> onSelectPost,
+        SnackbarController snackbars,
         IPostsRepository? repository = null)
     {
         var vm = Compose.ViewModel(() => new HomeViewModel(repository));
         var state = vm.UiState.CollectAsStateWithLifecycle().Value;
 
+        // Search-bar toggle: tap the magnifier in the action row to swap
+        // the wordmark title for an inline OutlinedTextField. The search
+        // is purely visual today — wiring it to filter the feed needs
+        // Modifier.interceptKey(Key.Enter), tracked in #159.
+        var searchOpen  = Compose.Remember(() => new MutableState<bool>(false));
+        var searchQuery = Compose.Remember(() => new MutableState<string>(string.Empty));
+        var snackbarMessage = snackbars.Message.Value;
+
         return new Scaffold
         {
-            TopBar = new CenterAlignedTopAppBar
+            TopBar = BuildTopBar(searchOpen, searchQuery, drawerState, vm),
+            SnackbarHost = snackbarMessage is null
+                ? null
+                : new Snackbar { Body = new Text(snackbarMessage) },
+            Body = state switch
             {
-                NavigationIcon = new IconButton(onClick: () => _ = drawerState.OpenAsync())
+                HomeUiState.Loading       => BuildLoading(),
+                HomeUiState.Error e       => BuildError(e.Message, () => _ = vm.RefreshAsync()),
+                HomeUiState.HasPosts h    => BuildBody(h, bookmarks, onSelectPost, vm, snackbars),
+                _                         => new Spacer(),
+            },
+        };
+    }
+
+    static ComposableNode BuildTopBar(
+        MutableState<bool> searchOpen,
+        MutableState<string> searchQuery,
+        DrawerStateHolder drawerState,
+        HomeViewModel vm) =>
+        new CenterAlignedTopAppBar
+        {
+            NavigationIcon = new IconButton(onClick: () => _ = drawerState.OpenAsync())
+            {
+                new Icon(Resource.Drawable.ic_menu, "Open navigation drawer"),
+            },
+            Title = searchOpen.Value
+                ? new OutlinedTextField(searchQuery)
                 {
-                    new Icon(Resource.Drawable.ic_menu, "Open navigation drawer"),
-                },
-                Title = new Icon(Resource.Drawable.ic_jetnews_wordmark, "JetNews")
+                    Modifier    = Modifier.Companion.FillMaxWidth().Padding(horizontal: 8, vertical: 0),
+                    SingleLine  = true,
+                    Placeholder = new Text("Search JetNews"),
+                }
+                : new Icon(Resource.Drawable.ic_jetnews_wordmark, "JetNews")
                 {
                     Modifier = Modifier.Companion.Height(24),
                 },
-                Actions = new Row
+            Actions = searchOpen.Value
+                ? new Row
                 {
+                    new IconButton(onClick: () =>
+                    {
+                        searchQuery.Value = string.Empty;
+                        searchOpen.Value  = false;
+                    })
+                    {
+                        new Icon(Resource.Drawable.ic_close, "Close search"),
+                    },
+                }
+                : new Row
+                {
+                    new IconButton(onClick: () => searchOpen.Value = true)
+                    {
+                        new Icon(Resource.Drawable.ic_search, "Search"),
+                    },
                     new IconButton(onClick: () => _ = vm.RefreshAsync())
                     {
                         new Icon(Resource.Drawable.ic_refresh, "Refresh"),
                     },
                 },
-            },
-            Body = state switch
-            {
-                HomeUiState.Loading       => BuildLoading(),
-                HomeUiState.Error e       => BuildError(e.Message, () => _ = vm.RefreshAsync()),
-                HomeUiState.HasPosts h    => BuildBody(h.Feed, bookmarks, onSelectPost),
-                _                         => new Spacer(),
-            },
         };
-    }
 
     static Box BuildLoading() =>
         new()
@@ -90,10 +132,13 @@ public static class HomeScreen
             },
         };
 
-    static LazyColumn<HomeRow> BuildBody(PostsFeed feed,
-                                         BookmarksViewModel bookmarks,
-                                         Action<string> onSelectPost)
+    static PullToRefreshBox BuildBody(HomeUiState.HasPosts state,
+                                      BookmarksViewModel bookmarks,
+                                      Action<string> onSelectPost,
+                                      HomeViewModel vm,
+                                      SnackbarController snackbars)
     {
+        var feed = state.Feed;
         var rows = new List<HomeRow>
         {
             new HomeRow.SectionHeader("Top stories for you"),
@@ -113,22 +158,38 @@ public static class HomeScreen
         foreach (var p in feed.Recent)
             rows.Add(new HomeRow.Recommended(p));
 
-        return new LazyColumn<HomeRow>(
-            items: rows,
-            itemContent: row => BuildRow(row, bookmarks, onSelectPost))
+        return new PullToRefreshBox(
+            isRefreshing: state.IsRefreshing,
+            onRefresh:    () =>
+            {
+                // Drop the gesture when a refresh is already in flight.
+                // Without this guard a quick second pull could stack
+                // two LoadFeedAsync invocations whose completion order
+                // isn't guaranteed.
+                if (!state.IsRefreshing)
+                    _ = vm.RefreshAsync();
+            })
         {
-            Modifier = Modifier.Companion.FillMaxSize(),
+            Modifier.Companion.FillMaxSize(),
+
+            new LazyColumn<HomeRow>(
+                items: rows,
+                itemContent: row => BuildRow(row, bookmarks, onSelectPost, snackbars))
+            {
+                Modifier = Modifier.Companion.FillMaxSize(),
+            },
         };
     }
 
     static ComposableNode BuildRow(HomeRow row,
                                    BookmarksViewModel bookmarks,
-                                   Action<string> onSelectPost) =>
+                                   Action<string> onSelectPost,
+                                   SnackbarController snackbars) =>
         row switch
         {
             HomeRow.Highlight h        => HomeCards.BuildHighlight(h.Post, onSelectPost),
             HomeRow.SectionHeader s    => BuildSectionHeader(s.Label),
-            HomeRow.Recommended r      => HomeCards.BuildSimple(r.Post, bookmarks, onSelectPost),
+            HomeRow.Recommended r      => HomeCards.BuildSimple(r.Post, bookmarks, onSelectPost, snackbars),
             HomeRow.PopularCarousel pc => BuildPopularCarousel(pc.Posts, onSelectPost),
             HomeRow.Divider            => new HorizontalDivider
             {

--- a/samples/JetNews/JetnewsApp.cs
+++ b/samples/JetNews/JetnewsApp.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using AndroidX.Compose.Runtime;
 using ComposeNet;
@@ -38,6 +39,18 @@ public static class JetnewsApp
     /// Currently selected tab index on the Interests screen (0 = Topics,
     /// 1 = People, 2 = Publications).
     /// </param>
+    /// <param name="snackbars">
+    /// App-wide snackbar controller — bookmark toggles and the share
+    /// dialog all route their transient feedback through this single
+    /// instance so navigating between Home and Post doesn't lose a
+    /// queued message mid-fade.
+    /// </param>
+    /// <param name="onShare">
+    /// Invoked when the user picks "Share anyway" in the article share
+    /// dialog. Typically wired to <see cref="Android.Content.Intent.ActionSend"/>
+    /// from <see cref="MainActivity"/> so the chooser launches with the
+    /// activity as its <see cref="Android.Content.Context"/>.
+    /// </param>
     public static ComposableNode Build(
         NavController nav,
         MutableState<string> currentRoute,
@@ -46,13 +59,15 @@ public static class JetnewsApp
         MutableStateList<string> selectedTopics,
         MutableStateList<string> selectedPeople,
         MutableStateList<string> selectedPublications,
-        MutableState<int> interestsTab) =>
+        MutableState<int> interestsTab,
+        SnackbarController snackbars,
+        Action<Post>? onShare = null) =>
         new MaterialTheme
         {
             new ModalNavigationDrawer(drawerState)
             {
                 Drawer  = JetnewsDrawer.Build(nav, currentRoute, drawerState),
-                Content = BuildNavHost(nav, currentRoute, drawerState, bookmarks, selectedTopics, selectedPeople, selectedPublications, interestsTab),
+                Content = BuildNavHost(nav, currentRoute, drawerState, bookmarks, selectedTopics, selectedPeople, selectedPublications, interestsTab, snackbars, onShare),
             },
         };
 
@@ -64,7 +79,9 @@ public static class JetnewsApp
         MutableStateList<string> selectedTopics,
         MutableStateList<string> selectedPeople,
         MutableStateList<string> selectedPublications,
-        MutableState<int> interestsTab)
+        MutableState<int> interestsTab,
+        SnackbarController snackbars,
+        Action<Post>? onShare)
     {
         return new NavHost(startDestination: Routes.Home, navController: nav)
         {
@@ -72,7 +89,7 @@ public static class JetnewsApp
                 HomeScreen.Build(bookmarks, drawerState, postId =>
                 {
                     nav.Navigate(Routes.Post(postId));
-                })),
+                }, snackbars)),
             new Composable(Routes.Interests)
             {
                 InterestsScreen.Build(selectedTopics, selectedPeople, selectedPublications, interestsTab, drawerState),
@@ -83,7 +100,9 @@ public static class JetnewsApp
                 return PostScreen.Build(
                     post:      PostsRepo.Find(id),
                     bookmarks: bookmarks,
-                    onBack:    () => nav.NavigateUp());
+                    onBack:    () => nav.NavigateUp(),
+                    snackbars: snackbars,
+                    onShare:   onShare);
             }),
         };
     }

--- a/samples/JetNews/MainActivity.cs
+++ b/samples/JetNews/MainActivity.cs
@@ -1,3 +1,4 @@
+using Android.Content;
 using Android.OS;
 using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
@@ -37,6 +38,7 @@ public class MainActivity : ComposeActivity
             var selectedPeople       = Remember(() => new MutableStateList<string>());
             var selectedPublications = Remember(() => new MutableStateList<string>());
             var interestsTab         = Remember(() => new MutableState<int>(0));
+            var snackbars            = Remember(() => new SnackbarController());
             return JetnewsApp.Build(
                 nav,
                 currentRoute,
@@ -45,7 +47,37 @@ public class MainActivity : ComposeActivity
                 selectedTopics,
                 selectedPeople,
                 selectedPublications,
-                interestsTab);
+                interestsTab,
+                snackbars,
+                onShare: post => SharePost(post, snackbars));
         });
+    }
+
+    void SharePost(Post post, SnackbarController snackbars)
+    {
+        // Build a plain text/plain intent — JetNews has no real article
+        // URL today, so the synthetic developer.android.com path stub
+        // matches the deep-link format upstream JetNews uses for its
+        // app-link demo (see #159's Navigation 3 / DeepLinkPattern bullet).
+        try
+        {
+            var send = new Intent(Intent.ActionSend);
+            send.SetType("text/plain");
+            send.PutExtra(Intent.ExtraSubject, post.Title);
+            send.PutExtra(
+                Intent.ExtraText,
+                $"{post.Title}\nhttps://developer.android.com/jetnews/post/{post.Id}");
+
+            // Wrap in a chooser so the user always sees the system
+            // picker rather than a possibly-stale default share target.
+            var chooser = Intent.CreateChooser(send, "Share article");
+            StartActivity(chooser);
+        }
+        catch (ActivityNotFoundException)
+        {
+            // No share target installed (e.g. minimal emulator image)
+            // — surface a snackbar instead of crashing.
+            snackbars.Show("No app available to share with");
+        }
     }
 }

--- a/samples/JetNews/PostScreen.cs
+++ b/samples/JetNews/PostScreen.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AndroidX.Compose.Runtime;
 using ComposeNet;
 
 namespace ComposeNet.Samples.JetNews;
@@ -12,30 +13,99 @@ namespace ComposeNet.Samples.JetNews;
 public static class PostScreen
 {
     /// <summary>Materialize the article screen for a single post.</summary>
-    public static Scaffold Build(Post post, BookmarksViewModel bookmarks, Action onBack) =>
-        new()
+    /// <param name="post">The post being rendered.</param>
+    /// <param name="bookmarks">Shared bookmark set; toggling fires <paramref name="snackbars"/>.</param>
+    /// <param name="onBack">Up-navigation callback, fired by the back arrow.</param>
+    /// <param name="snackbars">Sample-side snackbar controller for transient feedback.</param>
+    /// <param name="onShare">
+    /// Optional callback fired when the user picks "Share" in the
+    /// <see cref="AlertDialog"/> the share button now opens — typically
+    /// fires <see cref="Android.Content.Intent.ActionSend"/>. When
+    /// <c>null</c>, the dialog only shows the "not available" message.
+    /// </param>
+    public static ComposableNode Build(
+        Post post,
+        BookmarksViewModel bookmarks,
+        Action onBack,
+        SnackbarController snackbars,
+        Action<Post>? onShare = null)
+    {
+        var showShareDialog = Compose.Remember(() => new MutableState<bool>(false));
+        var snackbarMessage = snackbars.Message.Value;
+
+        // Wrap the Scaffold + the conditional dialog in a Box so the
+        // dialog renders as an overlay above the chrome regardless of
+        // where it sits in the tree (mirrors AlertDialogDemo's shape).
+        return new Box
         {
-            TopBar = new TopAppBar
+            Modifier.Companion.FillMaxSize(),
+
+            new Scaffold
             {
-                Title = new Text(post.Metadata.Author)
+                TopBar = new TopAppBar
                 {
-                    FontSize   = 16,
-                    FontWeight = FontWeight.Medium,
+                    Title = new Text(post.Metadata.Author)
+                    {
+                        FontSize   = 16,
+                        FontWeight = FontWeight.Medium,
+                    },
+                    NavigationIcon = new IconButton(onClick: onBack)
+                    {
+                        new Icon(Resource.Drawable.ic_arrow_back, "Back"),
+                    },
                 },
-                NavigationIcon = new IconButton(onClick: onBack)
+                BottomBar = new BottomAppBar
                 {
-                    new Icon(Resource.Drawable.ic_arrow_back, "Back"),
+                    BookmarkButton.Build(
+                        post.Id,
+                        bookmarks,
+                        onToggled: isChecked => snackbars.Show(isChecked
+                            ? "Added to bookmarks"
+                            : "Removed from bookmarks")),
+                    new IconButton(onClick: () => showShareDialog.Value = true)
+                    {
+                        new Icon(Resource.Drawable.ic_share, "Share"),
+                    },
                 },
+                SnackbarHost = snackbarMessage is null
+                    ? null
+                    : new Snackbar { Body = new Text(snackbarMessage) },
+                Body = BuildBody(post),
             },
-            BottomBar = new BottomAppBar
+
+            showShareDialog.Value
+                ? BuildShareDialog(post, showShareDialog, snackbars, onShare)
+                : (ComposableNode?)null,
+        };
+    }
+
+    static AlertDialog BuildShareDialog(Post post,
+                                        MutableState<bool> showShareDialog,
+                                        SnackbarController snackbars,
+                                        Action<Post>? onShare) =>
+        new(onDismissRequest: () => showShareDialog.Value = false)
+        {
+            Title = new Text("Share article"),
+            Text  = new Text("Functionality not available 😞"),
+            ConfirmButton = new Button(onClick: () =>
             {
-                BookmarkButton.Build(post.Id, bookmarks),
-                new IconButton(onClick: NoOp)
+                showShareDialog.Value = false;
+                if (onShare is not null)
                 {
-                    new Icon(Resource.Drawable.ic_share, "Share"),
-                },
+                    onShare(post);
+                }
+                else
+                {
+                    snackbars.Show("Sharing isn't wired up in this build");
+                }
+            })
+            {
+                new Text(onShare is null ? "OK" : "Share anyway"),
             },
-            Body = BuildBody(post),
+            DismissButton = new Button(onClick: () => showShareDialog.Value = false)
+            {
+                new Text("Cancel"),
+            },
         };
 
     static LazyColumn<PostRow> BuildBody(Post post)
@@ -93,6 +163,4 @@ public static class PostScreen
                 Modifier = Modifier.Companion.Padding(horizontal: 16, vertical: 8),
             },
         };
-
-    static void NoOp() { }
 }

--- a/samples/JetNews/Resources/drawable/ic_close.xml
+++ b/samples/JetNews/Resources/drawable/ic_close.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/samples/JetNews/SnackbarController.cs
+++ b/samples/JetNews/SnackbarController.cs
@@ -1,0 +1,63 @@
+using System.Threading;
+using Android.OS;
+using ComposeNet;
+
+namespace ComposeNet.Samples.JetNews;
+
+/// <summary>
+/// Sample-side bridge that emulates Material's
+/// <c>SnackbarHostState.showSnackbar</c> for screens that just need to
+/// flash a transient message ("Bookmark added", "Share unavailable",
+/// etc.). The bound <c>showSnackbar</c> is a Kotlin <c>suspend</c>
+/// function and isn't exposed through ComposeNet yet — see the
+/// <see cref="ComposeNet.SnackbarHost"/> docs that recommend toggling a
+/// <see cref="MutableState{T}"/> + rendering a
+/// <see cref="ComposeNet.Snackbar"/> directly into the
+/// <see cref="ComposeNet.Scaffold.SnackbarHost"/> slot. This class
+/// wraps that workaround behind a <see cref="Show"/> method so callers
+/// can fire-and-forget.
+/// </summary>
+/// <remarks>
+/// One controller is typically remembered at the activity / nav-graph
+/// level so feedback persists across screen swaps until the auto-clear
+/// timer expires (Material's own host state has the same behaviour).
+/// </remarks>
+public sealed class SnackbarController
+{
+    int _token;
+
+    /// <summary>
+    /// Currently-visible message, or <c>null</c> when no snackbar
+    /// should be drawn. Reading this property inside a composable
+    /// triggers recomposition when <see cref="Show"/> changes it.
+    /// </summary>
+    public MutableState<string?> Message { get; } = new(null);
+
+    /// <summary>
+    /// Display <paramref name="message"/> in any
+    /// <see cref="ComposeNet.SnackbarHost"/>-shaped slot bound to this
+    /// controller, then auto-clear it after
+    /// <paramref name="durationMs"/>. Calling <see cref="Show"/> again
+    /// before the previous timer fires replaces the visible message
+    /// and cancels the earlier auto-clear (via a monotonically
+    /// increasing token) so back-to-back taps don't blink the bar
+    /// off mid-display.
+    /// </summary>
+    /// <param name="message">User-visible text.</param>
+    /// <param name="durationMs">
+    /// Auto-clear delay, in milliseconds. Defaults to 2.5s — roughly
+    /// matches Material's <c>SnackbarDuration.Short</c>.
+    /// </param>
+    public void Show(string message, int durationMs = 2500)
+    {
+        var token = Interlocked.Increment(ref _token);
+        Message.Value = message;
+        new Handler(Looper.MainLooper!).PostDelayed(() =>
+        {
+            // Only clear if no later Show happened — without the token
+            // a fast tap-tap would dismiss the second message early.
+            if (Volatile.Read(ref _token) == token)
+                Message.Value = null;
+        }, durationMs);
+    }
+}


### PR DESCRIPTION
Cherry-picks the easy / cheap sample-side wins from #159 that use facades
the project already ships — "use what we have to match upstream JetNews"
rather than library work.

Addresses these bullets in #159 (parking-lot tracker stays open):

- [x] **PullToRefreshBox in the home feed** (#53, already bound) — pull
  gesture calls `HomeViewModel.RefreshAsync()`; spinner driven by
  `HomeUiState.HasPosts.IsRefreshing`. Concurrent-refresh guard drops a
  second pull while one is already in flight.
- [x] **`SnackbarHost` on Home + Post** — `SnackbarController` exposes a
  `MutableState<string?>` consumed by `Scaffold.SnackbarHost`. Tapping the
  bookmark icon (`BookmarkButton.onToggled`) fires
  `"Added to bookmarks"` / `"Removed from bookmarks"`. Auto-dismiss uses
  `Handler(Looper.MainLooper).PostDelayed` with a token counter so
  back-to-back `Show` calls don''t clobber each other.
- [x] **`AlertDialog` replacing the share `NoOp`** — `"Share article"` /
  `"Functionality not available 😞"` / Cancel + Share anyway. Share anyway
  routes to the new `Intent.ACTION_SEND` helper below.
- [x] **Inline `OutlinedTextField` search swap** in the home top app bar —
  tapping the magnifier replaces the wordmark title with a
  `"Search JetNews"` text field and swaps the actions row for a close icon.
  New `ic_close.xml` drawable for the collapse button. Wiring the field to
  filter the feed needs `Modifier.interceptKey(Key.Enter)` (still tracked
  in #159).
- [x] **`Intent.ACTION_SEND` share helper** on `MainActivity` — wraps the
  post title and a synthetic `developer.android.com/jetnews/post/{id}` URL
  in `Intent.CreateChooser`; catches `ActivityNotFoundException` to surface
  a snackbar fallback.

Skipped (need library work, stay in #159): Navigation 3,
`SharedTransitionLayout`, deep links, `Modifier.interceptKey(Key.Enter)`,
Glance widget, `stringResource` rework.

## Verified end-to-end on a Pixel device

| Tap                 | Result                                                                 |
| ------------------- | ---------------------------------------------------------------------- |
| Search icon         | Wordmark → `"Search JetNews"` `OutlinedTextField`; actions → close (X) |
| Close (X)           | Reverts to wordmark + Search/Refresh icons                             |
| Bookmark on feed    | Icon fills; `"Added to bookmarks"` snackbar fades                      |
| Tap row → Post      | Bookmark icon shows current state                                      |
| Bookmark on Post    | Icon fills; `"Added to bookmarks"` snackbar fades                      |
| Share on Post       | `AlertDialog` overlays the body                                        |
| Cancel              | Dialog dismisses                                                       |
| Share anyway        | System chooser launches with `"Sharing text"` title + URL preview      |

## Notes for reviewers

- Sample-side only — no public-API changes, no facade or generator changes.
- `BookmarkButton.cs` gains a single optional `Action<bool>? onToggled`
  parameter; existing callers stay compatible.
- `JetnewsApp.Build` / `HomeScreen.Build` / `PostScreen.Build` all gain
  required `SnackbarController` parameters; `JetnewsApp.Build` also gains
  optional `Action<Post>? onShare` so `MainActivity` keeps activity-context
  ownership of the chooser.
- Doesn''t touch `PostBody` / inline-run rendering — that''s #141.
