### PR TITLE
Move GC.KeepAlive boilerplate into ComposeBridge generator

### DIFF
--- a/src/ComposeNet.Compose/Compose.cs
+++ b/src/ComposeNet.Compose/Compose.cs
@@ -225,7 +225,7 @@ public static class Compose
         var handle = ComposeBridges.RememberSaveableSimple(
             inputs,
             jcw,
-            ((Java.Lang.Object)composer).Handle,
+            composer,
             changed: 0);
         try
         {
@@ -241,7 +241,6 @@ public static class Compose
                 Android.Runtime.JNIEnv.DeleteLocalRef(handle);
             if (ownsInputs && inputs != System.IntPtr.Zero)
                 Android.Runtime.JNIEnv.DeleteLocalRef(inputs);
-            System.GC.KeepAlive(composer);
         }
     }
 
@@ -273,7 +272,7 @@ public static class Compose
             inputs,
             ComposeBridges.SaverAutoSaver(),
             jcw,
-            ((Java.Lang.Object)composer).Handle,
+            composer,
             changed: 0);
         try
         {
@@ -290,7 +289,6 @@ public static class Compose
                 Android.Runtime.JNIEnv.DeleteLocalRef(handle);
             if (ownsInputs && inputs != System.IntPtr.Zero)
                 Android.Runtime.JNIEnv.DeleteLocalRef(inputs);
-            System.GC.KeepAlive(composer);
         }
     }
 

--- a/src/ComposeNet.Compose/ComposeBridges.cs
+++ b/src/ComposeNet.Compose/ComposeBridges.cs
@@ -6,6 +6,7 @@ using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI;
 using AndroidX.Compose.UI.State;
 using Kotlin.Jvm.Functions;
+using Painter = AndroidX.Compose.UI.Graphics.Painter.Painter;
 
 namespace ComposeNet;
 
@@ -637,7 +638,7 @@ internal static partial class ComposeBridges
         Defaults  = typeof(ImageDefault))]
     [ComposeFacade]
     public static partial void Image(
-        [PainterResource] IntPtr painter,
+        [PainterResource] Painter painter,
         string?       contentDescription,
         IModifier?    modifier,
         Alignment?    alignment,
@@ -657,7 +658,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V",
         Defaults  = typeof(IconPainterDefault))]
     public static partial void IconPainter(
-        IntPtr     painter,
+        Painter    painter,
         string?    contentDescription,
         IModifier? modifier,
         long       tint,
@@ -2337,7 +2338,9 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/input/nestedscroll/NestedScrollDispatcher;" +
                     "ILjava/lang/Object;)Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierNestedScrollDefault))]
-    internal static partial IntPtr ModifierNestedScroll(IntPtr modifier, IntPtr connection);
+    internal static partial IntPtr ModifierNestedScroll(
+        IntPtr modifier,
+        AndroidX.Compose.UI.Input.NestedScroll.INestedScrollConnection connection);
 
     // androidx.compose.material3.TopAppBarDefaults.enterAlwaysScrollBehavior —
     // @Composable instance method on the singleton. 4 user params; the
@@ -2354,7 +2357,9 @@ internal static partial class ComposeBridges
                         "Landroidx/compose/material3/TopAppBarScrollBehavior;",
         InstanceField = "INSTANCE",
         Defaults      = typeof(TopAppBarEnterAlwaysScrollBehaviorDefault))]
-    internal static partial IntPtr TopAppBarDefaultsEnterAlwaysScrollBehavior(IntPtr state, IComposer composer);
+    internal static partial IntPtr TopAppBarDefaultsEnterAlwaysScrollBehavior(
+        AndroidX.Compose.Material3.TopAppBarState state,
+        IComposer composer);
 
     // androidx.compose.material3.TopAppBarDefaults.exitUntilCollapsedScrollBehavior —
     // same shape as enterAlwaysScrollBehavior above.
@@ -2369,7 +2374,9 @@ internal static partial class ComposeBridges
                         "Landroidx/compose/material3/TopAppBarScrollBehavior;",
         InstanceField = "INSTANCE",
         Defaults      = typeof(TopAppBarExitUntilCollapsedScrollBehaviorDefault))]
-    internal static partial IntPtr TopAppBarDefaultsExitUntilCollapsedScrollBehavior(IntPtr state, IComposer composer);
+    internal static partial IntPtr TopAppBarDefaultsExitUntilCollapsedScrollBehavior(
+        AndroidX.Compose.Material3.TopAppBarState state,
+        IComposer composer);
 
     // BoxScope / RowScope / ColumnScope `align` and `matchParentSize`
     // are abstract interface methods on the scope class (no static

