### PR TITLE
Allow composer-aware builder lambdas to convert implicitly to ComposableNode

### DIFF
--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -193,7 +193,7 @@ public static class Conversation
 
             // Jump to bottom button shows up when the user has scrolled
             // away from the newest message (index 0 in reverse layout).
-            new Composed(c =>
+            c =>
             {
                 var visible = messagesScroll.FirstVisibleItemIndex != 0
                            || messagesScroll.FirstVisibleItemScrollOffset > 0;
@@ -210,7 +210,7 @@ public static class Conversation
                     Icon = new Icon(Resource.Drawable.ic_arrow_downward, "Jump to bottom"),
                     Text = new Text("Jump to bottom"),
                 };
-            }),
+            },
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose/ComposableContainer.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposableContainer.cs
@@ -21,6 +21,28 @@ public abstract class ComposableContainer : ComposableNode, IEnumerable
     }
 
     /// <summary>
+    /// Collection-initializer overload that lets callers drop a
+    /// composer-aware builder lambda inline as a child:
+    /// <code>
+    /// new Column
+    /// {
+    ///     c =&gt; new Text(c.ColorScheme().OnSurface.ToString()),
+    /// }
+    /// </code>
+    /// The lambda is wrapped in a <see cref="Composed"/> node, so it
+    /// runs once per composition pass and may return <see langword="null"/>
+    /// to skip rendering. This overload exists alongside the implicit
+    /// conversion on <see cref="Composed"/> because C# can only target-
+    /// type a bare lambda when the call-site parameter is itself a
+    /// delegate — the implicit operator is otherwise invisible.
+    /// </summary>
+    public void Add(Func<IComposer, ComposableNode?> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        _children.Add(new Composed(builder));
+    }
+
+    /// <summary>
     /// Collection-initializer overload that lets callers set
     /// <see cref="ComposableNode.Modifier"/> inline alongside children:
     /// <code>new Column { Modifier.Padding(16), new Text("Hi") }</code>

--- a/src/Microsoft.AndroidX.Compose/Composed.cs
+++ b/src/Microsoft.AndroidX.Compose/Composed.cs
@@ -53,6 +53,27 @@ public sealed class Composed : ComposableNode
         _builder = builder;
     }
 
+    /// <summary>
+    /// Implicit conversion from a composer-aware builder lambda to a
+    /// <see cref="Composed"/>, so callers can drop the explicit
+    /// <c>new Composed(...)</c> wrapper whenever the target type is
+    /// known to be <see cref="Composed"/>:
+    /// <code>
+    /// Composed node = c =&gt; new Text(c.ColorScheme().OnSurface.ToString());
+    /// </code>
+    /// <para>
+    /// Note: C# only considers user-defined implicit conversions when the
+    /// expression already has a target type that is a delegate
+    /// (<see cref="Func{T, TResult}"/> here). A bare lambda assigned to
+    /// <see cref="ComposableNode"/> still needs an explicit
+    /// <c>new Composed(...)</c> wrapper — collection-initializer support
+    /// for the bare-lambda form is provided separately via
+    /// <see cref="ComposableContainer.Add(System.Func{AndroidX.Compose.Runtime.IComposer, AndroidX.Compose.ComposableNode?})"/>.
+    /// </para>
+    /// </summary>
+    public static implicit operator Composed(Func<IComposer, ComposableNode?> builder) =>
+        new(builder);
+
     /// <inheritdoc />
     public override void Render(IComposer composer)
     {

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -154,6 +154,7 @@ AndroidX.Compose.Column.Column(AndroidX.Compose.Arrangement? verticalArrangement
 AndroidX.Compose.ComposableContainer
 AndroidX.Compose.ComposableContainer.Add(AndroidX.Compose.ComposableNode? child) -> void
 AndroidX.Compose.ComposableContainer.Add(AndroidX.Compose.Modifier! modifier) -> void
+AndroidX.Compose.ComposableContainer.Add(System.Func<AndroidX.Compose.Runtime.IComposer!, AndroidX.Compose.ComposableNode?>! builder) -> void
 AndroidX.Compose.ComposableContainer.Children.get -> System.Collections.Generic.IReadOnlyList<AndroidX.Compose.ComposableNode!>!
 AndroidX.Compose.ComposableContainer.ComposableContainer() -> void
 AndroidX.Compose.ComposableContainer.RenderChildren(AndroidX.Compose.Runtime.IComposer! composer) -> void
@@ -1434,6 +1435,7 @@ static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Run
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T!
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, object? key1, object? key2, object? key3, int line = 0, string! file = "") -> T!
 static AndroidX.Compose.ComposeExtensions.ViewModelKeyed<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, object?[]! keys, int line = 0, string! file = "") -> T!
