### PR TITLE
Rename TintArgb/ColorArgb → Tint/Color on hand-written facades

### DIFF
--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -85,7 +85,7 @@ public static class Conversation
                         .Clickable(() => popupOpen.Value = true)
                         .Padding(horizontal: 12, vertical: 16)
                         .Height(24),
-                    TintArgb = scheme.OnSurfaceVariant,
+                    Tint = scheme.OnSurfaceVariant,
                 },
                 new Icon(Resource.Drawable.ic_info, "Information")
                 {
@@ -93,7 +93,7 @@ public static class Conversation
                         .Clickable(() => popupOpen.Value = true)
                         .Padding(horizontal: 12, vertical: 16)
                         .Height(24),
-                    TintArgb = scheme.OnSurfaceVariant,
+                    Tint = scheme.OnSurfaceVariant,
                 },
             },
         };
@@ -221,7 +221,7 @@ public static class Conversation
             new HorizontalDivider
             {
                 Modifier  = Modifier.Weight(1f),
-                ColorArgb = scheme.OnSurface,
+                Color = scheme.OnSurface,
             },
             new Text(label)
             {
@@ -233,7 +233,7 @@ public static class Conversation
             new HorizontalDivider
             {
                 Modifier  = Modifier.Weight(1f),
-                ColorArgb = scheme.OnSurface,
+                Color = scheme.OnSurface,
             },
         };
 
@@ -426,7 +426,7 @@ public static class Conversation
         {
             new Icon(drawableId, contentDescription)
             {
-                TintArgb = selected ? scheme.OnSecondary : scheme.OnSurface,
+                Tint = selected ? scheme.OnSecondary : scheme.OnSurface,
             },
         };
         if (selected)

--- a/samples/Jetchat/JetchatDrawer.cs
+++ b/samples/Jetchat/JetchatDrawer.cs
@@ -107,7 +107,7 @@ public static class JetchatDrawer
             new Icon(Resource.Drawable.ic_jetchat, null)
             {
                 Modifier = Modifier.Padding(top: 16, bottom: 16, start: 16, end: 0),
-                TintArgb = iconTint,
+                Tint = iconTint,
             },
             new Text(channel)
             {

--- a/samples/Jetchat/JetchatIcon.cs
+++ b/samples/Jetchat/JetchatIcon.cs
@@ -40,12 +40,12 @@ public static class JetchatIcon
                 new Icon(Resource.Drawable.ic_jetchat_back, null)
                 {
                     Modifier = Modifier.Size(sizeDp),
-                    TintArgb = scheme.PrimaryContainer,
+                    Tint = scheme.PrimaryContainer,
                 },
                 new Icon(Resource.Drawable.ic_jetchat_front, contentDescription)
                 {
                     Modifier = Modifier.Size(sizeDp),
-                    TintArgb = scheme.Primary,
+                    Tint = scheme.Primary,
                 },
             };
         });

--- a/samples/Jetchat/Profile.cs
+++ b/samples/Jetchat/Profile.cs
@@ -46,7 +46,7 @@ public static class Profile
             {
                 new Icon(Resource.Drawable.ic_arrow_back, "Back")
                 {
-                    TintArgb = scheme.OnSurfaceVariant,
+                    Tint = scheme.OnSurfaceVariant,
                 },
             },
             Title   = new Text(""),
@@ -58,7 +58,7 @@ public static class Profile
                         .Clickable(() => popupOpen.Value = true)
                         .Padding(horizontal: 12, vertical: 16)
                         .Height(24),
-                    TintArgb = scheme.OnSurfaceVariant,
+                    Tint = scheme.OnSurfaceVariant,
                 },
             },
         };
@@ -147,7 +147,7 @@ public static class Profile
             Modifier.Padding(start: 16, end: 16, top: 0, bottom: 16),
             new HorizontalDivider
             {
-                ColorArgb = scheme.OnSurface,
+                Color = scheme.OnSurface,
             },
             new Text(label)
             {
@@ -186,7 +186,7 @@ public static class Profile
                 .WidthIn(min: 48),
             Icon = new Icon(iconRes, label)
             {
-                TintArgb = scheme.OnTertiaryContainer,
+                Tint = scheme.OnTertiaryContainer,
             },
             Text = new Text(label)
             {

--- a/samples/Jetchat/RecordButton.cs
+++ b/samples/Jetchat/RecordButton.cs
@@ -61,7 +61,7 @@ public static class RecordButton
                     innerModifier,
                     new Icon(Resource.Drawable.ic_mic, "Record voice message")
                     {
-                        TintArgb = recording ? scheme.OnPrimary : scheme.OnSurfaceVariant,
+                        Tint = recording ? scheme.OnPrimary : scheme.OnSurfaceVariant,
                         Modifier = Modifier.FillMaxSize(),
                     },
                 },
@@ -151,7 +151,7 @@ public static class RecordButton
 
                     new Icon(Resource.Drawable.ic_arrow_back, "Slide to cancel")
                     {
-                        TintArgb = scheme.OnSurfaceVariant,
+                        Tint = scheme.OnSurfaceVariant,
                         Modifier = Modifier.Align(Alignment.Vertical.CenterVertically).Size(24),
                     },
                     Spacer.Width(8),

--- a/samples/Reply/EmailDetailAppBar.cs
+++ b/samples/Reply/EmailDetailAppBar.cs
@@ -44,7 +44,7 @@ public static class EmailDetailAppBar
                 {
                     new Icon(Resource.Drawable.ic_more_vert, "More options")
                     {
-                        TintArgb = scheme.OnSurfaceVariant,
+                        Tint = scheme.OnSurfaceVariant,
                     },
                 };
             }),

--- a/samples/Reply/ReplyEmailListItem.cs
+++ b/samples/Reply/ReplyEmailListItem.cs
@@ -80,7 +80,7 @@ public static class ReplyEmailListItem
                     .Background(scheme.SurfaceVariant),
                 new Icon(Resource.Drawable.ic_star_border, "Favorite")
                 {
-                    TintArgb = scheme.Outline,
+                    Tint = scheme.Outline,
                 },
             },
         };

--- a/samples/Reply/ReplyEmailThreadItem.cs
+++ b/samples/Reply/ReplyEmailThreadItem.cs
@@ -63,7 +63,7 @@ public static class ReplyEmailThreadItem
                     .Background(scheme.SurfaceVariant),
                 new Icon(Resource.Drawable.ic_star_border, "Favorite")
                 {
-                    TintArgb = scheme.Outline,
+                    Tint = scheme.Outline,
                 },
             },
         };

--- a/samples/Reply/ReplyProfileImage.cs
+++ b/samples/Reply/ReplyProfileImage.cs
@@ -32,7 +32,7 @@ public static class ReplyProfileImage
                 new Icon(Resource.Drawable.ic_check, null)
                 {
                     Modifier = Modifier.Size(24),
-                    TintArgb = scheme.OnPrimary,
+                    Tint = scheme.OnPrimary,
                 },
             };
         });

--- a/samples/Reply/ReplySearchBar.cs
+++ b/samples/Reply/ReplySearchBar.cs
@@ -29,7 +29,7 @@ public sealed class ReplySearchBar : ComposableNode
                     Modifier.FillMaxWidth().Padding(horizontal: 16, vertical: 12),
                     new Icon(Resource.Drawable.ic_search, "Search")
                     {
-                        TintArgb = scheme.OnSurface,
+                        Tint = scheme.OnSurface,
                         Modifier = Modifier.Align(Alignment.Vertical.CenterVertically),
                     },
                     new Text("Search replies")

