### PR TITLE
Composed: forward Scaffold PaddingValues to inner node

### DIFF
--- a/src/Microsoft.AndroidX.Compose/Composed.cs
+++ b/src/Microsoft.AndroidX.Compose/Composed.cs
@@ -80,4 +80,29 @@ public sealed class Composed : ComposableNode
         var node = _builder(composer);
         node?.Render(composer);
     }
+
+    /// <summary>
+    /// Forward a parent-supplied <c>PaddingValues</c> handle (e.g. from
+    /// <see cref="Scaffold"/>'s content lambda) through to the node the
+    /// builder produces, so the inner node's <c>BuildModifier</c> picks
+    /// it up as if it had been the body itself.
+    ///
+    /// The base <see cref="ComposableNode"/> implementation stashes the
+    /// handle on the receiving node and consumes it in
+    /// <c>BuildModifier</c> — but <see cref="Composed"/> never calls
+    /// <c>BuildModifier</c> on itself; it just delegates to the
+    /// builder's result. Without this override the padding is dropped
+    /// on the floor and the inner content renders behind the top /
+    /// bottom bars.
+    /// </summary>
+    internal override void Render(IComposer composer, IntPtr contentPadding)
+    {
+        var node = _builder(composer);
+        if (node is null)
+            return;
+        if (contentPadding == IntPtr.Zero)
+            node.Render(composer);
+        else
+            node.Render(composer, contentPadding);
+    }
 }


### PR DESCRIPTION
## Problem

In Jetchat's Conversation screen (the launch screen, `#composers / 42 members`), the LazyColumn extends behind the `CenterAlignedTopAppBar`: the topmost message's avatar is clipped, and swiping down (reverse-layout scroll up) reveals older messages sliding behind the top bar instead of stopping at its bottom edge.

Reproduces on `main` — not introduced by any recent PR.

## Root cause

`Scaffold`'s content lambda hands the body its Material 3 `PaddingValues` handle:

```csharp
body.Render(c, paddingHandle)
```

`ComposableNode.Render(IComposer, IntPtr)` (the default impl, plumbed by #46/#105) stashes the handle on the receiving node and consumes it in the next `BuildModifier()` call — a `Modifier.padding(values)` op prepended to the chain via JNI, no managed wrapper. That works for direct facades like `Column` / `Box` / `LazyColumn`, all of which call `BuildModifier()` in `Render()`.

`Composed` is a passthrough — it builds an inner node via its captured lambda and delegates rendering to it. It never calls `BuildModifier` on itself. So when a `Composed` is used as a `Scaffold` body (Jetchat's `BuildBody` returns `new Composed(c => { var scheme = c.ColorScheme(); return new Column { ... }; })` so it can thread the `ColorScheme` through the composer), the padding handle is stashed on the `Composed` instance and silently dropped — the inner `Column` renders with no contentPadding.

## Fix

Override `Render(IComposer, IntPtr)` on `Composed` to forward the handle into the inner node:

```csharp
internal override void Render(IComposer composer, IntPtr contentPadding)
{
    var node = _builder(composer);
    if (node is null) return;
    if (contentPadding == IntPtr.Zero) node.Render(composer);
    else                               node.Render(composer, contentPadding);
}
```

Nested `Composed → Composed → Column` chains naturally — each layer forwards the same handle down until something calls `BuildModifier` and consumes it.

No public API change; the override is `internal`, matching the base.

## Verification

Deployed `samples/Jetchat` to a Pixel 10 device.

- ✅ Top of `#composers` — first visible message renders fully below the top app bar, avatar intact.
- ✅ Swipe down to scroll back through history — older messages stop at the top app bar's bottom edge instead of sliding behind it.

Other Scaffold usages (`samples/JetNews` `HomeScreen` / `PostScreen`, `samples/Reply` `ReplyApp` / `ReplyEmailDetail`, `samples/Jetchat` `Profile`) already work because their `Body` is a direct facade (`PullToRefreshBox`, `LazyColumn`, `NavHost`, `BoxWithConstraints`) that calls `BuildModifier()` itself — they don't go through `Composed`.