--- a/src/ComposeNet.Compose/Icon.cs
+++ b/src/ComposeNet.Compose/Icon.cs
@@ -94,22 +94,13 @@ public sealed class Icon : ComposableNode
 
         if (_painter is not null)
         {
-            // Caller owns the Painter peer; pass its global-ref handle
-            // directly and keep the wrapper alive across the bridge call.
-            try
-            {
-                ComposeBridges.IconPainter(
-                    painter:            ((IJavaObject)_painter).Handle,
-                    contentDescription: _contentDescription,
-                    modifier:           modifier,
-                    tint:               tint,
-                    defaults:           defaults,
-                    composer:           composer);
-            }
-            finally
-            {
-                System.GC.KeepAlive(_painter);
-            }
+            ComposeBridges.IconPainter(
+                painter:            _painter,
+                contentDescription: _contentDescription,
+                modifier:           modifier,
+                tint:               tint,
+                defaults:           defaults,
+                composer:           composer);
             return;
         }
 
@@ -118,21 +109,19 @@ public sealed class Icon : ComposableNode
         // The bridge enum (`IconPainterDefault`) has the same bit layout
         // as `IconDefault` for the user-visible bits (ContentDescription,
         // Modifier, Tint at bits 1-3), so the same `defaults` mask is
-        // valid for either path.
-        IntPtr painterRef = ComposeBridges.PainterResource(_resourceId!.Value, composer);
-        try
-        {
-            ComposeBridges.IconPainter(
-                painter:            painterRef,
-                contentDescription: _contentDescription,
-                modifier:           modifier,
-                tint:               tint,
-                defaults:           defaults,
-                composer:           composer);
-        }
-        finally
-        {
-            JNIEnv.DeleteLocalRef(painterRef);
-        }
+        // valid for either path. Wrap the local Painter ref into a managed
+        // peer via TransferLocalRef so the bridge's auto-emitted
+        // GC.KeepAlive keeps it alive across the call (and the local ref
+        // is consumed by the wrapper — no DeleteLocalRef needed).
+        var painter = Java.Lang.Object.GetObject<Painter>(
+            ComposeBridges.PainterResource(_resourceId!.Value, composer),
+            JniHandleOwnership.TransferLocalRef)!;
+        ComposeBridges.IconPainter(
+            painter:            painter,
+            contentDescription: _contentDescription,
+            modifier:           modifier,
+            tint:               tint,
+            defaults:           defaults,
+            composer:           composer);
     }
 }

--- a/src/ComposeNet.Compose/MaterialTheme.cs
+++ b/src/ComposeNet.Compose/MaterialTheme.cs
@@ -406,15 +406,7 @@ public sealed class MaterialTheme : ComposableContainer
         if (labelMedium     is null) defaults |= TypographyDefault.LabelMedium;
         if (labelSmall      is null) defaults |= TypographyDefault.LabelSmall;
 
-        // Materialize every non-null slot into a managed peer up front
-        // and root the whole array across the JNI call. If we instead
-        // inlined `ts.Build().Handle` per arg, the temporary peer
-        // wrappers would be eligible for collection between argument
-        // evaluations — releasing the underlying global ref before
-        // ComposeBridges.BuildTypography reads it. See the GC.KeepAlive
-        // pattern in SuspendBridges.cs and ComposeBridges.cs.
-        var built = new AndroidX.Compose.UI.Text.TextStyle?[]
-        {
+        return ComposeBridges.BuildTypography(
             displayLarge?.Build(),
             displayMedium?.Build(),
             displaySmall?.Build(),
@@ -430,25 +422,7 @@ public sealed class MaterialTheme : ComposableContainer
             labelLarge?.Build(),
             labelMedium?.Build(),
             labelSmall?.Build(),
-        };
-
-        try
-        {
-            return ComposeBridges.BuildTypography(
-                Handle(built[ 0]), Handle(built[ 1]), Handle(built[ 2]),
-                Handle(built[ 3]), Handle(built[ 4]), Handle(built[ 5]),
-                Handle(built[ 6]), Handle(built[ 7]), Handle(built[ 8]),
-                Handle(built[ 9]), Handle(built[10]), Handle(built[11]),
-                Handle(built[12]), Handle(built[13]), Handle(built[14]),
-                (int)defaults);
-        }
-        finally
-        {
-            System.GC.KeepAlive(built);
-        }
-
-        static System.IntPtr Handle(AndroidX.Compose.UI.Text.TextStyle? ts) =>
-            ts is null ? System.IntPtr.Zero : ((Java.Lang.Object)ts).Handle;
+            (int)defaults);
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/Modifier.cs
+++ b/src/ComposeNet.Compose/Modifier.cs
@@ -522,18 +522,7 @@ public sealed class Modifier
     public Modifier NestedScroll(AndroidX.Compose.UI.Input.NestedScroll.INestedScrollConnection connection)
     {
         ArgumentNullException.ThrowIfNull(connection);
-        IntPtr handle = ((Java.Lang.Object)connection).Handle;
-        return Append(curr =>
-        {
-            try
-            {
-                return ComposeBridges.ModifierNestedScroll(curr, handle);
-            }
-            finally
-            {
-                System.GC.KeepAlive(connection);
-            }
-        });
+        return Append(curr => ComposeBridges.ModifierNestedScroll(curr, connection));
     }
 
     /// <summary>

