### PR TITLE
Add IComposer.MutableStateOf extension and implicit MutableState<T> → T

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ public class MainActivity : ComponentActivity
         base.OnCreate(savedInstanceState);
         this.SetContent(c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new MaterialTheme
             {
                 new Column
@@ -95,9 +95,10 @@ The translation is mechanical — `new` instead of bare calls, commas instead of
 | `Column { … }`                                | `new Column { … }` (collection-initializer)                     |
 | `Button(onClick = { x++ }) { … }`             | `new Button(onClick: () => x++) { … }`                          |
 | `MaterialTheme { … }`                         | `new MaterialTheme { … }`                                       |
-| `var count by remember { mutableStateOf(0) }` | `var count = c.Remember(() => new MutableNumberState<int>(0))`  |
-| `count++`                                     | `count++` (operator on `MutableNumberState<T>`)                 |
+| `var count by remember { mutableStateOf(0) }` | `var count = c.MutableStateOf(0)`                               |
+| `count++`                                     | `count++` (operator on `MutableNumberState<T>`, picked by overload resolution for `int`/`long`/`float`/`double`) |
 | `"Count: $count"`                             | `$"Count: {count}"` (via `MutableState<T>.ToString`)            |
+| `if (count > 0) …`                            | `if (count > 0) …` (implicit `MutableState<T>` → `T`)           |
 
 That's an end-to-end Material 3 counter app in ~13 lines of composition — start from this shape when adding a new screen. The actual [`src/Microsoft.AndroidX.Compose.Gallery/MainActivity.cs`](src/Microsoft.AndroidX.Compose.Gallery/MainActivity.cs) in the repo is a much larger **gallery app** that exercises every facade across a navigable catalog with search; for a single-screen real-app example see [`samples/Jetchat`](samples/Jetchat).
 

--- a/samples/JetNews/HomeScreen.cs
+++ b/samples/JetNews/HomeScreen.cs
@@ -33,8 +33,8 @@ public static class HomeScreen
             // the wordmark title for an inline OutlinedTextField. The search
             // is purely visual today — wiring it to filter the feed needs
             // Modifier.interceptKey(Key.Enter), tracked in #159.
-            var searchOpen  = c.Remember(() => new MutableState<bool>(false));
-            var searchQuery = c.Remember(() => new MutableState<string>(string.Empty));
+            var searchOpen  = c.MutableStateOf(false);
+            var searchQuery = c.MutableStateOf(string.Empty);
             var snackbarMessage = snackbars.Message.Value;
 
             return new Scaffold

--- a/samples/JetNews/MainActivity.cs
+++ b/samples/JetNews/MainActivity.cs
@@ -25,7 +25,7 @@ public class MainActivity : ComponentActivity
         this.SetContent(c =>
         {
             var nav                  = c.Remember(() => new NavController());
-            var currentRoute         = c.Remember(() => new MutableState<string>(Routes.Home));
+            var currentRoute         = c.MutableStateOf(Routes.Home);
             var drawerState          = c.Remember(() => new DrawerStateHolder(DrawerValue.Closed));
             // Acquire bookmarks from the activity's ViewModelStore so
             // the toggled set survives configuration change AND is
@@ -37,7 +37,7 @@ public class MainActivity : ComponentActivity
             var selectedTopics       = c.Remember(() => new MutableStateList<string>());
             var selectedPeople       = c.Remember(() => new MutableStateList<string>());
             var selectedPublications = c.Remember(() => new MutableStateList<string>());
-            var interestsTab         = c.Remember(() => new MutableState<int>(0));
+            var interestsTab         = c.MutableStateOf(0);
             var snackbars            = c.Remember(() => new SnackbarController());
             return JetnewsApp.Build(
                 nav,

--- a/samples/JetNews/PostScreen.cs
+++ b/samples/JetNews/PostScreen.cs
@@ -26,7 +26,7 @@ public static class PostScreen
         Action<Post>? onShare = null) =>
         new Composed(c =>
         {
-            var showShareDialog = c.Remember(() => new MutableState<bool>(false));
+            var showShareDialog = c.MutableStateOf(false);
             var snackbarMessage = snackbars.Message.Value;
 
             // Wrap the Scaffold + the conditional dialog in a Box so the

--- a/samples/Jetchat/EmojiSelector.cs
+++ b/samples/Jetchat/EmojiSelector.cs
@@ -75,7 +75,7 @@ public static class EmojiSelector
     public static ComposableNode Build(MutableState<TextFieldValue> input, ColorScheme scheme) =>
         new Composed(c =>
         {
-            var selected = c.Remember(() => new MutableState<int>(0));
+            var selected = c.MutableStateOf(0);
             return new Column
             {
                 Modifier.Companion

--- a/samples/Jetchat/MainActivity.cs
+++ b/samples/Jetchat/MainActivity.cs
@@ -1,7 +1,6 @@
 using Android.Views;
 using AndroidX.Activity;
 using AndroidX.Compose.Material3;
-using AndroidX.Compose.UI.Text.Input;
 
 namespace AndroidX.Compose.Samples.Jetchat;
 
@@ -20,15 +19,15 @@ public class MainActivity : ComponentActivity
         this.SetContent(c =>
         {
             var ui               = c.Remember(() => new ConversationUiState("#composers", channelMembers: 42, FakeData.InitialMessages()));
-            var input            = c.Remember(() => new MutableState<TextFieldValue>(c.NewTextFieldValue()));
-            var selectedMenu     = c.Remember(() => new MutableState<string>("composers"));
+            var input            = c.MutableStateOf(c.NewTextFieldValue());
+            var selectedMenu     = c.MutableStateOf("composers");
             var drawerScroll     = c.Remember(() => new ScrollState());
             var drawerState      = c.Remember(() => new DrawerStateHolder(DrawerValue.Closed));
-            var selectedSelector = c.Remember(() => new MutableState<int>(0));
-            var popupOpen        = c.Remember(() => new MutableState<bool>(false));
+            var selectedSelector = c.MutableStateOf(0);
+            var popupOpen        = c.MutableStateOf(false);
             var messagesScroll   = c.RememberLazyListState();
-            var isRecording      = c.Remember(() => new MutableState<bool>(false));
-            var swipeOffset      = c.Remember(() => new MutableNumberState<float>(0f));
+            var isRecording      = c.MutableStateOf(false);
+            var swipeOffset      = c.MutableStateOf(0f);
             var nav              = c.Remember(() => new NavController());
             var profileViewModel = c.Remember(() => new ProfileViewModel());
             return JetchatApp.Build(

--- a/samples/Jetchat/Profile.cs
+++ b/samples/Jetchat/Profile.cs
@@ -17,7 +17,7 @@ public static class Profile
         new Composed(c =>
         {
             var scrollState = c.Remember(() => new ScrollState());
-            var popupOpen   = c.Remember(() => new MutableState<bool>(false));
+            var popupOpen   = c.MutableStateOf(false);
             var scheme      = MaterialTheme.CurrentColorScheme(c);
 
             var screen = new Scaffold

--- a/samples/Jetchat/RecordButton.cs
+++ b/samples/Jetchat/RecordButton.cs
@@ -75,8 +75,8 @@ public static class RecordButton
         ColorScheme               scheme) =>
         new Composed(c =>
         {
-            var pulse   = c.Remember(() => new MutableNumberState<float>(1f));
-            var seconds = c.Remember(() => new MutableNumberState<int>(0));
+            var pulse   = c.MutableStateOf(1f);
+            var seconds = c.MutableStateOf(0);
 
             float density   = Android.Content.Res.Resources.System!.DisplayMetrics!.Density;
             float threshold = SwipeToCancelThresholdDp * density;

--- a/samples/Reply/MainActivity.cs
+++ b/samples/Reply/MainActivity.cs
@@ -23,8 +23,8 @@ public class MainActivity : ComponentActivity
         this.SetContent(c =>
         {
             var nav              = c.Remember(() => new NavController());
-            var currentRoute     = c.Remember(() => new MutableState<string>(Route.Inbox));
-            var openedEmailId    = c.Remember(() => new MutableState<long>(0L));
+            var currentRoute     = c.MutableStateOf(Route.Inbox);
+            var openedEmailId    = c.MutableStateOf(0L);
             var selectedEmailIds = c.Remember(() => new MutableStateList<long>());
             return ReplyApp.Build(nav, currentRoute, openedEmailId, selectedEmailIds);
         });

--- a/src/Microsoft.AndroidX.Compose.Gallery/ComposeViewActivity.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/ComposeViewActivity.cs
@@ -43,7 +43,7 @@ public class ComposeViewActivity : ComponentActivity
         var compose = new ComposeView(this);
         compose.SetContent(c =>
         {
-            var taps = c.Remember(() => new MutableNumberState<int>(0));
+            var taps = c.MutableStateOf(0);
             return new MaterialTheme
             {
                 new Column

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/BottomAppBarActionsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/BottomAppBarActionsDemo.cs
@@ -13,7 +13,7 @@ public static class BottomAppBarActionsDemo
         Description: "Action icons laid out left-to-right; no FAB slot.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"count = {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/BottomAppBarWithFabDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/BottomAppBarWithFabDemo.cs
@@ -13,7 +13,7 @@ public static class BottomAppBarWithFabDemo
         Description: "BottomAppBar exposes a FloatingActionButton slot for the primary action.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"count = {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/FlexibleBottomAppBarDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/FlexibleBottomAppBarDemo.cs
@@ -13,7 +13,7 @@ public static class FlexibleBottomAppBarDemo
         Description: "Flexible variant of BottomAppBar; content drives the bar's height.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"count = {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/LargeFlexibleTopAppBarDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/LargeFlexibleTopAppBarDemo.cs
@@ -13,7 +13,7 @@ public static class LargeFlexibleTopAppBarDemo
         Description: "Big title for hero screens; supports Title / Subtitle / Actions.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new LargeFlexibleTopAppBar
             {
                 Title    = new Text("Tickets"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/MediumFlexibleTopAppBarDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/MediumFlexibleTopAppBarDemo.cs
@@ -13,7 +13,7 @@ public static class MediumFlexibleTopAppBarDemo
         Description: "Two-line app bar — Title + Subtitle.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new MediumFlexibleTopAppBar

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/PrimaryScrollableTabRowDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/PrimaryScrollableTabRowDemo.cs
@@ -13,7 +13,7 @@ public static class PrimaryScrollableTabRowDemo
         Description: "Scrolls horizontally when tabs overflow; mixes Tab, LeadingIconTab, CustomTab.",
         Build:       c =>
         {
-            var sub = c.Remember(() => new MutableNumberState<int>(0));
+            var sub = c.MutableStateOf(0);
             return new Column
             {
                 new PrimaryScrollableTabRow(selectedTabIndex: sub.Value)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/SecondaryScrollableTabRowDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/SecondaryScrollableTabRowDemo.cs
@@ -13,7 +13,7 @@ public static class SecondaryScrollableTabRowDemo
         Description: "M3 secondary tab row variant; same selection model as PrimaryScrollableTabRow.",
         Build:       c =>
         {
-            var sub = c.Remember(() => new MutableNumberState<int>(0));
+            var sub = c.MutableStateOf(0);
             return new Column
             {
                 new SecondaryScrollableTabRow(selectedTabIndex: sub.Value)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/ChipsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/ChipsDemo.cs
@@ -13,8 +13,8 @@ public static class ChipsDemo
         Description: "AssistChip, FilterChip, SuggestionChip (plus Elevated variants).",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
-            var liked = c.Remember(() => new MutableState<bool>(false));
+            var count = c.MutableStateOf(0);
+            var liked = c.MutableStateOf(false);
             return new Column(verticalArrangement: Arrangement.SpacedBy(8))
             {
                 new Text($"Count: {count}, liked: {liked.Value}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/FillStylesDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/FillStylesDemo.cs
@@ -13,7 +13,7 @@ public static class FillStylesDemo
         Description: "Filled, Elevated, Filled tonal, Outlined, and Text buttons.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"Tapped: {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/FloatingActionButtonsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/FloatingActionButtonsDemo.cs
@@ -13,7 +13,7 @@ public static class FloatingActionButtonsDemo
         Description: "FloatingActionButton, SmallFloatingActionButton, LargeFloatingActionButton, ExtendedFloatingActionButton.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column(verticalArrangement: Arrangement.SpacedBy(12))
             {
                 new Text($"Tapped: {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/HelloCounterDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/HelloCounterDemo.cs
@@ -5,8 +5,13 @@ namespace AndroidX.Compose.Gallery.Demos.Buttons;
 /// <summary>
 /// The README's "side-by-side Kotlin vs C#" hello-world sample, rendered
 /// inside the gallery. A <see cref="Text"/>, a <see cref="Button"/>, and
-/// a counter backed by <see cref="MutableNumberState{T}"/>.
+/// a counter created via <see cref="ComposeExtensions.MutableStateOf(AndroidX.Compose.Runtime.IComposer, int, int, string)"/>.
 /// </summary>
+/// <remarks>
+/// Doubles as the runtime exerciser for the implicit
+/// <c>MutableState&lt;T&gt; → T</c> conversion: <c>count &gt; 0</c> reads the
+/// wrapper as an <c>int</c> without an explicit <c>.Value</c>.
+/// </remarks>
 public static class HelloCounterDemo
 {
     /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
@@ -14,10 +19,10 @@ public static class HelloCounterDemo
         Id:          "buttons-hello",
         CategoryId:  "buttons",
         Title:       "Hello from .NET",
-        Description: "Material 3 hello-world from the README: Text + Button + counter via MutableNumberState<int>.",
+        Description: "Material 3 hello-world from the README: Text + Button + counter via c.MutableStateOf(0).",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text("Hello from .NET"),
@@ -26,6 +31,9 @@ public static class HelloCounterDemo
                 {
                     new Text("Tap to increment"),
                 },
+                count > 0
+                    ? new Text("count is non-zero")
+                    : null,
             };
         });
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconButtonsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconButtonsDemo.cs
@@ -13,7 +13,7 @@ public static class IconButtonsDemo
         Description: "IconButton, FilledIconButton, FilledTonalIconButton, OutlinedIconButton.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"Tapped: {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconToggleButtonsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconToggleButtonsDemo.cs
@@ -13,10 +13,10 @@ public static class IconToggleButtonsDemo
         Description: "IconToggleButton + filled/tonal/outlined variants.",
         Build:       c =>
         {
-            var a = c.Remember(() => new MutableState<bool>(false));
-            var b = c.Remember(() => new MutableState<bool>(false));
-            var ct = c.Remember(() => new MutableState<bool>(false));
-            var d = c.Remember(() => new MutableState<bool>(false));
+            var a = c.MutableStateOf(false);
+            var b = c.MutableStateOf(false);
+            var ct = c.MutableStateOf(false);
+            var d = c.MutableStateOf(false);
             return new Row
             {
                 new IconToggleButton(@checked: a.Value, onCheckedChange: v => a.Value = v)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/TooltipsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/TooltipsDemo.cs
@@ -13,7 +13,7 @@ public static class TooltipsDemo
         Description: "Tooltip wraps an Anchor; the Tip pops on long-press.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"Tapped: {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/AlertDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/AlertDialogDemo.cs
@@ -13,8 +13,8 @@ public static class AlertDialogDemo
         Description: "Modal alert with confirm + dismiss buttons.",
         Build:       c =>
         {
-            var open  = c.Remember(() => new MutableState<bool>(false));
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var open  = c.MutableStateOf(false);
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"count = {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
@@ -13,8 +13,8 @@ public static class DatePickerDialogDemo
         Description: "Tap Pick date to open a calendar dialog. Read SelectedDateMillis on confirm.",
         Build:       c =>
         {
-            var open   = c.Remember(() => new MutableState<bool>(false));
-            var picked = c.Remember(() => new MutableState<string>("(none)"));
+            var open   = c.MutableStateOf(false);
+            var picked = c.MutableStateOf("(none)");
             var state  = c.Remember(() => new DatePickerState());
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DateRangePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DateRangePickerDialogDemo.cs
@@ -13,8 +13,8 @@ public static class DateRangePickerDialogDemo
         Description: "Confirm reads SelectedStartDateMillis + SelectedEndDateMillis.",
         Build:       c =>
         {
-            var open   = c.Remember(() => new MutableState<bool>(false));
-            var picked = c.Remember(() => new MutableState<string>("(none)"));
+            var open   = c.MutableStateOf(false);
+            var picked = c.MutableStateOf("(none)");
             var state  = c.Remember(() => new DateRangePickerState());
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DropdownMenuDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DropdownMenuDemo.cs
@@ -13,8 +13,8 @@ public static class DropdownMenuDemo
         Description: "IconButton + DropdownMenu inside a shared Box for anchoring.",
         Build:       c =>
         {
-            var open      = c.Remember(() => new MutableState<bool>(false));
-            var selection = c.Remember(() => new MutableState<string>("(none)"));
+            var open      = c.MutableStateOf(false);
+            var selection = c.MutableStateOf("(none)");
             return new Column
             {
                 new Text($"Last menu choice: {selection}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/ExposedDropdownMenuBoxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/ExposedDropdownMenuBoxDemo.cs
@@ -13,8 +13,8 @@ public static class ExposedDropdownMenuBoxDemo
         Description: "Read-only TextField + ▼ button toggles an anchored popup list.",
         Build:       c =>
         {
-            var open     = c.Remember(() => new MutableState<bool>(false));
-            var selected = c.Remember(() => new MutableState<string>("Apple"));
+            var open     = c.MutableStateOf(false);
+            var selected = c.MutableStateOf("Apple");
             return new ExposedDropdownMenuBox(
                 expanded:         open.Value,
                 onExpandedChange: v => open.Value = v)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/ModalBottomSheetDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/ModalBottomSheetDemo.cs
@@ -13,7 +13,7 @@ public static class ModalBottomSheetDemo
         Description: "Drag down or tap outside to dismiss.",
         Build:       c =>
         {
-            var open = c.Remember(() => new MutableState<bool>(false));
+            var open = c.MutableStateOf(false);
             return new Column
             {
                 new Button(onClick: () => open.Value = true) { new Text("Show sheet") },

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/TimePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/TimePickerDialogDemo.cs
@@ -13,8 +13,8 @@ public static class TimePickerDialogDemo
         Description: "Confirm reads Hour + Minute from TimePickerState.",
         Build:       c =>
         {
-            var open   = c.Remember(() => new MutableState<bool>(false));
-            var picked = c.Remember(() => new MutableState<string>("(none)"));
+            var open   = c.MutableStateOf(false);
+            var picked = c.MutableStateOf("(none)");
             var state  = c.Remember(() => new TimePickerState(initialHour: 9, initialMinute: 30));
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/ListsGrids/LazyColumnLongDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/ListsGrids/LazyColumnLongDemo.cs
@@ -14,8 +14,8 @@ public static class LazyColumnLongDemo
         Description: "Only the visible window is composed; PullToRefreshBox surfaces the Material 3 pull gesture.",
         Build:       c =>
         {
-            var refreshing  = c.Remember(() => new MutableState<bool>(false));
-            var refreshTick = c.Remember(() => new MutableNumberState<int>(0));
+            var refreshing  = c.MutableStateOf(false);
+            var refreshTick = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"LazyColumn (1000 rows) — pull to refresh, rev {refreshTick}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/ListsGrids/PullToRefreshBoxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/ListsGrids/PullToRefreshBoxDemo.cs
@@ -14,8 +14,8 @@ public static class PullToRefreshBoxDemo
         Description: "Wraps a scrollable child and surfaces the M3 pull gesture; faked 1.2s reload.",
         Build:       c =>
         {
-            var refreshing = c.Remember(() => new MutableState<bool>(false));
-            var revision   = c.Remember(() => new MutableNumberState<int>(0));
+            var refreshing = c.MutableStateOf(false);
+            var revision   = c.MutableStateOf(0);
             return new PullToRefreshBox(
                 isRefreshing: refreshing.Value,
                 onRefresh:    () =>

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/CombinedClickableDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/CombinedClickableDemo.cs
@@ -13,7 +13,7 @@ public static class CombinedClickableDemo
         Description: "One gesture modifier that dispatches single / long / double taps to separate callbacks.",
         Build:       c =>
         {
-            var taps = c.Remember(() => new MutableNumberState<int>(0));
+            var taps = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"Taps (single+1, long+10, double+100): {taps}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/DetectTapGesturesDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/DetectTapGesturesDemo.cs
@@ -13,8 +13,8 @@ public static class DetectTapGesturesDemo
         Description: "Low-level pointer-input modifier: tap, press, long-press, double-tap — each reports the hit Offset.",
         Build:       c =>
         {
-            var lastEvent = c.Remember(() => new MutableState<string>("(none)"));
-            var taps = c.Remember(() => new MutableNumberState<int>(0));
+            var lastEvent = c.MutableStateOf("(none)");
+            var taps = c.MutableStateOf(0);
 
             string Fmt(string label, Offset offset) =>
                 $"{label} at ({offset.X:F0}, {offset.Y:F0})";

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/DragAndDropTargetDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/DragAndDropTargetDemo.cs
@@ -14,7 +14,7 @@ public static class DragAndDropTargetDemo
         Build:       _ => new Composed(c =>
         {
             var drops    = c.Remember(() => new MutableStateList<string>());
-            var hovering = c.Remember(() => new MutableState<bool>(false));
+            var hovering = c.MutableStateOf(false);
             var target = c.Remember(() => new DragAndDropTarget
             {
                 OnEntered = _ => hovering.Value = true,

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/DraggableOffsetDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/DraggableOffsetDemo.cs
@@ -14,7 +14,7 @@ public static class DraggableOffsetDemo
         Build:       c =>
         {
             var density = Android.Content.Res.Resources.System!.DisplayMetrics!.Density;
-            var dragX   = c.Remember(() => new MutableState<float>(0f));
+            var dragX   = c.MutableStateOf(0f);
             var state   = c.RememberDraggableState(delta => dragX.Value += delta / density);
 
             return new Column

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/FlowRowScopeDispatchDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/FlowRowScopeDispatchDemo.cs
@@ -19,7 +19,7 @@ public static class FlowRowScopeDispatchDemo
         Description: "Chips wrap onto multiple lines and each one calls Modifier.Align(Alignment.Vertical.CenterVertically), a RowScope-only modifier — proves FlowRow forwards its RowScope receiver.",
         Build:       c =>
         {
-            var taps = c.Remember(() => new MutableNumberState<int>(0));
+            var taps = c.MutableStateOf(0);
             var flow = new FlowRow
             {
                 Modifier.Companion.FillMaxWidth().Padding(4),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/FocusRequesterDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/FocusRequesterDemo.cs
@@ -14,7 +14,7 @@ public static class FocusRequesterDemo
         Build:       c =>
         {
             var focusReq    = c.Remember(() => new FocusRequester());
-            var focusStatus = c.Remember(() => new MutableState<string>("not focused"));
+            var focusStatus = c.MutableStateOf("not focused");
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/GraphicsLayerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/GraphicsLayerDemo.cs
@@ -14,7 +14,7 @@ public static class GraphicsLayerDemo
         Build:       c =>
         {
             var density = Android.Content.Res.Resources.System!.DisplayMetrics!.Density;
-            var dragX   = c.Remember(() => new MutableState<float>(0f));
+            var dragX   = c.MutableStateOf(0f);
             var state   = c.RememberDraggableState(delta => dragX.Value += delta / density);
 
             return new Column

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/MinimumInteractiveComponentSizeDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/MinimumInteractiveComponentSizeDemo.cs
@@ -18,7 +18,7 @@ public static class MinimumInteractiveComponentSizeDemo
         Description: "Reserves 48dp around an icon-only button to keep its touch target accessible.",
         Build:       c =>
         {
-            var taps = c.Remember(() => new MutableNumberState<int>(0));
+            var taps = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"Tapped: {taps}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/SemanticsBuilderDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/SemanticsBuilderDemo.cs
@@ -18,8 +18,8 @@ public static class SemanticsBuilderDemo
         Description: "Modifier.Semantics(s => s.Selected(..).Role(..).ContentDescription(..).OnClick(\"Open\", ..)). Enable TalkBack to hear the announcements.",
         Build:       c =>
         {
-            var selected = c.Remember(() => new MutableState<bool>(false));
-            var opens    = c.Remember(() => new MutableNumberState<int>(0));
+            var selected = c.MutableStateOf(false);
+            var opens    = c.MutableStateOf(0);
 
             // The card has TWO accessibility actions:
             //   1. The standard click — toggles selection.

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/ToggleableSelectableSemanticsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/ToggleableSelectableSemanticsDemo.cs
@@ -13,9 +13,9 @@ public static class ToggleableSelectableSemanticsDemo
         Description: "A Row collapsed into one a11y node, three Selectable rows acting as a radio group, and a Box that announces a custom semantic role.",
         Build:       c =>
         {
-            var liked       = c.Remember(() => new MutableState<bool>(false));
-            var selectedRow = c.Remember(() => new MutableNumberState<int>(0));
-            var taps        = c.Remember(() => new MutableNumberState<int>(0));
+            var liked       = c.MutableStateOf(false);
+            var selectedRow = c.MutableStateOf(0);
+            var taps        = c.MutableStateOf(0);
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BackHandlerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BackHandlerDemo.cs
@@ -16,8 +16,8 @@ public static class BackHandlerDemo
         Description: "Toggle interception of the back gesture; the counter ticks each time it's intercepted.",
         Build:       c =>
         {
-            var intercept = c.Remember(() => new MutableState<bool>(true));
-            var pressCount = c.Remember(() => new MutableNumberState<int>(0));
+            var intercept = c.MutableStateOf(true);
+            var pressCount = c.MutableStateOf(0);
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
@@ -32,7 +32,7 @@ public static class BottomNavOptionsDemo
             const string startRoute = "home";
 
             var nav      = c.Remember(() => new NavController());
-            var selected = c.Remember(() => new MutableState<string>(startRoute));
+            var selected = c.MutableStateOf(startRoute);
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/DismissibleDrawerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/DismissibleDrawerDemo.cs
@@ -14,7 +14,7 @@ public static class DismissibleDrawerDemo
         Description: "Drawer pushes the content rather than overlaying. Starts open via InitialValue.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Box
             {
                 Modifier.Companion.Height(320),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/ModalDrawerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/ModalDrawerDemo.cs
@@ -13,7 +13,7 @@ public static class ModalDrawerDemo
         Description: "Edge-swipe to reveal; scrim taps dismiss.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             // Drawers fill their parent. Bound them so they don't fight the
             // gallery's outer scroll for height.
             return new Box

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/ModalWideNavigationRailDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/ModalWideNavigationRailDemo.cs
@@ -13,8 +13,8 @@ public static class ModalWideNavigationRailDemo
         Description: "Overlay rail; tap an item or the Close row to dismiss.",
         Build:       c =>
         {
-            var idx     = c.Remember(() => new MutableNumberState<int>(0));
-            var visible = c.Remember(() => new MutableState<bool>(false));
+            var idx     = c.MutableStateOf(0);
+            var visible = c.MutableStateOf(false);
             return new Column
             {
                 new Text($"ModalWideNavigationRail (selected: {idx})"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/NavigationDrawerItemDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/NavigationDrawerItemDemo.cs
@@ -15,7 +15,7 @@ public static class NavigationDrawerItemDemo
         Description: "Selected-state pill, Icon and Badge slots, click handling.",
         Build:       c =>
         {
-            var selected = c.Remember(() => new MutableNumberState<int>(0));
+            var selected = c.MutableStateOf(0);
             string[] labels = { "Inbox", "Outbox", "Favorites", "Trash" };
             return new PermanentDrawerSheet
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/PermanentDrawerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/PermanentDrawerDemo.cs
@@ -13,7 +13,7 @@ public static class PermanentDrawerDemo
         Description: "Drawer is always shown beside the content.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Box
             {
                 Modifier.Companion.Height(320),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/WideNavigationRailDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/WideNavigationRailDemo.cs
@@ -13,7 +13,7 @@ public static class WideNavigationRailDemo
         Description: "Persistent vertical rail with three selectable items.",
         Build:       c =>
         {
-            var idx = c.Remember(() => new MutableNumberState<int>(0));
+            var idx = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"WideNavigationRail (selected: {idx})"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Search/DockedSearchBarDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Search/DockedSearchBarDemo.cs
@@ -19,8 +19,8 @@ public static class DockedSearchBarDemo
         Description: "Deprecated boolean-state variant of SearchBar; popup docks under the input.",
         Build:       c =>
         {
-            var open  = c.Remember(() => new MutableState<bool>(false));
-            var query = c.Remember(() => new MutableState<string>(""));
+            var open  = c.MutableStateOf(false);
+            var query = c.MutableStateOf("");
 
             var matches = Array.FindAll(
                 Fruits,

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Search/DockedSearchBarQueryDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Search/DockedSearchBarQueryDemo.cs
@@ -19,8 +19,8 @@ public static class DockedSearchBarQueryDemo
         Description: "Deprecated query/active overload — the bar renders its own input field.",
         Build:       c =>
         {
-            var query  = c.Remember(() => new MutableState<string>(""));
-            var active = c.Remember(() => new MutableState<bool>(false));
+            var query  = c.MutableStateOf("");
+            var active = c.MutableStateOf(false);
 
             var matches = Array.FindAll(
                 Fruits,

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Search/SearchBarPairDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Search/SearchBarPairDemo.cs
@@ -21,7 +21,7 @@ public static class SearchBarPairDemo
         {
             var state = c.Remember(() => new SearchBarState());
             var input = c.Remember(() => new SearchBarTextFieldState());
-            var query = c.Remember(() => new MutableState<string>(""));
+            var query = c.MutableStateOf("");
 
             var matches = Array.FindAll(
                 Fruits,

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/CheckboxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/CheckboxDemo.cs
@@ -13,7 +13,7 @@ public static class CheckboxDemo
         Description: "Plain two-state checkbox bound to a MutableState<bool>.",
         Build:       c =>
         {
-            var on = c.Remember(() => new MutableState<bool>(false));
+            var on = c.MutableStateOf(false);
             return new Column
             {
                 new Row

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/MultiChoiceSegmentedButtonsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/MultiChoiceSegmentedButtonsDemo.cs
@@ -13,8 +13,8 @@ public static class MultiChoiceSegmentedButtonsDemo
         Description: "MultiChoiceSegmentedButtonRow with two independently checkable SegmentedButtons.",
         Build:       c =>
         {
-            var bold   = c.Remember(() => new MutableState<bool>(false));
-            var italic = c.Remember(() => new MutableState<bool>(false));
+            var bold   = c.MutableStateOf(false);
+            var italic = c.MutableStateOf(false);
             return new Column
             {
                 new MultiChoiceSegmentedButtonRow

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RadioButtonGroupDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RadioButtonGroupDemo.cs
@@ -13,7 +13,7 @@ public static class RadioButtonGroupDemo
         Description: "Single-selection group built from three RadioButtons.",
         Build:       c =>
         {
-            var picked = c.Remember(() => new MutableNumberState<int>(0));
+            var picked = c.MutableStateOf(0);
             return new Column
             {
                 new Row

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RangeSliderDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RangeSliderDemo.cs
@@ -13,8 +13,8 @@ public static class RangeSliderDemo
         Description: "Two-thumb slider for a (start, end) interval.",
         Build:       c =>
         {
-            var start = c.Remember(() => new MutableNumberState<float>(0.2f));
-            var end   = c.Remember(() => new MutableNumberState<float>(0.8f));
+            var start = c.MutableStateOf(0.2f);
+            var end   = c.MutableStateOf(0.8f);
             return new Column
             {
                 new RangeSlider(

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SingleChoiceSegmentedButtonsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SingleChoiceSegmentedButtonsDemo.cs
@@ -13,7 +13,7 @@ public static class SingleChoiceSegmentedButtonsDemo
         Description: "SingleChoiceSegmentedButtonRow with three SegmentedButtons.",
         Build:       c =>
         {
-            var picked = c.Remember(() => new MutableNumberState<int>(0));
+            var picked = c.MutableStateOf(0);
             return new Column
             {
                 new SingleChoiceSegmentedButtonRow

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SliderDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SliderDemo.cs
@@ -13,7 +13,7 @@ public static class SliderDemo
         Description: "Continuous Slider mapped to a MutableNumberState<float>.",
         Build:       c =>
         {
-            var value = c.Remember(() => new MutableNumberState<float>(0.4f));
+            var value = c.MutableStateOf(0.4f);
             return new Column
             {
                 new Slider(value: value.Value, onValueChange: v => value.Value = v),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SwitchDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SwitchDemo.cs
@@ -13,7 +13,7 @@ public static class SwitchDemo
         Description: "Bool-bound Switch with live status text.",
         Build:       c =>
         {
-            var on = c.Remember(() => new MutableState<bool>(false));
+            var on = c.MutableStateOf(false);
             return new Column
             {
                 new Row

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/TriStateCheckboxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/TriStateCheckboxDemo.cs
@@ -14,7 +14,7 @@ public static class TriStateCheckboxDemo
         Description: "Cycles through On → Off → Indeterminate on tap.",
         Build:       c =>
         {
-            var state = c.Remember(() => new MutableState<ToggleableState>(ToggleableState.Indeterminate!));
+            var state = c.MutableStateOf(ToggleableState.Indeterminate!);
             return new Column
             {
                 new Row

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/AnimatedContentDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/AnimatedContentDemo.cs
@@ -13,7 +13,7 @@ public static class AnimatedContentDemo
         Description: "Like Crossfade, but with a slide and size change in addition to the fade. Each step uses a different colour so the transition is visible.",
         Build:       c =>
         {
-            var step = c.Remember(() => new MutableNumberState<int>(0));
+            var step = c.MutableStateOf(0);
             Color[] palette =
             [
                 Color.FromRgb(0xB3, 0xE5, 0xFC),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/AnimatedVisibilityDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/AnimatedVisibilityDemo.cs
@@ -13,7 +13,7 @@ public static class AnimatedVisibilityDemo
         Description: "Toggle a card in and out. Compose applies a default fade + expand transition.",
         Build:       c =>
         {
-            var visible = c.Remember(() => new MutableState<bool>(true));
+            var visible = c.MutableStateOf(true);
             return new Column
             {
                 new Button(onClick: () => visible.Value = !visible.Value)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/CrossfadeDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/CrossfadeDemo.cs
@@ -13,7 +13,7 @@ public static class CrossfadeDemo
         Description: "Whenever the int changes, the previous panel fades out as the new one fades in. Each step uses a different colour so the cross-dissolve is visible.",
         Build:       c =>
         {
-            var step = c.Remember(() => new MutableNumberState<int>(0));
+            var step = c.MutableStateOf(0);
             Color[] palette =
             [
                 Color.FromRgb(0xEF, 0x9A, 0x9A),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/DisposableEffectDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/DisposableEffectDemo.cs
@@ -13,8 +13,8 @@ public static class DisposableEffectDemo
         Description: "Fake 'register external listener' pattern. The cleanup callback bumps a counter on every key change / leaving composition.",
         Build:       c =>
         {
-            var cleanups = c.Remember(() => new MutableNumberState<int>(0));
-            var key      = c.Remember(() => new MutableNumberState<int>(0));
+            var cleanups = c.MutableStateOf(0);
+            var key      = c.MutableStateOf(0);
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/EnterExitTransitionsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/EnterExitTransitionsDemo.cs
@@ -13,7 +13,7 @@ public static class EnterExitTransitionsDemo
         Description: "Combine Transitions.FadeIn/Out, ScaleIn/Out, and SlideIn/OutVertically with AnimatedVisibility.",
         Build:       c =>
         {
-            var visible = c.Remember(() => new MutableState<bool>(true));
+            var visible = c.MutableStateOf(true);
             return new Column
             {
                 new Button(onClick: () => visible.Value = !visible.Value)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/LaunchedEffectDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/LaunchedEffectDemo.cs
@@ -13,8 +13,8 @@ public static class LaunchedEffectDemo
         Description: "Background tick loop scoped to this composition. Bumping the key cancels and restarts it.",
         Build:       c =>
         {
-            var ticks = c.Remember(() => new MutableNumberState<int>(0));
-            var key   = c.Remember(() => new MutableNumberState<int>(0));
+            var ticks = c.MutableStateOf(0);
+            var key   = c.MutableStateOf(0);
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/NullableMutableStateDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/NullableMutableStateDemo.cs
@@ -23,8 +23,8 @@ public static class NullableMutableStateDemo
         Description: "Nullable primitives (long?, int?, bool?) round-trip through MutableState and CompositionLocal without unbox errors. Toggle the selected ID between null and a value.",
         Build:       c =>
         {
-            var selectedId = c.Remember(() => new MutableState<long?>(null));
-            var taps       = c.Remember(() => new MutableNumberState<int>(0));
+            var selectedId = c.MutableStateOf<long?>(null);
+            var taps       = c.MutableStateOf(0);
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/ProduceStateTickerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/ProduceStateTickerDemo.cs
@@ -13,7 +13,7 @@ public static class ProduceStateTickerDemo
         Description: "A 1Hz tick loop publishes into a Compose State. Bumping the seed cancels the current loop and restarts it from 0.",
         Build:       c =>
         {
-            var seed   = c.Remember(() => new MutableNumberState<int>(0));
+            var seed   = c.MutableStateOf(0);
             var ticker = c.ProduceState(0, seed.Value, async (state, ct) =>
             {
                 state.Value = 0;

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/SideEffectDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/SideEffectDemo.cs
@@ -13,7 +13,7 @@ public static class SideEffectDemo
         Description: $"Writes a log line after every successful recomposition. Filter logcat for '{GalleryApp.LogTag}' to see it.",
         Build:       c =>
         {
-            var count = c.Remember(() => new MutableNumberState<int>(0));
+            var count = c.MutableStateOf(0);
             return new Column
             {
                 new Text($"Count: {count}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/SnapshotFlowDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/SnapshotFlowDemo.cs
@@ -13,9 +13,9 @@ public static class SnapshotFlowDemo
         Description: "ComposeExtensions.SnapshotFlow(producer) yields a new value on every snapshot apply. Tap +1 a few times — 'observed' tracks live. Tap Burst x10 — Kotlin's snapshot conflation means you usually only see the final value, demonstrating the bounded(1) DropOldest semantics.",
         Build:       c =>
         {
-            var counter  = c.Remember(() => new MutableNumberState<int>(0));
-            var observed = c.Remember(() => new MutableNumberState<int>(0));
-            var seen     = c.Remember(() => new MutableNumberState<int>(0));
+            var counter  = c.MutableStateOf(0);
+            var observed = c.MutableStateOf(0);
+            var seen     = c.MutableStateOf(0);
 
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/StateFactoriesDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/StateEffectsAnimation/StateFactoriesDemo.cs
@@ -13,11 +13,11 @@ public static class StateFactoriesDemo
         Description: "MutableState<T>, MutableNumberState<T> (int/long/float/double), MutableStateList<T>, MutableStateMap<K,V> — the Kotlin top-level factory family expressed as plain C# ctors.",
         Build:       c =>
         {
-            var name   = c.Remember(() => new MutableState<string>("Ada"));
-            var i      = c.Remember(() => new MutableNumberState<int>(0));
-            var l      = c.Remember(() => new MutableNumberState<long>(1_000_000_000L));
-            var f      = c.Remember(() => new MutableNumberState<float>(0.5f));
-            var d      = c.Remember(() => new MutableNumberState<double>(Math.PI));
+            var name   = c.MutableStateOf("Ada");
+            var i      = c.MutableStateOf(0);
+            var l      = c.MutableStateOf(1_000_000_000L);
+            var f      = c.MutableStateOf(0.5f);
+            var d      = c.MutableStateOf(Math.PI);
             var items  = c.Remember(() => new MutableStateList<string>("alpha", "beta"));
             var prefs  = c.Remember(() => new MutableStateMap<string, bool>());
 

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/OutlinedSecureTextFieldDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/OutlinedSecureTextFieldDemo.cs
@@ -15,7 +15,7 @@ public static class OutlinedSecureTextFieldDemo
         {
             var pwd     = c.Remember(() => new SecureTextFieldState());
             var confirm = c.Remember(() => new SecureTextFieldState());
-            var status  = c.Remember(() => new MutableState<string>("Tap Sign in to compare"));
+            var status  = c.MutableStateOf("Tap Sign in to compare");
             return new Column
             {
                 new SecureTextField(pwd)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/OutlinedTextFieldDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/OutlinedTextFieldDemo.cs
@@ -13,7 +13,7 @@ public static class OutlinedTextFieldDemo
         Description: "Outlined variant with Prefix and Suffix slots.",
         Build:       c =>
         {
-            var handle = c.Remember(() => new MutableState<string>(""));
+            var handle = c.MutableStateOf("");
             return new Column
             {
                 new OutlinedTextField(handle)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldCursorPlacementDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldCursorPlacementDemo.cs
@@ -22,7 +22,7 @@ public static class TextFieldCursorPlacementDemo
         Description: "TextFieldValue overload — append text and pin the caret to the end.",
         Build:       c =>
         {
-            var input = c.Remember(() => new MutableState<TextFieldValue>(c.NewTextFieldValue()));
+            var input = c.MutableStateOf(c.NewTextFieldValue());
             return new Column(verticalArrangement: Arrangement.SpacedBy(12))
             {
                 new Text("Tap an emoji — it appends to the field and the caret moves to the end so the next keystroke lands after it.")

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldSlotsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldSlotsDemo.cs
@@ -13,7 +13,7 @@ public static class TextFieldSlotsDemo
         Description: "Label, Placeholder, LeadingIcon, TrailingIcon, SupportingText, SingleLine.",
         Build:       c =>
         {
-            var name = c.Remember(() => new MutableState<string>(""));
+            var name = c.MutableStateOf("");
             return new Column
             {
                 new TextField(name)

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Theming/MaterialIconsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Theming/MaterialIconsDemo.cs
@@ -18,7 +18,7 @@ public static class MaterialIconsDemo
         Description: "Icons.Filled/Outlined/Rounded/Sharp/TwoTone + Icons.AutoMirrored.* — vector icons resolved through JNI (no drawable resources required).",
         Build:       c =>
         {
-            var tapped = c.Remember(() => new MutableState<string>("(none)"));
+            var tapped = c.MutableStateOf("(none)");
 
             ComposableNode Tile(string name, AndroidX.Compose.UI.Graphics.Vector.ImageVector vec) =>
                 new Column

--- a/src/Microsoft.AndroidX.Compose.Gallery/GalleryApp.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/GalleryApp.cs
@@ -32,7 +32,7 @@ public static class GalleryApp
         // drawer below (drives edge-swipe). Lives here so both see the
         // same MutableState; each route's body updates it in a
         // DisposableEffect.
-        var currentRoute = composer.Remember(() => new MutableState<string>("home"));
+        var currentRoute = composer.MutableStateOf("home");
 
         MainActivity.Nav = nav;
 

--- a/src/Microsoft.AndroidX.Compose.Gallery/Screens/SearchScreen.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Screens/SearchScreen.cs
@@ -23,7 +23,7 @@ public sealed class SearchScreen : ComposableNode
     {
         var searchState = composer.Remember(() => new SearchBarState());
         var inputState  = composer.Remember(() => new SearchBarTextFieldState());
-        var query       = composer.Remember(() => new MutableState<string>(""));
+        var query       = composer.MutableStateOf("");
 
         var matches = Catalog.Search(query.Value).ToList();
 

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.State.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.State.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using AndroidX.Compose.Runtime;
 
 namespace AndroidX.Compose;
@@ -63,4 +64,93 @@ public static partial class ComposeExtensions
     /// </summary>
     public static DerivedState<T> DerivedStateOf<T>(this IComposer composer, Func<T> calculation)
         => DerivedStateOf(calculation);
+
+    // ---- MutableStateOf ----
+    //
+    // Single name; five overloads. C# overload resolution prefers a
+    // non-generic match over a generic one, so:
+    //
+    //   c.MutableStateOf(0)       → int    overload → MutableNumberState<int>
+    //   c.MutableStateOf(1000L)   → long   overload → MutableNumberState<long>
+    //   c.MutableStateOf(0.5f)    → float  overload → MutableNumberState<float>
+    //   c.MutableStateOf(Math.PI) → double overload → MutableNumberState<double>
+    //   c.MutableStateOf("Ada")   → generic         → MutableState<string>
+    //   c.MutableStateOf(false)   → generic         → MutableState<bool>
+    //
+    // Numeric overloads return MutableNumberState<T> so `count++` / `--` work
+    // at the call site without the caller picking a different factory name.
+
+    /// <summary>
+    /// Allocate (once per call site) a <see cref="MutableState{T}"/>
+    /// holding <paramref name="initial"/>, cached in the composer's slot
+    /// table by <see cref="Remember{T}(IComposer, Func{T}, int, string)"/>.
+    /// C# parity of Kotlin's <c>remember { mutableStateOf(initial) }</c>.
+    /// </summary>
+    /// <remarks>
+    /// For <c>int</c>, <c>long</c>, <c>float</c>, and <c>double</c>
+    /// arguments, C# overload resolution prefers the non-generic numeric
+    /// overloads of <see cref="MutableStateOf(IComposer, int, int, string)"/>
+    /// etc., so the caller receives a
+    /// <see cref="MutableNumberState{T}"/> and can write <c>count++</c>
+    /// directly. Use explicit type args (e.g. <c>c.MutableStateOf&lt;long?&gt;(null)</c>)
+    /// when the literal can't infer <typeparamref name="T"/>.
+    /// </remarks>
+    public static MutableState<T> MutableStateOf<T>(
+        this IComposer composer,
+        T initial,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => composer.Remember(() => new MutableState<T>(initial), line, file);
+
+    /// <summary>
+    /// <c>int</c>-typed overload: backed by Compose's
+    /// <see cref="IMutableIntState"/> fast path (no <c>Java.Lang.Integer</c>
+    /// allocation per read/write) and returns
+    /// <see cref="MutableNumberState{T}"/> so the caller can write
+    /// <c>count++</c>.
+    /// </summary>
+    public static MutableNumberState<int> MutableStateOf(
+        this IComposer composer,
+        int initial,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => composer.Remember(() => new MutableNumberState<int>(initial), line, file);
+
+    /// <summary>
+    /// <c>long</c>-typed overload: backed by Compose's
+    /// <see cref="IMutableLongState"/> fast path and returns
+    /// <see cref="MutableNumberState{T}"/>.
+    /// </summary>
+    public static MutableNumberState<long> MutableStateOf(
+        this IComposer composer,
+        long initial,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => composer.Remember(() => new MutableNumberState<long>(initial), line, file);
+
+    /// <summary>
+    /// <c>float</c>-typed overload: backed by Compose's
+    /// <see cref="IMutableFloatState"/> fast path and returns
+    /// <see cref="MutableNumberState{T}"/>.
+    /// </summary>
+    public static MutableNumberState<float> MutableStateOf(
+        this IComposer composer,
+        float initial,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => composer.Remember(() => new MutableNumberState<float>(initial), line, file);
+
+    /// <summary>
+    /// <c>double</c>-typed overload: Compose has no
+    /// <c>MutableDoubleState</c> primitive, so this falls through to the
+    /// boxed path — but still returns <see cref="MutableNumberState{T}"/>
+    /// so the caller can write <c>x++</c> / <c>x.Value /= 2</c>
+    /// idiomatically.
+    /// </summary>
+    public static MutableNumberState<double> MutableStateOf(
+        this IComposer composer,
+        double initial,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+        => composer.Remember(() => new MutableNumberState<double>(initial), line, file);
 }

--- a/src/Microsoft.AndroidX.Compose/MutableNumberState.cs
+++ b/src/Microsoft.AndroidX.Compose/MutableNumberState.cs
@@ -1,123 +1,39 @@
 using System.Numerics;
-using System.Runtime.CompilerServices;
-using AndroidX.Compose.Runtime;
 
 namespace AndroidX.Compose;
 
 /// <summary>
-/// Numeric-specialized mutable state. Adds <c>operator ++/--</c> so user
-/// code reads almost identically to Kotlin:
+/// Thin <see cref="MutableState{T}"/> subclass that adds <c>operator ++/--</c>
+/// for numeric <typeparamref name="T"/> so user code reads almost
+/// identically to Kotlin:
 /// <code>
-/// var count = Remember(() => new MutableNumberState&lt;int&gt;(0));
-/// count++;                  // mutates the underlying value
-/// Text($"Count: {count}");  // ToString() forwards to Value
+/// var count = c.MutableStateOf(0);  // → MutableNumberState&lt;int&gt; via overload resolution
+/// count++;                          // mutates the underlying value
+/// Text($"Count: {count}");          // ToString() forwards to Value
 /// </code>
-///
-/// For <c>int</c>, <c>long</c>, and <c>float</c>, the underlying slot is
-/// a primitive Compose state (<c>MutableIntState</c>, <c>MutableLongState</c>,
-/// <c>MutableFloatState</c>), so reads/writes avoid the
-/// <c>Java.Lang.Integer</c>/<c>Long</c>/<c>Float</c> allocation that the
-/// generic <see cref="MutableState{T}"/> path pays on every access. All
-/// other <see cref="INumber{TSelf}"/> primitives that <see cref="MutableState{T}"/>
-/// can box (<c>sbyte</c>, <c>byte</c>, <c>short</c>, <c>ushort</c>,
-/// <c>uint</c>, <c>ulong</c>, <c>double</c>) still work — they fall through
-/// to the boxed path. Types that <see cref="MutableState{T}"/> can't box
-/// (<c>decimal</c>, <c>Half</c>, <c>BigInteger</c>, <c>nint</c>,
-/// <c>nuint</c>) compile but throw at construction.
+/// All primitive-fast-path machinery lives on the
+/// <see cref="MutableState{T}"/> base; this class exists purely so the
+/// <c>++/--</c> operators (which require <see cref="INumber{TSelf}"/> at
+/// compile time) can be expressed on the C# type. Constructed via
+/// <c>new MutableNumberState&lt;T&gt;(initial)</c> or — typically — via the
+/// <see cref="ComposeExtensions.MutableStateOf(AndroidX.Compose.Runtime.IComposer, int, int, string)"/>
+/// family of numeric overloads.
 /// </summary>
-/// <remarks>
-/// <para>
-/// The primitive-specialized fast path requires the underlying
-/// <see cref="IMutableState"/> to actually be a primitive subtype
-/// (<see cref="IMutableIntState"/>, <see cref="IMutableLongState"/>,
-/// <see cref="IMutableFloatState"/>). That's true when constructed
-/// via <c>new MutableNumberState&lt;int&gt;(0)</c> — <c>CreateState</c>
-/// picks the right Kotlin factory. It's <i>not</i> guaranteed when the
-/// wrapper is built around a state produced elsewhere, such as the
-/// boxed <c>mutableStateOf(restoredValue, policy)</c> that
-/// <see cref="ComposeExtensions.RememberSaveable{T}(Func{T}, int, string)"/> returns after a process
-/// death restore. The instance <c>_kind</c> field is probed from the
-/// supplied state once at construction so the <see cref="Value"/>
-/// getter/setter never attempts an invalid cast.
-/// </para>
-/// </remarks>
 public class MutableNumberState<T> : MutableState<T> where T : INumber<T>
 {
-    enum Kind { Other, Int, Long, Float }
+    /// <summary>
+    /// Wrap a fresh numeric Compose state initialized with
+    /// <paramref name="initial"/>. Delegates to <see cref="MutableState{T}"/>,
+    /// which picks the
+    /// <see cref="AndroidX.Compose.Runtime.IMutableIntState"/>/<c>Long</c>/<c>Float</c>
+    /// fast path for the matching <typeparamref name="T"/>.
+    /// </summary>
+    public MutableNumberState(T initial) : base(initial) { }
 
-    Kind _kind;
-
-    public MutableNumberState(T initial) : base(CreateState(initial))
-    {
-        _kind = ProbeKind(_state);
-    }
-
-    static IMutableState CreateState(T initial)
-    {
-        if (typeof(T) == typeof(int))
-            return SnapshotIntStateKt.MutableIntStateOf(Unsafe.As<T, int>(ref initial));
-        if (typeof(T) == typeof(long))
-            return SnapshotLongStateKt.MutableLongStateOf(Unsafe.As<T, long>(ref initial));
-        if (typeof(T) == typeof(float))
-            return PrimitiveSnapshotStateKt.MutableFloatStateOf(Unsafe.As<T, float>(ref initial));
-        return SnapshotStateKt.MutableStateOf(
-            MutableState<T>.ToJava(initial),
-            SnapshotStateKt.StructuralEqualityPolicy());
-    }
-
-    static Kind ProbeKind(IMutableState state) => state switch
-    {
-        IMutableIntState   => Kind.Int,
-        IMutableLongState  => Kind.Long,
-        IMutableFloatState => Kind.Float,
-        _                  => Kind.Other,
-    };
-
-    internal override void SetUnderlyingState(IMutableState state)
-    {
-        base.SetUnderlyingState(state);
-        _kind = ProbeKind(state);
-    }
-
-    public override T Value
-    {
-        get
-        {
-            switch (_kind)
-            {
-                case Kind.Int:
-                    int i = ((IMutableIntState)_state).IntValue;
-                    return Unsafe.As<int, T>(ref i);
-                case Kind.Long:
-                    long l = ((IMutableLongState)_state).LongValue;
-                    return Unsafe.As<long, T>(ref l);
-                case Kind.Float:
-                    float f = ((IMutableFloatState)_state).FloatValue;
-                    return Unsafe.As<float, T>(ref f);
-                default:
-                    return base.Value;
-            }
-        }
-        set
-        {
-            switch (_kind)
-            {
-                case Kind.Int:
-                    ((IMutableIntState)_state).IntValue = Unsafe.As<T, int>(ref value);
-                    break;
-                case Kind.Long:
-                    ((IMutableLongState)_state).LongValue = Unsafe.As<T, long>(ref value);
-                    break;
-                case Kind.Float:
-                    ((IMutableFloatState)_state).FloatValue = Unsafe.As<T, float>(ref value);
-                    break;
-                default:
-                    base.Value = value;
-                    break;
-            }
-        }
-    }
-
+    /// <summary>Pre-increment: equivalent to <c>s.Value = s.Value + T.One</c>.</summary>
     public static MutableNumberState<T> operator ++(MutableNumberState<T> s) { s.Value++; return s; }
+
+    /// <summary>Pre-decrement: equivalent to <c>s.Value = s.Value - T.One</c>.</summary>
     public static MutableNumberState<T> operator --(MutableNumberState<T> s) { s.Value--; return s; }
 }
+

--- a/src/Microsoft.AndroidX.Compose/MutableState.cs
+++ b/src/Microsoft.AndroidX.Compose/MutableState.cs
@@ -1,37 +1,86 @@
+using System.Runtime.CompilerServices;
 using AndroidX.Compose.Runtime;
 
 namespace AndroidX.Compose;
 
 /// <summary>
 /// Generic typed wrapper around <see cref="IMutableState"/>. Reads/writes
-/// boxed values through the JVM state container so changes are observed
-/// by the Compose runtime and trigger recomposition.
+/// values through the JVM state container so changes are observed by the
+/// Compose runtime and trigger recomposition.
 /// </summary>
+/// <remarks>
+/// <para>
+/// For <c>int</c>, <c>long</c>, and <c>float</c>, the ctor picks a
+/// primitive-specialized Compose state
+/// (<see cref="IMutableIntState"/>, <see cref="IMutableLongState"/>,
+/// <see cref="IMutableFloatState"/>) so reads/writes avoid the
+/// <c>Java.Lang.Integer</c>/<c>Long</c>/<c>Float</c> allocation that the
+/// generic boxed path pays on every access. All other primitives that
+/// <see cref="MutableState{T}"/> can box (<c>sbyte</c>, <c>byte</c>,
+/// <c>short</c>, <c>ushort</c>, <c>uint</c>, <c>ulong</c>, <c>double</c>,
+/// <c>bool</c>, <c>char</c>, <c>string</c>, <c>Nullable&lt;T&gt;</c> of any
+/// of those) fall through to the boxed path. Reference types deriving from
+/// <see cref="Java.Lang.Object"/> are stored as-is.
+/// </para>
+/// <para>
+/// The primitive-specialized fast path requires the underlying
+/// <see cref="IMutableState"/> to actually be a primitive subtype. That's
+/// true when constructed via <c>new MutableState&lt;int&gt;(0)</c> — the
+/// ctor picks the right Kotlin factory. It's <i>not</i> guaranteed when
+/// the wrapper is built around a state produced elsewhere, such as the
+/// boxed <c>mutableStateOf(restoredValue, policy)</c> that
+/// <see cref="ComposeExtensions.RememberSaveable{T}(System.Func{T}, int, string)"/>
+/// returns after a process-death restore. The instance <c>_kind</c> field
+/// is probed from the supplied state once at construction (and re-probed
+/// on every <see cref="SetUnderlyingState"/> swap) so the <see cref="Value"/>
+/// getter/setter never attempts an invalid cast.
+/// </para>
+/// </remarks>
 public class MutableState<T> : IMutableStateWrapper, IState<T>
 {
+    enum Kind { Other, Int, Long, Float }
+
     internal IMutableState _state;
-
-    public MutableState(T initial)
-    {
-        _state = SnapshotStateKt.MutableStateOf(
-            ToJava(initial),
-            SnapshotStateKt.StructuralEqualityPolicy());
-    }
-
-    // Subclass hook: lets MutableNumberState<int|long|float> inject a
-    // primitive-specialized IMutableState (MutableIntState etc.) so its
-    // overridden Value getter/setter can bypass the boxed slow path.
-    internal MutableState(IMutableState state) => _state = state;
+    Kind _kind;
 
     /// <summary>
-    /// Subclass hook for <see cref="IMutableStateWrapper.State"/>'s
-    /// setter. <see cref="MutableNumberState{T}"/> overrides this to
-    /// re-probe its specialized-state <c>_kind</c> when Compose hands
-    /// back a (potentially boxed) restored state after a process-death
-    /// round-trip through
-    /// <see cref="ComposeExtensions.RememberSaveable{T}(Func{T}, int, string)"/>.
+    /// Wrap a fresh Compose state initialized with <paramref name="initial"/>.
+    /// Picks the primitive-specialized
+    /// <see cref="IMutableIntState"/>/<see cref="IMutableLongState"/>/<see cref="IMutableFloatState"/>
+    /// when <typeparamref name="T"/> is <c>int</c>/<c>long</c>/<c>float</c>;
+    /// otherwise creates a boxed <c>mutableStateOf</c> with structural
+    /// equality.
     /// </summary>
-    internal virtual void SetUnderlyingState(IMutableState state) => _state = state;
+    public MutableState(T initial)
+    {
+        _state = CreateState(initial);
+        _kind = ProbeKind(_state);
+    }
+
+    // Subclass hook: lets a wrapper be built around a pre-existing
+    // IMutableState (e.g. one Compose handed back after RememberSaveable
+    // restoration). Probes _kind so the fast-path dispatch in Value stays
+    // correct regardless of who built the state.
+    internal MutableState(IMutableState state)
+    {
+        _state = state;
+        _kind = ProbeKind(state);
+    }
+
+    /// <summary>
+    /// Subclass hook for <see cref="IMutableStateWrapper.State"/>'s setter.
+    /// Swaps the underlying <see cref="IMutableState"/> and re-probes the
+    /// primitive-fast-path <c>_kind</c> field so subsequent
+    /// <see cref="Value"/> reads/writes target the right specialised getter.
+    /// Compose calls this through the <see cref="IMutableStateWrapper.State"/>
+    /// setter after <c>rememberSaveable</c> hands back a (potentially boxed)
+    /// restored state on first composition.
+    /// </summary>
+    internal virtual void SetUnderlyingState(IMutableState state)
+    {
+        _state = state;
+        _kind = ProbeKind(state);
+    }
 
     IMutableState IMutableStateWrapper.State
     {
@@ -39,10 +88,70 @@ public class MutableState<T> : IMutableStateWrapper, IState<T>
         set => SetUnderlyingState(value);
     }
 
+    /// <summary>
+    /// The current value. Reading inside a composition subscribes the
+    /// surrounding scope to changes; writing triggers recomposition of any
+    /// scope that previously read the value. For
+    /// <c>int</c>/<c>long</c>/<c>float</c>-typed instances, reads/writes
+    /// route through the primitive Compose state without any boxing.
+    /// </summary>
     public virtual T Value
     {
-        get => FromJava(_state.Value);
-        set => _state.Value = ToJava(value);
+        get
+        {
+            switch (_kind)
+            {
+                case Kind.Int:
+                    int i = ((IMutableIntState)_state).IntValue;
+                    return Unsafe.As<int, T>(ref i);
+                case Kind.Long:
+                    long l = ((IMutableLongState)_state).LongValue;
+                    return Unsafe.As<long, T>(ref l);
+                case Kind.Float:
+                    float f = ((IMutableFloatState)_state).FloatValue;
+                    return Unsafe.As<float, T>(ref f);
+                default:
+                    return FromJava(_state.Value);
+            }
+        }
+        set
+        {
+            switch (_kind)
+            {
+                case Kind.Int:
+                    ((IMutableIntState)_state).IntValue = Unsafe.As<T, int>(ref value);
+                    break;
+                case Kind.Long:
+                    ((IMutableLongState)_state).LongValue = Unsafe.As<T, long>(ref value);
+                    break;
+                case Kind.Float:
+                    ((IMutableFloatState)_state).FloatValue = Unsafe.As<T, float>(ref value);
+                    break;
+                default:
+                    _state.Value = ToJava(value);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Implicit conversion to the wrapped value so call sites read
+    /// idiomatically — e.g. <c>if (count &gt; 0)</c>, <c>int total = count;</c>,
+    /// <c>(int)Math.Sqrt(count)</c> — without sprinkling <c>.Value</c>
+    /// everywhere. Mirrors Kotlin's <c>by remember { mutableStateOf(...) }</c>
+    /// property-delegate ergonomics.
+    /// </summary>
+    /// <remarks>
+    /// String interpolation (<c>$"...{state}..."</c>) keeps calling
+    /// <see cref="ToString"/> — interpolation boxes its arguments as
+    /// <c>object</c>, and the C# compiler does <i>not</i> apply user-defined
+    /// conversions when boxing — so this operator does not change
+    /// interpolation behavior.
+    /// </remarks>
+    public static implicit operator T(MutableState<T> state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        return state.Value;
     }
 
     /// <summary>
@@ -51,6 +160,27 @@ public class MutableState<T> : IMutableStateWrapper, IState<T>
     /// (a null value renders as <c>"null"</c>).
     /// </summary>
     public override string ToString() => Value?.ToString() ?? "null";
+
+    static IMutableState CreateState(T initial)
+    {
+        if (typeof(T) == typeof(int))
+            return SnapshotIntStateKt.MutableIntStateOf(Unsafe.As<T, int>(ref initial));
+        if (typeof(T) == typeof(long))
+            return SnapshotLongStateKt.MutableLongStateOf(Unsafe.As<T, long>(ref initial));
+        if (typeof(T) == typeof(float))
+            return PrimitiveSnapshotStateKt.MutableFloatStateOf(Unsafe.As<T, float>(ref initial));
+        return SnapshotStateKt.MutableStateOf(
+            ToJava(initial),
+            SnapshotStateKt.StructuralEqualityPolicy());
+    }
+
+    static Kind ProbeKind(IMutableState state) => state switch
+    {
+        IMutableIntState   => Kind.Int,
+        IMutableLongState  => Kind.Long,
+        IMutableFloatState => Kind.Float,
+        _                  => Kind.Other,
+    };
 
     // Cached per-T: when T is Nullable<U> (e.g. long?, int?, bool?), this
     // is typeof(U) so the primitive dispatch in FromJava/ToJava treats
@@ -115,3 +245,4 @@ public class MutableState<T> : IMutableStateWrapper, IState<T>
             $"MutableState<{typeof(T).Name}>: don't know how to unwrap {value.GetType().Name}");
     }
 }
+

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -1334,8 +1334,6 @@ override AndroidX.Compose.ModalDrawerSheet.Render(AndroidX.Compose.Runtime.IComp
 override AndroidX.Compose.ModalNavigationDrawer.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.ModalWideNavigationRail.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.MultiChoiceSegmentedButtonRow.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
-override AndroidX.Compose.MutableNumberState<T>.Value.get -> T
-override AndroidX.Compose.MutableNumberState<T>.Value.set -> void
 override AndroidX.Compose.MutableState<T>.ToString() -> string!
 override AndroidX.Compose.NavHost.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.NavigationBar.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
@@ -1461,6 +1459,11 @@ static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.R
 static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, object? key2, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 static AndroidX.Compose.ComposeExtensions.MutableStateFlowOf<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, int line = 0, string! file = "") -> AndroidX.Compose.MutableStateFlow<T>!
+static AndroidX.Compose.ComposeExtensions.MutableStateOf(this AndroidX.Compose.Runtime.IComposer! composer, double initial, int line = 0, string! file = "") -> AndroidX.Compose.MutableNumberState<double>!
+static AndroidX.Compose.ComposeExtensions.MutableStateOf(this AndroidX.Compose.Runtime.IComposer! composer, float initial, int line = 0, string! file = "") -> AndroidX.Compose.MutableNumberState<float>!
+static AndroidX.Compose.ComposeExtensions.MutableStateOf(this AndroidX.Compose.Runtime.IComposer! composer, int initial, int line = 0, string! file = "") -> AndroidX.Compose.MutableNumberState<int>!
+static AndroidX.Compose.ComposeExtensions.MutableStateOf(this AndroidX.Compose.Runtime.IComposer! composer, long initial, int line = 0, string! file = "") -> AndroidX.Compose.MutableNumberState<long>!
+static AndroidX.Compose.ComposeExtensions.MutableStateOf<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initial, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
 static AndroidX.Compose.ComposeExtensions.NewTextFieldValue(string! text = "", long selection = 0, AndroidX.Compose.UI.Text.TextRange? composition = null) -> AndroidX.Compose.UI.Text.Input.TextFieldValue!
 static AndroidX.Compose.ComposeExtensions.NewTextFieldValue(this AndroidX.Compose.Runtime.IComposer! composer, string! text = "", long selection = 0, AndroidX.Compose.UI.Text.TextRange? composition = null) -> AndroidX.Compose.UI.Text.Input.TextFieldValue!
 static AndroidX.Compose.ComposeExtensions.PainterResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> AndroidX.Compose.UI.Graphics.Painter.Painter!
@@ -1843,6 +1846,7 @@ static AndroidX.Compose.MaterialTheme.LightColorScheme(AndroidX.Compose.Color? p
 static AndroidX.Compose.Modifier.Companion.get -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.MutableNumberState<T>.operator --(AndroidX.Compose.MutableNumberState<T>! s) -> AndroidX.Compose.MutableNumberState<T>!
 static AndroidX.Compose.MutableNumberState<T>.operator ++(AndroidX.Compose.MutableNumberState<T>! s) -> AndroidX.Compose.MutableNumberState<T>!
+static AndroidX.Compose.MutableState<T>.implicit operator T(AndroidX.Compose.MutableState<T>! state) -> T
 static AndroidX.Compose.Offset.operator !=(AndroidX.Compose.Offset a, AndroidX.Compose.Offset b) -> bool
 static AndroidX.Compose.Offset.operator ==(AndroidX.Compose.Offset a, AndroidX.Compose.Offset b) -> bool
 static AndroidX.Compose.Offset.Unspecified.get -> AndroidX.Compose.Offset


### PR DESCRIPTION
Brainstorm suggestion **#2 — `MutableStateOf` ergonomics**. Bring the C# call site closer to Kotlin's `var count by remember { mutableStateOf(0) }`.

## Before / after

Kotlin:

```kotlin
var count by remember { mutableStateOf(0) }
Column {
    Text("Count: $count")
    Button(onClick = { count++ }) { Text("Tap") }
    if (count > 0) Text("non-zero")
}
```

C# before:

```csharp
var count = c.Remember(() => new MutableNumberState<int>(0));
return new Column {
    new Text($"Count: {count}"),
    new Button(onClick: () => count++) { new Text("Tap") },
    count.Value > 0
        ? new Text("non-zero")
        : null,
};
```

C# after:

```csharp
var count = c.MutableStateOf(0);
return new Column {
    new Text($"Count: {count}"),
    new Button(onClick: () => count++) { new Text("Tap") },
    count > 0
        ? new Text("non-zero")
        : null,
};
```

## Three sub-changes (all landed)

### 1. `composer.MutableStateOf(initial)` extension family

Single name, five overloads in `ComposeExtensions.State.cs`:

- `MutableStateOf<T>(this IComposer, T)` — generic catch-all → `MutableState<T>`
- `MutableStateOf(this IComposer, int)` → `MutableNumberState<int>`
- `MutableStateOf(this IComposer, long)` → `MutableNumberState<long>`
- `MutableStateOf(this IComposer, float)` → `MutableNumberState<float>`
- `MutableStateOf(this IComposer, double)` → `MutableNumberState<double>`

C# overload resolution (§11.6.4.3) prefers the non-generic numeric overloads for literal `int`/`long`/`float`/`double` values, so `c.MutableStateOf(0)` returns `MutableNumberState<int>` and gets `++/--` for free, while `c.MutableStateOf("Ada")` falls through to the generic `MutableState<string>`. Each overload forwards `[CallerLineNumber]`/`[CallerFilePath]` to `Remember` so call sites own a stable slot key.

| Call site | Picked overload | Returned type | `++` |
|---|---|---|---|
| `c.MutableStateOf(0)` | `int` | `MutableNumberState<int>` | ✓ |
| `c.MutableStateOf(1000L)` | `long` | `MutableNumberState<long>` | ✓ |
| `c.MutableStateOf(0.5f)` | `float` | `MutableNumberState<float>` | ✓ |
| `c.MutableStateOf(Math.PI)` | `double` | `MutableNumberState<double>` | ✓ |
| `c.MutableStateOf("Ada")` | generic | `MutableState<string>` | n/a |
| `c.MutableStateOf(false)` | generic | `MutableState<bool>` | n/a |
| `c.MutableStateOf<long?>(null)` | generic (explicit T) | `MutableState<long?>` | n/a |

### 2. Implicit `MutableState<T> → T`

```csharp
public static implicit operator T(MutableState<T> state)
{
    ArgumentNullException.ThrowIfNull(state);
    return state.Value;
}
```

`if (count > 0)`, `int x = state;`, `state + 5` all light up. `$"Count: {count}"` interpolation keeps calling `ToString()` (interpolation boxes args as `object`, which doesn't trigger user-defined conversions), so existing formatting is preserved. Inherited by `MutableNumberState<T>` per the C# spec.

`HelloCounterDemo.cs` now runtime-exercises the conversion via a `count > 0 ? new Text(...) : null` line.

### 3. Fold the primitive fast path into `MutableState<T>`

`Kind` probe, `CreateState` (picks `IMutableIntState`/`IMutableLongState`/`IMutableFloatState`), specialised `Value` getter/setter, and re-probe on `SetUnderlyingState` for `RememberSaveable` round-trip — all moved from `MutableNumberState<T>` into the base. Now **every** `new MutableState<int>(0)` (and the new `c.MutableStateOf(0)`) benefits from the primitive backing. `MutableNumberState<T>` stays as a thin 4-line subclass that only adds `operator ++/--` (which still requires `T : INumber<T>`).

This was feasible because the fast-path machinery only checks `typeof(T)` — it never *needs* `INumber<T>`. Only `++/--` does.

## Migration

Swept **119 call sites across 79 files** in `samples/Jetchat`, `samples/JetNews`, `samples/Reply`, the gallery demos, and the facade internals from `c.Remember(() => new Mutable[Number]State<T>(x))` to `c.MutableStateOf(x)`. Sites needing explicit T for null literals (`c.MutableStateOf<long?>(null)`) handled by hand. `RememberSaveable(() => new MutableNumberState<int>(0))` left as-is — `RememberSaveable` is the explicit path for bundle persistence and doesn't fit the new family.

A handful of stale `using AndroidX.Compose.UI.Text.Input;` directives (no longer needed since `MutableState<TextFieldValue>` isn't named at call sites anymore) were trimmed via `dotnet format style --diagnostics IDE0005`.

## Public API delta

`PublicAPI.Unshipped.txt`:

- **Add (6 lines):** five `MutableStateOf` overloads + one `MutableState<T>.implicit operator T`.
- **Remove (2 lines):** `override AndroidX.Compose.MutableNumberState<T>.Value.get/set` — the getter/setter slot now lives on the base type. Binary compatibility preserved (callers continue to resolve through the inherited virtual).

## Verification

- `dotnet build src/Microsoft.AndroidX.Compose` — clean (RS0016/RS0017 included)
- `dotnet build src/Microsoft.AndroidX.Compose.Gallery` — clean
- `dotnet build samples/Jetchat`, `samples/JetNews`, `samples/Reply` — all clean
- `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` — **130/130 pass**

No `-t:Run` per request — implicit-conversion exercise lives in `HelloCounterDemo` for on-device follow-up.

## Possible follow-ups

- `MutableStateOf<T>(initial, SnapshotMutationPolicy policy)` — Kotlin power-user shape, file a separate issue if requested.
- `[Obsolete("Use MutableState<T> directly", error: false)]` on `MutableNumberState<T>` — could be considered now that the fast path lives on the base, but the subclass still uniquely provides `++/--` so kept un-marked. Worth a separate discussion.

## Coordination note

Two other parallel sessions are touching `MaterialTheme.cs` / `Modifier.cs` call sites. Merge conflicts on `PublicAPI.Unshipped.txt` at review time are expected and mechanical (re-sort).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>