### PR TITLE
Add implicit `long → Color` conversion and `IsSpecified`/`IsUnspecified`

### DIFF
--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -68,12 +68,12 @@ public static class Conversation
                 {
                     FontSize   = 16,
                     FontWeight = FontWeight.Medium,
-                    Color      = new Color(scheme.OnSurface),
+                    Color      = scheme.OnSurface,
                 },
                 new Text($"{ui.ChannelMembers} members")
                 {
                     FontSize = 12,
-                    Color    = new Color(scheme.OnSurfaceVariant),
+                    Color    = scheme.OnSurfaceVariant,
                     Modifier = Modifier.Companion.Padding(top: 2, bottom: 0, start: 0, end: 0),
                 },
             },
@@ -227,7 +227,7 @@ public static class Conversation
             {
                 FontSize   = 11,
                 FontWeight = FontWeight.Medium,
-                Color      = new Color(scheme.OnSurfaceVariant),
+                Color      = scheme.OnSurfaceVariant,
                 Modifier   = Modifier.Companion.Padding(horizontal: 16, vertical: 0),
             },
             new HorizontalDivider
@@ -263,8 +263,8 @@ public static class Conversation
             Modifier = Modifier.Companion
                 .Padding(horizontal: 16, vertical: 0)
                 .Size(42)
-                .Border(1.5f, new Color(accent),         Shape.Circle())
-                .Border(3,    new Color(scheme.Surface), Shape.Circle())
+                .Border(1.5f, accent,         Shape.Circle())
+                .Border(3,    scheme.Surface, Shape.Circle())
                 .Clip(21)
                 .Clickable(() => onAuthorClicked(userId)),
         };
@@ -290,14 +290,14 @@ public static class Conversation
             {
                 FontSize   = 16,
                 FontWeight = FontWeight.Medium,
-                Color      = new Color(scheme.OnSurface),
+                Color      = scheme.OnSurface,
                 Modifier   = Modifier.Companion.Padding(top: 0, bottom: 8, start: 0, end: 0),
             },
             new Spacer(Modifier.Companion.Width(8)),
             new Text(m.Timestamp)
             {
                 FontSize = 12,
-                Color    = new Color(scheme.OnSurfaceVariant),
+                Color    = scheme.OnSurfaceVariant,
                 Modifier = Modifier.Companion.Padding(top: 0, bottom: 8, start: 0, end: 0),
             },
         };
@@ -310,9 +310,9 @@ public static class Conversation
         var formatted = MessageFormatter.Format(m.Content, isMe, scheme, _ => popupOpen.Value = true);
         return new AnnotatedText(formatted)
         {
-            Color    = new Color(fg),
+            Color    = fg,
             Modifier = Modifier.Companion
-                .Background(new Color(bg), Shape.RoundedCorners(4, 20, 20, 20))
+                .Background(bg, Shape.RoundedCorners(4, 20, 20, 20))
                 .Padding(horizontal: 16, vertical: 16),
         };
     }
@@ -407,7 +407,7 @@ public static class Conversation
             new Text("Send")
             {
                 FontWeight = FontWeight.SemiBold,
-                Color      = enabled ? new Color(scheme.Primary) : new Color(scheme.OnSurfaceVariant),
+                Color      = enabled ? scheme.Primary : scheme.OnSurfaceVariant,
             },
         });
         return row;
@@ -430,7 +430,7 @@ public static class Conversation
             },
         };
         if (selected)
-            button.Modifier = Modifier.Companion.Background(new Color(scheme.Secondary), Shape.RoundedCorners(14, 14, 14, 14));
+            button.Modifier = Modifier.Companion.Background(scheme.Secondary, Shape.RoundedCorners(14, 14, 14, 14));
         return button;
     }
 
