### PR TITLE
Add Spacer.Width/.Height/.Size/.Weight static factories

### DIFF
--- a/samples/JetNews/HomeCards.cs
+++ b/samples/JetNews/HomeCards.cs
@@ -23,7 +23,7 @@ internal static class HomeCards
                     .AspectRatio(992f / 296f)
                     .Clip(16),
             },
-            new Spacer(Modifier.Companion.Height(16)),
+            Spacer.Height(16),
             new Text(post.Title)
             {
                 FontSize   = 22,
@@ -101,7 +101,7 @@ internal static class HomeCards
                         FontWeight = FontWeight.SemiBold,
                         MaxLines   = 2,
                     },
-                    new Spacer(Modifier.Companion.Weight(1f, fill: true)),
+                    Spacer.Weight(1f),
                     new Text(post.Metadata.Author)
                     {
                         FontSize = 13,

--- a/samples/JetNews/JetnewsDrawer.cs
+++ b/samples/JetNews/JetnewsDrawer.cs
@@ -48,7 +48,7 @@ public static class JetnewsDrawer
         {
             Modifier.Companion.FillMaxWidth().Padding(horizontal: 28, vertical: 24),
             new Icon(Resource.Drawable.ic_jetnews_logo, "JetNews logo"),
-            new Spacer(Modifier.Companion.Width(8)),
+            Spacer.Width(8),
             new Icon(Resource.Drawable.ic_jetnews_wordmark, "JetNews"),
         };
 

--- a/samples/JetNews/PostBody.cs
+++ b/samples/JetNews/PostBody.cs
@@ -80,7 +80,7 @@ internal static class PostBody
             {
                 Modifier.Companion.Width(4).Height(40).Background(QuoteBar),
             },
-            new Spacer(Modifier.Companion.Width(12)),
+            Spacer.Width(12),
             Styled(p,
                 fontSize:  16,
                 fontStyle: FontStyle.Italic),

--- a/samples/JetNews/PostScreen.cs
+++ b/samples/JetNews/PostScreen.cs
@@ -141,13 +141,13 @@ public static class PostScreen
                     FontSize   = 22,
                     FontWeight = FontWeight.SemiBold,
                 },
-                new Spacer(Modifier.Companion.Height(4)),
+                Spacer.Height(4),
                 new Text(post.Subtitle)
                 {
                     FontSize = 14,
                     Color    = Color.FromHex("#666666"),
                 },
-                new Spacer(Modifier.Companion.Height(8)),
+                Spacer.Height(8),
                 new Text($"{post.Metadata.Author} · {post.Metadata.Date} · {post.Metadata.ReadTimeMinutes} min read")
                 {
                     FontSize = 12,

--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -183,7 +183,7 @@ public static class Conversation
                 {
                     MessageRow mr => BuildMessageRow(mr.Msg, mr.IsFirstByAuthor, mr.IsLastByAuthor, scheme, popupOpen, onAuthorClicked),
                     HeaderRow  hr => BuildDayHeader(hr.Label, scheme),
-                    _             => new Spacer(Modifier.Companion.Width(0)),
+                    _             => Spacer.Width(0),
                 })
             {
                 Modifier      = Modifier.Companion.FillMaxSize(),
@@ -247,7 +247,7 @@ public static class Conversation
         if (isLastByAuthor)
             row.Add(BuildAvatar(m, scheme, onAuthorClicked));
         else
-            row.Add(new Spacer(Modifier.Companion.Width(74)));
+            row.Add(Spacer.Width(74));
 
         row.Add(BuildAuthorAndTextMessage(m, isFirstByAuthor, isLastByAuthor, scheme, popupOpen));
         return row;
@@ -279,7 +279,7 @@ public static class Conversation
         if (isLastByAuthor)
             col.Add(BuildAuthorNameTimestamp(m, scheme));
         col.Add(BuildChatItemBubble(m, scheme, popupOpen));
-        col.Add(new Spacer(Modifier.Companion.Height(isFirstByAuthor ? 8 : 4)));
+        col.Add(Spacer.Height(isFirstByAuthor ? 8 : 4));
         return col;
     }
 
@@ -293,7 +293,7 @@ public static class Conversation
                 Color      = new Color(scheme.OnSurface),
                 Modifier   = Modifier.Companion.Padding(top: 0, bottom: 8, start: 0, end: 0),
             },
