### PR TITLE
Disable drawer edge-swipe on gallery sub-pages

### DIFF
--- a/src/Microsoft.AndroidX.Compose.Gallery/GalleryApp.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/GalleryApp.cs
@@ -24,8 +24,13 @@ public static class GalleryApp
     /// </summary>
     public static ComposableNode Build()
     {
-        var nav    = ComposeRuntime.Remember(() => new NavController());
-        var drawer = ComposeRuntime.Remember(() => new DrawerStateHolder(global::AndroidX.Compose.Material3.DrawerValue.Closed));
+        var nav          = ComposeRuntime.Remember(() => new NavController());
+        var drawer       = ComposeRuntime.Remember(() => new DrawerStateHolder(global::AndroidX.Compose.Material3.DrawerValue.Closed));
+        // Shared by GalleryScaffold (drives back-arrow / title) and the
+        // drawer below (drives edge-swipe). Lives here so both see the
+        // same MutableState; each route's body updates it in a
+        // DisposableEffect.
+        var currentRoute = ComposeRuntime.Remember(() => new MutableState<string>("home"));
 
         MainActivity.Nav = nav;
 
@@ -36,8 +41,15 @@ public static class GalleryApp
                 Modifier.Companion.FillMaxSize(),
                 new ModalNavigationDrawer(drawerState: drawer)
                 {
-                    Drawer       = new GalleryDrawer(nav, drawer),
-                    Content      = new GalleryScaffold(nav, drawer),
+                    Drawer          = new GalleryDrawer(nav, drawer),
+                    Content         = new GalleryScaffold(nav, drawer, currentRoute),
+                    // Match the top-app-bar affordance: edge-swipe to open
+                    // the drawer only when the hamburger is showing
+                    // (i.e. at the home destination). On sub-pages the
+                    // bar shows a back arrow, so swipe-to-open would
+                    // contradict the visible nav contract and step on
+                    // the system back-gesture.
+                    GesturesEnabled = currentRoute.Value == "home",
                 },
             },
         };

--- a/src/Microsoft.AndroidX.Compose.Gallery/GalleryScaffold.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/GalleryScaffold.cs
@@ -15,28 +15,35 @@ public sealed class GalleryScaffold : ComposableNode
 {
     readonly NavController _nav;
     readonly DrawerStateHolder _drawer;
+    readonly MutableState<string> _currentRoute;
 
     /// <summary>Construct the scaffold bound to <paramref name="nav"/> + <paramref name="drawer"/>.</summary>
-    public GalleryScaffold(NavController nav, DrawerStateHolder drawer)
+    /// <param name="nav">The shared <see cref="NavController"/>.</param>
+    /// <param name="drawer">The shared <see cref="DrawerStateHolder"/>.</param>
+    /// <param name="currentRoute">
+    /// The shared route <see cref="MutableState{T}"/> owned by
+    /// <see cref="GalleryApp"/>. Each route's body updates it in a
+    /// <see cref="DisposableEffect"/>; the top app bar reads it to
+    /// decide between hamburger (home) and back arrow (anywhere else),
+    /// and the surrounding drawer reads it to toggle the edge-swipe
+    /// gesture.
+    /// </param>
+    public GalleryScaffold(NavController nav, DrawerStateHolder drawer, MutableState<string> currentRoute)
     {
-        _nav    = nav;
-        _drawer = drawer;
+        _nav          = nav;
+        _drawer       = drawer;
+        _currentRoute = currentRoute;
     }
 
     public override void Render(IComposer composer)
     {
-        // Tracked separately from NavController because the binding doesn't
-        // expose currentBackStackEntryAsState. Each route's body updates
-        // this MutableState in a DisposableEffect; the top app bar reads it
-        // to decide between hamburger (home) and back arrow (anywhere else).
-        var currentRoute = ComposeRuntime.Remember(() => new MutableState<string>("home"));
-        var atRoot       = currentRoute.Value == "home";
+        var atRoot = _currentRoute.Value == "home";
 
         new Scaffold
         {
             TopBar = new CenterAlignedTopAppBar
             {
-                Title = new Text(TitleFor(currentRoute.Value)),
+                Title = new Text(TitleFor(_currentRoute.Value)),
                 NavigationIcon = atRoot
                     ? new IconButton(onClick: () => _ = _drawer.OpenAsync())
                     {
@@ -54,7 +61,7 @@ public sealed class GalleryScaffold : ComposableNode
                     },
                 },
             },
-            Body = BuildNavHost(currentRoute),
+            Body = BuildNavHost(_currentRoute),
         }.Render(composer);
     }
 

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1722,12 +1722,14 @@ internal static partial class ComposeBridges
         [StateHolder(Remember = nameof(RememberDrawerState),
                      StateType = typeof(DrawerStateHolder),
                      SharedState = true)] IntPtr drawerState,