@@ -446,20 +446,20 @@ public static class Conversation
         string subtitle = "Grab a beverage and check back later!";
         return new Column
         {
-            Modifier.Companion.FillMaxWidth().Height(320).Background(new Color(scheme.SurfaceVariant)),
+            Modifier.Companion.FillMaxWidth().Height(320).Background(scheme.SurfaceVariant),
             new Spacer(Modifier.Companion.Height(96)),
             new Text(title)
             {
                 FontSize   = 16,
                 FontWeight = FontWeight.Medium,
-                Color      = new Color(scheme.OnSurfaceVariant),
+                Color      = scheme.OnSurfaceVariant,
                 Modifier   = Modifier.Companion.Padding(horizontal: 16, vertical: 0),
             },
             new Spacer(Modifier.Companion.Height(8)),
             new Text(subtitle)
             {
                 FontSize = 14,
-                Color    = new Color(scheme.OnSurfaceVariant),
+                Color    = scheme.OnSurfaceVariant,
                 Modifier = Modifier.Companion.Padding(horizontal: 16, vertical: 0),
             },
         };

--- a/samples/Jetchat/EmojiSelector.cs
+++ b/samples/Jetchat/EmojiSelector.cs
@@ -80,7 +80,7 @@ public static class EmojiSelector
             {
                 Modifier.Companion
                     .FillMaxWidth()
-                    .Background(new Color(scheme.SurfaceVariant)),
+                    .Background(scheme.SurfaceVariant),
                 new PrimaryTabRow(selectedTabIndex: selected.Value)
                 {
                     new Tab(selected: selected.Value == 0, onClick: () => selected.Value = 0)
@@ -116,7 +116,7 @@ public static class EmojiSelector
                 rowNode.Add(new Text(emoji)
                 {
                     FontSize = 18,
-                    Color    = new Color(scheme.OnSurface),
+                    Color    = scheme.OnSurface,
                     Modifier = Modifier.Companion
                         .Clickable(() =>
                         {
@@ -147,7 +147,7 @@ public static class EmojiSelector
             new Text("Stickers not yet implemented in this port.")
             {
                 FontSize = 14,
-                Color    = new Color(scheme.OnSurfaceVariant),
+                Color    = scheme.OnSurfaceVariant,
             },
         };
 }

--- a/samples/Jetchat/JetchatDrawer.cs
+++ b/samples/Jetchat/JetchatDrawer.cs
@@ -25,7 +25,7 @@ public static class JetchatDrawer
         Action<string> onChatClicked,
         Action<string> onProfileClicked)
     {
-        var sheet = new ModalDrawerSheet { ContainerColor = new Color(scheme.Surface) };
+        var sheet = new ModalDrawerSheet { ContainerColor = scheme.Surface };
         sheet.Add(new Column
         {
             Modifier.Companion.FillMaxWidth().VerticalScroll(scroll),
@@ -53,7 +53,7 @@ public static class JetchatDrawer
             {
                 FontSize   = 18,
                 FontWeight = FontWeight.SemiBold,
-                Color      = new Color(scheme.OnSurface),
+                Color      = scheme.OnSurface,
             },
         };
 
@@ -72,7 +72,7 @@ public static class JetchatDrawer
             new Text(label)
             {
                 FontSize = 14,
-                Color    = new Color(scheme.OnSurfaceVariant),
+                Color    = scheme.OnSurfaceVariant,
                 Modifier = Modifier.Companion.Padding(top: 16, bottom: 0, start: 0, end: 0),
             },
         };
@@ -96,7 +96,7 @@ public static class JetchatDrawer
                 _ = drawerState.CloseAsync();
             });
         if (selected)
-            modifier = modifier.Background(new Color(scheme.PrimaryContainer));
+            modifier = modifier.Background(scheme.PrimaryContainer);
 
         long iconTint  = selected ? scheme.Primary : scheme.OnSurfaceVariant;
         long textColor = selected ? scheme.Primary : scheme.OnSurface;
@@ -113,7 +113,7 @@ public static class JetchatDrawer
             {
                 FontSize   = 14,
                 FontWeight = selected ? FontWeight.SemiBold : FontWeight.Normal,
-                Color      = new Color(textColor),
+                Color      = textColor,
                 Modifier   = Modifier.Companion.Padding(top: 16, bottom: 16, start: 12, end: 0),
             },
         };
@@ -140,7 +140,7 @@ public static class JetchatDrawer
                 _ = drawerState.CloseAsync();
             });
         if (selected)
