### PR TITLE
Rename Composable to NavDestination for clarity

### DIFF
--- a/samples/JetNews/JetnewsApp.cs
+++ b/samples/JetNews/JetnewsApp.cs
@@ -80,16 +80,16 @@ public static class JetnewsApp
     {
         return new NavHost(startDestination: Routes.Home, navController: nav)
         {
-            new Composable(Routes.Home, _ =>
+            new NavDestination(Routes.Home, _ =>
                 HomeScreen.Build(bookmarks, drawerState, postId =>
                 {
                     nav.Navigate(Routes.Post(postId));
                 }, snackbars)),
-            new Composable(Routes.Interests)
+            new NavDestination(Routes.Interests)
             {
                 InterestsScreen.Build(selectedTopics, selectedPeople, selectedPublications, interestsTab, drawerState),
             },
-            new Composable(Routes.PostPattern, entry =>
+            new NavDestination(Routes.PostPattern, entry =>
             {
                 var id = entry.Arguments?.GetString("postId") ?? string.Empty;
                 return PostScreen.Build(

--- a/samples/JetNews/PostsRepo.cs
+++ b/samples/JetNews/PostsRepo.cs
@@ -167,13 +167,13 @@ public static class PostsRepo
             new(ParagraphType.Text,
                 "Allocate a NavController inside Remember, hand it to a NavHost, " +
                 "and add destinations as collection-initializer children. " +
-                "Static destinations are Composable(\"home\") { children }; dynamic " +
+                "Static destinations are NavDestination(\"home\") { children }; dynamic " +
                 "destinations take a Func<NavBackStackEntry, ComposableNode> " +
                 "factory so they can read route placeholders."),
             new(ParagraphType.CodeBlock,
                 "new NavHost(startDestination: \"home\", navController: nav)"),
             new(ParagraphType.CodeBlock,
-                "    { new Composable(\"home\") { ... } }"),
+                "    { new NavDestination(\"home\") { ... } }"),
         });
 
     static readonly Post _stateHolders = new(

--- a/samples/Jetchat/JetchatApp.cs
+++ b/samples/Jetchat/JetchatApp.cs
@@ -67,7 +67,7 @@ public static class JetchatApp
                     }),
                 Content = new NavHost(startDestination: Routes.Home, navController: nav)
                 {
-                    new Composable(Routes.Home)
+                    new NavDestination(Routes.Home)
                     {
                         Conversation.Build(
                             ui:               ui,
@@ -85,7 +85,7 @@ public static class JetchatApp
                                 nav.Navigate(Routes.Profile(userId));
                             }),
                     },
-                    new Composable(Routes.ProfilePattern, entry =>
+                    new NavDestination(Routes.ProfilePattern, entry =>
                     {
                         var userId = entry.Arguments?.GetString("userId");
                         return Profile.Build(

--- a/samples/Reply/ReplyApp.cs
+++ b/samples/Reply/ReplyApp.cs
@@ -42,7 +42,7 @@ public static class ReplyApp
     {
         return new NavHost(startDestination: Route.Inbox, navController: nav)
         {
-            new Composable(Route.Inbox)
+            new NavDestination(Route.Inbox)
             {
                 ReplyInboxScreen.Build(
                     emails:           LocalEmailsDataProvider.AllEmails,
@@ -61,10 +61,10 @@ public static class ReplyApp
                             selectedEmailIds.Add(id);
                     }),
             },
-            new Composable(Route.Articles)   { EmptyComingSoon.Build() },
-            new Composable(Route.DirectMessages) { EmptyComingSoon.Build() },
-            new Composable(Route.Groups)     { EmptyComingSoon.Build() },
-            new Composable(Route.EmailDetailPattern, entry =>
+            new NavDestination(Route.Articles)   { EmptyComingSoon.Build() },
+            new NavDestination(Route.DirectMessages) { EmptyComingSoon.Build() },
+            new NavDestination(Route.Groups)     { EmptyComingSoon.Build() },
+            new NavDestination(Route.EmailDetailPattern, entry =>
             {
                 var idStr = entry.Arguments?.GetString("emailId") ?? "0";
                 if (!long.TryParse(idStr, out var id))

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
@@ -48,9 +48,9 @@ public static class BottomNavOptionsDemo
                     Modifier.Companion.FillMaxWidth().Height(260),
                     new NavHost(startDestination: startRoute, navController: nav)
                     {
-                        new Composable(startRoute,    _ => new CounterPane("🏠 Home")),
-                        new Composable("search",      _ => new CounterPane("🔍 Search")),
-                        new Composable("profile",     _ => new CounterPane("👤 Profile")),
+                        new NavDestination(startRoute,    _ => new CounterPane("🏠 Home")),
+                        new NavDestination("search",      _ => new CounterPane("🔍 Search")),
+                        new NavDestination("profile",     _ => new CounterPane("👤 Profile")),
                     },
                 },
 

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/NavHostRouteArgsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/NavHostRouteArgsDemo.cs
@@ -21,7 +21,7 @@ public static class NavHostRouteArgsDemo
                 {
                     Modifier.Companion.FillMaxWidth().Height(360),
 
-                    new Composable("home")
+                    new NavDestination("home")
                     {
                         new Column
                         {
@@ -31,7 +31,7 @@ public static class NavHostRouteArgsDemo
                             new Button(onClick: () => nav.Navigate("user/42")) { new Text("Open user 42") },
                         },
                     },
-                    new Composable("detail")
+                    new NavDestination("detail")
                     {
                         new Column
                         {
@@ -41,7 +41,7 @@ public static class NavHostRouteArgsDemo
                             new Button(onClick: () => nav.PopBackStack()) { new Text("Back") },
                         },
                     },
-                    new Composable("user/{id}", entry => new Column
+                    new NavDestination("user/{id}", entry => new Column
                     {
                         Modifier.Companion.Padding(16),
                         new Text($"👤 User #{entry.Arguments?.GetString("id") ?? "?"}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/GalleryScaffold.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/GalleryScaffold.cs
@@ -78,12 +78,12 @@ public sealed class GalleryScaffold : ComposableNode
     {
         var host = new NavHost(startDestination: "home", navController: _nav)
         {
-            new Composable("home", _ => new Column
+            new NavDestination("home", _ => new Column
             {
                 new DisposableEffect("home", _ => { currentRoute.Value = "home"; return () => { }; }),
                 HomeScreen.Build(_nav),
             }),
-            new Composable("category/{id}", entry =>
+            new NavDestination("category/{id}", entry =>
             {
                 var id = entry.Arguments?.GetString("id");
                 var category = Catalog.FindCategory(id);
@@ -99,7 +99,7 @@ public sealed class GalleryScaffold : ComposableNode
                         : CategoryScreen.Build(category, _nav),
                 };
             }),
-            new Composable("demo/{id}", entry =>
+            new NavDestination("demo/{id}", entry =>
             {
                 var id = entry.Arguments?.GetString("id");
                 var demo = Catalog.FindDemo(id);
@@ -115,7 +115,7 @@ public sealed class GalleryScaffold : ComposableNode
                         : DemoScreen.Build(demo),
                 };
             }),
-            new Composable("search", _ => new Column
+            new NavDestination("search", _ => new Column
             {
                 new DisposableEffect("search", _ => { currentRoute.Value = "search"; return () => { }; }),
                 new SearchScreen(_nav),

--- a/src/Microsoft.AndroidX.Compose/NavBackStackEntry.cs
+++ b/src/Microsoft.AndroidX.Compose/NavBackStackEntry.cs
@@ -10,10 +10,10 @@ namespace AndroidX.Compose;
 /// <c>NavDestination</c>.
 ///
 /// <para>
-/// Usage with the dynamic-content overload of <see cref="Composable"/>:
+/// Usage with the dynamic-content overload of <see cref="NavDestination"/>:
 /// </para>
 /// <code>
-/// new Composable("user/{id}", entry =&gt;
+/// new NavDestination("user/{id}", entry =&gt;
 /// {
 ///     var id = entry.Arguments?.GetString("id") ?? "?";
 ///     return new Text($"User #{id}");
@@ -44,7 +44,7 @@ public sealed class NavBackStackEntry
 
     /// <summary>
     /// Route registered for this destination — the same string the
-    /// caller passed to <see cref="Composable(string)"/>.
+    /// caller passed to <see cref="NavDestination(string)"/>.
     /// <c>null</c> if the destination was registered without a route
     /// (e.g. by an integer id graph). Mirrors Kotlin's
     /// <c>NavBackStackEntry.destination.route</c>.

--- a/src/Microsoft.AndroidX.Compose/NavController.cs
+++ b/src/Microsoft.AndroidX.Compose/NavController.cs
@@ -22,14 +22,14 @@ namespace AndroidX.Compose;
 ///
 /// new NavHost(startDestination: "home", navController: nav)
 /// {
-///     new Composable("home")
+///     new NavDestination("home")
 ///     {
 ///         new Button(onClick: () =&gt; nav.Navigate("detail"))
 ///         {
 ///             new Text("Go to detail"),
 ///         },
 ///     },
-///     new Composable("detail")
+///     new NavDestination("detail")
 ///     {
 ///         new Text("Detail screen"),
 ///     },
@@ -55,7 +55,7 @@ public sealed class NavController
     /// <summary>
     /// Navigate to <paramref name="route"/>. Equivalent to
     /// Kotlin's <c>navController.navigate(route)</c>. The route must
-    /// be registered via a <see cref="Composable"/> child of the
+    /// be registered via a <see cref="NavDestination"/> child of the
     /// owning <see cref="NavHost"/>.
     /// </summary>
     public void Navigate(string route)

--- a/src/Microsoft.AndroidX.Compose/NavDestination.cs
+++ b/src/Microsoft.AndroidX.Compose/NavDestination.cs
@@ -18,13 +18,13 @@ namespace AndroidX.Compose;
 /// </para>
 /// <code>
 /// // Static — same children every time the route is shown
-/// new Composable("home")
+/// new NavDestination("home")
 /// {
 ///     new Text("Home"),
 /// }
 ///
 /// // Dynamic — read the {id} placeholder from the back-stack entry
-/// new Composable("user/{id}", entry =&gt;
+/// new NavDestination("user/{id}", entry =&gt;
 /// {
 ///     var id = entry.Arguments?.GetString("id") ?? "?";
 ///     return new Text($"User #{id}");
@@ -33,13 +33,17 @@ namespace AndroidX.Compose;
 ///
 /// <para>
 /// Mirrors Kotlin's <c>NavGraphBuilder.composable(route) { backStackEntry -&gt; ... }</c>.
+/// Named <c>NavDestination</c> rather than <c>Composable</c> to avoid
+/// confusion with the unrelated <see cref="ComposableNode"/> base class
+/// and Kotlin's <c>@Composable</c> annotation — this type isn't a UI
+/// node, it's a route registration.
 /// Add instances to a <see cref="NavHost"/> via collection-initializer
 /// — they're not normal <see cref="ComposableNode"/>s, since their
 /// content is composed inside the NavHost's per-route subcomposition,
 /// not the surrounding tree.
 /// </para>
 /// </summary>
-public sealed class Composable : IEnumerable
+public sealed class NavDestination : IEnumerable
 {
     readonly List<ComposableNode> _staticChildren = new();
     readonly Func<NavBackStackEntry, ComposableNode>? _factory;
@@ -48,7 +52,7 @@ public sealed class Composable : IEnumerable
     /// Register a destination with a static child tree. Add children
     /// via collection-initializer syntax.
     /// </summary>
-    public Composable(string route)
+    public NavDestination(string route)
     {
         ArgumentNullException.ThrowIfNull(route);
         Route = route;
@@ -60,7 +64,7 @@ public sealed class Composable : IEnumerable
     /// route placeholders (e.g. <c>{id}</c> in <c>"user/{id}"</c>)
     /// from the entry's <see cref="NavBackStackEntry.Arguments"/>.
     /// </summary>
-    public Composable(string route, Func<NavBackStackEntry, ComposableNode> content)
+    public NavDestination(string route, Func<NavBackStackEntry, ComposableNode> content)
     {
         ArgumentNullException.ThrowIfNull(route);
         Route    = route;
@@ -80,7 +84,7 @@ public sealed class Composable : IEnumerable
     {
         if (_factory is not null)
             throw new InvalidOperationException(
-                "Composable was constructed with a dynamic content factory; collection-init children are not supported.");
+                "NavDestination was constructed with a dynamic content factory; collection-init children are not supported.");
         if (child is not null)
             _staticChildren.Add(child);
     }
@@ -103,7 +107,7 @@ public sealed class Composable : IEnumerable
     IEnumerator IEnumerable.GetEnumerator() => _staticChildren.GetEnumerator();
 
     // Register this route into the surrounding NavHost's NavGraphBuilder.
-    // Called once per Composable per NavHost composition pass — Kotlin
+    // Called once per NavDestination per NavHost composition pass — Kotlin
     // composable() runs synchronously inside the builder lambda, so the
     // outer NavHost composer is still active here. The destination's
     // content lambda, however, is invoked LATER inside the route's own

--- a/src/Microsoft.AndroidX.Compose/NavHost.cs
+++ b/src/Microsoft.AndroidX.Compose/NavHost.cs
@@ -6,7 +6,7 @@ namespace AndroidX.Compose;
 /// <summary>
 /// Compose Navigation host — the C# moral equivalent of Kotlin's
 /// <c>NavHost(navController, startDestination) { composable("a") { ... } }</c>.
-/// Holds a graph of <see cref="Composable"/> destinations and switches
+/// Holds a graph of <see cref="NavDestination"/> destinations and switches
 /// the visible one based on the bound
 /// <see cref="AndroidX.Compose.NavController"/>'s back stack.
 ///
@@ -22,14 +22,14 @@ namespace AndroidX.Compose;
 ///
 /// new NavHost(startDestination: "home", navController: nav)
 /// {
-///     new Composable("home")
+///     new NavDestination("home")
 ///     {
 ///         new Button(onClick: () =&gt; nav.Navigate("detail"))
 ///         {
 ///             new Text("Go to detail"),
 ///         },
 ///     },
-///     new Composable("detail")
+///     new NavDestination("detail")
 ///     {
 ///         new Button(onClick: () =&gt; nav.PopBackStack())
 ///         {
@@ -51,7 +51,7 @@ public sealed class NavHost : ComposableNode, IEnumerable
 {
     readonly string _startDestination;
     readonly NavController _navController;
-    readonly List<Composable> _routes = new();
+    readonly List<NavDestination> _routes = new();
 
     /// <summary>
     /// Create a navigation host that starts at <paramref name="startDestination"/>.
@@ -74,7 +74,7 @@ public sealed class NavHost : ComposableNode, IEnumerable
     public NavController NavController => _navController;
 
     /// <summary>Add a destination via collection-initializer syntax.</summary>
-    public void Add(Composable? route)
+    public void Add(NavDestination? route)
     {
         if (route is not null)
             _routes.Add(route);

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -152,12 +152,6 @@ AndroidX.Compose.Color.WithOpacity(float opacity) -> AndroidX.Compose.Color
 AndroidX.Compose.Column
 AndroidX.Compose.Column.Column() -> void
 AndroidX.Compose.Column.Column(AndroidX.Compose.Arrangement? verticalArrangement) -> void
-AndroidX.Compose.Composable
-AndroidX.Compose.Composable.Add(AndroidX.Compose.ComposableNode? child) -> void
-AndroidX.Compose.Composable.Add(AndroidX.Compose.Modifier! modifier) -> void
-AndroidX.Compose.Composable.Composable(string! route, System.Func<AndroidX.Compose.NavBackStackEntry!, AndroidX.Compose.ComposableNode!>! content) -> void
-AndroidX.Compose.Composable.Composable(string! route) -> void
-AndroidX.Compose.Composable.Route.get -> string!
 AndroidX.Compose.ComposableContainer
 AndroidX.Compose.ComposableContainer.Add(AndroidX.Compose.ComposableNode? child) -> void
 AndroidX.Compose.ComposableContainer.Add(AndroidX.Compose.Modifier! modifier) -> void
@@ -775,8 +769,14 @@ AndroidX.Compose.NavController.Navigate(string! route) -> void
 AndroidX.Compose.NavController.NavigateUp() -> bool
 AndroidX.Compose.NavController.PopBackStack() -> bool
 AndroidX.Compose.NavController.PopBackStack(string! route, bool inclusive) -> bool
+AndroidX.Compose.NavDestination
+AndroidX.Compose.NavDestination.Add(AndroidX.Compose.ComposableNode? child) -> void
+AndroidX.Compose.NavDestination.Add(AndroidX.Compose.Modifier! modifier) -> void
+AndroidX.Compose.NavDestination.NavDestination(string! route, System.Func<AndroidX.Compose.NavBackStackEntry!, AndroidX.Compose.ComposableNode!>! content) -> void
+AndroidX.Compose.NavDestination.NavDestination(string! route) -> void
+AndroidX.Compose.NavDestination.Route.get -> string!
 AndroidX.Compose.NavHost
-AndroidX.Compose.NavHost.Add(AndroidX.Compose.Composable? route) -> void
+AndroidX.Compose.NavHost.Add(AndroidX.Compose.NavDestination? route) -> void
 AndroidX.Compose.NavHost.Add(AndroidX.Compose.Modifier! modifier) -> void
 AndroidX.Compose.NavHost.NavController.get -> AndroidX.Compose.NavController!
 AndroidX.Compose.NavHost.NavHost(string! startDestination, AndroidX.Compose.NavController? navController = null) -> void


### PR DESCRIPTION
## Why

The public sealed class `AndroidX.Compose.Composable` registers a route with a `NavHost`. The name was a footgun:

- "Composable" in Compose vocabulary normally means an `@Composable` function.
- Our own UI-node base class is `ComposableNode` — `Composable` sat awkwardly next to it (the two are *not* related; `Composable` doesn't derive from `ComposableNode`, it's a route registration).
- Kotlin spells the API `composable(route) { ... }` (lowercase builder DSL), not a type. Translating it as a C# class called `Composable` is what introduced the conflict.

Rename to `NavDestination` (the actual concept). Reads naturally next to `NavHost` / `NavController`.

Before:
```csharp
new NavHost(navController) {
    new Composable("home")  { new Text("Home") },
    new Composable("user/{id}", entry => new Text($"User {entry.Args["id"]}")),
}
```

After:
```csharp
new NavHost(navController) {
    new NavDestination("home")  { new Text("Home") },
    new NavDestination("user/{id}", entry => new Text($"User {entry.Args["id"]}")),
}
```

## Clean break — no `[Obsolete]` alias

All affected API lines live in `PublicAPI.Unshipped.txt` (never released in a stable build). Shipping an `[Obsolete]` `Composable : NavDestination` would just defer the same churn for downstream callers and clutter the public surface with two names for one concept.

## Changes

| Area | Files | Notes |
|---|---|---|
| Facade rename | `src/Microsoft.AndroidX.Compose/Composable.cs` → `NavDestination.cs` | Class + both ctors + XML `<summary>` + error string + internal Render comment |
| Facade internals | `NavHost.cs`, `NavController.cs`, `NavBackStackEntry.cs` | crefs, doc examples, `List<Composable>` field, `Add(Composable?)` param |
| Call sites (21) | Jetchat (2), JetNews (3 + 1 string literal in `PostsRepo.cs`), Reply (5), Gallery scaffold (4), `BottomNavOptionsDemo` (3), `NavHostRouteArgsDemo` (3) | `new Composable(...)` → `new NavDestination(...)` |
| Public API | `PublicAPI.Unshipped.txt` | 5 `Composable.*` lines → `NavDestination.*`; `NavHost.Add(Composable?)` → `NavHost.Add(NavDestination?)` |

No doc/README edits needed — remaining `Composable` mentions in `README.md`, `docs/*`, and sample READMEs refer to Kotlin's `@Composable` annotation or our unrelated `ComposableNode` / `ComposableLambdas`, not the renamed type.

The internal helpers `ComposableLambdas.InstantiateNavComposable` and `ComposeBridges.NavGraphBuilderComposable` keep their names — they're named after the Kotlin runtime they wrap (`composableLambdaInstance`, `composable()`) and aren't the renamed public type.

## Verification

- `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` — **130/130 passing**.
- `dotnet build src/Microsoft.AndroidX.Compose` — clean (BG8605/BG8606 pre-existing binding warnings unchanged; no new RS0016/RS0017).
- `dotnet build src/Microsoft.AndroidX.Compose.Gallery` — **0 warnings, 0 errors**.
- No device deploy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>