### PR TITLE
Use ArgumentNullException.ThrowIfNull() for parameter validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -943,6 +943,10 @@ Confirm render, contrast, layout, no crash.
   class`, public ctor/method/property gets a `<summary>` (and `<remarks>`
   when there's nuance). Internal helpers get a one-line `//` when non-
   obvious; otherwise leave bare.
+- Use `ArgumentNullException.ThrowIfNull(x)` for parameter null checks —
+  not hand-written `if (x is null) throw new ArgumentNullException(nameof(x));`.
+  Applies to net10.0 / net10.0-android projects only; the netstandard2.0
+  source generator doesn't have `ThrowIfNull`.
 - Don't add markdown planning docs to the repo — use the session artifact
   folder.
 - Commit trailer: `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.

--- a/src/ComposeNet.Compose/AnimatedContent.cs
+++ b/src/ComposeNet.Compose/AnimatedContent.cs
@@ -46,7 +46,7 @@ public sealed class AnimatedContent<T> : ComposableNode
     public AnimatedContent(T targetState, System.Func<T, ComposableNode> content)
     {
         _targetState = targetState;
-        _content     = content ?? throw new System.ArgumentNullException(nameof(content));
+        _content     = content ?? throw new ArgumentNullException(nameof(content));
     }
 
     /// <summary>The state value passed to the underlying <c>AnimatedContent</c>.</summary>

--- a/src/ComposeNet.Compose/AnimatedContent.cs
+++ b/src/ComposeNet.Compose/AnimatedContent.cs
@@ -46,7 +46,8 @@ public sealed class AnimatedContent<T> : ComposableNode
     public AnimatedContent(T targetState, System.Func<T, ComposableNode> content)
     {
         _targetState = targetState;
-        _content     = content ?? throw new ArgumentNullException(nameof(content));
+        ArgumentNullException.ThrowIfNull(content);
+        _content     = content;
     }
 
     /// <summary>The state value passed to the underlying <c>AnimatedContent</c>.</summary>

--- a/src/ComposeNet.Compose/AnnotatedStringBuilder.cs
+++ b/src/ComposeNet.Compose/AnnotatedStringBuilder.cs
@@ -43,7 +43,7 @@ public sealed class AnnotatedStringBuilder
     /// to pop down to a specific level.</returns>
     public int PushStyle(SpanStyle style)
     {
-        System.ArgumentNullException.ThrowIfNull(style);
+        ArgumentNullException.ThrowIfNull(style);
         return _builder.PushStyle(style.Build());
     }
 
@@ -55,7 +55,7 @@ public sealed class AnnotatedStringBuilder
     /// <returns>The stack index of the pushed annotation.</returns>
     public int PushLink(LinkAnnotation link)
     {
-        System.ArgumentNullException.ThrowIfNull(link);
+        ArgumentNullException.ThrowIfNull(link);
         return _builder.PushLink(link.Binding);
     }
 
@@ -79,14 +79,14 @@ public sealed class AnnotatedStringBuilder
     /// <summary>Apply a <see cref="SpanStyle"/> to a specific range.</summary>
     public void AddStyle(SpanStyle style, int start, int end)
     {
-        System.ArgumentNullException.ThrowIfNull(style);
+        ArgumentNullException.ThrowIfNull(style);
         _builder.AddStyle(style.Build(), start, end);
     }
 
     /// <summary>Attach a <see cref="LinkAnnotation"/> to a specific range.</summary>
     public void AddLink(LinkAnnotation link, int start, int end)
     {
-        System.ArgumentNullException.ThrowIfNull(link);
+        ArgumentNullException.ThrowIfNull(link);
         switch (link.Binding)
         {
             case AndroidX.Compose.UI.Text.LinkAnnotation.Url url:

--- a/src/ComposeNet.Compose/AnnotatedText.cs
+++ b/src/ComposeNet.Compose/AnnotatedText.cs
@@ -28,7 +28,7 @@ public sealed class AnnotatedText : ComposableNode
     /// <summary>Construct a rich-text node from an <see cref="AnnotatedString"/>.</summary>
     public AnnotatedText(AnnotatedString text)
     {
-        System.ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(text);
         _text = text;
     }
 

--- a/src/ComposeNet.Compose/BoxWithConstraints.cs
+++ b/src/ComposeNet.Compose/BoxWithConstraints.cs
@@ -35,7 +35,8 @@ public sealed class BoxWithConstraints : ComposableNode
     /// </summary>
     public BoxWithConstraints(Func<BoxConstraints, ComposableNode> content)
     {
-        _content = content ?? throw new ArgumentNullException(nameof(content));
+        ArgumentNullException.ThrowIfNull(content);
+        _content = content;
     }
 
     public override void Render(IComposer composer)

--- a/src/ComposeNet.Compose/Color.cs
+++ b/src/ComposeNet.Compose/Color.cs
@@ -94,7 +94,7 @@ public readonly struct Color : System.IEquatable<Color>
     /// <exception cref="System.FormatException">The string is not a valid color literal.</exception>
     public static Color FromHex(string hex)
     {
-        System.ArgumentNullException.ThrowIfNull(hex);
+        ArgumentNullException.ThrowIfNull(hex);
         var span = hex.AsSpan().Trim();
         if (span.Length > 0 && span[0] == '#') span = span.Slice(1);
         switch (span.Length)

--- a/src/ComposeNet.Compose/Color.cs
+++ b/src/ComposeNet.Compose/Color.cs
@@ -94,7 +94,7 @@ public readonly struct Color : System.IEquatable<Color>
     /// <exception cref="System.FormatException">The string is not a valid color literal.</exception>
     public static Color FromHex(string hex)
     {
-        if (hex is null) throw new System.ArgumentNullException(nameof(hex));
+        System.ArgumentNullException.ThrowIfNull(hex);
         var span = hex.AsSpan().Trim();
         if (span.Length > 0 && span[0] == '#') span = span.Slice(1);
         switch (span.Length)

--- a/src/ComposeNet.Compose/Composable.cs
+++ b/src/ComposeNet.Compose/Composable.cs
@@ -53,7 +53,8 @@ public sealed class Composable : IEnumerable
     /// </summary>
     public Composable(string route)
     {
-        Route = route ?? throw new ArgumentNullException(nameof(route));
+        ArgumentNullException.ThrowIfNull(route);
+        Route = route;
     }
 
     /// <summary>
@@ -64,8 +65,10 @@ public sealed class Composable : IEnumerable
     /// </summary>
     public Composable(string route, Func<NavBackStackEntry, ComposableNode> content)
     {
-        Route    = route   ?? throw new ArgumentNullException(nameof(route));
-        _factory = content ?? throw new ArgumentNullException(nameof(content));
+        ArgumentNullException.ThrowIfNull(route);
+        Route    = route;
+        ArgumentNullException.ThrowIfNull(content);
+        _factory = content;
     }
 
     /// <summary>The route string used to navigate to this destination.</summary>

--- a/src/ComposeNet.Compose/ComposableLambda2.cs
+++ b/src/ComposeNet.Compose/ComposableLambda2.cs
@@ -19,7 +19,7 @@ internal sealed class ComposableLambda2 : Java.Lang.Object, IFunction2
     // Unit.INSTANCE. See ComposableLambda0 / issue #43 for the rationale.
     public Java.Lang.Object Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1)
     {
-        System.ArgumentNullException.ThrowIfNull(p0);
+        ArgumentNullException.ThrowIfNull(p0);
         var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p0);
         using var _ = ComposeContext.Push(composer);
         _body(composer);

--- a/src/ComposeNet.Compose/ComposableLambda3.cs
+++ b/src/ComposeNet.Compose/ComposableLambda3.cs
@@ -45,7 +45,7 @@ internal sealed class ComposableLambda3 : Java.Lang.Object, IFunction3
     // Unit.INSTANCE. See ComposableLambda0 / issue #43 for the rationale.
     public Java.Lang.Object Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1, Java.Lang.Object? p2)
     {
-        System.ArgumentNullException.ThrowIfNull(p1);
+        ArgumentNullException.ThrowIfNull(p1);
         var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p1);
         using var _ = ComposeContext.Push(composer);
         _body(p0, composer);

--- a/src/ComposeNet.Compose/ComposableLambda4.cs
+++ b/src/ComposeNet.Compose/ComposableLambda4.cs
@@ -22,7 +22,7 @@ internal sealed class ComposableLambda4 : Java.Lang.Object, IFunction4
 
     public Java.Lang.Object? Invoke(Java.Lang.Object? p0, Java.Lang.Object? p1, Java.Lang.Object? p2, Java.Lang.Object? p3)
     {
-        System.ArgumentNullException.ThrowIfNull(p2);
+        ArgumentNullException.ThrowIfNull(p2);
         var composer = Android.Runtime.Extensions.JavaCast<IComposer>(p2);
         using var _ = ComposeContext.Push(composer);
         _body(p0?.Handle ?? IntPtr.Zero, p1, composer);

--- a/src/ComposeNet.Compose/ComposableNode.cs
+++ b/src/ComposeNet.Compose/ComposableNode.cs
@@ -71,7 +71,7 @@ public abstract class ComposableNode
     /// </summary>
     public void PrependModifier(Modifier modifier)
     {
-        System.ArgumentNullException.ThrowIfNull(modifier);
+        ArgumentNullException.ThrowIfNull(modifier);
         _prepended = modifier;
     }
 
@@ -84,7 +84,7 @@ public abstract class ComposableNode
     /// </summary>
     public void AppendModifier(Modifier modifier)
     {
-        System.ArgumentNullException.ThrowIfNull(modifier);
+        ArgumentNullException.ThrowIfNull(modifier);
         _appended = modifier;
     }
 

--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -741,7 +741,7 @@ public static class Compose
     /// </summary>
     public static DerivedState<T> DerivedStateOf<T>(System.Func<T> calculation)
     {
-        if (calculation is null) throw new System.ArgumentNullException(nameof(calculation));
+        System.ArgumentNullException.ThrowIfNull(calculation);
         var jcw = new ObjectFunction0(() => MutableState<T>.ToJava(calculation()));
         var state = SnapshotStateKt.DerivedStateOf(jcw);
         return new DerivedState<T>(state);
@@ -848,7 +848,7 @@ public static class Compose
         int line,
         string file)
     {
-        if (producer is null) throw new System.ArgumentNullException(nameof(producer));
+        System.ArgumentNullException.ThrowIfNull(producer);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.ProduceState<T> must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
@@ -1067,7 +1067,7 @@ public static class Compose
     static T ViewModelCore<T>(System.Func<T> factory, object?[]? keys, int line, string file)
         where T : ComposeNet.ViewModel
     {
-        if (factory is null) throw new System.ArgumentNullException(nameof(factory));
+        System.ArgumentNullException.ThrowIfNull(factory);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.ViewModel<T> must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");

--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -88,7 +88,7 @@ public static class Compose
         object?[] keys,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
-        => RememberCore(factory, keys ?? throw new System.ArgumentNullException(nameof(keys)), line, file);
+        => RememberCore(factory, keys ?? throw new ArgumentNullException(nameof(keys)), line, file);
 
     static T RememberCore<T>(System.Func<T> factory, object?[]? keys, int line, string file)
     {
@@ -192,7 +192,7 @@ public static class Compose
         object?[] keys,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
-        => RememberSaveableCore(factory, keys ?? throw new System.ArgumentNullException(nameof(keys)), line, file);
+        => RememberSaveableCore(factory, keys ?? throw new ArgumentNullException(nameof(keys)), line, file);
 
     static T RememberSaveableCore<T>(System.Func<T> factory, object?[]? keys, int line, string file)
     {
@@ -315,7 +315,7 @@ public static class Compose
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
     {
-        System.ArgumentNullException.ThrowIfNull(onDelta);
+        ArgumentNullException.ThrowIfNull(onDelta);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.RememberDraggableState must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
@@ -428,7 +428,7 @@ public static class Compose
     /// </remarks>
     public static void SideEffect(System.Action effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.SideEffect must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
@@ -464,7 +464,7 @@ public static class Compose
         object? key1,
         System.Func<AndroidX.Compose.Runtime.DisposableEffectScope, System.Action> effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.DisposableEffect must be called inside a composition.");
@@ -485,7 +485,7 @@ public static class Compose
         object? key2,
         System.Func<AndroidX.Compose.Runtime.DisposableEffectScope, System.Action> effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.DisposableEffect must be called inside a composition.");
@@ -508,7 +508,7 @@ public static class Compose
         object? key3,
         System.Func<AndroidX.Compose.Runtime.DisposableEffectScope, System.Action> effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.DisposableEffect must be called inside a composition.");
@@ -556,7 +556,7 @@ public static class Compose
         object? key1,
         System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
     {
-        System.ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(body);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.LaunchedEffect must be called inside a composition.");
@@ -577,7 +577,7 @@ public static class Compose
         object? key2,
         System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
     {
-        System.ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(body);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.LaunchedEffect must be called inside a composition.");
@@ -600,7 +600,7 @@ public static class Compose
         object? key3,
         System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
     {
-        System.ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(body);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.LaunchedEffect must be called inside a composition.");
@@ -741,7 +741,7 @@ public static class Compose
     /// </summary>
     public static DerivedState<T> DerivedStateOf<T>(System.Func<T> calculation)
     {
-        System.ArgumentNullException.ThrowIfNull(calculation);
+        ArgumentNullException.ThrowIfNull(calculation);
         var jcw = new ObjectFunction0(() => MutableState<T>.ToJava(calculation()));
         var state = SnapshotStateKt.DerivedStateOf(jcw);
         return new DerivedState<T>(state);
@@ -839,7 +839,7 @@ public static class Compose
         System.Func<MutableState<T>, System.Threading.CancellationToken, System.Threading.Tasks.Task> producer,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
-        => ProduceStateCore(initialValue, producer, keys ?? throw new System.ArgumentNullException(nameof(keys)), line, file);
+        => ProduceStateCore(initialValue, producer, keys ?? throw new ArgumentNullException(nameof(keys)), line, file);
 
     static MutableState<T> ProduceStateCore<T>(
         T initialValue,
@@ -848,7 +848,7 @@ public static class Compose
         int line,
         string file)
     {
-        System.ArgumentNullException.ThrowIfNull(producer);
+        ArgumentNullException.ThrowIfNull(producer);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.ProduceState<T> must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
@@ -947,7 +947,7 @@ public static class Compose
     /// </remarks>
     public static System.Collections.Generic.IAsyncEnumerable<T> SnapshotFlow<T>(System.Func<T> producer)
     {
-        System.ArgumentNullException.ThrowIfNull(producer);
+        ArgumentNullException.ThrowIfNull(producer);
         return new SnapshotFlowEnumerable<T>(producer);
     }
 
@@ -1062,12 +1062,12 @@ public static class Compose
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
         where T : ComposeNet.ViewModel
-        => ViewModelCore(factory, keys ?? throw new System.ArgumentNullException(nameof(keys)), line, file);
+        => ViewModelCore(factory, keys ?? throw new ArgumentNullException(nameof(keys)), line, file);
 
     static T ViewModelCore<T>(System.Func<T> factory, object?[]? keys, int line, string file)
         where T : ComposeNet.ViewModel
     {
-        System.ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(factory);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "Compose.ViewModel<T> must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");

--- a/src/ComposeNet.Compose/Composed.cs
+++ b/src/ComposeNet.Compose/Composed.cs
@@ -50,7 +50,8 @@ public sealed class Composed : ComposableNode
     /// </summary>
     public Composed(Func<IComposer, ComposableNode?> builder)
     {
-        _builder = builder ?? throw new ArgumentNullException(nameof(builder));
+        ArgumentNullException.ThrowIfNull(builder);
+        _builder = builder;
     }
 
     /// <inheritdoc />

--- a/src/ComposeNet.Compose/CompositionLocal.cs
+++ b/src/ComposeNet.Compose/CompositionLocal.cs
@@ -76,7 +76,7 @@ public sealed class CompositionLocal<T>
     /// </summary>
     public static CompositionLocal<T> StaticOf(Func<T> defaultFactory)
     {
-        if (defaultFactory is null) throw new ArgumentNullException(nameof(defaultFactory));
+        ArgumentNullException.ThrowIfNull(defaultFactory);
         var peer = CompositionLocalKt.StaticCompositionLocalOf(
             new ObjectFunction0(() => ToJava(defaultFactory())));
         return new CompositionLocal<T>(peer);
@@ -89,7 +89,7 @@ public sealed class CompositionLocal<T>
     /// </summary>
     public static CompositionLocal<T> Of(Func<T> defaultFactory)
     {
-        if (defaultFactory is null) throw new ArgumentNullException(nameof(defaultFactory));
+        ArgumentNullException.ThrowIfNull(defaultFactory);
         var peer = CompositionLocalKt.CompositionLocalOf(
             SnapshotStateKt.StructuralEqualityPolicy(),
             new ObjectFunction0(() => ToJava(defaultFactory())));
@@ -104,7 +104,7 @@ public sealed class CompositionLocal<T>
     /// </summary>
     public T GetCurrent(IComposer composer)
     {
-        if (composer is null) throw new ArgumentNullException(nameof(composer));
+        ArgumentNullException.ThrowIfNull(composer);
         return FromJava(_peer.GetCurrent(composer, 0));
     }
 

--- a/src/ComposeNet.Compose/Crossfade.cs
+++ b/src/ComposeNet.Compose/Crossfade.cs
@@ -53,7 +53,8 @@ public sealed class Crossfade<T> : ComposableNode
     public Crossfade(T targetState, System.Func<T, ComposableNode> content)
     {
         _targetState = targetState;
-        _content     = content ?? throw new ArgumentNullException(nameof(content));
+        ArgumentNullException.ThrowIfNull(content);
+        _content     = content;
     }
 
     /// <summary>The state value passed to the underlying <c>Crossfade</c>.</summary>

--- a/src/ComposeNet.Compose/Crossfade.cs
+++ b/src/ComposeNet.Compose/Crossfade.cs
@@ -53,7 +53,7 @@ public sealed class Crossfade<T> : ComposableNode
     public Crossfade(T targetState, System.Func<T, ComposableNode> content)
     {
         _targetState = targetState;
-        _content     = content ?? throw new System.ArgumentNullException(nameof(content));
+        _content     = content ?? throw new ArgumentNullException(nameof(content));
     }
 
     /// <summary>The state value passed to the underlying <c>Crossfade</c>.</summary>

--- a/src/ComposeNet.Compose/DisposableEffect.cs
+++ b/src/ComposeNet.Compose/DisposableEffect.cs
@@ -30,7 +30,7 @@ public sealed class DisposableEffect : ComposableNode
         object? key1,
         System.Func<DisposableEffectScope, System.Action> effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         _key1 = key1; _keyCount = 1; _effect = effect;
     }
 
@@ -40,7 +40,7 @@ public sealed class DisposableEffect : ComposableNode
         object? key2,
         System.Func<DisposableEffectScope, System.Action> effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         _key1 = key1; _key2 = key2; _keyCount = 2; _effect = effect;
     }
 
@@ -51,7 +51,7 @@ public sealed class DisposableEffect : ComposableNode
         object? key3,
         System.Func<DisposableEffectScope, System.Action> effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         _key1 = key1; _key2 = key2; _key3 = key3; _keyCount = 3; _effect = effect;
     }
 

--- a/src/ComposeNet.Compose/DragAndDropEvent.cs
+++ b/src/ComposeNet.Compose/DragAndDropEvent.cs
@@ -21,7 +21,7 @@ public sealed class DragAndDropEvent
 
     internal DragAndDropEvent(AndroidX.Compose.UI.Draganddrop.DragAndDropEvent jvm)
     {
-        System.ArgumentNullException.ThrowIfNull(jvm);
+        ArgumentNullException.ThrowIfNull(jvm);
         Jvm = jvm;
     }
 

--- a/src/ComposeNet.Compose/DraggableState.cs
+++ b/src/ComposeNet.Compose/DraggableState.cs
@@ -45,7 +45,7 @@ public sealed class DraggableState
     /// </summary>
     public DraggableState(System.Action<float> onDelta)
     {
-        System.ArgumentNullException.ThrowIfNull(onDelta);
+        ArgumentNullException.ThrowIfNull(onDelta);
         var jcw = new ComposableLambda1(boxed =>
         {
             var f = boxed as Java.Lang.Float

--- a/src/ComposeNet.Compose/HorizontalCenteredHeroCarousel.cs
+++ b/src/ComposeNet.Compose/HorizontalCenteredHeroCarousel.cs
@@ -30,8 +30,10 @@ public sealed class HorizontalCenteredHeroCarousel<T> : ComposableNode
 
     public HorizontalCenteredHeroCarousel(IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/HorizontalMultiBrowseCarousel.cs
+++ b/src/ComposeNet.Compose/HorizontalMultiBrowseCarousel.cs
@@ -32,8 +32,10 @@ public sealed class HorizontalMultiBrowseCarousel<T> : ComposableNode
 
     public HorizontalMultiBrowseCarousel(IReadOnlyList<T> items, float preferredItemWidth, Func<T, ComposableNode> itemContent)
     {
-        _items              = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent        = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(items);
+        _items              = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent        = itemContent;
         _preferredItemWidth = preferredItemWidth;
     }
 

--- a/src/ComposeNet.Compose/HorizontalPager.cs
+++ b/src/ComposeNet.Compose/HorizontalPager.cs
@@ -37,8 +37,10 @@ public sealed class HorizontalPager<T> : ComposableNode
     /// </summary>
     public HorizontalPager(IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/HorizontalUncontainedCarousel.cs
+++ b/src/ComposeNet.Compose/HorizontalUncontainedCarousel.cs
@@ -39,8 +39,10 @@ public sealed class HorizontalUncontainedCarousel<T> : ComposableNode
 
     public HorizontalUncontainedCarousel(IReadOnlyList<T> items, float itemWidth, Func<T, ComposableNode> itemContent)
     {
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
         _itemWidth   = itemWidth;
     }
 

--- a/src/ComposeNet.Compose/Icon.cs
+++ b/src/ComposeNet.Compose/Icon.cs
@@ -55,7 +55,7 @@ public sealed class Icon : ComposableNode
     /// <summary>Render a pre-resolved <see cref="Painter"/> (typically from <see cref="Resources.PainterResource"/>).</summary>
     public Icon(Painter painter, string? contentDescription)
     {
-        System.ArgumentNullException.ThrowIfNull(painter);
+        ArgumentNullException.ThrowIfNull(painter);
         _painter = painter;
         _contentDescription = contentDescription;
     }

--- a/src/ComposeNet.Compose/LaunchedEffect.cs
+++ b/src/ComposeNet.Compose/LaunchedEffect.cs
@@ -33,7 +33,7 @@ public sealed class LaunchedEffect : ComposableNode
         object? key1,
         System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
     {
-        System.ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(body);
         _key1 = key1; _keyCount = 1; _body = body;
     }
 
@@ -43,7 +43,7 @@ public sealed class LaunchedEffect : ComposableNode
         object? key2,
         System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
     {
-        System.ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(body);
         _key1 = key1; _key2 = key2; _keyCount = 2; _body = body;
     }
 
@@ -54,7 +54,7 @@ public sealed class LaunchedEffect : ComposableNode
         object? key3,
         System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body)
     {
-        System.ArgumentNullException.ThrowIfNull(body);
+        ArgumentNullException.ThrowIfNull(body);
         _key1 = key1; _key2 = key2; _key3 = key3; _keyCount = 3; _body = body;
     }
 

--- a/src/ComposeNet.Compose/LazyColumn.cs
+++ b/src/ComposeNet.Compose/LazyColumn.cs
@@ -45,8 +45,10 @@ public sealed class LazyColumn<T> : ComposableNode
 
     public LazyColumn(IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/LazyHorizontalGrid.cs
+++ b/src/ComposeNet.Compose/LazyHorizontalGrid.cs
@@ -27,9 +27,12 @@ public sealed class LazyHorizontalGrid<T> : ComposableNode
 
     public LazyHorizontalGrid(IGridCells rows, IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _rows        = rows        ?? throw new ArgumentNullException(nameof(rows));
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(rows);
+        _rows        = rows;
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/LazyHorizontalStaggeredGrid.cs
+++ b/src/ComposeNet.Compose/LazyHorizontalStaggeredGrid.cs
@@ -33,9 +33,12 @@ public sealed class LazyHorizontalStaggeredGrid<T> : ComposableNode
     /// </summary>
     public LazyHorizontalStaggeredGrid(IStaggeredGridCells rows, IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _rows        = rows        ?? throw new ArgumentNullException(nameof(rows));
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(rows);
+        _rows        = rows;
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/LazyRow.cs
+++ b/src/ComposeNet.Compose/LazyRow.cs
@@ -23,8 +23,10 @@ public sealed class LazyRow<T> : ComposableNode
 
     public LazyRow(IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/LazyVerticalGrid.cs
+++ b/src/ComposeNet.Compose/LazyVerticalGrid.cs
@@ -27,9 +27,12 @@ public sealed class LazyVerticalGrid<T> : ComposableNode
 
     public LazyVerticalGrid(IGridCells columns, IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _columns     = columns     ?? throw new ArgumentNullException(nameof(columns));
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(columns);
+        _columns     = columns;
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/LazyVerticalStaggeredGrid.cs
+++ b/src/ComposeNet.Compose/LazyVerticalStaggeredGrid.cs
@@ -34,9 +34,12 @@ public sealed class LazyVerticalStaggeredGrid<T> : ComposableNode
     /// </summary>
     public LazyVerticalStaggeredGrid(IStaggeredGridCells columns, IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _columns     = columns     ?? throw new ArgumentNullException(nameof(columns));
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(columns);
+        _columns     = columns;
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/LinkAnnotation.cs
+++ b/src/ComposeNet.Compose/LinkAnnotation.cs
@@ -51,7 +51,7 @@ public sealed class LinkAnnotation
     /// the linked range.</param>
     public static LinkAnnotation Clickable(string tag, System.Action<string> onClick, SpanStyle? style = null)
     {
-        System.ArgumentNullException.ThrowIfNull(onClick);
+        ArgumentNullException.ThrowIfNull(onClick);
         var styles   = style is null ? null : new BindingTextLinkStyles(style.Build(), null, null, null);
         var listener = new LinkClickListener(tag, onClick);
         return new LinkAnnotation(new BindingLink.Clickable(tag, styles, listener));

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -82,7 +82,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Then(Modifier other)
     {
-        System.ArgumentNullException.ThrowIfNull(other);
+        ArgumentNullException.ThrowIfNull(other);
         if (other._ops.Length == 0) return this;
         if (_ops.Length == 0) return other;
         var arr = new System.Func<IntPtr, IntPtr>[_ops.Length + other._ops.Length];
@@ -337,7 +337,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Clip(Shape shape)
     {
-        System.ArgumentNullException.ThrowIfNull(shape);
+        ArgumentNullException.ThrowIfNull(shape);
         return Append(curr => ComposeBridges.ModifierClip(curr, shape.Handle));
     }
 
@@ -348,7 +348,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Clickable(System.Action onClick)
     {
-        System.ArgumentNullException.ThrowIfNull(onClick);
+        ArgumentNullException.ThrowIfNull(onClick);
 
         var lambda = new ComposableLambda0(onClick);
         return Append(curr => ComposeBridges.ModifierClickable(curr, lambda));
@@ -394,8 +394,8 @@ public sealed class Modifier
         System.Func<DragAndDropEvent, bool> shouldStartDragAndDrop,
         DragAndDropTarget target)
     {
-        System.ArgumentNullException.ThrowIfNull(shouldStartDragAndDrop);
-        System.ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(shouldStartDragAndDrop);
+        ArgumentNullException.ThrowIfNull(target);
         var predicate = new ShouldStartDragAndDropCallback(shouldStartDragAndDrop);
         return Append(curr => ComposeBridges.ModifierDragAndDropTarget(curr, predicate, target));
     }
@@ -429,7 +429,7 @@ public sealed class Modifier
     /// content). Defaults to <c>false</c>.</param>
     public Modifier VerticalScroll(ScrollState state, bool enabled = true, bool reverseScrolling = false)
     {
-        System.ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(state);
         var jvm = state.Jvm;
         return Append(curr =>
             ComposeBridges.ModifierVerticalScroll(
@@ -456,7 +456,7 @@ public sealed class Modifier
     /// of the viewport. Defaults to <c>false</c>.</param>
     public Modifier HorizontalScroll(ScrollState state, bool enabled = true, bool reverseScrolling = false)
     {
-        System.ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(state);
         var jvm = state.Jvm;
         return Append(curr =>
             ComposeBridges.ModifierHorizontalScroll(
@@ -486,7 +486,7 @@ public sealed class Modifier
     /// touch input. Defaults to <c>true</c>.</param>
     public Modifier Draggable(DraggableState state, Orientation orientation, bool enabled = true)
     {
-        System.ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(state);
         var jvm = state.Jvm;
         var jvmOrientation = orientation == Orientation.Horizontal
             ? AndroidX.Compose.Foundation.Gestures.Orientation.Horizontal!
@@ -521,7 +521,7 @@ public sealed class Modifier
     /// </param>
     public Modifier NestedScroll(AndroidX.Compose.UI.Input.NestedScroll.INestedScrollConnection connection)
     {
-        System.ArgumentNullException.ThrowIfNull(connection);
+        ArgumentNullException.ThrowIfNull(connection);
         IntPtr handle = ((Java.Lang.Object)connection).Handle;
         return Append(curr =>
         {
@@ -893,7 +893,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier TestTag(string tag)
     {
-        System.ArgumentNullException.ThrowIfNull(tag);
+        ArgumentNullException.ThrowIfNull(tag);
         return Append(curr => ComposeBridges.ModifierTestTag(curr, tag));
     }
 
@@ -904,7 +904,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Align(Alignment alignment)
     {
-        System.ArgumentNullException.ThrowIfNull(alignment);
+        ArgumentNullException.ThrowIfNull(alignment);
         return Append(curr =>
         {
             IntPtr scope = RenderContext.CurrentScope;
@@ -923,7 +923,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Align(Alignment.Vertical alignment)
     {
-        System.ArgumentNullException.ThrowIfNull(alignment);
+        ArgumentNullException.ThrowIfNull(alignment);
         return Append(curr =>
         {
             IntPtr scope = RenderContext.CurrentScope;
@@ -942,7 +942,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Align(Alignment.Horizontal alignment)
     {
-        System.ArgumentNullException.ThrowIfNull(alignment);
+        ArgumentNullException.ThrowIfNull(alignment);
         return Append(curr =>
         {
             IntPtr scope = RenderContext.CurrentScope;
@@ -996,7 +996,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier OnFocusChanged(System.Action<FocusState> onFocusChanged)
     {
-        System.ArgumentNullException.ThrowIfNull(onFocusChanged);
+        ArgumentNullException.ThrowIfNull(onFocusChanged);
         var f1 = new ComposableLambda1(arg =>
         {
             if (arg is null) return;
@@ -1014,7 +1014,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier FocusRequester(FocusRequester requester)
     {
-        System.ArgumentNullException.ThrowIfNull(requester);
+        ArgumentNullException.ThrowIfNull(requester);
         return Append(curr =>
             ComposeBridges.ModifierFocusRequester(curr, ((Java.Lang.Object)requester.Java).Handle));
     }
@@ -1030,7 +1030,7 @@ public sealed class Modifier
         System.Action? onLongClick = null,
         System.Action? onDoubleClick = null)
     {
-        System.ArgumentNullException.ThrowIfNull(onClick);
+        ArgumentNullException.ThrowIfNull(onClick);
         var click = new ComposableLambda0(onClick);
         var longClick = onLongClick is null ? null : new ComposableLambda0(onLongClick);
         var doubleClick = onDoubleClick is null ? null : new ComposableLambda0(onDoubleClick);
@@ -1046,7 +1046,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Selectable(bool selected, System.Action onClick)
     {
-        System.ArgumentNullException.ThrowIfNull(onClick);
+        ArgumentNullException.ThrowIfNull(onClick);
         var click = new ComposableLambda0(onClick);
         return Append(curr =>
             ComposeBridges.ModifierSelectable(curr, selected, click));
@@ -1060,7 +1060,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Toggleable(bool value, System.Action<bool> onValueChange)
     {
-        System.ArgumentNullException.ThrowIfNull(onValueChange);
+        ArgumentNullException.ThrowIfNull(onValueChange);
         var f1 = new ComposableLambda1(arg =>
         {
             bool v = arg is Java.Lang.Boolean jb && jb.BooleanValue();
@@ -1305,7 +1305,7 @@ public sealed class Modifier
     /// <see cref="SemanticsScope"/> for available property setters.</param>
     public Modifier Semantics(bool mergeDescendants, System.Action<SemanticsScope> properties)
     {
-        System.ArgumentNullException.ThrowIfNull(properties);
+        ArgumentNullException.ThrowIfNull(properties);
         var lambda = WrapSemanticsBuilder(properties);
         return Append(curr =>
             ComposeBridges.ModifierSemantics(curr, mergeDescendants, lambda));
@@ -1323,7 +1323,7 @@ public sealed class Modifier
     /// <see cref="SemanticsScope"/> for available property setters.</param>
     public Modifier ClearAndSetSemantics(System.Action<SemanticsScope> properties)
     {
-        System.ArgumentNullException.ThrowIfNull(properties);
+        ArgumentNullException.ThrowIfNull(properties);
         var lambda = WrapSemanticsBuilder(properties);
         return Append(curr =>
             ComposeBridges.ModifierClearAndSetSemantics(curr, lambda));

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -348,8 +348,7 @@ public sealed class Modifier
     /// </summary>
     public Modifier Clickable(System.Action onClick)
     {
-        if (onClick is null)
-            throw new System.ArgumentNullException(nameof(onClick));
+        System.ArgumentNullException.ThrowIfNull(onClick);
 
         var lambda = new ComposableLambda0(onClick);
         return Append(curr => ComposeBridges.ModifierClickable(curr, lambda));

--- a/src/ComposeNet.Compose/NavBackStackEntry.cs
+++ b/src/ComposeNet.Compose/NavBackStackEntry.cs
@@ -32,7 +32,8 @@ public sealed class NavBackStackEntry
 
     internal NavBackStackEntry(AndroidX.Navigation.NavBackStackEntry jvm)
     {
-        Jvm = jvm ?? throw new ArgumentNullException(nameof(jvm));
+        ArgumentNullException.ThrowIfNull(jvm);
+        Jvm = jvm;
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/NavGraphBuilderLambda.cs
+++ b/src/ComposeNet.Compose/NavGraphBuilderLambda.cs
@@ -30,7 +30,7 @@ internal sealed class NavGraphBuilderLambda : Java.Lang.Object, IFunction1
     // Unit.INSTANCE — see ComposableLambda0/1 for the rationale.
     public Java.Lang.Object Invoke(Java.Lang.Object? p0)
     {
-        System.ArgumentNullException.ThrowIfNull(p0);
+        ArgumentNullException.ThrowIfNull(p0);
         var graphBuilder = Android.Runtime.Extensions.JavaCast<NavGraphBuilder>(p0);
         _body(graphBuilder);
         return global::Kotlin.Unit.Instance!;

--- a/src/ComposeNet.Compose/NavHost.cs
+++ b/src/ComposeNet.Compose/NavHost.cs
@@ -64,7 +64,8 @@ public sealed class NavHost : ComposableNode, IEnumerable
     /// </summary>
     public NavHost(string startDestination, NavController? navController = null)
     {
-        _startDestination = startDestination ?? throw new ArgumentNullException(nameof(startDestination));
+        ArgumentNullException.ThrowIfNull(startDestination);
+        _startDestination = startDestination;
         _navController    = navController    ?? new NavController();
     }
 

--- a/src/ComposeNet.Compose/OutlinedTextField.cs
+++ b/src/ComposeNet.Compose/OutlinedTextField.cs
@@ -71,7 +71,7 @@ public sealed class OutlinedTextField : ComposableNode
     /// </summary>
     public OutlinedTextField(MutableState<TextFieldValue> state)
     {
-        _tfvState = state ?? throw new System.ArgumentNullException(nameof(state));
+        _tfvState = state ?? throw new ArgumentNullException(nameof(state));
     }
 
     /// <inheritdoc/>

--- a/src/ComposeNet.Compose/OutlinedTextField.cs
+++ b/src/ComposeNet.Compose/OutlinedTextField.cs
@@ -71,7 +71,8 @@ public sealed class OutlinedTextField : ComposableNode
     /// </summary>
     public OutlinedTextField(MutableState<TextFieldValue> state)
     {
-        _tfvState = state ?? throw new ArgumentNullException(nameof(state));
+        ArgumentNullException.ThrowIfNull(state);
+        _tfvState = state;
     }
 
     /// <inheritdoc/>

--- a/src/ComposeNet.Compose/PagerState.cs
+++ b/src/ComposeNet.Compose/PagerState.cs
@@ -80,7 +80,7 @@ public sealed class PagerState
     /// </param>
     public PagerState(Func<int> pageCount, int initialPage = 0, float initialPageOffsetFraction = 0f)
     {
-        if (pageCount is null) throw new ArgumentNullException(nameof(pageCount));
+        ArgumentNullException.ThrowIfNull(pageCount);
         _pageCountFn = new ComposableLambda0Int(pageCount);
         Jvm = PagerStateKt.PagerState(
             currentPage:               initialPage,

--- a/src/ComposeNet.Compose/Resources.cs
+++ b/src/ComposeNet.Compose/Resources.cs
@@ -68,7 +68,7 @@ public static class Resources
     /// <returns>The formatted localized string for the active configuration.</returns>
     public static string StringResource(int id, params object?[] formatArgs)
     {
-        System.ArgumentNullException.ThrowIfNull(formatArgs);
+        ArgumentNullException.ThrowIfNull(formatArgs);
         var composer = RequireComposer(nameof(StringResource));
         var (boxed, owned) = BoxArgs(formatArgs);
         try
@@ -118,7 +118,7 @@ public static class Resources
     /// </param>
     public static string PluralStringResource(int id, int count, params object?[] formatArgs)
     {
-        System.ArgumentNullException.ThrowIfNull(formatArgs);
+        ArgumentNullException.ThrowIfNull(formatArgs);
         var composer = RequireComposer(nameof(PluralStringResource));
         var (boxed, owned) = BoxArgs(formatArgs);
         try

--- a/src/ComposeNet.Compose/SemanticsScope.cs
+++ b/src/ComposeNet.Compose/SemanticsScope.cs
@@ -106,7 +106,7 @@ public sealed class SemanticsScope
     /// <returns>This scope, to chain further calls.</returns>
     public SemanticsScope ContentDescription(string description)
     {
-        System.ArgumentNullException.ThrowIfNull(description);
+        ArgumentNullException.ThrowIfNull(description);
         ComposeBridges.SemanticsSetContentDescription(Handle, description);
         return this;
     }
@@ -122,7 +122,7 @@ public sealed class SemanticsScope
     /// <returns>This scope, to chain further calls.</returns>
     public SemanticsScope StateDescription(string description)
     {
-        System.ArgumentNullException.ThrowIfNull(description);
+        ArgumentNullException.ThrowIfNull(description);
         ComposeBridges.SemanticsSetStateDescription(Handle, description);
         return this;
     }
@@ -143,7 +143,7 @@ public sealed class SemanticsScope
     /// <returns>This scope, to chain further calls.</returns>
     public SemanticsScope OnClick(string? label, System.Func<bool> action)
     {
-        System.ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(action);
         var f0 = new ObjectFunction0(() => action()
             ? (Java.Lang.Object)Java.Lang.Boolean.True!
             : Java.Lang.Boolean.False!);
@@ -163,7 +163,7 @@ public sealed class SemanticsScope
     /// <returns>This scope, to chain further calls.</returns>
     public SemanticsScope OnClick(string? label, System.Action action)
     {
-        System.ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(action);
         return OnClick(label, () => { action(); return true; });
     }
 

--- a/src/ComposeNet.Compose/SideEffect.cs
+++ b/src/ComposeNet.Compose/SideEffect.cs
@@ -25,7 +25,7 @@ public sealed class SideEffect : ComposableNode
     /// every successful recomposition.</summary>
     public SideEffect(System.Action effect)
     {
-        System.ArgumentNullException.ThrowIfNull(effect);
+        ArgumentNullException.ThrowIfNull(effect);
         _effect = effect;
     }
 

--- a/src/ComposeNet.Compose/StateFlowExtensions.cs
+++ b/src/ComposeNet.Compose/StateFlowExtensions.cs
@@ -38,7 +38,7 @@ public static class StateFlowExtensions
     /// </remarks>
     public static IState<T> CollectAsStateWithLifecycle<T>(this IStateFlow<T> flow)
     {
-        System.ArgumentNullException.ThrowIfNull(flow);
+        ArgumentNullException.ThrowIfNull(flow);
         // Reading Value here registers the surrounding composition
         // scope with the underlying tick counter, mirroring the
         // dependency-tracking effect of Kotlin's

--- a/src/ComposeNet.Compose/SuspendBridge.cs
+++ b/src/ComposeNet.Compose/SuspendBridge.cs
@@ -83,8 +83,8 @@ internal static class SuspendBridge
         Func<Java.Lang.Object?, T> unbox,
         CancellationToken cancellationToken = default)
     {
-        if (call is null) throw new ArgumentNullException(nameof(call));
-        if (unbox is null) throw new ArgumentNullException(nameof(unbox));
+        ArgumentNullException.ThrowIfNull(call);
+        ArgumentNullException.ThrowIfNull(unbox);
 
         if (cancellationToken.IsCancellationRequested)
             return Task.FromCanceled<T>(cancellationToken);

--- a/src/ComposeNet.Compose/TextField.cs
+++ b/src/ComposeNet.Compose/TextField.cs
@@ -88,7 +88,7 @@ public sealed class TextField : ComposableNode
     /// </summary>
     public TextField(MutableState<TextFieldValue> state)
     {
-        _tfvState = state ?? throw new System.ArgumentNullException(nameof(state));
+        _tfvState = state ?? throw new ArgumentNullException(nameof(state));
     }
 
     /// <inheritdoc/>

--- a/src/ComposeNet.Compose/TextField.cs
+++ b/src/ComposeNet.Compose/TextField.cs
@@ -88,7 +88,8 @@ public sealed class TextField : ComposableNode
     /// </summary>
     public TextField(MutableState<TextFieldValue> state)
     {
-        _tfvState = state ?? throw new ArgumentNullException(nameof(state));
+        ArgumentNullException.ThrowIfNull(state);
+        _tfvState = state;
     }
 
     /// <inheritdoc/>

--- a/src/ComposeNet.Compose/TopAppBarDefaults.cs
+++ b/src/ComposeNet.Compose/TopAppBarDefaults.cs
@@ -98,7 +98,7 @@ public static class TopAppBarDefaults
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
     {
-        System.ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(state);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "TopAppBarDefaults factories must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");
@@ -158,7 +158,7 @@ public static class TopAppBarDefaults
         TopAppBarState state, int line, string file,
         System.Func<IntPtr, IComposer, IntPtr> bridge)
     {
-        System.ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(state);
         var composer = ComposeContext.Current
             ?? throw new System.InvalidOperationException(
                 "TopAppBarDefaults factories must be called inside a composition (e.g. inside a SetContent body or a ComposableNode.Render override).");

--- a/src/ComposeNet.Compose/VerticalPager.cs
+++ b/src/ComposeNet.Compose/VerticalPager.cs
@@ -33,8 +33,10 @@ public sealed class VerticalPager<T> : ComposableNode
     /// </summary>
     public VerticalPager(IReadOnlyList<T> items, Func<T, ComposableNode> itemContent)
     {
-        _items       = items       ?? throw new ArgumentNullException(nameof(items));
-        _itemContent = itemContent ?? throw new ArgumentNullException(nameof(itemContent));
+        ArgumentNullException.ThrowIfNull(items);
+        _items       = items;
+        ArgumentNullException.ThrowIfNull(itemContent);
+        _itemContent = itemContent;
     }
 
     /// <summary>


### PR DESCRIPTION
Pure simplification — replace hand-written `if (x is null) throw new ArgumentNullException(nameof(x));` boilerplate with the .NET 6+ `ArgumentNullException.ThrowIfNull()` helper. **No behavior change.**

## Touched files

- `src/ComposeNet.Compose/Color.cs`
- `src/ComposeNet.Compose/Compose.cs`
- `src/ComposeNet.Compose/CompositionLocal.cs`
- `src/ComposeNet.Compose/Modifier.cs`
- `src/ComposeNet.Compose/PagerState.cs`
- `src/ComposeNet.Compose/SuspendBridge.cs`

`src/ComposeNet.SourceGenerators` (netstandard2.0) intentionally untouched — `ThrowIfNull` isn't available there. `src/ComposeNet.Gallery` and `src/ComposeNet.SourceGenerators.Tests` had no matching sites.

## Verified

- `dotnet build src/ComposeNet.Compose` — 0 errors (pre-existing BG8605/BG8606 binding warnings only)
- `dotnet build src/ComposeNet.Gallery` — 0 warnings, 0 errors
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 112/112 pass