-            modifier = modifier.Background(new Color(scheme.PrimaryContainer));
+            modifier = modifier.Background(scheme.PrimaryContainer);
 
         return new Row
         {
@@ -155,7 +155,7 @@ public static class JetchatDrawer
             new Text(name)
             {
                 FontSize = 14,
-                Color    = new Color(scheme.OnSurface),
+                Color    = scheme.OnSurface,
                 Modifier = Modifier.Companion.Padding(top: 16, bottom: 16, start: 12, end: 0),
             },
         };

--- a/samples/Jetchat/MessageFormatter.cs
+++ b/samples/Jetchat/MessageFormatter.cs
@@ -37,8 +37,8 @@ public static partial class MessageFormatter
         ArgumentNullException.ThrowIfNull(scheme);
 
         var builder = new AnnotatedStringBuilder();
-        var codeSnippetBackground = new Color(primary ? scheme.Secondary : scheme.Surface);
-        var accent                = new Color(primary ? scheme.InversePrimary : scheme.Primary);
+        long codeSnippetBackground = primary ? scheme.Secondary : scheme.Surface;
+        long accent                = primary ? scheme.InversePrimary : scheme.Primary;
 
         int cursor = 0;
         bool any = false;

--- a/samples/Jetchat/Profile.cs
+++ b/samples/Jetchat/Profile.cs
@@ -130,13 +130,13 @@ public static class Profile
             {
                 FontSize   = 24,
                 FontWeight = FontWeight.Medium,
-                Color      = new Color(scheme.OnSurface),
+                Color      = scheme.OnSurface,
                 Modifier   = Modifier.Companion.Padding(top: 8, bottom: 0, start: 0, end: 0),
             },
             new Text(state.Position)
             {
                 FontSize = 16,
-                Color    = new Color(scheme.OnSurfaceVariant),
+                Color    = scheme.OnSurfaceVariant,
                 Modifier = Modifier.Companion.Padding(top: 4, bottom: 20, start: 0, end: 0),
             },
         };
@@ -152,13 +152,13 @@ public static class Profile
             new Text(label)
             {
                 FontSize = 12,
-                Color    = new Color(scheme.OnSurfaceVariant),
+                Color    = scheme.OnSurfaceVariant,
                 Modifier = Modifier.Companion.Padding(top: 8, bottom: 0, start: 0, end: 0),
             },
             new Text(value)
             {
                 FontSize = 16,
-                Color    = isLink ? new Color(scheme.Primary) : new Color(scheme.OnSurface),
+                Color    = isLink ? scheme.Primary : scheme.OnSurface,
                 Modifier = Modifier.Companion.Padding(top: 4, bottom: 0, start: 0, end: 0),
             },
         };
@@ -190,7 +190,7 @@ public static class Profile
             },
             Text = new Text(label)
             {
-                Color = new Color(scheme.OnTertiaryContainer),
+                Color = scheme.OnTertiaryContainer,
             },
         };
     }

--- a/samples/Jetchat/RecordButton.cs
+++ b/samples/Jetchat/RecordButton.cs
@@ -136,7 +136,7 @@ public static class RecordButton
                     Modifier   = Modifier.Companion.Align(Alignment.Vertical.CenterVertically),
                     FontSize   = 22,
                     FontWeight = FontWeight.Medium,
-                    Color      = new Color(scheme.OnSurface),
+                    Color      = scheme.OnSurface,
                 },
 
                 new Spacer(Modifier.Companion.Width(16)),
@@ -159,7 +159,7 @@ public static class RecordButton
                     {
                         Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically),
                         FontSize = 16,
-                        Color    = new Color(scheme.OnSurfaceVariant),
+                        Color    = scheme.OnSurfaceVariant,
                     },
                 },
             };