-            new Spacer(Modifier.Companion.Width(8)),
+            Spacer.Width(8),
             new Text(m.Timestamp)
             {
                 FontSize = 12,
@@ -440,14 +440,14 @@ public static class Conversation
         MutableState<int>    selectedSelector)
     {
         int sel = selectedSelector.Value;
-        if (sel == 0) return new Spacer(Modifier.Companion.Width(0));
+        if (sel == 0) return Spacer.Width(0);
         if (sel == SelEmoji) return EmojiSelector.Build(input, scheme);
         string title    = "Functionality currently not available";
         string subtitle = "Grab a beverage and check back later!";
         return new Column
         {
             Modifier.Companion.FillMaxWidth().Height(320).Background(new Color(scheme.SurfaceVariant)),
-            new Spacer(Modifier.Companion.Height(96)),
+            Spacer.Height(96),
             new Text(title)
             {
                 FontSize   = 16,
@@ -455,7 +455,7 @@ public static class Conversation
                 Color      = new Color(scheme.OnSurfaceVariant),
                 Modifier   = Modifier.Companion.Padding(horizontal: 16, vertical: 0),
             },
-            new Spacer(Modifier.Companion.Height(8)),
+            Spacer.Height(8),
             new Text(subtitle)
             {
                 FontSize = 14,

--- a/samples/Jetchat/JetchatDrawer.cs
+++ b/samples/Jetchat/JetchatDrawer.cs
@@ -48,7 +48,7 @@ public static class JetchatDrawer
         {
             Modifier.Companion.FillMaxWidth().Padding(16),
             JetchatIcon.Build(contentDescription: null, sizeDp: 24),
-            new Spacer(Modifier.Companion.Width(8)),
+            Spacer.Width(8),
             new Text("Jetchat")
             {
                 FontSize   = 18,

--- a/samples/Jetchat/Profile.cs
+++ b/samples/Jetchat/Profile.cs
@@ -86,7 +86,7 @@ public static class Profile
     static ComposableNode BuildProfileHeader(ProfileScreenState state, float containerHeight)
     {
         if (state.Photo is null)
-            return new Spacer(Modifier.Companion.Width(0));
+            return Spacer.Width(0);
 
         float heroMax = containerHeight / 2f;
         if (heroMax < 1f) heroMax = 240f;
@@ -105,7 +105,7 @@ public static class Profile
     {
         var col = new Column
         {
-            new Spacer(Modifier.Companion.Height(8)),
+            Spacer.Height(8),
             BuildNameAndPosition(state, scheme),
             BuildProfileProperty("Display name", state.DisplayName, scheme),
             BuildProfileProperty("Status",       state.Status,      scheme),
@@ -118,7 +118,7 @@ public static class Profile
         // the device, in order to always leave some content at the top.
         float trailing = containerHeight - 320f;
         if (trailing < 0f) trailing = 0f;
-        col.Add(new Spacer(Modifier.Companion.Height((int)trailing)));
+        col.Add(Spacer.Height((int)trailing));
         return col;
     }
 

--- a/samples/Jetchat/RecordButton.cs
+++ b/samples/Jetchat/RecordButton.cs
@@ -139,7 +139,7 @@ public static class RecordButton
                     Color      = new Color(scheme.OnSurface),
                 },
 
-                new Spacer(Modifier.Companion.Width(16)),
+                Spacer.Width(16),
 
                 new Row
                 {
@@ -154,7 +154,7 @@ public static class RecordButton
                         TintArgb = scheme.OnSurfaceVariant,
                         Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically).Size(24),
                     },
-                    new Spacer(Modifier.Companion.Width(8)),
+                    Spacer.Width(8),
                     new Text("Slide to cancel")
                     {
                         Modifier = Modifier.Companion.Align(Alignment.Vertical.CenterVertically),

--- a/samples/Reply/EmptyComingSoon.cs
+++ b/samples/Reply/EmptyComingSoon.cs
@@ -22,7 +22,7 @@ public static class EmptyComingSoon
                     Color      = new Color(scheme.Primary),
                     Modifier   = Modifier.Companion.FillMaxWidth(),
                 },
-                new Spacer(Modifier.Companion.Height(8)),
+                Spacer.Height(8),
                 new Text("This screen is still under construction. This sample will help you learn about adaptive layouts in Jetpack Compose")
                 {
                     FontSize = 14,

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BackHandlerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BackHandlerDemo.cs
@@ -28,20 +28,20 @@ public static class BackHandlerDemo
                     enabled: intercept.Value),
 
                 new Text("BackHandler is registered while this screen is active."),
-                new Spacer(Modifier.Companion.Height(12)),
+                Spacer.Height(12),
 
                 new Row
                 {
                     new Switch(@checked: intercept.Value, onCheckedChange: v => intercept.Value = v),
-                    new Spacer(Modifier.Companion.Width(12)),
+                    Spacer.Width(12),
                     new Text(intercept.Value
                         ? "Intercepting — system back is consumed"
                         : "Letting back through — pops the gallery screen"),
                 },
-                new Spacer(Modifier.Companion.Height(16)),
+                Spacer.Height(16),
 
                 new Text($"Back presses intercepted: {pressCount}"),
-                new Spacer(Modifier.Companion.Height(16)),
+                Spacer.Height(16),
 
                 new Text("Try pressing the system back button or swiping from the edge:"),
                 new Text("• With the switch ON the counter ticks and you stay on this screen."),

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -1858,6 +1858,11 @@ static AndroidX.Compose.Sp.operator !=(AndroidX.Compose.Sp left, AndroidX.Compos
 static AndroidX.Compose.Sp.operator ==(AndroidX.Compose.Sp left, AndroidX.Compose.Sp right) -> bool
 static AndroidX.Compose.Sp.Pack(AndroidX.Compose.Sp? value) -> long
 static AndroidX.Compose.Sp.Zero.get -> AndroidX.Compose.Sp
+static AndroidX.Compose.Spacer.Height(AndroidX.Compose.Dp dp) -> AndroidX.Compose.Spacer!
+static AndroidX.Compose.Spacer.Size(AndroidX.Compose.Dp dp) -> AndroidX.Compose.Spacer!
+static AndroidX.Compose.Spacer.Size(AndroidX.Compose.Dp width, AndroidX.Compose.Dp height) -> AndroidX.Compose.Spacer!
+static AndroidX.Compose.Spacer.Weight(float weight, bool fill = true) -> AndroidX.Compose.Spacer!
+static AndroidX.Compose.Spacer.Width(AndroidX.Compose.Dp dp) -> AndroidX.Compose.Spacer!
 static AndroidX.Compose.StaggeredGridCells.Adaptive(float minSizeDp) -> AndroidX.Compose.Foundation.Lazy.Staggeredgrid.IStaggeredGridCells!
 static AndroidX.Compose.StaggeredGridCells.Fixed(int count) -> AndroidX.Compose.Foundation.Lazy.Staggeredgrid.IStaggeredGridCells!
 static AndroidX.Compose.StaggeredGridCells.FixedSize(float sizeDp) -> AndroidX.Compose.Foundation.Lazy.Staggeredgrid.IStaggeredGridCells!

--- a/src/Microsoft.AndroidX.Compose/Spacer.cs
+++ b/src/Microsoft.AndroidX.Compose/Spacer.cs
@@ -20,4 +20,44 @@ public sealed partial class Spacer
 
     /// <summary>Convenience overload that sets <see cref="ComposableNode.Modifier"/>.</summary>
     public Spacer(Modifier modifier) => Modifier = modifier;
+
+    /// <summary>
+    /// Creates a <see cref="Spacer"/> with a fixed width and no height. Equivalent
+    /// to <c>new Spacer(Modifier.Width(dp))</c>; the <see cref="int"/>-to-<see cref="Dp"/>
+    /// implicit conversion lets callers write <c>Spacer.Width(8)</c>.
+    /// </summary>
+    public static Spacer Width(Dp dp) => new(Modifier.Companion.Width(dp));
+
+    /// <summary>
+    /// Creates a <see cref="Spacer"/> with a fixed height and no width. Equivalent
+    /// to <c>new Spacer(Modifier.Height(dp))</c>; the <see cref="int"/>-to-<see cref="Dp"/>
+    /// implicit conversion lets callers write <c>Spacer.Height(8)</c>.
+    /// </summary>
+    public static Spacer Height(Dp dp) => new(Modifier.Companion.Height(dp));
+
+    /// <summary>
+    /// Creates a square <see cref="Spacer"/> of the given size. Equivalent to
+    /// <c>new Spacer(Modifier.Size(dp))</c>.
+    /// </summary>
+    public static Spacer Size(Dp dp) => new(Modifier.Companion.Size(dp));
+
+    /// <summary>
+    /// Creates a rectangular <see cref="Spacer"/> with the given width and height.
+    /// Equivalent to <c>new Spacer(Modifier.Size(width, height))</c>.
+    /// </summary>
+    public static Spacer Size(Dp width, Dp height) => new(Modifier.Companion.Size(width, height));
+
+    /// <summary>
+    /// Creates a <see cref="Spacer"/> that takes a share of the leftover main-axis
+    /// space inside its parent <see cref="Row"/> or <see cref="Column"/> — the
+    /// canonical "push siblings apart" idiom. Equivalent to
+    /// <c>new Spacer(Modifier.Weight(weight, fill))</c>. As with
+    /// <see cref="Modifier.Weight"/>, only valid inside a Row/Column or
+    /// Row/Column-shaped scope.
+    /// </summary>
+    /// <param name="weight">Relative share of the leftover space (must be positive).</param>
+    /// <param name="fill">When <see langword="true"/> (the default) the Spacer
+    /// fills its allotted slot; <see langword="false"/> lets it be smaller.</param>
+    public static Spacer Weight(float weight, bool fill = true) =>
+        new(Modifier.Companion.Weight(weight, fill));
 }


### PR DESCRIPTION
Brainstorm idea #7 — make the "insert a small gap" idiom one expression instead of three.

## Motivation

Inserting an 8-dp gap reads:

```csharp
// before
new Spacer(Modifier.Companion.Width(8))
new Spacer(Modifier.Companion.Height(8))
new Spacer(Modifier.Companion.Weight(1f, fill: true))

// after
Spacer.Width(8)
Spacer.Height(8)
Spacer.Weight(1f)
```

Mirrors the shape of `Modifier.Width`/`Height`/`Size`. Same lowering — each factory is `new Spacer(Modifier.Companion.X(...))` under the hood, no new properties on `Spacer`, no behavioural change.

## API

Five new statics on `AndroidX.Compose.Spacer`:

| Factory | Equivalent |
|---|---|
| `Spacer.Width(Dp)` | `new Spacer(Modifier.Width(dp))` |
| `Spacer.Height(Dp)` | `new Spacer(Modifier.Height(dp))` |
| `Spacer.Size(Dp)` | `new Spacer(Modifier.Size(dp))` |
| `Spacer.Size(Dp, Dp)` | `new Spacer(Modifier.Size(w, h))` |
| `Spacer.Weight(float, bool fill = true)` | `new Spacer(Modifier.Weight(w, fill))` |

All take `Dp`; the existing `implicit operator Dp(int)` lets callers write `Spacer.Width(8)` literally.

The two existing ctors (`Spacer()`, `Spacer(Modifier)`) are **kept** — one site (`JetchatDrawer.cs:32` `StatusBarsPadding`) still legitimately uses the modifier ctor and four sentinel `new Spacer()` calls live in pattern-match defaults. Not removing them; this PR is non-breaking despite the original suggestion's openness to breaking changes.

## Migrated call sites (24)

| File | W/H/S | Weight |
|---|---|---|
| samples/Jetchat/Conversation.cs | 7 | |
| samples/Jetchat/JetchatDrawer.cs | 1 | |
| samples/Jetchat/Profile.cs | 3 | |
| samples/Jetchat/RecordButton.cs | 2 | |
| samples/JetNews/HomeCards.cs | 1 | 1 |
| samples/JetNews/JetnewsDrawer.cs | 1 | |
| samples/JetNews/PostBody.cs | 1 | |
| samples/JetNews/PostScreen.cs | 2 | |
| samples/Reply/EmptyComingSoon.cs | 1 | |
| src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BackHandlerDemo.cs | 4 | |
| **Total** | **23** | **1** |

Out-of-scope (untouched): 4 sentinel `new Spacer()` arms in `HomeScreen.cs` / `PostScreen.cs`, plus 1 `new Spacer(Modifier.Companion.StatusBarsPadding())` in `JetchatDrawer.cs`.

## Coordination — Modifier-statics race

The Modifier-statics PR (`jonathanpeppers/modifier-static-factories`) hasn't merged. **Factory bodies use `Modifier.Companion.Width(dp)`** (existing instance method on `Modifier.Companion`), not `Modifier.Width(dp)` (the not-yet-merged static). Once that PR lands a trivial mechanical follow-up can strip `.Companion` from these five lines in `Spacer.cs`.

## Verified

- ✅ `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` — 130/130 passing
- ✅ `dotnet build src/Microsoft.AndroidX.Compose` — 0 errors
- ✅ `dotnet build src/Microsoft.AndroidX.Compose.Gallery` — 0 errors, 0 warnings
- ✅ `dotnet build samples/{Jetchat,JetNews,Reply}` — all green

No device deploy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>