--- a/src/ComposeNet.Compose/SaveableBridges.cs
+++ b/src/ComposeNet.Compose/SaveableBridges.cs
@@ -95,7 +95,7 @@ internal static partial class ComposeBridges
     internal static unsafe System.IntPtr RememberSaveableSimple(
         System.IntPtr inputs,
         ObjectFunction0 init,
-        System.IntPtr composer,
+        AndroidX.Compose.Runtime.IComposer composer,
         int changed)
     {
         if (s_rememberSaveableSimple_method == System.IntPtr.Zero)
@@ -113,7 +113,7 @@ internal static partial class ComposeBridges
             JValue* args = stackalloc JValue[4];
             args[0] = new JValue(inputs);
             args[1] = new JValue(init.Handle);
-            args[2] = new JValue(composer);
+            args[2] = new JValue(((Java.Lang.Object)composer).Handle);
             args[3] = new JValue(changed);
             return JNIEnv.CallStaticObjectMethod(
                 s_rememberSaveableSimple_class,
@@ -123,6 +123,7 @@ internal static partial class ComposeBridges
         finally
         {
             System.GC.KeepAlive(init);
+            System.GC.KeepAlive(composer);
         }
     }
 
@@ -145,7 +146,7 @@ internal static partial class ComposeBridges
         System.IntPtr inputs,
         System.IntPtr stateSaver,
         ObjectFunction0 init,
-        System.IntPtr composer,
+        AndroidX.Compose.Runtime.IComposer composer,
         int changed)
     {
         if (s_rememberSaveableState_method == System.IntPtr.Zero)
@@ -164,7 +165,7 @@ internal static partial class ComposeBridges
             args[0] = new JValue(inputs);
             args[1] = new JValue(stateSaver);
             args[2] = new JValue(init.Handle);
-            args[3] = new JValue(composer);
+            args[3] = new JValue(((Java.Lang.Object)composer).Handle);
             args[4] = new JValue(changed);
             return JNIEnv.CallStaticObjectMethod(
                 s_rememberSaveableState_class,
@@ -174,6 +175,7 @@ internal static partial class ComposeBridges
         finally
         {
             System.GC.KeepAlive(init);
+            System.GC.KeepAlive(composer);
         }
     }
 

--- a/src/ComposeNet.Compose/TopAppBarDefaults.cs
+++ b/src/ComposeNet.Compose/TopAppBarDefaults.cs
@@ -113,7 +113,6 @@ public static class TopAppBarDefaults
         }
         finally
         {
-            System.GC.KeepAlive(state);
             composer.EndReplaceableGroup();
         }
     }