--- a/src/Microsoft.AndroidX.Compose/CircularProgressIndicator.cs
+++ b/src/Microsoft.AndroidX.Compose/CircularProgressIndicator.cs
@@ -15,14 +15,14 @@ namespace AndroidX.Compose;
 /// </summary>
 public sealed class CircularProgressIndicator : ComposableNode
 {
-    /// <summary>Optional ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
-    public long? ColorArgb { get; set; }
+    /// <summary>Optional explicit color. Leave null to use the Material default.</summary>
+    public Color? Color { get; set; }
 
     /// <summary>Optional stroke width in Dp. Leave null for the Material default.</summary>
     public float? StrokeWidthDp { get; set; }
 
-    /// <summary>Optional track ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
-    public long? TrackColorArgb { get; set; }
+    /// <summary>Optional explicit track color. Leave null to use the Material default.</summary>
+    public Color? TrackColor { get; set; }
 
     public override void Render(IComposer composer)
     {
@@ -30,15 +30,15 @@ public sealed class CircularProgressIndicator : ComposableNode
 
         int defaults = (int)CircularProgressIndicatorDefault.All;
         if (modifier is not null)        defaults &= ~(int)CircularProgressIndicatorDefault.Modifier;
-        if (ColorArgb.HasValue)          defaults &= ~(int)CircularProgressIndicatorDefault.Color;
+        if (Color.HasValue)              defaults &= ~(int)CircularProgressIndicatorDefault.Color;
         if (StrokeWidthDp.HasValue)      defaults &= ~(int)CircularProgressIndicatorDefault.StrokeWidth;
-        if (TrackColorArgb.HasValue)     defaults &= ~(int)CircularProgressIndicatorDefault.TrackColor;
+        if (TrackColor.HasValue)         defaults &= ~(int)CircularProgressIndicatorDefault.TrackColor;
 
         ProgressIndicatorKt.CircularProgressIndicator(
             modifier:    modifier,
-            color:       ColorArgb       ?? 0L,
+            color:       Color      is { } c ? c : 0L,
             strokeWidth: StrokeWidthDp   ?? 0f,
-            trackColor:  TrackColorArgb  ?? 0L,
+            trackColor:  TrackColor is { } t ? t : 0L,
             p4:          0,
             gapSize:     0f,
             _composer:   composer,

--- a/src/Microsoft.AndroidX.Compose/HorizontalDivider.cs
+++ b/src/Microsoft.AndroidX.Compose/HorizontalDivider.cs
@@ -13,8 +13,8 @@ public sealed class HorizontalDivider : ComposableNode
     /// <summary>Optional explicit thickness in Dp. Leave null to use the Material default.</summary>
     public float? ThicknessDp { get; set; }
 
-    /// <summary>Optional explicit ARGB color (packed into a Compose <c>Color</c> long). Leave null to use the Material default.</summary>
-    public long? ColorArgb { get; set; }
+    /// <summary>Optional explicit color. Leave null to use the Material default.</summary>
+    public Color? Color { get; set; }
 
     public override void Render(IComposer composer)
     {
@@ -23,12 +23,12 @@ public sealed class HorizontalDivider : ComposableNode
         int defaults = (int)HorizontalDividerDefault.All;
         if (modifier is not null)        defaults &= ~(int)HorizontalDividerDefault.Modifier;
         if (ThicknessDp.HasValue)        defaults &= ~(int)HorizontalDividerDefault.Thickness;
-        if (ColorArgb.HasValue)          defaults &= ~(int)HorizontalDividerDefault.Color;
+        if (Color.HasValue)              defaults &= ~(int)HorizontalDividerDefault.Color;
 
         DividerKt.HorizontalDivider(
             modifier:  modifier,
             thickness: ThicknessDp ?? 0f,
-            color:     ColorArgb   ?? 0L,
+            color:     Color is { } c ? c : 0L,
             _composer: composer,
             p4:        0,
             _changed:  defaults);

--- a/src/Microsoft.AndroidX.Compose/Icon.cs
+++ b/src/Microsoft.AndroidX.Compose/Icon.cs
@@ -33,10 +33,10 @@ public sealed class Icon : ComposableNode
     readonly string? _contentDescription;
 
     /// <summary>
-    /// Optional ARGB color packed into a Compose <c>Color</c> long.
-    /// Leave null to inherit the surrounding Material content color.
+    /// Optional fill color. Leave null to inherit the surrounding
+    /// Material content color (Compose's <c>LocalContentColor</c>).
     /// </summary>
-    public long? TintArgb { get; set; }
+    public Color? Tint { get; set; }
 
     /// <summary>Render an <see cref="ImageVector"/> (e.g. from a Compose icon library).</summary>
     public Icon(ImageVector imageVector, string? contentDescription)
@@ -75,9 +75,9 @@ public sealed class Icon : ComposableNode
                        & ~(int)IconDefault.ImageVector
                        & ~(int)IconDefault.ContentDescription;
         if (modifier is not null) defaults &= ~(int)IconDefault.Modifier;
-        if (TintArgb.HasValue)    defaults &= ~(int)IconDefault.Tint;
+        if (Tint.HasValue)        defaults &= ~(int)IconDefault.Tint;
 
-        long tint = TintArgb ?? 0L;
+        long tint = Tint is { } c ? c : 0L;
 
         if (_vector is not null)
         {

--- a/src/Microsoft.AndroidX.Compose/LinearProgressIndicator.cs
+++ b/src/Microsoft.AndroidX.Compose/LinearProgressIndicator.cs
@@ -15,11 +15,11 @@ namespace AndroidX.Compose;
 /// </summary>
 public sealed class LinearProgressIndicator : ComposableNode
 {
-    /// <summary>Optional ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
-    public long? ColorArgb { get; set; }
+    /// <summary>Optional explicit color. Leave null to use the Material default.</summary>
+    public Color? Color { get; set; }
 
-    /// <summary>Optional track ARGB color (packed Compose <c>Color</c> long). Leave null for the Material default.</summary>
-    public long? TrackColorArgb { get; set; }
+    /// <summary>Optional explicit track color. Leave null to use the Material default.</summary>
+    public Color? TrackColor { get; set; }
 
     public override void Render(IComposer composer)
     {
@@ -27,13 +27,13 @@ public sealed class LinearProgressIndicator : ComposableNode
 
         int defaults = (int)LinearProgressIndicatorDefault.All;
         if (modifier is not null)        defaults &= ~(int)LinearProgressIndicatorDefault.Modifier;
-        if (ColorArgb.HasValue)          defaults &= ~(int)LinearProgressIndicatorDefault.Color;
-        if (TrackColorArgb.HasValue)     defaults &= ~(int)LinearProgressIndicatorDefault.TrackColor;
+        if (Color.HasValue)              defaults &= ~(int)LinearProgressIndicatorDefault.Color;
+        if (TrackColor.HasValue)         defaults &= ~(int)LinearProgressIndicatorDefault.TrackColor;
 
         ProgressIndicatorKt.LinearProgressIndicator(
             modifier:   modifier,
-            color:      ColorArgb       ?? 0L,
-            trackColor: TrackColorArgb  ?? 0L,
+            color:      Color      is { } c ? c : 0L,
+            trackColor: TrackColor is { } t ? t : 0L,
             p3:         0,
             gapSize:    0f,
             _composer:  composer,

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+~override AndroidX.Compose.TextOverflow.Equals(object obj) -> bool
+~override AndroidX.Compose.TextOverflow.ToString() -> string
+abstract AndroidX.Compose.ComposableNode.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 AndroidX.Compose.AlertDialog
 AndroidX.Compose.AlertDialog.AlertDialog(System.Action! onDismissRequest) -> void
 AndroidX.Compose.AlertDialog.ConfirmButton.get -> AndroidX.Compose.ComposableNode?
@@ -76,8 +79,8 @@ AndroidX.Compose.AssistChip.LeadingIcon.set -> void
 AndroidX.Compose.AssistChip.TrailingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.AssistChip.TrailingIcon.set -> void
 AndroidX.Compose.BackHandler
-AndroidX.Compose.BackHandler.BackHandler(System.Action! onBack) -> void
 AndroidX.Compose.BackHandler.BackHandler(System.Action! onBack, bool enabled) -> void
+AndroidX.Compose.BackHandler.BackHandler(System.Action! onBack) -> void
 AndroidX.Compose.Badge
 AndroidX.Compose.Badge.Badge() -> void
 AndroidX.Compose.BadgedBox
@@ -126,12 +129,12 @@ AndroidX.Compose.Checkbox
 AndroidX.Compose.Checkbox.Checkbox(bool checked, System.Action<bool>! onCheckedChange) -> void
 AndroidX.Compose.CircularProgressIndicator
 AndroidX.Compose.CircularProgressIndicator.CircularProgressIndicator() -> void
-AndroidX.Compose.CircularProgressIndicator.ColorArgb.get -> long?
-AndroidX.Compose.CircularProgressIndicator.ColorArgb.set -> void
+AndroidX.Compose.CircularProgressIndicator.Color.get -> AndroidX.Compose.Color?
+AndroidX.Compose.CircularProgressIndicator.Color.set -> void
 AndroidX.Compose.CircularProgressIndicator.StrokeWidthDp.get -> float?
 AndroidX.Compose.CircularProgressIndicator.StrokeWidthDp.set -> void
-AndroidX.Compose.CircularProgressIndicator.TrackColorArgb.get -> long?
-AndroidX.Compose.CircularProgressIndicator.TrackColorArgb.set -> void
+AndroidX.Compose.CircularProgressIndicator.TrackColor.get -> AndroidX.Compose.Color?
+AndroidX.Compose.CircularProgressIndicator.TrackColor.set -> void
 AndroidX.Compose.Color
 AndroidX.Compose.Color.A.get -> byte
 AndroidX.Compose.Color.B.get -> byte
@@ -163,9 +166,9 @@ AndroidX.Compose.ComposableNode.ComposableNode() -> void
 AndroidX.Compose.ComposableNode.Modifier.get -> AndroidX.Compose.Modifier?
 AndroidX.Compose.ComposableNode.Modifier.set -> void
 AndroidX.Compose.ComposableNode.PrependModifier(AndroidX.Compose.Modifier! modifier) -> void
-AndroidX.Compose.ComposeExtensions
 AndroidX.Compose.Composed
 AndroidX.Compose.Composed.Composed(System.Func<AndroidX.Compose.Runtime.IComposer!, AndroidX.Compose.ComposableNode?>! builder) -> void
+AndroidX.Compose.ComposeExtensions
 AndroidX.Compose.CompositionLocal
 AndroidX.Compose.CompositionLocal<T>
 AndroidX.Compose.CompositionLocal<T>.Current(AndroidX.Compose.Runtime.IComposer! composer) -> T
@@ -235,9 +238,9 @@ AndroidX.Compose.DismissibleNavigationDrawer.GesturesEnabled.set -> void
 AndroidX.Compose.DismissibleNavigationDrawer.InitialValue.get -> AndroidX.Compose.Material3.DrawerValue?
 AndroidX.Compose.DismissibleNavigationDrawer.InitialValue.init -> void
 AndroidX.Compose.DisposableEffect
-AndroidX.Compose.DisposableEffect.DisposableEffect(object? key1, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
-AndroidX.Compose.DisposableEffect.DisposableEffect(object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 AndroidX.Compose.DisposableEffect.DisposableEffect(object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+AndroidX.Compose.DisposableEffect.DisposableEffect(object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+AndroidX.Compose.DisposableEffect.DisposableEffect(object? key1, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 AndroidX.Compose.DockedSearchBar
 AndroidX.Compose.DockedSearchBar.DockedSearchBar(bool expanded, System.Action<bool>! onExpandedChange) -> void
 AndroidX.Compose.DockedSearchBar.DockedSearchBar(string! query, System.Action<string!>! onQueryChange, System.Action<string!>! onSearch, bool active, System.Action<bool>! onActiveChange) -> void
@@ -399,8 +402,8 @@ AndroidX.Compose.HorizontalCenteredHeroCarousel<T>.State.set -> void
 AndroidX.Compose.HorizontalCenteredHeroCarousel<T>.UserScrollEnabled.get -> bool?
 AndroidX.Compose.HorizontalCenteredHeroCarousel<T>.UserScrollEnabled.set -> void
 AndroidX.Compose.HorizontalDivider
-AndroidX.Compose.HorizontalDivider.ColorArgb.get -> long?
-AndroidX.Compose.HorizontalDivider.ColorArgb.set -> void
+AndroidX.Compose.HorizontalDivider.Color.get -> AndroidX.Compose.Color?
+AndroidX.Compose.HorizontalDivider.Color.set -> void
 AndroidX.Compose.HorizontalDivider.HorizontalDivider() -> void
 AndroidX.Compose.HorizontalDivider.ThicknessDp.get -> float?
 AndroidX.Compose.HorizontalDivider.ThicknessDp.set -> void
@@ -424,19 +427,14 @@ AndroidX.Compose.HorizontalUncontainedCarousel<T>.State.get -> AndroidX.Compose.
 AndroidX.Compose.HorizontalUncontainedCarousel<T>.State.set -> void
 AndroidX.Compose.HorizontalUncontainedCarousel<T>.UserScrollEnabled.get -> bool?
 AndroidX.Compose.HorizontalUncontainedCarousel<T>.UserScrollEnabled.set -> void
-AndroidX.Compose.IState<T>
-AndroidX.Compose.IState<T>.Value.get -> T
-AndroidX.Compose.IStateFlow<T>
 AndroidX.Compose.Icon
 AndroidX.Compose.Icon.Icon(AndroidX.Compose.UI.Graphics.Painter.Painter! painter, string? contentDescription) -> void
 AndroidX.Compose.Icon.Icon(AndroidX.Compose.UI.Graphics.Vector.ImageVector! imageVector, string? contentDescription) -> void
 AndroidX.Compose.Icon.Icon(int drawableResourceId, string? contentDescription) -> void
-AndroidX.Compose.Icon.TintArgb.get -> long?
-AndroidX.Compose.Icon.TintArgb.set -> void
+AndroidX.Compose.Icon.Tint.get -> AndroidX.Compose.Color?
+AndroidX.Compose.Icon.Tint.set -> void
 AndroidX.Compose.IconButton
 AndroidX.Compose.IconButton.IconButton(System.Action! onClick) -> void
-AndroidX.Compose.IconToggleButton
-AndroidX.Compose.IconToggleButton.IconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 AndroidX.Compose.Icons
 AndroidX.Compose.Icons.AutoMirrored
 AndroidX.Compose.Icons.AutoMirrored.Default
@@ -451,6 +449,8 @@ AndroidX.Compose.Icons.Outlined
 AndroidX.Compose.Icons.Rounded
 AndroidX.Compose.Icons.Sharp
 AndroidX.Compose.Icons.TwoTone
+AndroidX.Compose.IconToggleButton
+AndroidX.Compose.IconToggleButton.IconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
 AndroidX.Compose.Image
 AndroidX.Compose.Image.Alignment.get -> AndroidX.Compose.Alignment?
 AndroidX.Compose.Image.Alignment.set -> void
@@ -459,8 +459,8 @@ AndroidX.Compose.Image.Alpha.set -> void
 AndroidX.Compose.Image.ContentScale.get -> AndroidX.Compose.ContentScale?
 AndroidX.Compose.Image.ContentScale.set -> void
 AndroidX.Compose.Image.Image(AndroidX.Compose.UI.Graphics.Painter.Painter! painter, string? contentDescription) -> void
-AndroidX.Compose.Image.Image(int drawableResourceId) -> void
 AndroidX.Compose.Image.Image(int drawableResourceId, string? contentDescription) -> void
+AndroidX.Compose.Image.Image(int drawableResourceId) -> void
 AndroidX.Compose.InputChip
 AndroidX.Compose.InputChip.Avatar.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.InputChip.Avatar.set -> void
@@ -471,6 +471,9 @@ AndroidX.Compose.InputChip.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.InputChip.LeadingIcon.set -> void
 AndroidX.Compose.InputChip.TrailingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.InputChip.TrailingIcon.set -> void
+AndroidX.Compose.IState<T>
+AndroidX.Compose.IState<T>.Value.get -> T
+AndroidX.Compose.IStateFlow<T>
 AndroidX.Compose.LargeFlexibleTopAppBar
 AndroidX.Compose.LargeFlexibleTopAppBar.Actions.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.LargeFlexibleTopAppBar.Actions.set -> void
@@ -498,9 +501,9 @@ AndroidX.Compose.LargeTopAppBar.Subtitle.set -> void
 AndroidX.Compose.LargeTopAppBar.Title.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.LargeTopAppBar.Title.set -> void
 AndroidX.Compose.LaunchedEffect
-AndroidX.Compose.LaunchedEffect.LaunchedEffect(object? key1, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
-AndroidX.Compose.LaunchedEffect.LaunchedEffect(object? key1, object? key2, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 AndroidX.Compose.LaunchedEffect.LaunchedEffect(object? key1, object? key2, object? key3, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+AndroidX.Compose.LaunchedEffect.LaunchedEffect(object? key1, object? key2, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+AndroidX.Compose.LaunchedEffect.LaunchedEffect(object? key1, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 AndroidX.Compose.LazyColumn<T>
 AndroidX.Compose.LazyColumn<T>.ContentPadding.get -> AndroidX.Compose.Foundation.Layout.IPaddingValues?
 AndroidX.Compose.LazyColumn<T>.ContentPadding.set -> void
@@ -549,11 +552,11 @@ AndroidX.Compose.LeadingIconTab.LeadingIconTab(bool selected, System.Action! onC
 AndroidX.Compose.LeadingIconTab.Text.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.LeadingIconTab.Text.set -> void
 AndroidX.Compose.LinearProgressIndicator
-AndroidX.Compose.LinearProgressIndicator.ColorArgb.get -> long?
-AndroidX.Compose.LinearProgressIndicator.ColorArgb.set -> void
+AndroidX.Compose.LinearProgressIndicator.Color.get -> AndroidX.Compose.Color?
+AndroidX.Compose.LinearProgressIndicator.Color.set -> void
 AndroidX.Compose.LinearProgressIndicator.LinearProgressIndicator() -> void
-AndroidX.Compose.LinearProgressIndicator.TrackColorArgb.get -> long?
-AndroidX.Compose.LinearProgressIndicator.TrackColorArgb.set -> void
+AndroidX.Compose.LinearProgressIndicator.TrackColor.get -> AndroidX.Compose.Color?
+AndroidX.Compose.LinearProgressIndicator.TrackColor.set -> void
 AndroidX.Compose.LinkAnnotation
 AndroidX.Compose.ListItem
 AndroidX.Compose.ListItem.Headline.get -> AndroidX.Compose.ComposableNode?
@@ -659,8 +662,8 @@ AndroidX.Compose.MutableStateList<T>.IndexOf(T item) -> int
 AndroidX.Compose.MutableStateList<T>.Insert(int index, T item) -> void
 AndroidX.Compose.MutableStateList<T>.IsReadOnly.get -> bool
 AndroidX.Compose.MutableStateList<T>.MutableStateList() -> void
-AndroidX.Compose.MutableStateList<T>.MutableStateList(System.Collections.Generic.IEnumerable<T>! initial) -> void
 AndroidX.Compose.MutableStateList<T>.MutableStateList(params T[]! elements) -> void
+AndroidX.Compose.MutableStateList<T>.MutableStateList(System.Collections.Generic.IEnumerable<T>! initial) -> void
 AndroidX.Compose.MutableStateList<T>.Remove(T item) -> bool
 AndroidX.Compose.MutableStateList<T>.RemoveAt(int index) -> void
 AndroidX.Compose.MutableStateList<T>.this[int index].get -> T
@@ -680,26 +683,26 @@ AndroidX.Compose.MutableStateMap<TKey, TValue>.MutableStateMap() -> void
 AndroidX.Compose.MutableStateMap<TKey, TValue>.MutableStateMap(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>! initial) -> void
 AndroidX.Compose.MutableStateMap<TKey, TValue>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) -> bool
 AndroidX.Compose.MutableStateMap<TKey, TValue>.Remove(TKey key) -> bool
-AndroidX.Compose.MutableStateMap<TKey, TValue>.TryGetValue(TKey key, out TValue value) -> bool
-AndroidX.Compose.MutableStateMap<TKey, TValue>.Values.get -> System.Collections.Generic.ICollection<TValue>!
 AndroidX.Compose.MutableStateMap<TKey, TValue>.this[TKey key].get -> TValue
 AndroidX.Compose.MutableStateMap<TKey, TValue>.this[TKey key].set -> void
+AndroidX.Compose.MutableStateMap<TKey, TValue>.TryGetValue(TKey key, out TValue value) -> bool
+AndroidX.Compose.MutableStateMap<TKey, TValue>.Values.get -> System.Collections.Generic.ICollection<TValue>!
 AndroidX.Compose.NavBackStackEntry
 AndroidX.Compose.NavBackStackEntry.Arguments.get -> Android.OS.Bundle?
 AndroidX.Compose.NavBackStackEntry.Route.get -> string?
 AndroidX.Compose.NavController
 AndroidX.Compose.NavController.CurrentBackStackEntry.get -> AndroidX.Compose.NavBackStackEntry?
 AndroidX.Compose.NavController.NavController() -> void
-AndroidX.Compose.NavController.Navigate(string! route) -> void
 AndroidX.Compose.NavController.Navigate(string! route, AndroidX.Compose.NavOptions! options) -> void
+AndroidX.Compose.NavController.Navigate(string! route) -> void
 AndroidX.Compose.NavController.NavigateUp() -> bool
 AndroidX.Compose.NavController.PopBackStack() -> bool
 AndroidX.Compose.NavController.PopBackStack(string! route, bool inclusive) -> bool
 AndroidX.Compose.NavDestination
 AndroidX.Compose.NavDestination.Add(AndroidX.Compose.ComposableNode? child) -> void
 AndroidX.Compose.NavDestination.Add(AndroidX.Compose.Modifier! modifier) -> void
-AndroidX.Compose.NavDestination.NavDestination(string! route) -> void
 AndroidX.Compose.NavDestination.NavDestination(string! route, System.Func<AndroidX.Compose.NavBackStackEntry!, AndroidX.Compose.ComposableNode!>! content) -> void
+AndroidX.Compose.NavDestination.NavDestination(string! route) -> void
 AndroidX.Compose.NavDestination.Route.get -> string!
 AndroidX.Compose.NavHost
 AndroidX.Compose.NavHost.Add(AndroidX.Compose.Modifier! modifier) -> void
@@ -707,18 +710,6 @@ AndroidX.Compose.NavHost.Add(AndroidX.Compose.NavDestination? route) -> void
 AndroidX.Compose.NavHost.NavController.get -> AndroidX.Compose.NavController!
 AndroidX.Compose.NavHost.NavHost(string! startDestination, AndroidX.Compose.NavController? navController = null) -> void
 AndroidX.Compose.NavHost.StartDestination.get -> string!
-AndroidX.Compose.NavOptions
-AndroidX.Compose.NavOptions.LaunchSingleTop.get -> bool
-AndroidX.Compose.NavOptions.LaunchSingleTop.set -> void
-AndroidX.Compose.NavOptions.NavOptions() -> void
-AndroidX.Compose.NavOptions.PopUpToInclusive.get -> bool
-AndroidX.Compose.NavOptions.PopUpToInclusive.set -> void
-AndroidX.Compose.NavOptions.PopUpToRoute.get -> string?
-AndroidX.Compose.NavOptions.PopUpToRoute.set -> void
-AndroidX.Compose.NavOptions.PopUpToSaveState.get -> bool
-AndroidX.Compose.NavOptions.PopUpToSaveState.set -> void
-AndroidX.Compose.NavOptions.RestoreState.get -> bool
-AndroidX.Compose.NavOptions.RestoreState.set -> void
 AndroidX.Compose.NavigationBar
 AndroidX.Compose.NavigationBar.NavigationBar() -> void
 AndroidX.Compose.NavigationBarItem
@@ -743,6 +734,18 @@ AndroidX.Compose.NavigationRailItem.Icon.set -> void
 AndroidX.Compose.NavigationRailItem.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.NavigationRailItem.Label.set -> void
 AndroidX.Compose.NavigationRailItem.NavigationRailItem(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.NavOptions
+AndroidX.Compose.NavOptions.LaunchSingleTop.get -> bool
+AndroidX.Compose.NavOptions.LaunchSingleTop.set -> void
+AndroidX.Compose.NavOptions.NavOptions() -> void
+AndroidX.Compose.NavOptions.PopUpToInclusive.get -> bool
+AndroidX.Compose.NavOptions.PopUpToInclusive.set -> void
+AndroidX.Compose.NavOptions.PopUpToRoute.get -> string?
+AndroidX.Compose.NavOptions.PopUpToRoute.set -> void
+AndroidX.Compose.NavOptions.PopUpToSaveState.get -> bool
+AndroidX.Compose.NavOptions.PopUpToSaveState.set -> void
+AndroidX.Compose.NavOptions.RestoreState.get -> bool
+AndroidX.Compose.NavOptions.RestoreState.set -> void
 AndroidX.Compose.Offset
 AndroidX.Compose.Offset.Equals(AndroidX.Compose.Offset other) -> bool
 AndroidX.Compose.Offset.Offset() -> void
@@ -855,6 +858,8 @@ AndroidX.Compose.Scaffold.SnackbarHost.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Scaffold.SnackbarHost.set -> void
 AndroidX.Compose.Scaffold.TopBar.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Scaffold.TopBar.set -> void
+AndroidX.Compose.ScrollableTabRow
+AndroidX.Compose.ScrollableTabRow.ScrollableTabRow(int selectedTabIndex) -> void
 AndroidX.Compose.ScrollState
 AndroidX.Compose.ScrollState.AnimateScrollToAsync(int value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 AndroidX.Compose.ScrollState.CanScrollBackward.get -> bool
@@ -865,8 +870,6 @@ AndroidX.Compose.ScrollState.ScrollState(int initial = 0) -> void
 AndroidX.Compose.ScrollState.ScrollToAsync(int value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<float>!
 AndroidX.Compose.ScrollState.Value.get -> int
 AndroidX.Compose.ScrollState.ViewportSize.get -> int
-AndroidX.Compose.ScrollableTabRow
-AndroidX.Compose.ScrollableTabRow.ScrollableTabRow(int selectedTabIndex) -> void
 AndroidX.Compose.SearchBar
 AndroidX.Compose.SearchBar.InputField.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.SearchBar.InputField.set -> void
@@ -928,10 +931,10 @@ AndroidX.Compose.SemanticsRole.Tab = 4 -> AndroidX.Compose.SemanticsRole
 AndroidX.Compose.SemanticsRole.ValuePicker = 7 -> AndroidX.Compose.SemanticsRole
 AndroidX.Compose.SemanticsScope
 AndroidX.Compose.SemanticsScope.ContentDescription(string! description) -> AndroidX.Compose.SemanticsScope!
-AndroidX.Compose.SemanticsScope.OnClick(System.Action! action) -> AndroidX.Compose.SemanticsScope!
-AndroidX.Compose.SemanticsScope.OnClick(System.Func<bool>! action) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.OnClick(string? label, System.Action! action) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.OnClick(string? label, System.Func<bool>! action) -> AndroidX.Compose.SemanticsScope!
+AndroidX.Compose.SemanticsScope.OnClick(System.Action! action) -> AndroidX.Compose.SemanticsScope!
+AndroidX.Compose.SemanticsScope.OnClick(System.Func<bool>! action) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.Role(AndroidX.Compose.SemanticsRole role) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.Selected(bool isSelected) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.StateDescription(string! description) -> AndroidX.Compose.SemanticsScope!
@@ -1144,8 +1147,8 @@ AndroidX.Compose.Transitions
 AndroidX.Compose.TriStateCheckbox
 AndroidX.Compose.TriStateCheckbox.TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState! state, System.Action! onClick) -> void
 AndroidX.Compose.VerticalDivider
-AndroidX.Compose.VerticalDivider.ColorArgb.get -> long?
-AndroidX.Compose.VerticalDivider.ColorArgb.set -> void
+AndroidX.Compose.VerticalDivider.Color.get -> AndroidX.Compose.Color?
+AndroidX.Compose.VerticalDivider.Color.set -> void
 AndroidX.Compose.VerticalDivider.ThicknessDp.get -> float?
 AndroidX.Compose.VerticalDivider.ThicknessDp.set -> void
 AndroidX.Compose.VerticalDivider.VerticalDivider() -> void
@@ -1171,7 +1174,6 @@ AndroidX.Compose.WideNavigationRailState.CurrentValue.get -> AndroidX.Compose.Ma
 AndroidX.Compose.WideNavigationRailState.InitialValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!
 AndroidX.Compose.WideNavigationRailState.TargetValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!
 AndroidX.Compose.WideNavigationRailState.WideNavigationRailState(AndroidX.Compose.Material3.WideNavigationRailValue? initialValue = null) -> void
-abstract AndroidX.Compose.ComposableNode.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.AlertDialog.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.AnimatedContent<T>.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.AnimatedVisibility.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
@@ -1347,9 +1349,9 @@ static AndroidX.Compose.Arrangement.Center.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.End.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.SpaceAround.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.SpaceBetween.get -> AndroidX.Compose.Arrangement!
-static AndroidX.Compose.Arrangement.SpaceEvenly.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.SpacedBy(AndroidX.Compose.Dp dp) -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.SpacedBy(int dp) -> AndroidX.Compose.Arrangement!
+static AndroidX.Compose.Arrangement.SpaceEvenly.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Start.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Top.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Color.Black.get -> AndroidX.Compose.Color
@@ -1362,34 +1364,34 @@ static AndroidX.Compose.Color.FromHex(string! hex) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.FromRgb(byte red, byte green, byte blue) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Gray.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Green.get -> AndroidX.Compose.Color
+static AndroidX.Compose.Color.implicit operator AndroidX.Compose.Color(long packedValue) -> AndroidX.Compose.Color
+static AndroidX.Compose.Color.implicit operator long(AndroidX.Compose.Color c) -> long
 static AndroidX.Compose.Color.LightGray.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Magenta.get -> AndroidX.Compose.Color
+static AndroidX.Compose.Color.operator !=(AndroidX.Compose.Color left, AndroidX.Compose.Color right) -> bool
+static AndroidX.Compose.Color.operator ==(AndroidX.Compose.Color left, AndroidX.Compose.Color right) -> bool
 static AndroidX.Compose.Color.Red.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Transparent.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Unspecified.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.White.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Yellow.get -> AndroidX.Compose.Color
-static AndroidX.Compose.Color.implicit operator AndroidX.Compose.Color(long packedValue) -> AndroidX.Compose.Color
-static AndroidX.Compose.Color.implicit operator long(AndroidX.Compose.Color c) -> long
-static AndroidX.Compose.Color.operator !=(AndroidX.Compose.Color left, AndroidX.Compose.Color right) -> bool
-static AndroidX.Compose.Color.operator ==(AndroidX.Compose.Color left, AndroidX.Compose.Color right) -> bool
 static AndroidX.Compose.ComposeExtensions.BooleanResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> bool
 static AndroidX.Compose.ComposeExtensions.ColorResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> long
 static AndroidX.Compose.ComposeExtensions.ColorScheme(this AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.Material3.ColorScheme!
 static AndroidX.Compose.ComposeExtensions.DerivedStateOf<T>(System.Func<T>! calculation) -> AndroidX.Compose.DerivedState<T>!
 static AndroidX.Compose.ComposeExtensions.DerivedStateOf<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T>! calculation) -> AndroidX.Compose.DerivedState<T>!
 static AndroidX.Compose.ComposeExtensions.DimensionResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> AndroidX.Compose.Dp
-static AndroidX.Compose.ComposeExtensions.DisposableEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
-static AndroidX.Compose.ComposeExtensions.DisposableEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 static AndroidX.Compose.ComposeExtensions.DisposableEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+static AndroidX.Compose.ComposeExtensions.DisposableEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, object? key2, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
+static AndroidX.Compose.ComposeExtensions.DisposableEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, System.Func<AndroidX.Compose.Runtime.DisposableEffectScope!, System.Action!>! effect) -> void
 static AndroidX.Compose.ComposeExtensions.EnableEdgeToEdge(this AndroidX.Activity.ComponentActivity! activity) -> void
 static AndroidX.Compose.ComposeExtensions.EnterAlwaysScrollBehavior(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Material3.TopAppBarState! state, int line = 0, string! file = "") -> AndroidX.Compose.Material3.ITopAppBarScrollBehavior!
 static AndroidX.Compose.ComposeExtensions.ExitUntilCollapsedScrollBehavior(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Material3.TopAppBarState! state, int line = 0, string! file = "") -> AndroidX.Compose.Material3.ITopAppBarScrollBehavior!
 static AndroidX.Compose.ComposeExtensions.IntegerArrayResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> int[]!
 static AndroidX.Compose.ComposeExtensions.IntegerResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> int
-static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
-static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, object? key2, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, object? key2, object? key3, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, object? key2, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
+static AndroidX.Compose.ComposeExtensions.LaunchedEffect(this AndroidX.Compose.Runtime.IComposer! composer, object? key1, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! body) -> void
 static AndroidX.Compose.ComposeExtensions.MutableStateFlowOf<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, int line = 0, string! file = "") -> AndroidX.Compose.MutableStateFlow<T>!
 static AndroidX.Compose.ComposeExtensions.MutableStateOf(this AndroidX.Compose.Runtime.IComposer! composer, double initial, int line = 0, string! file = "") -> AndroidX.Compose.MutableNumberState<double>!
 static AndroidX.Compose.ComposeExtensions.MutableStateOf(this AndroidX.Compose.Runtime.IComposer! composer, float initial, int line = 0, string! file = "") -> AndroidX.Compose.MutableNumberState<float>!
@@ -1400,12 +1402,12 @@ static AndroidX.Compose.ComposeExtensions.NewTextFieldValue(string! text = "", l
 static AndroidX.Compose.ComposeExtensions.NewTextFieldValue(this AndroidX.Compose.Runtime.IComposer! composer, string! text = "", long selection = 0, AndroidX.Compose.UI.Text.TextRange? composition = null) -> AndroidX.Compose.UI.Text.Input.TextFieldValue!
 static AndroidX.Compose.ComposeExtensions.PainterResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> AndroidX.Compose.UI.Graphics.Painter.Painter!
 static AndroidX.Compose.ComposeExtensions.PinnedScrollBehavior(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Material3.TopAppBarState! state, int line = 0, string! file = "") -> AndroidX.Compose.Material3.ITopAppBarScrollBehavior!
-static AndroidX.Compose.ComposeExtensions.PluralStringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id, int count) -> string!
 static AndroidX.Compose.ComposeExtensions.PluralStringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id, int count, params object?[]! formatArgs) -> string!
-static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
-static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object? key1, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
-static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object? key1, object? key2, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
+static AndroidX.Compose.ComposeExtensions.PluralStringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id, int count) -> string!
 static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
+static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object? key1, object? key2, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
+static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object? key1, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
+static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
 static AndroidX.Compose.ComposeExtensions.ProduceStateKeyed<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object?[]! keys, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
 static AndroidX.Compose.ComposeExtensions.Remember<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T>! factory, int line = 0, string! file = "") -> T
 static AndroidX.Compose.ComposeExtensions.Remember<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
@@ -1426,8 +1428,8 @@ static AndroidX.Compose.ComposeExtensions.Shapes(this AndroidX.Compose.Runtime.I
 static AndroidX.Compose.ComposeExtensions.SideEffect(this AndroidX.Compose.Runtime.IComposer! composer, System.Action! effect) -> void
 static AndroidX.Compose.ComposeExtensions.SnapshotFlow<T>(System.Func<T>! producer) -> System.Collections.Generic.IAsyncEnumerable<T>!
 static AndroidX.Compose.ComposeExtensions.StringArrayResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> string![]!
-static AndroidX.Compose.ComposeExtensions.StringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> string!
 static AndroidX.Compose.ComposeExtensions.StringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id, params object?[]! formatArgs) -> string!
+static AndroidX.Compose.ComposeExtensions.StringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> string!
 static AndroidX.Compose.ComposeExtensions.Typography(this AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.Material3.Typography!
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, int line = 0, string! file = "") -> T!
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, object? key1, int line = 0, string! file = "") -> T!
@@ -1445,8 +1447,6 @@ static AndroidX.Compose.ContentScale.FillWidth.get -> AndroidX.Compose.ContentSc
 static AndroidX.Compose.ContentScale.Fit.get -> AndroidX.Compose.ContentScale!
 static AndroidX.Compose.ContentScale.Inside.get -> AndroidX.Compose.ContentScale!
 static AndroidX.Compose.ContentScale.None.get -> AndroidX.Compose.ContentScale!
-static AndroidX.Compose.Dp.Pack(AndroidX.Compose.Dp? value) -> float
-static AndroidX.Compose.Dp.Zero.get -> AndroidX.Compose.Dp
 static AndroidX.Compose.Dp.implicit operator AndroidX.Compose.Dp(float value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.Dp.implicit operator AndroidX.Compose.Dp(int value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.Dp.operator -(AndroidX.Compose.Dp a, AndroidX.Compose.Dp b) -> AndroidX.Compose.Dp
@@ -1462,6 +1462,8 @@ static AndroidX.Compose.Dp.operator <=(AndroidX.Compose.Dp a, AndroidX.Compose.D
 static AndroidX.Compose.Dp.operator ==(AndroidX.Compose.Dp left, AndroidX.Compose.Dp right) -> bool
 static AndroidX.Compose.Dp.operator >(AndroidX.Compose.Dp a, AndroidX.Compose.Dp b) -> bool
 static AndroidX.Compose.Dp.operator >=(AndroidX.Compose.Dp a, AndroidX.Compose.Dp b) -> bool
+static AndroidX.Compose.Dp.Pack(AndroidX.Compose.Dp? value) -> float
+static AndroidX.Compose.Dp.Zero.get -> AndroidX.Compose.Dp
 static AndroidX.Compose.DpExtensions.Dp(this float value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.DpExtensions.Dp(this int value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.FontFamily.Cursive.get -> AndroidX.Compose.FontFamily!
@@ -1805,15 +1807,15 @@ static AndroidX.Compose.Modifier.Align(AndroidX.Compose.Alignment.Horizontal! al
 static AndroidX.Compose.Modifier.Align(AndroidX.Compose.Alignment.Vertical! alignment) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Alpha(float alpha) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.AspectRatio(float ratio, bool matchHeightConstraintsFirst = false) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.Background(AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Background(AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.Border(AndroidX.Compose.Dp width, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.Background(AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Border(AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Border(AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.Border(AndroidX.Compose.Dp width, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.CaptionBarPadding() -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.ClearAndSetSemantics(System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.ClearAndSetSemantics(string! contentDescription) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.ClearAndSetSemantics(string? contentDescription, AndroidX.Compose.SemanticsRole? role) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.ClearAndSetSemantics(System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Clickable(System.Action! onClick) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Clip(AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Clip(AndroidX.Compose.Shape! shape) -> AndroidX.Compose.Modifier!
@@ -1827,9 +1829,9 @@ static AndroidX.Compose.Modifier.Draggable(AndroidX.Compose.DraggableState! stat
 static AndroidX.Compose.Modifier.FillMaxHeight(float fraction = 1) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.FillMaxSize(float fraction = 1) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.FillMaxWidth(float fraction = 1) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.Focusable(bool enabled = true) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.FocusGroup() -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.FocusRequester(AndroidX.Compose.FocusRequester! requester) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.Focusable(bool enabled = true) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, long? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Height(AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.HeightIn(AndroidX.Compose.Dp? min = null, AndroidX.Compose.Dp? max = null) -> AndroidX.Compose.Modifier!
@@ -1857,12 +1859,12 @@ static AndroidX.Compose.Modifier.Scale(float scale) -> AndroidX.Compose.Modifier
 static AndroidX.Compose.Modifier.Scale(float scaleX, float scaleY) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Selectable(bool selected, System.Action! onClick) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Semantics(AndroidX.Compose.SemanticsRole role) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.Semantics(System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.Semantics(bool mergeDescendants, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Semantics(bool mergeDescendants, string! contentDescription) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Semantics(bool mergeDescendants, string? contentDescription, AndroidX.Compose.SemanticsRole? role) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.Semantics(bool mergeDescendants, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Semantics(string! contentDescription) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Semantics(string? contentDescription, AndroidX.Compose.SemanticsRole? role) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.Semantics(System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Shadow(AndroidX.Compose.Dp elevation, AndroidX.Compose.Shape? shape = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Size(AndroidX.Compose.Dp size) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Size(AndroidX.Compose.Dp width, AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
@@ -1887,15 +1889,15 @@ static AndroidX.Compose.ModifierExtensions.Align(this AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Align(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Alignment.Vertical! alignment) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Alpha(this AndroidX.Compose.Modifier! modifier, float alpha) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.AspectRatio(this AndroidX.Compose.Modifier! modifier, float ratio, bool matchHeightConstraintsFirst = false) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.CaptionBarPadding(this AndroidX.Compose.Modifier! modifier) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.ClearAndSetSemantics(this AndroidX.Compose.Modifier! modifier, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.ClearAndSetSemantics(this AndroidX.Compose.Modifier! modifier, string! contentDescription) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.ClearAndSetSemantics(this AndroidX.Compose.Modifier! modifier, string? contentDescription, AndroidX.Compose.SemanticsRole? role) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.ClearAndSetSemantics(this AndroidX.Compose.Modifier! modifier, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Clickable(this AndroidX.Compose.Modifier! modifier, System.Action! onClick) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Clip(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Clip(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Shape! shape) -> AndroidX.Compose.Modifier!
@@ -1908,9 +1910,9 @@ static AndroidX.Compose.ModifierExtensions.Draggable(this AndroidX.Compose.Modif
 static AndroidX.Compose.ModifierExtensions.FillMaxHeight(this AndroidX.Compose.Modifier! modifier, float fraction = 1) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.FillMaxSize(this AndroidX.Compose.Modifier! modifier, float fraction = 1) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.FillMaxWidth(this AndroidX.Compose.Modifier! modifier, float fraction = 1) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Focusable(this AndroidX.Compose.Modifier! modifier, bool enabled = true) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.FocusGroup(this AndroidX.Compose.Modifier! modifier) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.FocusRequester(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.FocusRequester! requester) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.Focusable(this AndroidX.Compose.Modifier! modifier, bool enabled = true) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.GraphicsLayer(this AndroidX.Compose.Modifier! modifier, float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, long? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Height(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.HeightIn(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp? min = null, AndroidX.Compose.Dp? max = null) -> AndroidX.Compose.Modifier!
@@ -1938,12 +1940,12 @@ static AndroidX.Compose.ModifierExtensions.Scale(this AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Scale(this AndroidX.Compose.Modifier! modifier, float scaleX, float scaleY) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Selectable(this AndroidX.Compose.Modifier! modifier, bool selected, System.Action! onClick) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.SemanticsRole role) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, bool mergeDescendants, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, bool mergeDescendants, string! contentDescription) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, bool mergeDescendants, string? contentDescription, AndroidX.Compose.SemanticsRole? role) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, bool mergeDescendants, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, string! contentDescription) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, string? contentDescription, AndroidX.Compose.SemanticsRole? role) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Semantics(this AndroidX.Compose.Modifier! modifier, System.Action<AndroidX.Compose.SemanticsScope!>! properties) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Shadow(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp elevation, AndroidX.Compose.Shape? shape = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Size(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp size) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Size(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
@@ -1962,21 +1964,19 @@ static AndroidX.Compose.ModifierExtensions.WrapContentHeight(this AndroidX.Compo
 static AndroidX.Compose.ModifierExtensions.WrapContentSize(this AndroidX.Compose.Modifier! modifier, bool unbounded = false) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.WrapContentWidth(this AndroidX.Compose.Modifier! modifier, bool unbounded = false) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.ZIndex(this AndroidX.Compose.Modifier! modifier, float z) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.MutableNumberState<T>.operator ++(AndroidX.Compose.MutableNumberState<T>! s) -> AndroidX.Compose.MutableNumberState<T>!
 static AndroidX.Compose.MutableNumberState<T>.operator --(AndroidX.Compose.MutableNumberState<T>! s) -> AndroidX.Compose.MutableNumberState<T>!
+static AndroidX.Compose.MutableNumberState<T>.operator ++(AndroidX.Compose.MutableNumberState<T>! s) -> AndroidX.Compose.MutableNumberState<T>!
 static AndroidX.Compose.MutableState<T>.implicit operator T(AndroidX.Compose.MutableState<T>! state) -> T
-static AndroidX.Compose.Offset.Unspecified.get -> AndroidX.Compose.Offset
-static AndroidX.Compose.Offset.Zero.get -> AndroidX.Compose.Offset
 static AndroidX.Compose.Offset.operator !=(AndroidX.Compose.Offset a, AndroidX.Compose.Offset b) -> bool
 static AndroidX.Compose.Offset.operator ==(AndroidX.Compose.Offset a, AndroidX.Compose.Offset b) -> bool
+static AndroidX.Compose.Offset.Unspecified.get -> AndroidX.Compose.Offset
+static AndroidX.Compose.Offset.Zero.get -> AndroidX.Compose.Offset
 static AndroidX.Compose.Shape.Circle() -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.CutCorners(AndroidX.Compose.Dp cornerSize) -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.CutCornersPercent(int percent) -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.RoundedCorners(AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.RoundedCorners(AndroidX.Compose.Dp topStart, AndroidX.Compose.Dp topEnd, AndroidX.Compose.Dp bottomEnd, AndroidX.Compose.Dp bottomStart) -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.RoundedPercent(int percent) -> AndroidX.Compose.Shape!
-static AndroidX.Compose.Sp.Pack(AndroidX.Compose.Sp? value) -> long
-static AndroidX.Compose.Sp.Zero.get -> AndroidX.Compose.Sp
 static AndroidX.Compose.Sp.implicit operator AndroidX.Compose.Sp(int value) -> AndroidX.Compose.Sp
 static AndroidX.Compose.Sp.operator -(AndroidX.Compose.Sp a) -> AndroidX.Compose.Sp
 static AndroidX.Compose.Sp.operator !=(AndroidX.Compose.Sp left, AndroidX.Compose.Sp right) -> bool
@@ -1988,17 +1988,19 @@ static AndroidX.Compose.Sp.operator <=(AndroidX.Compose.Sp a, AndroidX.Compose.S
 static AndroidX.Compose.Sp.operator ==(AndroidX.Compose.Sp left, AndroidX.Compose.Sp right) -> bool
 static AndroidX.Compose.Sp.operator >(AndroidX.Compose.Sp a, AndroidX.Compose.Sp b) -> bool
 static AndroidX.Compose.Sp.operator >=(AndroidX.Compose.Sp a, AndroidX.Compose.Sp b) -> bool
-static AndroidX.Compose.SpExtensions.Sp(this int value) -> AndroidX.Compose.Sp
+static AndroidX.Compose.Sp.Pack(AndroidX.Compose.Sp? value) -> long
+static AndroidX.Compose.Sp.Zero.get -> AndroidX.Compose.Sp
 static AndroidX.Compose.Spacer.Height(AndroidX.Compose.Dp dp) -> AndroidX.Compose.Spacer!
 static AndroidX.Compose.Spacer.Size(AndroidX.Compose.Dp dp) -> AndroidX.Compose.Spacer!
 static AndroidX.Compose.Spacer.Size(AndroidX.Compose.Dp width, AndroidX.Compose.Dp height) -> AndroidX.Compose.Spacer!
 static AndroidX.Compose.Spacer.Weight(float weight, bool fill = true) -> AndroidX.Compose.Spacer!
 static AndroidX.Compose.Spacer.Width(AndroidX.Compose.Dp dp) -> AndroidX.Compose.Spacer!
+static AndroidX.Compose.SpExtensions.Sp(this int value) -> AndroidX.Compose.Sp
 static AndroidX.Compose.StaggeredGridCells.Adaptive(float minSizeDp) -> AndroidX.Compose.Foundation.Lazy.Staggeredgrid.IStaggeredGridCells!
 static AndroidX.Compose.StaggeredGridCells.Fixed(int count) -> AndroidX.Compose.Foundation.Lazy.Staggeredgrid.IStaggeredGridCells!
 static AndroidX.Compose.StaggeredGridCells.FixedSize(float sizeDp) -> AndroidX.Compose.Foundation.Lazy.Staggeredgrid.IStaggeredGridCells!
-static AndroidX.Compose.StateFlowExtensions.CollectAsStateWithLifecycle<T>(this AndroidX.Compose.IStateFlow<T>! flow) -> AndroidX.Compose.IState<T>!
 static AndroidX.Compose.StateFlowExtensions.CollectAsStateWithLifecycle<T>(this AndroidX.Compose.IStateFlow<T>! flow, T initialValue) -> AndroidX.Compose.IState<T>!
+static AndroidX.Compose.StateFlowExtensions.CollectAsStateWithLifecycle<T>(this AndroidX.Compose.IStateFlow<T>! flow) -> AndroidX.Compose.IState<T>!
 static AndroidX.Compose.TextAlign.Center.get -> AndroidX.Compose.TextAlign!
 static AndroidX.Compose.TextAlign.End.get -> AndroidX.Compose.TextAlign!
 static AndroidX.Compose.TextAlign.Justify.get -> AndroidX.Compose.TextAlign!
@@ -2012,11 +2014,11 @@ static AndroidX.Compose.TextDecoration.Underline.get -> AndroidX.Compose.TextDec
 static AndroidX.Compose.TextOverflow.Clip.get -> AndroidX.Compose.TextOverflow
 static AndroidX.Compose.TextOverflow.Ellipsis.get -> AndroidX.Compose.TextOverflow
 static AndroidX.Compose.TextOverflow.MiddleEllipsis.get -> AndroidX.Compose.TextOverflow
+static AndroidX.Compose.TextOverflow.operator !=(AndroidX.Compose.TextOverflow left, AndroidX.Compose.TextOverflow right) -> bool
+static AndroidX.Compose.TextOverflow.operator ==(AndroidX.Compose.TextOverflow left, AndroidX.Compose.TextOverflow right) -> bool
 static AndroidX.Compose.TextOverflow.Pack(AndroidX.Compose.TextOverflow? value) -> int
 static AndroidX.Compose.TextOverflow.StartEllipsis.get -> AndroidX.Compose.TextOverflow
 static AndroidX.Compose.TextOverflow.Visible.get -> AndroidX.Compose.TextOverflow
-static AndroidX.Compose.TextOverflow.operator !=(AndroidX.Compose.TextOverflow left, AndroidX.Compose.TextOverflow right) -> bool
-static AndroidX.Compose.TextOverflow.operator ==(AndroidX.Compose.TextOverflow left, AndroidX.Compose.TextOverflow right) -> bool
 static AndroidX.Compose.TransformOrigin.Center.get -> long
 static AndroidX.Compose.TransformOrigin.Pack(float pivotFractionX, float pivotFractionY) -> long
 static AndroidX.Compose.Transitions.FadeIn(float initialAlpha = 0, AndroidX.Compose.Animation.Core.IFiniteAnimationSpec? animationSpec = null) -> AndroidX.Compose.Animation.EnterTransition!
@@ -2030,5 +2032,3 @@ static AndroidX.Compose.Transitions.SlideOutVertically(System.Func<int, int>? ta
 virtual AndroidX.Compose.MutableState<T>.Value.get -> T
 virtual AndroidX.Compose.MutableState<T>.Value.set -> void
 virtual AndroidX.Compose.ViewModel.OnClearedCore() -> void
-~override AndroidX.Compose.TextOverflow.Equals(object obj) -> bool
-~override AndroidX.Compose.TextOverflow.ToString() -> string

--- a/src/Microsoft.AndroidX.Compose/VerticalDivider.cs
+++ b/src/Microsoft.AndroidX.Compose/VerticalDivider.cs
@@ -12,8 +12,8 @@ public sealed class VerticalDivider : ComposableNode
     /// <summary>Optional explicit thickness in Dp. Leave null to use the Material default.</summary>
     public float? ThicknessDp { get; set; }
 
-    /// <summary>Optional explicit ARGB color (packed into a Compose <c>Color</c> long). Leave null to use the Material default.</summary>
-    public long? ColorArgb { get; set; }
+    /// <summary>Optional explicit color. Leave null to use the Material default.</summary>
+    public Color? Color { get; set; }
 
     public override void Render(IComposer composer)
     {
@@ -22,12 +22,12 @@ public sealed class VerticalDivider : ComposableNode
         int defaults = (int)VerticalDividerDefault.All;
         if (modifier is not null)        defaults &= ~(int)VerticalDividerDefault.Modifier;
         if (ThicknessDp.HasValue)        defaults &= ~(int)VerticalDividerDefault.Thickness;
-        if (ColorArgb.HasValue)          defaults &= ~(int)VerticalDividerDefault.Color;
+        if (Color.HasValue)              defaults &= ~(int)VerticalDividerDefault.Color;
 
         DividerKt.VerticalDivider(
             modifier:  modifier,
             thickness: ThicknessDp ?? 0f,
-            color:     ColorArgb   ?? 0L,
+            color:     Color is { } c ? c : 0L,
             _composer: composer,
             p4:        0,
             _changed:  defaults);


### PR DESCRIPTION
After [#221](../pull/221) (implicit `long → Color` conversion) and [#222](../pull/222) (theme reads off composer), the `*Argb` suffix on color properties is vestigial — callers can pass `scheme.OnSurface` (a `long`) straight to a `Color?` property and the implicit conversion does the rest. The five hand-written facades that still exposed `long? *Argb` are renamed here to match the shape the source-generated `Text` facade already uses (`public Color? Color`).

### Renames

| File | Before | After |
|------|--------|-------|
| `Icon.cs` | `long? TintArgb` | `Color? Tint` |
| `HorizontalDivider.cs` | `long? ColorArgb` | `Color? Color` |
| `VerticalDivider.cs` | `long? ColorArgb` | `Color? Color` |
| `CircularProgressIndicator.cs` | `long? ColorArgb`, `long? TrackColorArgb` | `Color? Color`, `Color? TrackColor` |
| `LinearProgressIndicator.cs` | `long? ColorArgb`, `long? TrackColorArgb` | `Color? Color`, `Color? TrackColor` |

The render bodies still call the bound `DividerKt` / `ProgressIndicatorKt` / `IconKt` bindings (and the `IconPainter` bridge) with a `long` color slot; the new properties are converted via `Color is { } c ? c : 0L`.

### No `[Obsolete]` aliases

Same rationale as [#221](../pull/221), [#223](../pull/223), [#225](../pull/225), [#226](../pull/226), [#229](../pull/229): every removed entry was in `PublicAPI.Unshipped.txt`, never `Shipped.txt`, so a clean break is acceptable pre-1.0. Verified — only `Color.FromArgb(...)` factories remain (intentional, those aren't being renamed).

### Sweep

19 callsite renames across two samples; JetNews and the Gallery had no references.

| Sample | File | Hits |
|--------|------|------|
| Jetchat | `Conversation.cs` | 5 |
| Jetchat | `Profile.cs` | 4 |
| Jetchat | `RecordButton.cs` | 2 |
| Jetchat | `JetchatIcon.cs` | 2 |
| Jetchat | `JetchatDrawer.cs` | 1 |
| Reply | `EmailDetailAppBar.cs` | 1 |
| Reply | `ReplyEmailListItem.cs` | 1 |
| Reply | `ReplyEmailThreadItem.cs` | 1 |
| Reply | `ReplyProfileImage.cs` | 1 |
| Reply | `ReplySearchBar.cs` | 1 |

### Verified

- ✅ `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` — 132/132
- ✅ `dotnet build src/Microsoft.AndroidX.Compose` — clean (no RS0016/RS0017)
- ✅ `dotnet build src/Microsoft.AndroidX.Compose.Gallery`
- ✅ `dotnet build samples/Jetchat`
- ✅ `dotnet build samples/JetNews`
- ✅ `dotnet build samples/Reply`

Not deployed to a device — leaving smoke-test for the user.

### Coordination

Round-2 #2. Disjoint file set from sibling round-2 PRs except for `PublicAPI.Unshipped.txt` — expect a mechanical sort conflict on merge with round-2 #1 (`Modifier.Padding` defaults) and round-2 #3 (`Func<IComposer, ComposableNode>` implicit).