### PR TITLE
Expose `enabled` (and `steps` / `alwaysShowLabel`) on toggle facades

### DIFF
--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
@@ -42,12 +42,18 @@ public static class BottomNavOptionsDemo
 
                 new Text("Tap Search or Profile, hit Increment a few times, switch to another tab and come back — the counter survives via popUpTo(saveState) + restoreState. (Selection follows taps; back-stack changes via the system Back button don't update the highlight in this v1 demo.)"),
 
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(16), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
-                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
-                    new Text(enabled.Value ? "Enabled" : "Disabled"),
-                    new Switch(@checked: alwaysShowLabel.Value, onCheckedChange: v => alwaysShowLabel.Value = v),
-                    new Text(alwaysShowLabel.Value ? "AlwaysShowLabel" : "Selected-only label"),
+                    new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
+                    {
+                        new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                        new Text(enabled.Value ? "Enabled" : "Disabled"),
+                    },
+                    new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
+                    {
+                        new Switch(@checked: alwaysShowLabel.Value, onCheckedChange: v => alwaysShowLabel.Value = v),
+                        new Text(alwaysShowLabel.Value ? "AlwaysShowLabel" : "Selected-only label"),
+                    },
                 },
 
                 // Bounded NavHost so the inner subcomposition has a

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/BottomNavOptionsDemo.cs
@@ -31,14 +31,24 @@ public static class BottomNavOptionsDemo
         {
             const string startRoute = "home";
 
-            var nav      = c.Remember(() => new NavController());
-            var selected = c.MutableStateOf(startRoute);
+            var nav             = c.Remember(() => new NavController());
+            var selected        = c.MutableStateOf(startRoute);
+            var enabled         = c.MutableStateOf(true);
+            var alwaysShowLabel = c.MutableStateOf(true);
 
             return new Column
             {
                 Modifier.FillMaxWidth(),
 
                 new Text("Tap Search or Profile, hit Increment a few times, switch to another tab and come back — the counter survives via popUpTo(saveState) + restoreState. (Selection follows taps; back-stack changes via the system Back button don't update the highlight in this v1 demo.)"),
+
+                new Row
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                    new Text(enabled.Value ? "Enabled" : "Disabled"),
+                    new Switch(@checked: alwaysShowLabel.Value, onCheckedChange: v => alwaysShowLabel.Value = v),
+                    new Text(alwaysShowLabel.Value ? "AlwaysShowLabel" : "Selected-only label"),
+                },
 
                 // Bounded NavHost so the inner subcomposition has a
                 // finite slot to lay out into; the NavigationBar below
@@ -57,22 +67,28 @@ public static class BottomNavOptionsDemo
                 new NavigationBar
                 {
                     new NavigationBarItem(
-                        selected: selected.Value == startRoute,
-                        onClick:  () => GoToTab(nav, selected, startRoute, startRoute))
+                        selected:        selected.Value == startRoute,
+                        onClick:         () => GoToTab(nav, selected, startRoute, startRoute),
+                        enabled:         enabled.Value,
+                        alwaysShowLabel: alwaysShowLabel.Value)
                     {
                         Icon  = new Text("🏠"),
                         Label = new Text("Home"),
                     },
                     new NavigationBarItem(
-                        selected: selected.Value == "search",
-                        onClick:  () => GoToTab(nav, selected, "search", startRoute))
+                        selected:        selected.Value == "search",
+                        onClick:         () => GoToTab(nav, selected, "search", startRoute),
+                        enabled:         enabled.Value,
+                        alwaysShowLabel: alwaysShowLabel.Value)
                     {
                         Icon  = new Text("🔍"),
                         Label = new Text("Search"),
                     },
                     new NavigationBarItem(
-                        selected: selected.Value == "profile",
-                        onClick:  () => GoToTab(nav, selected, "profile", startRoute))
+                        selected:        selected.Value == "profile",
+                        onClick:         () => GoToTab(nav, selected, "profile", startRoute),
+                        enabled:         enabled.Value,
+                        alwaysShowLabel: alwaysShowLabel.Value)
                     {
                         Icon  = new Text("👤"),
                         Label = new Text("Profile"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/WideNavigationRailDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/WideNavigationRailDemo.cs
@@ -17,7 +17,7 @@ public static class WideNavigationRailDemo
             var enabled = c.MutableStateOf(true);
             return new Column
             {
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
                     new Text(enabled.Value ? "Enabled" : "Disabled"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/WideNavigationRailDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/WideNavigationRailDemo.cs
@@ -10,12 +10,18 @@ public static class WideNavigationRailDemo
         Id:          "navigation-rail-wide",
         CategoryId:  "navigation",
         Title:       "WideNavigationRail",
-        Description: "Persistent vertical rail with three selectable items.",
+        Description: "Persistent vertical rail with three selectable items. The enabled toggle disables all rail items.",
         Build:       c =>
         {
-            var idx = c.MutableStateOf(0);
+            var idx     = c.MutableStateOf(0);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
+                new Row
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                    new Text(enabled.Value ? "Enabled" : "Disabled"),
+                },
                 new Text($"WideNavigationRail (selected: {idx})"),
                 // The rail wants to fill its parent vertically. The DemoScreen
                 // wrapper provides infinite height (vertical scroll), so we
@@ -25,17 +31,17 @@ public static class WideNavigationRailDemo
                     Modifier.Height(320),
                     new WideNavigationRail
                     {
-                        new WideNavigationRailItem(selected: idx.Value == 0, onClick: () => idx.Value = 0)
+                        new WideNavigationRailItem(selected: idx.Value == 0, onClick: () => idx.Value = 0, enabled: enabled.Value)
                         {
                             Icon  = new Text("🏠"),
                             Label = new Text("Home"),
                         },
-                        new WideNavigationRailItem(selected: idx.Value == 1, onClick: () => idx.Value = 1)
+                        new WideNavigationRailItem(selected: idx.Value == 1, onClick: () => idx.Value = 1, enabled: enabled.Value)
                         {
                             Icon  = new Text("🔍"),
                             Label = new Text("Search"),
                         },
-                        new WideNavigationRailItem(selected: idx.Value == 2, onClick: () => idx.Value = 2)
+                        new WideNavigationRailItem(selected: idx.Value == 2, onClick: () => idx.Value = 2, enabled: enabled.Value)
                         {
                             Icon  = new Text("⚙"),
                             Label = new Text("Settings"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/CheckboxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/CheckboxDemo.cs
@@ -17,12 +17,12 @@ public static class CheckboxDemo
             var enabled = c.MutableStateOf(true);
             return new Column
             {
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
                     new Text(enabled.Value ? "Enabled" : "Disabled"),
                 },
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Checkbox(@checked: on.Value, onCheckedChange: v => on.Value = v, enabled: enabled.Value),
                     new Text(on.Value ? "Checked" : "Unchecked"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/CheckboxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/CheckboxDemo.cs
@@ -10,15 +10,21 @@ public static class CheckboxDemo
         Id:          "selection-checkbox",
         CategoryId:  "selection",
         Title:       "Checkbox",
-        Description: "Plain two-state checkbox bound to a MutableState<bool>.",
+        Description: "Plain two-state checkbox bound to a MutableState<bool>. The enabled toggle greys out the checkbox and ignores taps.",
         Build:       c =>
         {
-            var on = c.MutableStateOf(false);
+            var on      = c.MutableStateOf(false);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
                 new Row
                 {
-                    new Checkbox(@checked: on.Value, onCheckedChange: v => on.Value = v),
+                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                    new Text(enabled.Value ? "Enabled" : "Disabled"),
+                },
+                new Row
+                {
+                    new Checkbox(@checked: on.Value, onCheckedChange: v => on.Value = v, enabled: enabled.Value),
                     new Text(on.Value ? "Checked" : "Unchecked"),
                 },
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RadioButtonGroupDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RadioButtonGroupDemo.cs
@@ -17,12 +17,12 @@ public static class RadioButtonGroupDemo
             var enabled = c.MutableStateOf(true);
             return new Column
             {
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
                     new Text(enabled.Value ? "Enabled" : "Disabled"),
                 },
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(4), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new RadioButton(selected: picked.Value == 0, onClick: () => picked.Value = 0, enabled: enabled.Value),
                     new Text("A"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RadioButtonGroupDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/RadioButtonGroupDemo.cs
@@ -10,19 +10,25 @@ public static class RadioButtonGroupDemo
         Id:          "selection-radio-group",
         CategoryId:  "selection",
         Title:       "RadioButton group",
-        Description: "Single-selection group built from three RadioButtons.",
+        Description: "Single-selection group built from three RadioButtons. Toggle Enabled to disable the whole group.",
         Build:       c =>
         {
-            var picked = c.MutableStateOf(0);
+            var picked  = c.MutableStateOf(0);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
                 new Row
                 {
-                    new RadioButton(selected: picked.Value == 0, onClick: () => picked.Value = 0),
+                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                    new Text(enabled.Value ? "Enabled" : "Disabled"),
+                },
+                new Row
+                {
+                    new RadioButton(selected: picked.Value == 0, onClick: () => picked.Value = 0, enabled: enabled.Value),
                     new Text("A"),
-                    new RadioButton(selected: picked.Value == 1, onClick: () => picked.Value = 1),
+                    new RadioButton(selected: picked.Value == 1, onClick: () => picked.Value = 1, enabled: enabled.Value),
                     new Text("B"),
-                    new RadioButton(selected: picked.Value == 2, onClick: () => picked.Value = 2),
+                    new RadioButton(selected: picked.Value == 2, onClick: () => picked.Value = 2, enabled: enabled.Value),
                     new Text("C"),
                 },
                 new Text($"Picked: {(char)('A' + picked.Value)}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SliderDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SliderDemo.cs
@@ -10,7 +10,7 @@ public static class SliderDemo
         Id:          "selection-slider",
         CategoryId:  "selection",
         Title:       "Slider",
-        Description: "Continuous Slider mapped to a MutableNumberState<float>. The enabled toggle disables the slider; steps = 4 snaps the second one to 5 discrete positions.",
+        Description: "Continuous Slider mapped to a MutableNumberState<float>. The enabled toggle disables the slider; steps = 4 snaps the second one to 6 discrete positions (the 2 endpoints + 4 internal stops).",
         Build:       c =>
         {
             var value   = c.MutableStateOf(0.4f);
@@ -18,7 +18,7 @@ public static class SliderDemo
             var enabled = c.MutableStateOf(true);
             return new Column
             {
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
                     new Text(enabled.Value ? "Enabled" : "Disabled"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SliderDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SliderDemo.cs
@@ -10,14 +10,23 @@ public static class SliderDemo
         Id:          "selection-slider",
         CategoryId:  "selection",
         Title:       "Slider",
-        Description: "Continuous Slider mapped to a MutableNumberState<float>.",
+        Description: "Continuous Slider mapped to a MutableNumberState<float>. The enabled toggle disables the slider; steps = 4 snaps the second one to 5 discrete positions.",
         Build:       c =>
         {
-            var value = c.MutableStateOf(0.4f);
+            var value   = c.MutableStateOf(0.4f);
+            var stepped = c.MutableStateOf(0.5f);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
-                new Slider(value: value.Value, onValueChange: v => value.Value = v),
-                new Text($"Value: {value.Value:F2}"),
+                new Row
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                    new Text(enabled.Value ? "Enabled" : "Disabled"),
+                },
+                new Slider(value: value.Value, onValueChange: v => value.Value = v, enabled: enabled.Value),
+                new Text($"Continuous: {value.Value:F2}"),
+                new Slider(value: stepped.Value, onValueChange: v => stepped.Value = v, enabled: enabled.Value, steps: 4),
+                new Text($"Stepped (4 internal stops): {stepped.Value:F2}"),
             };
         });
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SwitchDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SwitchDemo.cs
@@ -17,12 +17,12 @@ public static class SwitchDemo
             var enabled = c.MutableStateOf(true);
             return new Column
             {
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
                     new Text(enabled.Value ? "Enabled" : "Disabled"),
                 },
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Switch(@checked: on.Value, onCheckedChange: v => on.Value = v, enabled: enabled.Value),
                     new Text(on.Value ? "On" : "Off"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SwitchDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/SwitchDemo.cs
@@ -10,15 +10,21 @@ public static class SwitchDemo
         Id:          "selection-switch",
         CategoryId:  "selection",
         Title:       "Switch",
-        Description: "Bool-bound Switch with live status text.",
+        Description: "Bool-bound Switch with live status text. The enabled toggle disables the lower switch.",
         Build:       c =>
         {
-            var on = c.MutableStateOf(false);
+            var on      = c.MutableStateOf(false);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
                 new Row
                 {
-                    new Switch(@checked: on.Value, onCheckedChange: v => on.Value = v),
+                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                    new Text(enabled.Value ? "Enabled" : "Disabled"),
+                },
+                new Row
+                {
+                    new Switch(@checked: on.Value, onCheckedChange: v => on.Value = v, enabled: enabled.Value),
                     new Text(on.Value ? "On" : "Off"),
                 },
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/TriStateCheckboxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/TriStateCheckboxDemo.cs
@@ -11,12 +11,18 @@ public static class TriStateCheckboxDemo
         Id:          "selection-tristate-checkbox",
         CategoryId:  "selection",
         Title:       "TriStateCheckbox",
-        Description: "Cycles through On → Off → Indeterminate on tap.",
+        Description: "Cycles through On → Off → Indeterminate on tap. The enabled toggle disables the cycling checkbox.",
         Build:       c =>
         {
-            var state = c.MutableStateOf(ToggleableState.Indeterminate!);
+            var state   = c.MutableStateOf(ToggleableState.Indeterminate!);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
+                new Row
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
+                    new Text(enabled.Value ? "Enabled" : "Disabled"),
+                },
                 new Row
                 {
                     new TriStateCheckbox(
@@ -25,7 +31,8 @@ public static class TriStateCheckboxDemo
                             ? ToggleableState.Off
                             : state.Value == ToggleableState.Off
                                 ? ToggleableState.Indeterminate
-                                : ToggleableState.On)!),
+                                : ToggleableState.On)!,
+                        enabled: enabled.Value),
                     new Text(state.Value.ToString() ?? "?"),
                 },
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/TriStateCheckboxDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Selection/TriStateCheckboxDemo.cs
@@ -18,12 +18,12 @@ public static class TriStateCheckboxDemo
             var enabled = c.MutableStateOf(true);
             return new Column
             {
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new Switch(@checked: enabled.Value, onCheckedChange: v => enabled.Value = v),
                     new Text(enabled.Value ? "Enabled" : "Disabled"),
                 },
-                new Row
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8), verticalAlignment: Alignment.Vertical.CenterVertically)
                 {
                     new TriStateCheckbox(
                         state:   state.Value,

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -3467,17 +3467,18 @@ internal static partial class ComposeBridges
 
     // Internal forwarder for Row — see the Column helper above for why
     // this isn't an auto-generated facade. Row.cs supplies the typed
-    // horizontalArrangement and matching $default mask.
+    // horizontalArrangement / verticalAlignment and matching $default mask.
     internal static void Row(
         IModifier? modifier,
         AndroidX.Compose.Foundation.Layout.Arrangement.IHorizontal? horizontalArrangement,
+        IAlignmentVertical? verticalAlignment,
         IFunction3 content,
         int defaults,
         IComposer composer)
         => RowKt.Row(
             modifier:              modifier,
             horizontalArrangement: horizontalArrangement,
-            verticalAlignment:     null,
+            verticalAlignment:     verticalAlignment,
             content:               content,
             _composer:             composer,
             p5:                    0,
@@ -3574,6 +3575,11 @@ internal static partial class ComposeBridges
         int                         defaults = 0,
         IComposer                   composer = null!);
 
+    // Slot rename pattern: C# `p5` is the real Kotlin `steps` Int; C# named
+    // `steps:` is the JVM `$changed` recomposition int; `_changed` is `$default`.
+    // Cross-check with RangeSlider above, which uses the same SliderKt
+    // overload (both pass `steps: 0` for $changed and route the user-facing
+    // steps through `p5:`).
     public static partial void Slider(float value, IFunction1 onValueChange, IModifier? modifier, bool enabled, int steps, int defaults, IComposer composer)
         => SliderKt.Slider(
             value:                  value,
@@ -3581,12 +3587,12 @@ internal static partial class ComposeBridges
             modifier:               modifier,
             enabled:                enabled,
             valueRange:             null,
-            p5:                     0,
+            p5:                     steps,
             onValueChangeFinished:  null,
             colors:                 null,
             interactionSource:      null,
             _composer:              composer,
-            steps:                  steps,
+            steps:                  0,
             _changed:               defaults);
 
     // FlowRow / FlowColumn — Phase 8 wrapper-passthrough facades. The

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1488,8 +1488,10 @@ internal static partial class ComposeBridges
         IFunction2  icon,
         IModifier?  modifier,
         IFunction2? label,
-        int         defaults,
-        IComposer   composer);
+        bool        enabled         = true,
+        bool        alwaysShowLabel = true,
+        int         defaults        = 0,
+        IComposer   composer        = null!);
 
     // androidx.compose.material3.NavigationRailKt.NavigationRail-qi6gXK8
     [ComposeBridge(
@@ -3501,15 +3503,16 @@ internal static partial class ComposeBridges
         [Callback(typeof(bool))]
         IFunction1                 onCheckedChange,
         IModifier?                 modifier,
-        int                        defaults,
-        IComposer                  composer);
+        bool                       enabled  = true,
+        int                        defaults = 0,
+        IComposer                  composer = null!);
 
-    public static partial void Checkbox(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, int defaults, IComposer composer)
+    public static partial void Checkbox(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, bool enabled, int defaults, IComposer composer)
         => CheckboxKt.Checkbox(
             @checked:          @checked,
             onCheckedChange:   onCheckedChange,
             modifier:          modifier,
-            enabled:           true,
+            enabled:           enabled,
             colors:            null,
             interactionSource: null,
             _composer:         composer,
@@ -3522,16 +3525,17 @@ internal static partial class ComposeBridges
         [Callback(typeof(bool))]
         IFunction1                 onCheckedChange,
         IModifier?                 modifier,
-        int                        defaults,
-        IComposer                  composer);
+        bool                       enabled  = true,
+        int                        defaults = 0,
+        IComposer                  composer = null!);
 
-    public static partial void Switch(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, int defaults, IComposer composer)
+    public static partial void Switch(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, bool enabled, int defaults, IComposer composer)
         => SwitchKt.Switch(
             @checked:          @checked,
             onCheckedChange:   onCheckedChange,
             modifier:          modifier,
             thumbContent:      null,
-            enabled:           true,
+            enabled:           enabled,
             colors:            null,
             interactionSource: null,
             _composer:         composer,
@@ -3543,15 +3547,16 @@ internal static partial class ComposeBridges
         bool        selected,
         IFunction0  onClick,
         IModifier?  modifier,
-        int         defaults,
-        IComposer   composer);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!);
 
-    public static partial void RadioButton(bool selected, IFunction0 onClick, IModifier? modifier, int defaults, IComposer composer)
+    public static partial void RadioButton(bool selected, IFunction0 onClick, IModifier? modifier, bool enabled, int defaults, IComposer composer)
         => RadioButtonKt.RadioButton(
             selected:          selected,
             onClick:           onClick,
             modifier:          modifier,
-            enabled:           true,
+            enabled:           enabled,
             colors:            null,
             interactionSource: null,
             _composer:         composer,
@@ -3564,22 +3569,24 @@ internal static partial class ComposeBridges
         [Callback(typeof(float))]
         IFunction1                  onValueChange,
         IModifier?                  modifier,
-        int                         defaults,
-        IComposer                   composer);
+        bool                        enabled  = true,
+        int                         steps    = 0,
+        int                         defaults = 0,
+        IComposer                   composer = null!);
 
-    public static partial void Slider(float value, IFunction1 onValueChange, IModifier? modifier, int defaults, IComposer composer)
+    public static partial void Slider(float value, IFunction1 onValueChange, IModifier? modifier, bool enabled, int steps, int defaults, IComposer composer)
         => SliderKt.Slider(
             value:                  value,
             onValueChange:          onValueChange,
             modifier:               modifier,
-            enabled:                true,
+            enabled:                enabled,
             valueRange:             null,
             p5:                     0,
             onValueChangeFinished:  null,
             colors:                 null,
             interactionSource:      null,
             _composer:              composer,
-            steps:                  0,
+            steps:                  steps,
             _changed:               defaults);
 
     // FlowRow / FlowColumn — Phase 8 wrapper-passthrough facades. The
@@ -3636,10 +3643,11 @@ internal static partial class ComposeBridges
         IFunction2  icon,
         IFunction2? label,
         IModifier?  modifier,
-        int         defaults,
-        IComposer   composer);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!);
 
-    public static partial void WideNavigationRailItem(bool selected, IFunction0 onClick, IFunction2 icon, IFunction2? label, IModifier? modifier, int defaults, IComposer composer)
+    public static partial void WideNavigationRailItem(bool selected, IFunction0 onClick, IFunction2 icon, IFunction2? label, IModifier? modifier, bool enabled, int defaults, IComposer composer)
         => AndroidX.Compose.Material3.WideNavigationRailKt.WideNavigationRailItem(
             selected:          selected,
             onClick:           onClick,
@@ -3647,7 +3655,7 @@ internal static partial class ComposeBridges
             label:             label,
             railExpanded:      false,
             modifier:          modifier,
-            enabled:           true,
+            enabled:           enabled,
             p7:                0,
             colors:            null,
             interactionSource: null,
@@ -3660,15 +3668,16 @@ internal static partial class ComposeBridges
         ToggleableState state,
         IFunction0  onClick,
         IModifier?  modifier,
-        int         defaults,
-        IComposer   composer);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!);
 
-    public static partial void TriStateCheckbox(ToggleableState state, IFunction0 onClick, IModifier? modifier, int defaults, IComposer composer)
+    public static partial void TriStateCheckbox(ToggleableState state, IFunction0 onClick, IModifier? modifier, bool enabled, int defaults, IComposer composer)
         => AndroidX.Compose.Material3.CheckboxKt.TriStateCheckbox(
             state:             state,
             onClick:           onClick,
             modifier:          modifier,
-            enabled:           true,
+            enabled:           enabled,
             colors:            null,
             interactionSource: null,
             _composer:         composer,

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -934,6 +934,7 @@ AndroidX.Compose.RoundedCornerShape.RoundedCornerShape(int topStartPercent, int 
 AndroidX.Compose.Row
 AndroidX.Compose.Row.Row() -> void
 AndroidX.Compose.Row.Row(AndroidX.Compose.Arrangement? horizontalArrangement) -> void
+AndroidX.Compose.Row.Row(AndroidX.Compose.Arrangement? horizontalArrangement, AndroidX.Compose.Alignment.Vertical? verticalAlignment) -> void
 AndroidX.Compose.Scaffold
 AndroidX.Compose.Scaffold.Body.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Scaffold.Body.set -> void

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -136,7 +136,7 @@ AndroidX.Compose.CenterAlignedTopAppBar.ScrollBehavior.set -> void
 AndroidX.Compose.CenterAlignedTopAppBar.Title.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.CenterAlignedTopAppBar.Title.set -> void
 AndroidX.Compose.Checkbox
-AndroidX.Compose.Checkbox.Checkbox(bool checked, System.Action<bool>! onCheckedChange) -> void
+AndroidX.Compose.Checkbox.Checkbox(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
 AndroidX.Compose.CircularProgressIndicator
 AndroidX.Compose.CircularProgressIndicator.CircularProgressIndicator() -> void
 AndroidX.Compose.CircularProgressIndicator.Color.get -> AndroidX.Compose.Color?
@@ -778,7 +778,7 @@ AndroidX.Compose.NavigationBarItem.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.NavigationBarItem.Icon.set -> void
 AndroidX.Compose.NavigationBarItem.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.NavigationBarItem.Label.set -> void
-AndroidX.Compose.NavigationBarItem.NavigationBarItem(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.NavigationBarItem.NavigationBarItem(bool selected, System.Action! onClick, bool enabled = true, bool alwaysShowLabel = true) -> void
 AndroidX.Compose.NavigationDrawerItem
 AndroidX.Compose.NavigationDrawerItem.Badge.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.NavigationDrawerItem.Badge.set -> void
@@ -921,7 +921,7 @@ AndroidX.Compose.PullToRefreshState.DistanceFraction.get -> float
 AndroidX.Compose.PullToRefreshState.IsAnimating.get -> bool
 AndroidX.Compose.PullToRefreshState.PullToRefreshState() -> void
 AndroidX.Compose.RadioButton
-AndroidX.Compose.RadioButton.RadioButton(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.RadioButton.RadioButton(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.RangeSlider
 AndroidX.Compose.RangeSlider.RangeSlider((float Start, float End) value, System.Action<(float Start, float End)>! onValueChange) -> void
 AndroidX.Compose.Resource
@@ -1034,7 +1034,7 @@ AndroidX.Compose.SideEffect.SideEffect(System.Action! effect) -> void
 AndroidX.Compose.SingleChoiceSegmentedButtonRow
 AndroidX.Compose.SingleChoiceSegmentedButtonRow.SingleChoiceSegmentedButtonRow() -> void
 AndroidX.Compose.Slider
-AndroidX.Compose.Slider.Slider(float value, System.Action<float>! onValueChange) -> void
+AndroidX.Compose.Slider.Slider(float value, System.Action<float>! onValueChange, bool enabled = true, int steps = 0) -> void
 AndroidX.Compose.SmallFloatingActionButton
 AndroidX.Compose.SmallFloatingActionButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.SmallFloatingActionButton.Shape.set -> void
@@ -1095,7 +1095,7 @@ AndroidX.Compose.Surface.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.Surface.Shape.set -> void
 AndroidX.Compose.Surface.Surface() -> void
 AndroidX.Compose.Switch
-AndroidX.Compose.Switch.Switch(bool checked, System.Action<bool>! onCheckedChange) -> void
+AndroidX.Compose.Switch.Switch(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
 AndroidX.Compose.Tab
 AndroidX.Compose.Tab.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Tab.Icon.set -> void
@@ -1247,7 +1247,7 @@ AndroidX.Compose.TopSearchBar.TopSearchBar(AndroidX.Compose.SearchBarState! stat
 AndroidX.Compose.TransformOrigin
 AndroidX.Compose.Transitions
 AndroidX.Compose.TriStateCheckbox
-AndroidX.Compose.TriStateCheckbox.TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState! state, System.Action! onClick) -> void
+AndroidX.Compose.TriStateCheckbox.TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState! state, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.VerticalDivider
 AndroidX.Compose.VerticalDivider.Color.get -> AndroidX.Compose.Color?
 AndroidX.Compose.VerticalDivider.Color.set -> void
@@ -1272,7 +1272,7 @@ AndroidX.Compose.WideNavigationRailItem.Icon.get -> AndroidX.Compose.ComposableN
 AndroidX.Compose.WideNavigationRailItem.Icon.set -> void
 AndroidX.Compose.WideNavigationRailItem.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.WideNavigationRailItem.Label.set -> void
-AndroidX.Compose.WideNavigationRailItem.WideNavigationRailItem(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.WideNavigationRailItem.WideNavigationRailItem(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.WideNavigationRailState
 AndroidX.Compose.WideNavigationRailState.CurrentValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!
 AndroidX.Compose.WideNavigationRailState.InitialValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!

--- a/src/Microsoft.AndroidX.Compose/Row.cs
+++ b/src/Microsoft.AndroidX.Compose/Row.cs
@@ -10,20 +10,26 @@ namespace AndroidX.Compose;
 /// new Row { new Text("A"), new Spacer { Modifier = ... }, new Text("B") }
 /// </code>
 /// Pass an optional <see cref="Arrangement"/> to control how children
-/// are distributed along the horizontal axis:
+/// are distributed along the horizontal axis, and an optional
+/// <see cref="Alignment.Vertical"/> to control how shorter children
+/// align across the Row's vertical extent:
 /// <code>
-/// new Row(horizontalArrangement: Arrangement.SpaceBetween) { /* … */ }
+/// new Row(
+///     horizontalArrangement: Arrangement.SpaceBetween,
+///     verticalAlignment:     Alignment.CenterVertically) { /* … */ }
 /// </code>
 /// </summary>
 public sealed class Row : ComposableContainer
 {
     readonly Arrangement? _horizontalArrangement;
+    readonly Alignment.Vertical? _verticalAlignment;
 
     /// <summary>
     /// Lay out children left-to-right with Compose's default
-    /// horizontal arrangement (<c>Arrangement.Start</c>).
+    /// horizontal arrangement (<c>Arrangement.Start</c>) and default
+    /// vertical alignment (<c>Alignment.Top</c>).
     /// </summary>
-    public Row() : this(null) { }
+    public Row() : this(null, null) { }
 
     /// <summary>
     /// Lay out children left-to-right using
@@ -42,7 +48,31 @@ public sealed class Row : ComposableContainer
     /// <see cref="Arrangement.Bottom"/>) throws
     /// <see cref="ArgumentException"/>.
     /// </param>
-    public Row(Arrangement? horizontalArrangement)
+    public Row(Arrangement? horizontalArrangement) : this(horizontalArrangement, null) { }
+
+    /// <summary>
+    /// Lay out children left-to-right using
+    /// <paramref name="horizontalArrangement"/> and
+    /// <paramref name="verticalAlignment"/>. Either may be
+    /// <see langword="null"/> to keep Compose's default for that axis
+    /// (<c>Arrangement.Start</c> / <c>Alignment.Top</c>).
+    /// </summary>
+    /// <param name="horizontalArrangement">
+    /// One of the <see cref="Arrangement"/> static factories — see the
+    /// single-argument constructor for the full list of permitted
+    /// values.
+    /// </param>
+    /// <param name="verticalAlignment">
+    /// One of the <see cref="Alignment.Vertical"/> singletons
+    /// (<see cref="Alignment.Vertical.Top"/>,
+    /// <see cref="Alignment.Vertical.CenterVertically"/>,
+    /// <see cref="Alignment.Vertical.Bottom"/>). Controls how children
+    /// shorter than the Row's measured height are placed along its
+    /// vertical axis — useful when mixing visually tall and short
+    /// children (e.g. a <c>Switch</c> next to a single-line
+    /// <c>Text</c>).
+    /// </param>
+    public Row(Arrangement? horizontalArrangement, Alignment.Vertical? verticalAlignment)
     {
         if (horizontalArrangement is not null && horizontalArrangement.Horizontal is null)
         {
@@ -54,16 +84,19 @@ public sealed class Row : ComposableContainer
         }
 
         _horizontalArrangement = horizontalArrangement;
+        _verticalAlignment = verticalAlignment;
     }
 
     public override void Render(IComposer composer)
     {
         var horizontal = _horizontalArrangement?.Horizontal;
+        var vertical = _verticalAlignment?.Java;
         var modifier = BuildModifier();
 
         int defaults = (int)RowDefault.All;
         if (modifier is not null)   defaults &= ~(int)RowDefault.Modifier;
         if (horizontal is not null) defaults &= ~(int)RowDefault.HorizontalArrangement;
+        if (vertical is not null)   defaults &= ~(int)RowDefault.VerticalAlignment;
 
         var content = ComposableLambdas.Wrap3(composer, (scope, c) =>
         {
@@ -71,6 +104,6 @@ public sealed class Row : ComposableContainer
             RenderChildren(c);
         });
 
-        ComposeBridges.Row(modifier, horizontal, content, defaults, composer);
+        ComposeBridges.Row(modifier, horizontal, vertical, content, defaults, composer);
     }
 }


### PR DESCRIPTION
Follow-up to #240, which added `HasExplicitDefaultValue` support to `ComposeFacadeGenerator` so primitive ctor slots can carry real defaults. This PR uses that capability to surface previously-hardcoded primitives on seven facades, unlocking the ability to disable these controls (which was not possible before).

## Migrated facades

| Facade | New defaulted ctor params |
|---|---|
| `Checkbox` | `bool enabled = true` |
| `Switch` | `bool enabled = true` |
| `RadioButton` | `bool enabled = true` |
| `Slider` | `bool enabled = true, int steps = 0` |
| `TriStateCheckbox` | `bool enabled = true` |
| `WideNavigationRailItem` | `bool enabled = true` |
| `NavigationBarItem` | `bool enabled = true, bool alwaysShowLabel = true` |

For the six Phase 8 wrapper-passthrough facades, the change is:
1. Add `bool enabled = true` to the public `[ComposeFacade]` partial signature.
2. Replace the hardcoded `enabled: true` in the wrapper body with `enabled: enabled`.

`NavigationBarItem` is Phase 3 multi-slot, so it only needed the partial signature change — the generator handles auto-masking and forwarding.

All seven `[assembly: ComposeDefaults(...)]` maps already reserved the relevant bits, so no defaults-map edits were needed.

## Gallery demos

Each migrated control already had a demo; rather than adding new ones, the existing demos now include an `enabled` toggle `Switch` at the top:

- `CheckboxDemo`, `SwitchDemo`, `RadioButtonGroupDemo`, `SliderDemo` (also adds a stepped variant with `steps: 4`), `TriStateCheckboxDemo`, `WideNavigationRailDemo`, `BottomNavOptionsDemo` (NavigationBarItem — also adds an `alwaysShowLabel` toggle to demonstrate icon-only mode).

## Verification

- `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` — 145/145 pass (regression check; no generator changes).
- `dotnet build src/Microsoft.AndroidX.Compose` — clean, `PublicAPI.Unshipped.txt` updated for new ctor surfaces.
- `dotnet build Microsoft.AndroidX.Compose.slnx` — clean (Gallery + Jetnews + Jetchat).

## Out of scope (tracked separately)

- TextField / OutlinedTextField nullable-sentinel cleanup — #242.
- Sibling facades (`NavigationRailItem`, `Tab`, `NavigationDrawerItem`, chip family) — #243.
- `WideNavigationRailItem.railExpanded` — not a Kotlin default, intentionally left hardcoded as `false`.