+        bool?             gesturesEnabled,
         [Slot("Content")] IFunction2 content,
         int               defaults,
         IComposer         composer);
 
     public static partial void ModalNavigationDrawer(
         IFunction2 drawerContent, IModifier? modifier, IntPtr drawerState,
+        bool? gesturesEnabled,
         IFunction2 content, int defaults, IComposer composer)
     {
         // The bound binding takes a typed DrawerState; reconstitute it
@@ -1738,7 +1740,10 @@ internal static partial class ComposeBridges
             drawerContent:    drawerContent,
             modifier:         modifier,
             drawerState:      stateObj,
-            gesturesEnabled:  true,
+            // gesturesEnabled: null → Kotlin default (true). When the caller
+            // supplies a value, the facade's auto-mask clears the matching
+            // GesturesEnabled bit in `defaults` so Kotlin uses our value.
+            gesturesEnabled:  gesturesEnabled ?? true,
             scrimColor:       0L,
             content:          content,
             _composer:        composer,
@@ -1753,12 +1758,14 @@ internal static partial class ComposeBridges
         [StateHolder(Remember = nameof(RememberDrawerState),
                      StateType = typeof(DrawerStateHolder),
                      SharedState = true)] IntPtr drawerState,
+        bool?             gesturesEnabled,
         [Slot("Content")] IFunction2 content,
         int               defaults,
         IComposer         composer);
 
     public static partial void DismissibleNavigationDrawer(
         IFunction2 drawerContent, IModifier? modifier, IntPtr drawerState,
+        bool? gesturesEnabled,
         IFunction2 content, int defaults, IComposer composer)
     {
         var stateObj = Java.Lang.Object.GetObject<DrawerState>(
@@ -1767,7 +1774,7 @@ internal static partial class ComposeBridges
             drawerContent:    drawerContent,
             modifier:         modifier,
             drawerState:      stateObj,
-            gesturesEnabled:  true,
+            gesturesEnabled:  gesturesEnabled ?? true,
             content:          content,
             _composer:        composer,
             p6:               0,

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -251,6 +251,8 @@ Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.Content.set -> void
 Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.DismissibleNavigationDrawer(Microsoft.AndroidX.Compose.DrawerStateHolder? drawerState = null) -> void
 Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.Drawer.get -> Microsoft.AndroidX.Compose.ComposableNode?
 Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.Drawer.set -> void
+Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.GesturesEnabled.get -> bool?
+Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.GesturesEnabled.set -> void
 Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.InitialValue.get -> AndroidX.Compose.Material3.DrawerValue?
 Microsoft.AndroidX.Compose.DismissibleNavigationDrawer.InitialValue.init -> void
 Microsoft.AndroidX.Compose.DisposableEffect
@@ -636,6 +638,8 @@ Microsoft.AndroidX.Compose.ModalNavigationDrawer.Content.get -> Microsoft.Androi
 Microsoft.AndroidX.Compose.ModalNavigationDrawer.Content.set -> void
 Microsoft.AndroidX.Compose.ModalNavigationDrawer.Drawer.get -> Microsoft.AndroidX.Compose.ComposableNode?
 Microsoft.AndroidX.Compose.ModalNavigationDrawer.Drawer.set -> void
+Microsoft.AndroidX.Compose.ModalNavigationDrawer.GesturesEnabled.get -> bool?
+Microsoft.AndroidX.Compose.ModalNavigationDrawer.GesturesEnabled.set -> void
 Microsoft.AndroidX.Compose.ModalNavigationDrawer.InitialValue.get -> AndroidX.Compose.Material3.DrawerValue?
 Microsoft.AndroidX.Compose.ModalNavigationDrawer.InitialValue.init -> void
 Microsoft.AndroidX.Compose.ModalNavigationDrawer.ModalNavigationDrawer(Microsoft.AndroidX.Compose.DrawerStateHolder? drawerState = null) -> void


### PR DESCRIPTION
## Why

In the gallery the navigation drawer responded to an edge-swipe everywhere, including on category and demo sub-pages where the top app bar shows a back arrow instead of the hamburger. The swipe-to-open gesture is supposed to mirror the visible nav affordance, and on sub-pages it also collides with the system back-gesture contract.

## What

Expose `gesturesEnabled` on the `ModalNavigationDrawer` / `DismissibleNavigationDrawer` Phase 8 wrapper-passthroughs as an optional `bool? GesturesEnabled { get; set; }` property -- the existing `OptionalValue` slot path. `null` (the default) leaves Kotlin's `true` default in place; passing `false` flips the `GesturesEnabled` bit in the `$default` mask and disables the gesture. No facade-generator changes were needed.

In the gallery, hoist the `currentRoute` `MutableState<string>` out of `GalleryScaffold` and up into `GalleryApp` so the surrounding drawer and the scaffold both share the same instance, then set `GesturesEnabled = currentRoute.Value == "home"` on the drawer. The scaffold now takes the state through its ctor instead of allocating its own `Remember`.

## Notes for reviewers

- The `bool?` shape is consistent with other optional override slots in the facade (`FontWeight?`, `Shape?`, `TextAlign?`). A more bool-idiomatic `bool gesturesEnabled = true` ctor parameter would require teaching the facade generator to honor `HasExplicitDefaultValue` on `Primitive` slots; happy to do that as a follow-up if we'd rather standardize on that shape for new optional toggles.
- Verified: generator tests 112/112 pass, facade and gallery builds clean, and the deployed app navigates between home and a demo sub-page without issue. Manual swipe verification on device confirms the drawer only opens via swipe at `home`.