@@ -156,7 +155,7 @@ public static class TopAppBarDefaults
 
     static ITopAppBarScrollBehavior Invoke(
         TopAppBarState state, int line, string file,
-        System.Func<IntPtr, IComposer, IntPtr> bridge)
+        System.Func<TopAppBarState, IComposer, IntPtr> bridge)
     {
         ArgumentNullException.ThrowIfNull(state);
         var composer = ComposeContext.Current
@@ -166,8 +165,7 @@ public static class TopAppBarDefaults
         composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
         try
         {
-            IntPtr stateHandle = ((Java.Lang.Object)state).Handle;
-            IntPtr handle = bridge(stateHandle, composer);
+            IntPtr handle = bridge(state, composer);
             try
             {
                 return Java.Lang.Object.GetObject<ITopAppBarScrollBehavior>(
@@ -182,7 +180,6 @@ public static class TopAppBarDefaults
         }
         finally
         {
-            System.GC.KeepAlive(state);
             composer.EndReplaceableGroup();
         }
     }

--- a/src/ComposeNet.Compose/TypographyBridges.cs
+++ b/src/ComposeNet.Compose/TypographyBridges.cs
@@ -37,33 +37,32 @@ internal static partial class ComposeBridges
 
     /// <summary>
     /// Build a Material 3 <see cref="Typography"/> with per-slot
-    /// overrides. Each <see cref="System.IntPtr"/> is either a
-    /// <c>TextStyle</c> JNI handle to use for that slot, or
-    /// <see cref="System.IntPtr.Zero"/> to fall back to the M3
-    /// baseline default for that slot via Kotlin's synthetic
-    /// <c>$default</c> mechanism.
+    /// overrides. Each <see cref="AndroidX.Compose.UI.Text.TextStyle"/>
+    /// is either a wrapper to use for that slot, or <c>null</c> to fall
+    /// back to the M3 baseline default for that slot via Kotlin's
+    /// synthetic <c>$default</c> mechanism.
     /// </summary>
     /// <param name="defaults">
     /// 15-bit mask: bit N set means "leave slot N at the Kotlin
-    /// default" (the corresponding handle is ignored). Bit 0 is
+    /// default" (the corresponding wrapper is ignored). Bit 0 is
     /// displayLarge, bit 14 is labelSmall.
     /// </param>
     internal static unsafe Typography BuildTypography(
-        System.IntPtr displayLarge,
-        System.IntPtr displayMedium,
-        System.IntPtr displaySmall,
-        System.IntPtr headlineLarge,
-        System.IntPtr headlineMedium,
-        System.IntPtr headlineSmall,
-        System.IntPtr titleLarge,
-        System.IntPtr titleMedium,
-        System.IntPtr titleSmall,
-        System.IntPtr bodyLarge,
-        System.IntPtr bodyMedium,
-        System.IntPtr bodySmall,
-        System.IntPtr labelLarge,
-        System.IntPtr labelMedium,
-        System.IntPtr labelSmall,
+        AndroidX.Compose.UI.Text.TextStyle? displayLarge,
+        AndroidX.Compose.UI.Text.TextStyle? displayMedium,
+        AndroidX.Compose.UI.Text.TextStyle? displaySmall,
+        AndroidX.Compose.UI.Text.TextStyle? headlineLarge,
+        AndroidX.Compose.UI.Text.TextStyle? headlineMedium,
+        AndroidX.Compose.UI.Text.TextStyle? headlineSmall,
+        AndroidX.Compose.UI.Text.TextStyle? titleLarge,
+        AndroidX.Compose.UI.Text.TextStyle? titleMedium,
+        AndroidX.Compose.UI.Text.TextStyle? titleSmall,
+        AndroidX.Compose.UI.Text.TextStyle? bodyLarge,
+        AndroidX.Compose.UI.Text.TextStyle? bodyMedium,
+        AndroidX.Compose.UI.Text.TextStyle? bodySmall,
+        AndroidX.Compose.UI.Text.TextStyle? labelLarge,
+        AndroidX.Compose.UI.Text.TextStyle? labelMedium,
+        AndroidX.Compose.UI.Text.TextStyle? labelSmall,
         int defaults)
     {
         if (s_typographyCtor_method == System.IntPtr.Zero)
@@ -72,26 +71,54 @@ internal static partial class ComposeBridges
             s_typographyCtor_method = JNIEnv.GetMethodID(s_typographyCtor_class, "<init>", TypographyDefaultCtorSig);
         }
 
-        JValue* args = stackalloc JValue[17];
-        args[0]  = new JValue(displayLarge);
-        args[1]  = new JValue(displayMedium);
-        args[2]  = new JValue(displaySmall);
-        args[3]  = new JValue(headlineLarge);
-        args[4]  = new JValue(headlineMedium);
-        args[5]  = new JValue(headlineSmall);
-        args[6]  = new JValue(titleLarge);
-        args[7]  = new JValue(titleMedium);
-        args[8]  = new JValue(titleSmall);
-        args[9]  = new JValue(bodyLarge);
-        args[10] = new JValue(bodyMedium);
-        args[11] = new JValue(bodySmall);
-        args[12] = new JValue(labelLarge);
-        args[13] = new JValue(labelMedium);
-        args[14] = new JValue(labelSmall);
-        args[15] = new JValue(defaults);
-        args[16] = new JValue(System.IntPtr.Zero);
+        try
+        {
+            JValue* args = stackalloc JValue[17];
+            args[0]  = new JValue(Handle(displayLarge));
+            args[1]  = new JValue(Handle(displayMedium));
+            args[2]  = new JValue(Handle(displaySmall));
+            args[3]  = new JValue(Handle(headlineLarge));
+            args[4]  = new JValue(Handle(headlineMedium));
+            args[5]  = new JValue(Handle(headlineSmall));
+            args[6]  = new JValue(Handle(titleLarge));
+            args[7]  = new JValue(Handle(titleMedium));
+            args[8]  = new JValue(Handle(titleSmall));
+            args[9]  = new JValue(Handle(bodyLarge));
+            args[10] = new JValue(Handle(bodyMedium));
+            args[11] = new JValue(Handle(bodySmall));
+            args[12] = new JValue(Handle(labelLarge));
+            args[13] = new JValue(Handle(labelMedium));
+            args[14] = new JValue(Handle(labelSmall));
+            args[15] = new JValue(defaults);
+            args[16] = new JValue(System.IntPtr.Zero);
 
-        System.IntPtr handle = JNIEnv.NewObject(s_typographyCtor_class, s_typographyCtor_method, args);
-        return Java.Lang.Object.GetObject<Typography>(handle, JniHandleOwnership.TransferLocalRef)!;
+            System.IntPtr handle = JNIEnv.NewObject(s_typographyCtor_class, s_typographyCtor_method, args);
+            return Java.Lang.Object.GetObject<Typography>(handle, JniHandleOwnership.TransferLocalRef)!;
+        }
+        finally
+        {
+            // Keep every wrapper alive across the JNI call so its
+            // backing global ref isn't released between the Handle()
+            // reads above and JNIEnv.NewObject. The bridge owns this
+            // responsibility — facade callers shouldn't have to.
+            System.GC.KeepAlive(displayLarge);
+            System.GC.KeepAlive(displayMedium);
+            System.GC.KeepAlive(displaySmall);
+            System.GC.KeepAlive(headlineLarge);
+            System.GC.KeepAlive(headlineMedium);
+            System.GC.KeepAlive(headlineSmall);
+            System.GC.KeepAlive(titleLarge);
+            System.GC.KeepAlive(titleMedium);
+            System.GC.KeepAlive(titleSmall);
+            System.GC.KeepAlive(bodyLarge);
+            System.GC.KeepAlive(bodyMedium);
+            System.GC.KeepAlive(bodySmall);
+            System.GC.KeepAlive(labelLarge);
+            System.GC.KeepAlive(labelMedium);
+            System.GC.KeepAlive(labelSmall);
+        }
+
+        static System.IntPtr Handle(AndroidX.Compose.UI.Text.TextStyle? ts) =>
+            ts is null ? System.IntPtr.Zero : ((Java.Lang.Object)ts).Handle;
     }
 }

