### PR TITLE
Strip implicit usings from scripts/*.cs to satisfy IDE0005

### DIFF
--- a/scripts/api-comparison.cs
+++ b/scripts/api-comparison.cs
@@ -21,15 +21,9 @@
 // Re-run after bumping a Compose package version in Directory.Build.targets
 // and the report auto-refreshes.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 const string CacheRoot       = "obj/api-coverage";
 const string SourcesDir      = CacheRoot + "/sources";

--- a/scripts/manual-jni-report.cs
+++ b/scripts/manual-jni-report.cs
@@ -26,11 +26,7 @@
 // scripts/api-comparison.cs. The repo's "one type per file" discipline
 // makes regex sufficient.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 


### PR DESCRIPTION
PR #212 promoted IDE0005 (unnecessary using directives) to error severity, which broke both `dotnet run`-style scripts under `scripts/`. .NET 10 file-based programs ship an implicit-using set that already covers `System`, `System.Collections.Generic`, `System.IO`, `System.Linq`, `System.Net.Http`, and `System.Threading.Tasks`, so the explicit `using` directives at the top of both scripts now fail the build.

## Repro (before this PR)

```
> dotnet run scripts/api-comparison.cs
scripts\api-comparison.cs(24,1): error IDE0005: Using directive is unnecessary.
scripts\api-comparison.cs(28,1): error IDE0005: Using directive is unnecessary.
scripts\api-comparison.cs(32,1): error IDE0005: Using directive is unnecessary.
```

`scripts/manual-jni-report.cs` had the same problem on its `System` and `System.IO` lines.

## Fix

Remove just the usings the analyzer flagged — keep the ones that are **not** implicit:

- `scripts/api-comparison.cs` keeps `System.IO.Compression`, `System.Text`, `System.Text.RegularExpressions`.
- `scripts/manual-jni-report.cs` keeps `System.Globalization`, `System.Text`, `System.Text.RegularExpressions`.

No `NoWarn`, no `#pragma warning disable`, no workaround — root-cause fix as requested. Searched the repo for stale `NoWarn=IDE0005` / `#pragma warning disable IDE0005` added at call sites for these scripts; none exist.

## Verification

```
> dotnet run scripts/api-comparison.cs
Kotlin symbols scanned: 2282
C# public symbols:      2147
Report written: docs/api-coverage.md

> dotnet run scripts/manual-jni-report.cs
Files scanned:           273
Report written: docs/manual-jni.md
```

Both regenerate their reports successfully. Per the api-coverage skill's "Don't commit the script run on its own" rule, the regenerated `docs/api-coverage.md` and `docs/manual-jni.md` are **not** included here — the next session that adds a facade or bumps a package will refresh them naturally.