--- a/samples/Reply/EmailDetailAppBar.cs
+++ b/samples/Reply/EmailDetailAppBar.cs
@@ -19,12 +19,12 @@ public static class EmailDetailAppBar
                     new Text(email.Subject)
                     {
                         FontSize = 16,
-                        Color    = new Color(scheme.OnSurfaceVariant),
+                        Color    = scheme.OnSurfaceVariant,
                     },
                     new Text($"{email.Threads.Count} Messages")
                     {
                         FontSize = 12,
-                        Color    = new Color(scheme.Outline),
+                        Color    = scheme.Outline,
                         Modifier = Modifier.Companion.Padding(top: 4, bottom: 0, start: 0, end: 0),
                     },
                 };

--- a/samples/Reply/EmptyComingSoon.cs
+++ b/samples/Reply/EmptyComingSoon.cs
@@ -19,14 +19,14 @@ public static class EmptyComingSoon
                 {
                     FontSize   = 18,
                     FontWeight = FontWeight.SemiBold,
-                    Color      = new Color(scheme.Primary),
+                    Color      = scheme.Primary,
                     Modifier   = Modifier.Companion.FillMaxWidth(),
                 },
                 new Spacer(Modifier.Companion.Height(8)),
                 new Text("This screen is still under construction. This sample will help you learn about adaptive layouts in Jetpack Compose")
                 {
                     FontSize = 14,
-                    Color    = new Color(scheme.OnSurfaceVariant),
+                    Color    = scheme.OnSurfaceVariant,
                     Modifier = Modifier.Companion.Padding(horizontal: 16, vertical: 0),
                 },
             };