--- a/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/ComposeNet.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -1063,12 +1063,13 @@ public class FacadeGeneratorTests
     // ---------------------------------------------------------------
 
     [Fact]
-    public void PainterResource_EmitsTryFinallyDeleteLocalRef()
+    public void PainterResource_EmitsTypedPainterPeer()
     {
         var code = """
             using System;
             using AndroidX.Compose.Runtime;
             using AndroidX.Compose.UI;
+            using AndroidX.Compose.UI.Graphics.Painter;
             using ComposeNet;
             using Kotlin.Jvm.Functions;
 
@@ -1082,7 +1083,7 @@ public class FacadeGeneratorTests
                                    Signature="(Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V",
                                    Defaults=typeof(ImageDefault))]
                     [ComposeFacade]
-                    public static partial void Image([PainterResource] IntPtr painter,
+                    public static partial void Image([PainterResource] Painter painter,
                         string? contentDescription, IModifier? modifier,
                         int defaults, IComposer composer);
                 }
@@ -1104,21 +1105,27 @@ public class FacadeGeneratorTests
         // Painter ctor null-guards and stores into `_painter`.
         Assert.Contains("_painter = painter ?? throw new global::System.ArgumentNullException(nameof(painter));", emitted);
 
-        // Render preamble branches: caller-owned Painter forwards a
-        // global-ref handle; resource-id path resolves a local ref we
-        // must release.
+        // Render preamble: caller-owned Painter is forwarded directly;
+        // resource-id path wraps the local ref into a managed peer via
+        // TransferLocalRef (consumes the local ref — no DeleteLocalRef
+        // needed) so the bridge's auto-emitted GC.KeepAlive covers both
+        // shapes uniformly.
+        Assert.Contains("global::AndroidX.Compose.UI.Graphics.Painter.Painter __painterPeer;", emitted);
         Assert.Contains("if (_painter is not null)", emitted);
-        Assert.Contains("__painterRef = ((global::Android.Runtime.IJavaObject)_painter).Handle;", emitted);
-        Assert.Contains("__painterOwned = false;", emitted);
+        Assert.Contains("__painterPeer = _painter;", emitted);
         Assert.Contains("__painterRef = global::ComposeNet.ComposeBridges.PainterResource(_drawableResourceId, composer);", emitted);
-        Assert.Contains("__painterOwned = true;", emitted);
-        Assert.Contains("try", emitted);
-        Assert.Contains("finally", emitted);
-        Assert.Contains("if (__painterOwned) global::Android.Runtime.JNIEnv.DeleteLocalRef(__painterRef);", emitted);
-        Assert.Contains("global::System.GC.KeepAlive(_painter);", emitted);
+        Assert.Contains("__painterPeer = global::Java.Lang.Object.GetObject<global::AndroidX.Compose.UI.Graphics.Painter.Painter>(", emitted);
+        Assert.Contains("__painterRef, global::Android.Runtime.JniHandleOwnership.TransferLocalRef)!;", emitted);
 
-        // Bridge call inside try block — uses __painterRef for painter arg.
-        Assert.Contains("global::ComposeNet.ComposeBridges.Image(__painterRef", emitted);
+        // No facade-side try/finally + DeleteLocalRef + GC.KeepAlive
+        // anymore — pushed down to the bridge (auto-emits KeepAlive on
+        // typed Painter param) / TransferLocalRef (consumes local ref).
+        Assert.DoesNotContain("__painterOwned", emitted);
+        Assert.DoesNotContain("JNIEnv.DeleteLocalRef(__painterRef)", emitted);
+        Assert.DoesNotContain("global::System.GC.KeepAlive(_painter);", emitted);
+
+        // Bridge call passes typed __painterPeer for the painter arg.
+        Assert.Contains("global::ComposeNet.ComposeBridges.Image(__painterPeer", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
@@ -1202,6 +1209,7 @@ public class FacadeGeneratorTests
             using System;
             using AndroidX.Compose.Runtime;
             using AndroidX.Compose.UI;
+            using AndroidX.Compose.UI.Graphics.Painter;
             using ComposeNet;
 
             [assembly: ComposeDefaults("FooDefault", "!a", "!b")]
@@ -1214,7 +1222,7 @@ public class FacadeGeneratorTests
                                    Signature="(Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/runtime/Composer;II)V",
                                    Defaults=typeof(FooDefault))]
                     [ComposeFacade]
-                    public static partial void Foo([PainterResource] IntPtr a, [PainterResource] IntPtr b,
+                    public static partial void Foo([PainterResource] Painter a, [PainterResource] Painter b,
                         int defaults, IComposer composer);
                 }
             }
@@ -3028,7 +3036,7 @@ public class FacadeGeneratorTests
                         Defaults=typeof(ImageDefault))]
                     [ComposeFacade]
                     public static partial void Image(
-                        [PainterResource] System.IntPtr painter,
+                        [PainterResource] global::AndroidX.Compose.UI.Graphics.Painter.Painter painter,
                         string? contentDescription,
                         IModifier? modifier,
                         Alignment? alignment,

--- a/src/ComposeNet.SourceGenerators/Attributes.cs
+++ b/src/ComposeNet.SourceGenerators/Attributes.cs
@@ -268,15 +268,18 @@ internal static class Attributes
             }
 
             /// <summary>
-            /// Phase 7 — apply to the <c>IntPtr</c> bridge parameter
-            /// that takes the resolved <c>Painter</c> handle. The facade
+            /// Phase 7 — apply to the <c>Painter</c> bridge parameter
+            /// that takes the resolved Painter wrapper. The facade
             /// replaces this parameter with a synthetic ctor argument
             /// <c>int drawableResourceId</c>; <c>Render</c> calls
             /// <c>ComposeBridges.PainterResource(id, composer)</c> to
-            /// resolve the handle, forwards it to the annotated
-            /// parameter, and wraps the bridge invocation in
-            /// <c>try</c> / <c>finally</c> + <c>JNIEnv.DeleteLocalRef</c>.
-            /// At most one bridge parameter may carry <c>[PainterResource]</c>.
+            /// resolve the handle, wraps it into a managed
+            /// <c>Painter</c> peer via
+            /// <c>JniHandleOwnership.TransferLocalRef</c>, and forwards
+            /// it to the annotated parameter. The bridge's
+            /// auto-emitted <c>GC.KeepAlive(painter)</c> keeps the
+            /// peer alive across the call. At most one bridge
+            /// parameter may carry <c>[PainterResource]</c>.
             /// </summary>
             [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
                                            AllowMultiple = false)]

--- a/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/ComposeNet.SourceGenerators/ComposeFacadeGenerator.cs
@@ -784,16 +784,16 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 confirmStateChanges: confirmInfos.ToArray());
         }
 
-        // [PainterResource] — annotates the IntPtr bridge param that
-        // takes the resolved Painter handle. The facade exposes a
-        // synthetic `int drawableResourceId` ctor arg in its place.
+        // [PainterResource] — annotates the bridge param that takes
+        // the resolved Painter wrapper. The facade exposes a synthetic
+        // `int drawableResourceId` ctor arg in its place.
         if (c.PainterAttr is not null &&
             p.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, c.PainterAttr)))
         {
-            if (p.Type.SpecialType != SpecialType.System_IntPtr)
+            if (!IsPainterType(p.Type))
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadePainterMisuse, loc, methodName,
-                    $"[PainterResource] must annotate an 'IntPtr' parameter; '{p.Name}' is '{p.Type.ToDisplayString()}'"));
+                    $"[PainterResource] must annotate an 'AndroidX.Compose.UI.Graphics.Painter.Painter' parameter; '{p.Name}' is '{p.Type.ToDisplayString()}'"));
                 return null;
             }
             return new FacadeSlot(p, FacadeSlotKind.PainterResource);
@@ -1165,34 +1165,32 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
               .Append(composerName).Append(", 0).").Append(Pascal(themeColor)).AppendLine(";");
         }
 
-        // Phase 7 — PainterResource preamble. Resolves the painter
-        // handle two ways: if the caller used the Painter ctor, we
-        // forward the wrapper's global-ref handle directly (no
-        // local-ref ownership). Otherwise we resolve the drawable
-        // resource id inside the composition via painterResource(id)
-        // — that produces a local ref we must clean up in `finally`.
+        // Phase 7 — `[PainterResource]` lowering. If the caller used
+        // the Painter ctor, forward the wrapper itself; the bridge's
+        // auto-`GC.KeepAlive(painter)` covers it. Otherwise we resolve
+        // the drawable resource id inside the composition via
+        // `painterResource(id)` and wrap the local ref into a fresh
+        // managed peer (`TransferLocalRef` consumes the local ref so
+        // there is nothing to `DeleteLocalRef` afterwards).
         var painterIdSlot = slots.FirstOrDefault(s => s.Kind == FacadeSlotKind.PainterResource);
         bool hasPainter = painterIdSlot.Param is not null;
         if (hasPainter)
         {
-            sb.AppendLine("            global::System.IntPtr __painterRef;");
-            sb.AppendLine("            bool __painterOwned;");
+            sb.AppendLine("            global::AndroidX.Compose.UI.Graphics.Painter.Painter __painterPeer;");
             sb.AppendLine("            if (_painter is not null)");
             sb.AppendLine("            {");
-            sb.AppendLine("                __painterRef = ((global::Android.Runtime.IJavaObject)_painter).Handle;");
-            sb.AppendLine("                __painterOwned = false;");
+            sb.AppendLine("                __painterPeer = _painter;");
             sb.AppendLine("            }");
             sb.AppendLine("            else");
             sb.AppendLine("            {");
-            sb.AppendLine("                __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_drawableResourceId, "
+            sb.AppendLine("                var __painterRef = global::ComposeNet.ComposeBridges.PainterResource(_drawableResourceId, "
                 + composerName + ");");
-            sb.AppendLine("                __painterOwned = true;");
+            sb.AppendLine("                __painterPeer = global::Java.Lang.Object.GetObject<global::AndroidX.Compose.UI.Graphics.Painter.Painter>(");
+            sb.AppendLine("                    __painterRef, global::Android.Runtime.JniHandleOwnership.TransferLocalRef)!;");
             sb.AppendLine("            }");
-            sb.AppendLine("            try");
-            sb.AppendLine("            {");
         }
 
-        string indent = hasPainter ? "                " : "            ";
+        string indent = "            ";
 
         // Phase 3 — auto-mask defaults + bridge call.
         if (branchInfo is not null)
@@ -1227,16 +1225,6 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             }
             if (!first) sb.Append(", ");
             sb.Append(composerName).AppendLine(");");
-        }
-
-        if (hasPainter)
-        {
-            sb.AppendLine("            }");
-            sb.AppendLine("            finally");
-            sb.AppendLine("            {");
-            sb.AppendLine("                if (__painterOwned) global::Android.Runtime.JNIEnv.DeleteLocalRef(__painterRef);");
-            sb.AppendLine("                global::System.GC.KeepAlive(_painter);");
-            sb.AppendLine("            }");
         }
 
         sb.AppendLine("        }");
@@ -1460,7 +1448,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             FacadeSlotKind.RequiredFunction3 => "__" + s.Param.Name,
             FacadeSlotKind.Callback         => "__" + s.Param.Name,
             FacadeSlotKind.Primitive        => "_" + s.Param.Name,
-            FacadeSlotKind.PainterResource  => "__painterRef",
+            FacadeSlotKind.PainterResource  => "__painterPeer",
             FacadeSlotKind.ThemeColor       => "__color",
             FacadeSlotKind.ScopeReceiver    => "global::ComposeNet.RenderContext.CurrentScope",
             FacadeSlotKind.StateHolder      => "__" + s.Param.Name,
@@ -1583,6 +1571,11 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         type is INamedTypeSymbol n &&
         n.Name == "IModifier" &&
         n.ContainingNamespace?.ToDisplayString() == "AndroidX.Compose.UI";
+
+    static bool IsPainterType(ITypeSymbol type) =>
+        type is INamedTypeSymbol n &&
+        n.Name == "Painter" &&
+        n.ContainingNamespace?.ToDisplayString() == "AndroidX.Compose.UI.Graphics.Painter";
 
     static int KotlinFunctionArity(ITypeSymbol type)
     {


### PR DESCRIPTION
Several facades wrapped `[ComposeBridge]` (or hand-written JNI helper) calls in `try/finally + GC.KeepAlive(wrapper)` to keep a managed JCW alive across the JNI call. The bridge generator already auto-emits a `GC.KeepAlive` for every typed `IJavaObject`-derived parameter — so when the bridge declared an `IntPtr` param and the facade did the `((Java.Lang.Object)wrapper).Handle` cast, the generator had no way to emit a KeepAlive for the originating wrapper and the facade ended up with redundant boilerplate.

This change pushes that responsibility down to the bridge layer by widening each `IntPtr` bridge param to its typed wrapper. The generator then emits the cast + `GC.KeepAlive` itself. For hand-written raw-JNI helpers (`TypographyBridges`, `SaveableBridges`) we inline the same pattern in the helper body instead of in each call site.

## Per-file summary

| File | Change |
|---|---|
| `ComposeBridges.cs` | `Image` + `IconPainter` painter: `IntPtr` → `Painter`. `ModifierNestedScroll` connection: `IntPtr` → `INestedScrollConnection`. Two `TopAppBarDefaults*ScrollBehavior` bridges: `IntPtr state` → `TopAppBarState state`. |
| `Icon.cs` | Drop `try/finally + GC.KeepAlive(_painter)` (pre-resolved Painter path). Wrap resource-id `painterRef` via `Java.Lang.Object.GetObject<Painter>(.., TransferLocalRef)` so the bridge's auto-`KeepAlive` covers it. |
| `Modifier.cs:NestedScroll` | Drop manual cast + try/finally + KeepAlive. |
| `TopAppBarDefaults.cs` | Drop redundant `GC.KeepAlive(state)` around `PinnedScrollBehavior` (bound binding auto-keeps `IJavaPeerable` args). Rewrite the EnterAlways/ExitUntilCollapsed `Invoke` helper to forward typed `TopAppBarState` directly. |
| `MaterialTheme.cs` / `TypographyBridges.cs` | Bridge now takes 15 typed `TextStyle?` params; cast + 15× `GC.KeepAlive` moved into the bridge body. Facade simplified to a direct call passing `?.Build()` per slot. |
| `Compose.cs` / `SaveableBridges.cs` | Bridges take typed `IComposer`; facade drops `((Java.Lang.Object)composer).Handle` cast and try/finally. |
| `ComposeFacadeGenerator.cs` (Phase 7) | `[PainterResource]` now accepts `Painter` (not `IntPtr`). Render emission declares a typed `Painter __painterPeer`; the caller-Painter branch aliases `_painter`, the resource-id branch wraps the local ref via `GetObject<Painter>(.., TransferLocalRef)`. Drops the trailing `try/finally + DeleteLocalRef + GC.KeepAlive(_painter)` block. |
| `Attributes.cs` | `[PainterResource]` doc updated for the new typed-`Painter` shape. |
| `FacadeGeneratorTests.cs` | Phase 7 emission test rewritten to assert the new shape (`__painterPeer`, `GetObject<Painter>`, `TransferLocalRef`) and that the old shape is gone. Image-style + multi-painter tests updated to use the `Painter` param type. |

## Sites that legitimately keep `GC.KeepAlive`

- `AnnotatedString.cs:28` — peer-construction pattern.
- `LaunchedEffectBody.cs:228` — JCW kept alive across Kotlin job lifetime.
- `Modifier.cs:1265-1266` — calls hand-written raw-JNI helper `ModifierPointerInput` with two `IntPtr` handles.
- `ComposeBridges.cs:2961+, 3707` — hand-written raw-JNI bridges (`ExposedDropdownMenu`, `RememberNavController`).
- Push-down sites in `TypographyBridges.cs`, `SaveableBridges.cs` — `GC.KeepAlive` now lives inside the bridge body (correct), not in the facade.
- `PointerInputBlock.cs`, `KotlinResult.cs`, `SuspendBridge.cs`, `SuspendBridges.cs`, `TextFieldValueBridges.cs` — raw-JNI sites.

## Verification

Build:

- `dotnet build src/ComposeNet.Compose` — clean.
- `dotnet test src/ComposeNet.SourceGenerators.Tests` — 112/112 pass.
- `dotnet build src/ComposeNet.Gallery` — clean.

On-device (deployed to Pixel, deep-linked to each impacted demo, scroll-input verified):

| Scenario | Code path exercised | Result |
|---|---|---|
| `misc-image` | Phase 7 facade generator + `Image` bridge (typed `Painter`) | ⭐ renders via `__painterPeer = GetObject<Painter>(.., TransferLocalRef)` |
| `misc-image-content-scale` | Phase 7 generator with more slots | renders |
| `misc-icon` | `Icon.cs` Painter ctor + resource-id ctor + ImageVector ctor | ⚙ + ★ + magnifier all render |
| `theming-typography` | `MaterialTheme.BuildTypography` (15× typed `TextStyle?`) | label/title overrides apply |
| `state-remembersaveable` | `RememberSaveableScalar/Wrapper` (typed `IComposer`) | counter + TextField persist |
| `appbars-pinned-scroll-behavior` | `TopAppBarDefaults.PinnedScrollBehavior` | pinned bar stays put |
| `appbars-enter-always-scroll-behavior` | `TopAppBarDefaultsEnterAlwaysScrollBehavior` (typed `TopAppBarState`) + `Modifier.NestedScroll` (typed `INestedScrollConnection`) | bar collapses/expands on swipe |
| `appbars-medium-flexible` / `appbars-large-flexible` | `TopAppBarDefaultsExitUntilCollapsedScrollBehavior` (typed state) | header collapses on scroll |

App PID stable across all navigations + scroll bursts. Logcat clean — no `AndroidRuntime` errors, no fatal signals, no managed exceptions.

No public-API surface changed.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>