+static AndroidX.Compose.Composed.implicit operator AndroidX.Compose.Composed!(System.Func<AndroidX.Compose.Runtime.IComposer!, AndroidX.Compose.ComposableNode?>! builder) -> AndroidX.Compose.Composed!
 static AndroidX.Compose.CompositionLocal.Of<T>(System.Func<T>! defaultFactory) -> AndroidX.Compose.CompositionLocal<T>!
 static AndroidX.Compose.CompositionLocal.StaticOf<T>(System.Func<T>! defaultFactory) -> AndroidX.Compose.CompositionLocal<T>!
 static AndroidX.Compose.CompositionLocal<T>.Of(System.Func<T>! defaultFactory) -> AndroidX.Compose.CompositionLocal<T>!


### PR DESCRIPTION
Round-2 brainstorm #3 — implicit `Func<IComposer, ComposableNode?>` → `ComposableNode`.

## What changed

Two additions to enable callers to drop the explicit `new Composed(...)` wrapper:

1. **`Composed.cs`** — `public static implicit operator Composed(Func<IComposer, ComposableNode?>)`.
2. **`ComposableContainer.cs`** — `public void Add(Func<IComposer, ComposableNode?> builder)` overload that wraps the lambda in a `Composed` and appends it.

Both were needed. **The implicit operator alone is not sufficient for the headline collection-init pattern.**

## Pre-sweep verification (the C# inference question)

The brainstorm flagged this as a hard blocker — verified in a scratch project first:

```csharp
var col = new Column { c => new Text(c.ColorScheme().OnSurface.ToString()) };
```

…does **not** compile with only the implicit operator. CS1660: *"Cannot convert lambda expression to type 'ComposableNode' because it is not a delegate type."* C# does not consider a user-defined implicit conversion when the call-site parameter is `ComposableNode` (not a delegate) — the lambda has no target type, so the implicit operator is invisible.

Adding the `Add(Func<IComposer, ComposableNode?>)` overload directly on `ComposableContainer` fixes it because the lambda now has a delegate target type at the `Add` call site. The implicit op is still useful for the narrower scenario where the expression already has a `Composed` target type:

```csharp
Composed node = c => new Text("hi");  // implicit op kicks in
```

The same target-type limitation also rules out the simplification for **property setters** like `Title = c => ...` (the brainstorm presumed this would work — it does not, same CS1660). The two pieces in this PR enable exactly the two scenarios C# inference allows.

## Sweep

Out of **20** existing `new Composed(c => ...)` call sites (across samples + gallery), only **1** is in collection-init shape and was rewritten:

- `samples/Jetchat/Conversation.cs:196` — jump-to-bottom FAB inside a `Box`'s collection-initializer.

The remaining 19 are method-return expression bodies (`=> new Composed(c => ...)`), argument passing, property setters (`Title = new Composed(...)`), or `var` assignments — none of which the new APIs can simplify due to the target-type inference limit. **The bulk of the value here is forward-looking ergonomics for new code, not retroactive cleanup.**

## Before / after

`Conversation.cs:196`:

```csharp
// before
new Composed(c =>
{
    var visible = messagesScroll.FirstVisibleItemIndex != 0
               || messagesScroll.FirstVisibleItemScrollOffset > 0;
    if (!visible)
        return null;
    return new ExtendedFloatingActionButton(...) { ... };
}),

// after
c =>
{
    var visible = messagesScroll.FirstVisibleItemIndex != 0
               || messagesScroll.FirstVisibleItemScrollOffset > 0;
    if (!visible)
        return null;
    return new ExtendedFloatingActionButton(...) { ... };
},
```

Returning `null` from the builder remains a no-op render (existing `Composed.Render` already guards with `node?.Render(composer)`).

## Verification

| Step | Result |
| --- | --- |
| Pre-sweep CS1660 reproduction (scratch project) | ✅ Confirmed implicit op alone insufficient; `Add(Func)` overload required |
| `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` | ✅ 132/132 passed |
| `dotnet build src/Microsoft.AndroidX.Compose` | ✅ clean (after adding the two `PublicAPI.Unshipped.txt` entries) |
| `dotnet build src/Microsoft.AndroidX.Compose.Gallery` | ✅ clean |
| `dotnet build samples/Jetchat` | ✅ clean |
| `dotnet build samples/JetNews` | ✅ clean |
| `dotnet build samples/Reply` | ✅ clean |

Not deployed to a device — owner will smoke-test.

## Coordination

`PublicAPI.Unshipped.txt` will hit a mechanical sort-order conflict with sibling round-2 sessions (#1 padding defaults, #2 `*Argb` rename). Easy fix at merge time — just keep all new entries and re-sort.

Draft for review.