--- a/samples/Reply/ReplyEmailListItem.cs
+++ b/samples/Reply/ReplyEmailListItem.cs
@@ -25,7 +25,7 @@ public static class ReplyEmailListItem
             {
                 Modifier.Companion
                     .Padding(horizontal: 16, vertical: 4)
-                    .Background(new Color(bg))
+                    .Background(bg)
                     .CombinedClickable(
                         onClick:     () => navigateToDetail(email.Id),
                         onLongClick: () => toggleSelection(email.Id)),
@@ -77,7 +77,7 @@ public static class ReplyEmailListItem
             {
                 Modifier.Companion
                     .Clip(Shape.Circle())
-                    .Background(new Color(scheme.SurfaceVariant)),
+                    .Background(scheme.SurfaceVariant),
                 new Icon(Resource.Drawable.ic_star_border, "Favorite")
                 {
                     TintArgb = scheme.Outline,

--- a/samples/Reply/ReplyEmailThreadItem.cs
+++ b/samples/Reply/ReplyEmailThreadItem.cs
@@ -15,7 +15,7 @@ public static class ReplyEmailThreadItem
             {
                 Modifier.Companion
                     .Padding(horizontal: 16, vertical: 4)
-                    .Background(new Color(scheme.SurfaceVariant)),
+                    .Background(scheme.SurfaceVariant),
                 new Column
                 {
                     Modifier.Companion.FillMaxWidth().Padding(20),
@@ -23,13 +23,13 @@ public static class ReplyEmailThreadItem
                     new Text(email.Subject)
                     {
                         FontSize  = 14,
-                        Color     = new Color(scheme.Outline),
+                        Color     = scheme.Outline,
                         Modifier  = Modifier.Companion.Padding(top: 12, bottom: 8, start: 0, end: 0),
                     },
                     new Text(email.Body)
                     {
                         FontSize = 16,
-                        Color    = new Color(scheme.OnSurfaceVariant),
+                        Color    = scheme.OnSurfaceVariant,
                     },
                     BuildActionRow(scheme),
                 },
@@ -53,14 +53,14 @@ public static class ReplyEmailThreadItem
                 new Text("20 mins ago")
                 {
                     FontSize = 12,
-                    Color    = new Color(scheme.Outline),
+                    Color    = scheme.Outline,
                 },
             },
             new IconButton(onClick: NoOp)
             {
                 Modifier.Companion
                     .Clip(Shape.Circle())
-                    .Background(new Color(scheme.SurfaceVariant)),
+                    .Background(scheme.SurfaceVariant),
                 new Icon(Resource.Drawable.ic_star_border, "Favorite")
                 {
                     TintArgb = scheme.Outline,
@@ -79,7 +79,7 @@ public static class ReplyEmailThreadItem
                 Modifier.Companion.Weight(1f),
                 new Text("Reply")
                 {
-                    Color = new Color(scheme.OnSurface),
+                    Color = scheme.OnSurface,
                 },
             },
             new Button(onClick: NoOp)
@@ -87,7 +87,7 @@ public static class ReplyEmailThreadItem
                 Modifier.Companion.Weight(1f),
                 new Text("Reply All")
                 {
-                    Color = new Color(scheme.OnSurface),
+                    Color = scheme.OnSurface,
                 },
             },
         };

--- a/samples/Reply/ReplyProfileImage.cs
+++ b/samples/Reply/ReplyProfileImage.cs
@@ -28,7 +28,7 @@ public static class ReplyProfileImage
                 Modifier.Companion
                     .Size(40)
                     .Clip(Shape.Circle())
-                    .Background(new Color(scheme.Primary)),
+                    .Background(scheme.Primary),
                 new Icon(Resource.Drawable.ic_check, null)
                 {
                     Modifier = Modifier.Companion.Size(24),

--- a/samples/Reply/ReplySearchBar.cs
+++ b/samples/Reply/ReplySearchBar.cs
@@ -23,7 +23,7 @@ public sealed class ReplySearchBar : ComposableNode
                     .FillMaxWidth()
                     .Padding(horizontal: 16, vertical: 8)
                     .Clip(Shape.RoundedCorners(28))
-                    .Background(new Color(scheme.SurfaceVariant)),
+                    .Background(scheme.SurfaceVariant),
                 new Row
                 {
                     Modifier.Companion.FillMaxWidth().Padding(horizontal: 16, vertical: 12),
@@ -35,7 +35,7 @@ public sealed class ReplySearchBar : ComposableNode
                     new Text("Search replies")
                     {
                         FontSize = 14,
-                        Color    = new Color(scheme.OnSurface),
+                        Color    = scheme.OnSurface,
                         Modifier = Modifier.Companion
                             .Align(Alignment.Vertical.CenterVertically)
                             .Padding(start: 16, end: 0, top: 0, bottom: 0)

--- a/src/Microsoft.AndroidX.Compose/Color.cs
+++ b/src/Microsoft.AndroidX.Compose/Color.cs
@@ -152,6 +152,29 @@ public readonly struct Color : IEquatable<Color>
     /// </summary>
     public static implicit operator long(Color c) => unchecked((long)c.PackedValue);
 
+    /// <summary>
+    /// Implicit conversion from the packed <see cref="long"/> the Compose
+    /// bindings surface (the Kotlin
+    /// <c>@JvmInline value class Color(val value: ULong)</c> lowers to a
+    /// packed long across JNI). Lets callers pass <c>scheme.OnSurface</c>
+    /// directly anywhere a <see cref="Color"/> is expected without
+    /// wrapping in <c>new Color(...)</c>.
+    /// </summary>
+    public static implicit operator Color(long packedValue) => new(packedValue);
+
+    /// <summary>
+    /// Whether this color carries a real value. Matches Kotlin's
+    /// <c>Color.isSpecified</c> &#8212; useful for "fall back to theme"
+    /// branches where <see cref="Unspecified"/> is the sentinel.
+    /// </summary>
+    public bool IsSpecified => PackedValue != Unspecified.PackedValue;
+
+    /// <summary>
+    /// Inverse of <see cref="IsSpecified"/> &#8212; matches Kotlin's
+    /// <c>Color.isUnspecified</c>.
+    /// </summary>
+    public bool IsUnspecified => PackedValue == Unspecified.PackedValue;
+
     // ----- Named constants matching androidx.compose.ui.graphics.Color.Companion -----
 
     /// <summary>Fully-opaque black (<c>#FF000000</c>).</summary>

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -145,6 +145,8 @@ AndroidX.Compose.Color.Color(long packedValue) -> void
 AndroidX.Compose.Color.Color(ulong packedValue) -> void
 AndroidX.Compose.Color.Equals(AndroidX.Compose.Color other) -> bool
 AndroidX.Compose.Color.G.get -> byte
+AndroidX.Compose.Color.IsSpecified.get -> bool
+AndroidX.Compose.Color.IsUnspecified.get -> bool
 AndroidX.Compose.Color.PackedValue.get -> ulong
 AndroidX.Compose.Color.R.get -> byte
 AndroidX.Compose.Color.WithAlpha(byte alpha) -> AndroidX.Compose.Color
@@ -1434,6 +1436,7 @@ static AndroidX.Compose.Color.FromHex(string! hex) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.FromRgb(byte red, byte green, byte blue) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Gray.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Green.get -> AndroidX.Compose.Color
+static AndroidX.Compose.Color.implicit operator AndroidX.Compose.Color(long packedValue) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.implicit operator long(AndroidX.Compose.Color c) -> long
 static AndroidX.Compose.Color.LightGray.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Magenta.get -> AndroidX.Compose.Color


### PR DESCRIPTION
Brings `AndroidX.Compose.Color` closer to Kotlin's `androidx.compose.ui.graphics.Color` surface by adding the missing inverse of the existing `Color → long` implicit, plus the two `IsSpecified` / `IsUnspecified` properties.

From the "API improvement ideas" brainstorm session (parent: `jonathanpeppers/fictional-happiness`).

## Why

Theme color getters on the bound `ColorScheme` return `long` because Compose's `androidx.compose.ui.graphics.Color` is a `@JvmInline value class` over `ULong`. We already have `implicit operator long(Color)` going one way, so a `Color` flows into bindings without ceremony. The inverse was missing, so every call site reading a theme color into a facade slot wrapped it explicitly:

```csharp
Color    = new Color(scheme.OnSurface),
Modifier = Modifier.Companion.Background(new Color(scheme.Primary)),
```

After this change:

```csharp
Color    = scheme.OnSurface,
Modifier = Modifier.Companion.Background(scheme.Primary),
```

Kotlin's `Color` also exposes `isSpecified` / `isUnspecified` extension members on the inline class that peek at the packed sentinel. We didn't expose either — useful for "fall back to the parent / theme default" branches where `Color.Unspecified` is the marker:

```csharp
if (scheme.OnSurface.IsSpecified)
{
    …
}
```

## What changed

- **`src/Microsoft.AndroidX.Compose/Color.cs`** — three new public members alongside the existing implicit operator:
  - `public static implicit operator Color(long packedValue)` → `new(packedValue)`
  - `public bool IsSpecified` → `PackedValue != Unspecified.PackedValue`
  - `public bool IsUnspecified` → inverse
- **`samples/Jetchat/`, `samples/Reply/`** — dropped the now-redundant `new Color(...)` wraps around binding-typed `long`s (theme colors + `long` locals derived from them). The implicit fires once at the property / parameter slot instead. In `MessageFormatter.cs` two `var` locals became explicit `long` since they're plumbed through to `Color` parameters elsewhere.
- **`PublicAPI.Unshipped.txt`** — three new entries.

Hex-literal constructors (`new Color(0xFFAARRGGBB)`) and other `Color(…)` ctor shapes are unaffected — only `new Color(<binding long>)` wraps were dropped.

## Ambiguity check

Confirmed via grep before adding the implicit:
- No methods take both `long` and `Color` parameters where overload resolution would flip.
- No `(long)` casts on `Color` exist in `src/` or samples.
- No callers compare to `Color.Unspecified` today (so the `IsSpecified` migration step is a no-op for now — the property is still added for parity with Kotlin).
- `Color == long` becoming legal (via implicit lift) is benign — no `Color == 0` or similar usages exist.

## Verification

```
dotnet test  src/Microsoft.AndroidX.Compose.SourceGenerators.Tests    # 130/130 pass
dotnet build src/Microsoft.AndroidX.Compose                  # clean
dotnet build src/Microsoft.AndroidX.Compose.Gallery                  # clean
dotnet build samples/Jetchat                         # clean
dotnet build samples/Reply                           # clean
dotnet build samples/JetNews                         # clean
```

Not deployed — `@jonathanpeppers` is smoke-testing locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>