### PR TITLE
Add Brush + gradient backgrounds (slice of #64)

### DIFF
--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BrushDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BrushDemo.cs
@@ -1,4 +1,5 @@
 using AndroidX.Compose.Gallery.Registry;
+using BoundBrush = AndroidX.Compose.UI.Graphics.Brush;
 
 namespace AndroidX.Compose.Gallery.Demos.Containers;
 
@@ -20,7 +21,7 @@ public static class BrushDemo
         var yellow = new Color(0xFF, 0xFF, 0xFF, 0x00);
         var orange = new Color(0xFF, 0xFF, 0x88, 0x00);
 
-        Box Tile(Brush brush, Shape? shape = null) =>
+        Box Tile(BoundBrush brush, Shape? shape = null) =>
             new()
             {
                 Modifier.FillMaxWidth()

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BrushDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BrushDemo.cs
@@ -1,0 +1,62 @@
+using AndroidX.Compose.Gallery.Registry;
+
+namespace AndroidX.Compose.Gallery.Demos.Containers;
+
+/// <summary>Brush gradients applied via <c>Modifier.Background</c> / <c>Modifier.Border</c>.</summary>
+public static class BrushDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id: "containers-brush",
+        CategoryId: "containers",
+        Title: "Brush gradients",
+        Description: "Linear, horizontal, vertical, radial and sweep gradients via Brush.* factories.",
+        Build: _ => Build());
+
+    static Column Build()
+    {
+        var magenta = new Color(0xFF, 0xFF, 0x00, 0xFF);
+        var cyan = new Color(0xFF, 0x00, 0xFF, 0xFF);
+        var yellow = new Color(0xFF, 0xFF, 0xFF, 0x00);
+        var orange = new Color(0xFF, 0xFF, 0x88, 0x00);
+
+        Box Tile(Brush brush, Shape? shape = null) =>
+            new()
+            {
+                Modifier.FillMaxWidth()
+                    .Height(new Dp(80))
+                    .Background(brush, shape),
+            };
+
+        return new Column(verticalArrangement: Arrangement.SpacedBy(12))
+        {
+            Modifier.FillMaxWidth(),
+
+            new Text("LinearGradient — top→bottom"),
+            Tile(Brush.LinearGradient(magenta, cyan)),
+
+            new Text("HorizontalGradient — left→right"),
+            Tile(Brush.HorizontalGradient(yellow, orange)),
+
+            new Text("VerticalGradient — RoundedCornerShape(16)"),
+            Tile(Brush.VerticalGradient(magenta, yellow, cyan), new RoundedCornerShape(new Dp(16))),
+
+            new Text("RadialGradient — Shape.Circle"),
+            Tile(Brush.RadialGradient(yellow, magenta), Shape.Circle()),
+
+            new Text("SweepGradient — rainbow"),
+            Tile(Brush.SweepGradient(magenta, yellow, cyan, magenta)),
+
+            new Text("SolidColor brush (sanity check)"),
+            Tile(Brush.SolidColor(orange)),
+
+            new Text("Border with horizontal gradient"),
+            new Box
+            {
+                Modifier.FillMaxWidth()
+                    .Height(new Dp(80))
+                    .Border(new Dp(4), Brush.HorizontalGradient(magenta, cyan, yellow), new RoundedCornerShape(new Dp(12))),
+            },
+        };
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Gallery/Registry/Catalog.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Registry/Catalog.cs
@@ -78,6 +78,7 @@ public static class Catalog
         // ---- Containers ----
         D.Containers.CardVariantsDemo.Demo,
         D.Containers.RoundedCornerShapeDemo.Demo,
+        D.Containers.BrushDemo.Demo,
         D.Containers.SurfaceDemo.Demo,
         D.Containers.BoxAlignmentDemo.Demo,
         D.Containers.ColumnRowArrangementsDemo.Demo,

--- a/src/Microsoft.AndroidX.Compose/Brush.cs
+++ b/src/Microsoft.AndroidX.Compose/Brush.cs
@@ -28,9 +28,9 @@ namespace AndroidX.Compose;
 /// composition build a fresh instance each pass.
 /// </para>
 /// </remarks>
-public class Brush : Java.Lang.Object
+public sealed class Brush : Java.Lang.Object
 {
-    private protected Brush(IntPtr handle, JniHandleOwnership transfer)
+    Brush(IntPtr handle, JniHandleOwnership transfer)
         : base(handle, transfer) { }
 
     /// <summary>
@@ -71,13 +71,15 @@ public class Brush : Java.Lang.Object
     }
 
     /// <summary>
-    /// Convenience overload — <c>LinearGradient(colors, Offset.Zero,
-    /// new Offset(0f, Single.PositiveInfinity), Clamp)</c>. Produces a
-    /// top-to-bottom vertical fade matching Kotlin's
-    /// <c>Brush.linearGradient(colors)</c> default.
+    /// Convenience overload — matches Kotlin's
+    /// <c>Brush.linearGradient(colors)</c> default of
+    /// <c>start = Offset.Zero, end = Offset.Infinite,
+    /// tileMode = Clamp</c>. <see cref="Offset.Infinite"/> resolves to
+    /// the bottom-right corner of the drawing region at paint time, so
+    /// this produces a top-left-to-bottom-right diagonal gradient.
     /// </summary>
     public static Brush LinearGradient(params Color[] colors) =>
-        LinearGradient(colors, Offset.Zero, new Offset(0f, float.PositiveInfinity), TileMode.Clamp);
+        LinearGradient(colors, Offset.Zero, Offset.Infinite, TileMode.Clamp);
 
     /// <summary>
     /// <c>Brush.horizontalGradient(colors, startX, endX, tileMode)</c>

--- a/src/Microsoft.AndroidX.Compose/Brush.cs
+++ b/src/Microsoft.AndroidX.Compose/Brush.cs
@@ -1,4 +1,5 @@
 using Android.Runtime;
+using BoundBrush = AndroidX.Compose.UI.Graphics.Brush;
 
 namespace AndroidX.Compose;
 
@@ -63,11 +64,10 @@ public class Brush : Java.Lang.Object
         Offset end,
         TileMode tileMode = TileMode.Clamp)
     {
-        ArgumentNullException.ThrowIfNull(colors);
-        long[] packed = PackColors(colors);
-        IntPtr handle = ComposeBridges.BrushLinearGradient(
-            packed, start.Packed, end.Packed, (int)tileMode);
-        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+        var list = ComposeBridges.ToColorList(colors);
+        var bound = ComposeBridges.BrushCompanion().LinearGradient_mHitzGk(
+            list, start.Packed, end.Packed, (int)tileMode);
+        return FromBound(bound);
     }
 
     /// <summary>
@@ -90,11 +90,10 @@ public class Brush : Java.Lang.Object
         float endX = float.PositiveInfinity,
         TileMode tileMode = TileMode.Clamp)
     {
-        ArgumentNullException.ThrowIfNull(colors);
-        long[] packed = PackColors(colors);
-        IntPtr handle = ComposeBridges.BrushHorizontalGradient(
-            packed, startX, endX, (int)tileMode);
-        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+        var list = ComposeBridges.ToColorList(colors);
+        var bound = ComposeBridges.BrushCompanion().HorizontalGradient_8A_3gB4(
+            list, startX, endX, (int)tileMode);
+        return FromBound(bound);
     }
 
     /// <summary>
@@ -115,11 +114,10 @@ public class Brush : Java.Lang.Object
         float endY = float.PositiveInfinity,
         TileMode tileMode = TileMode.Clamp)
     {
-        ArgumentNullException.ThrowIfNull(colors);
-        long[] packed = PackColors(colors);
-        IntPtr handle = ComposeBridges.BrushVerticalGradient(
-            packed, startY, endY, (int)tileMode);
-        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+        var list = ComposeBridges.ToColorList(colors);
+        var bound = ComposeBridges.BrushCompanion().VerticalGradient_8A_3gB4(
+            list, startY, endY, (int)tileMode);
+        return FromBound(bound);
     }
 
     /// <summary>
@@ -142,11 +140,10 @@ public class Brush : Java.Lang.Object
         float radius = float.PositiveInfinity,
         TileMode tileMode = TileMode.Clamp)
     {
-        ArgumentNullException.ThrowIfNull(colors);
-        long[] packed = PackColors(colors);
-        IntPtr handle = ComposeBridges.BrushRadialGradient(
-            packed, center.Packed, radius, (int)tileMode);
-        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+        var list = ComposeBridges.ToColorList(colors);
+        var bound = ComposeBridges.BrushCompanion().RadialGradient_P_Vx_Ks(
+            list, center.Packed, radius, (int)tileMode);
+        return FromBound(bound);
     }
 
     /// <summary>
@@ -164,10 +161,10 @@ public class Brush : Java.Lang.Object
     /// </summary>
     public static Brush SweepGradient(Color[] colors, Offset center)
     {
-        ArgumentNullException.ThrowIfNull(colors);
-        long[] packed = PackColors(colors);
-        IntPtr handle = ComposeBridges.BrushSweepGradient(packed, center.Packed);
-        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+        var list = ComposeBridges.ToColorList(colors);
+        var bound = ComposeBridges.BrushCompanion().SweepGradient_Uv8p0NA(
+            list, center.Packed);
+        return FromBound(bound);
     }
 
     /// <summary>
@@ -177,14 +174,21 @@ public class Brush : Java.Lang.Object
     public static Brush SweepGradient(params Color[] colors) =>
         SweepGradient(colors, Offset.Unspecified);
 
-    static long[] PackColors(Color[] colors)
+    // Take ownership of a bound Brush peer's handle and wrap it in our
+    // facade type. The bound peer goes out of scope after this call, so
+    // we use DoNotTransfer + GC.KeepAlive to keep the JNI handle alive
+    // until our wrapper has taken its own managed reference.
+    static Brush FromBound(BoundBrush bound)
     {
-        if (colors.Length == 0)
-            throw new ArgumentException(
-                "Gradient must have at least one color stop.", nameof(colors));
-        long[] packed = new long[colors.Length];
-        for (int i = 0; i < colors.Length; i++)
-            packed[i] = colors[i];
-        return packed;
+        try
+        {
+            return new Brush(
+                ((Java.Lang.Object)bound).Handle,
+                JniHandleOwnership.DoNotTransfer);
+        }
+        finally
+        {
+            GC.KeepAlive(bound);
+        }
     }
 }

--- a/src/Microsoft.AndroidX.Compose/Brush.cs
+++ b/src/Microsoft.AndroidX.Compose/Brush.cs
@@ -1,74 +1,65 @@
 using Android.Runtime;
 using BoundBrush = AndroidX.Compose.UI.Graphics.Brush;
+using BoundSolidColor = AndroidX.Compose.UI.Graphics.SolidColor;
 
 namespace AndroidX.Compose;
 
 /// <summary>
-/// C# wrapper around Kotlin's <c>androidx.compose.ui.graphics.Brush</c>
-/// — the value passed to fill / stroke slots that want richer paint
-/// than a single <see cref="Color"/>.
+/// Static factory entrypoint for Kotlin's
+/// <c>androidx.compose.ui.graphics.Brush</c> — the value passed to fill
+/// / stroke slots that want richer paint than a single
+/// <see cref="Color"/>. The instances returned by these factories are
+/// bound <see cref="AndroidX.Compose.UI.Graphics.Brush"/> peers and can
+/// be passed straight to <c>Modifier.Background(brush, …)</c> /
+/// <c>Modifier.Border(width, brush, …)</c>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Build a <see cref="Brush"/> via the static factory methods:
-/// <see cref="SolidColor(Color)"/>,
-/// <see cref="LinearGradient(Color[], Offset, Offset, TileMode)"/>,
-/// <see cref="HorizontalGradient(Color[], float, float, TileMode)"/>,
-/// <see cref="VerticalGradient(Color[], float, float, TileMode)"/>,
-/// <see cref="RadialGradient(Color[], Offset, float, TileMode)"/>, and
-/// <see cref="SweepGradient(Color[], Offset)"/>.
+/// Mirrors Kotlin's <c>Brush.linearGradient(…)</c>,
+/// <c>Brush.horizontalGradient(…)</c>, etc. — Kotlin exposes these via
+/// <c>Brush.Companion</c>, but the binder doesn't surface a public
+/// accessor for the singleton (and the gradient factories' inline
+/// <c>Color</c> / <c>TileMode</c> params come through under mangled
+/// names like <c>LinearGradient_mHitzGk</c>), so this class wraps the
+/// Companion call into a friendly C# entrypoint.
 /// </para>
 /// <para>
-/// Pass the returned instance to <c>Modifier.Background(brush)</c> /
-/// <c>Modifier.Background(brush, shape)</c> /
-/// <c>Modifier.Border(width, brush)</c> / etc. Brush instances are
-/// immutable — keep one in a field (or
-/// <c>composer.Remember(() =&gt; Brush.HorizontalGradient(...))</c>)
+/// Brush instances are immutable — keep one in a field (or
+/// <c>composer.Remember(() =&gt; Brush.HorizontalGradient(…))</c>)
 /// when the same brush renders every frame; otherwise let the
 /// composition build a fresh instance each pass.
 /// </para>
 /// </remarks>
-public sealed class Brush : Java.Lang.Object
+public static class Brush
 {
-    Brush(IntPtr handle, JniHandleOwnership transfer)
-        : base(handle, transfer) { }
-
     /// <summary>
-    /// <c>SolidColor(color)</c> — a <see cref="Brush"/> that paints a
-    /// single flat color. Mostly useful for APIs that demand a
-    /// <c>Brush</c> rather than a <see cref="Color"/>; for the typical
-    /// "fill with a color" case prefer the
-    /// <c>Modifier.Background(Color)</c> overload, which avoids the
-    /// extra JNI allocation.
+    /// <c>SolidColor(color)</c> — a brush that paints a single flat
+    /// color. Mostly useful for APIs that demand a brush rather than a
+    /// <see cref="Color"/>; for the typical "fill with a color" case
+    /// prefer the <c>Modifier.Background(Color)</c> overload, which
+    /// avoids the extra JNI allocation.
     /// </summary>
-    public static Brush SolidColor(Color color)
-    {
-        IntPtr handle = ComposeBridges.BrushSolidColor(color);
-        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
-    }
+    public static BoundBrush SolidColor(Color color) =>
+        Java.Lang.Object.GetObject<BoundSolidColor>(
+            ComposeBridges.BrushSolidColor(color),
+            JniHandleOwnership.TransferLocalRef)!;
 
     /// <summary>
     /// <c>Brush.linearGradient(colors, start, end, tileMode)</c> —
     /// gradient interpolating along the line from
     /// <paramref name="start"/> to <paramref name="end"/>. Colors are
     /// spaced evenly along the line; pass
-    /// <see cref="Offset.Zero"/> and a far-away <see cref="Offset"/>
-    /// for endpoint pinning, or
-    /// <c>(Offset.Zero, new Offset(0f, Single.PositiveInfinity))</c>
-    /// for a fill-the-whole-vertical-axis gradient (matches Kotlin's
-    /// default of <c>Offset(0f, Float.POSITIVE_INFINITY)</c>).
+    /// <see cref="Offset.Zero"/> and <see cref="Offset.Infinite"/> for
+    /// a fill-the-region diagonal gradient (matches Kotlin's
+    /// <c>Brush.linearGradient(colors)</c> default).
     /// </summary>
-    public static Brush LinearGradient(
+    public static BoundBrush LinearGradient(
         Color[] colors,
         Offset start,
         Offset end,
-        TileMode tileMode = TileMode.Clamp)
-    {
-        var list = ComposeBridges.ToColorList(colors);
-        var bound = ComposeBridges.BrushCompanion().LinearGradient_mHitzGk(
-            list, start.Packed, end.Packed, (int)tileMode);
-        return FromBound(bound);
-    }
+        TileMode tileMode = TileMode.Clamp) =>
+        ComposeBridges.BrushCompanion().LinearGradient_mHitzGk(
+            ComposeBridges.ToColorList(colors), start.Packed, end.Packed, (int)tileMode);
 
     /// <summary>
     /// Convenience overload — matches Kotlin's
@@ -78,7 +69,7 @@ public sealed class Brush : Java.Lang.Object
     /// the bottom-right corner of the drawing region at paint time, so
     /// this produces a top-left-to-bottom-right diagonal gradient.
     /// </summary>
-    public static Brush LinearGradient(params Color[] colors) =>
+    public static BoundBrush LinearGradient(params Color[] colors) =>
         LinearGradient(colors, Offset.Zero, Offset.Infinite, TileMode.Clamp);
 
     /// <summary>
@@ -86,23 +77,19 @@ public sealed class Brush : Java.Lang.Object
     /// — gradient along the X axis. The Y component spans the full
     /// height of whatever box this brush is painted onto.
     /// </summary>
-    public static Brush HorizontalGradient(
+    public static BoundBrush HorizontalGradient(
         Color[] colors,
         float startX = 0f,
         float endX = float.PositiveInfinity,
-        TileMode tileMode = TileMode.Clamp)
-    {
-        var list = ComposeBridges.ToColorList(colors);
-        var bound = ComposeBridges.BrushCompanion().HorizontalGradient_8A_3gB4(
-            list, startX, endX, (int)tileMode);
-        return FromBound(bound);
-    }
+        TileMode tileMode = TileMode.Clamp) =>
+        ComposeBridges.BrushCompanion().HorizontalGradient_8A_3gB4(
+            ComposeBridges.ToColorList(colors), startX, endX, (int)tileMode);
 
     /// <summary>
     /// <c>Brush.horizontalGradient(colors)</c> — Kotlin default
     /// (full-width sweep, <see cref="TileMode.Clamp"/>).
     /// </summary>
-    public static Brush HorizontalGradient(params Color[] colors) =>
+    public static BoundBrush HorizontalGradient(params Color[] colors) =>
         HorizontalGradient(colors, 0f, float.PositiveInfinity, TileMode.Clamp);
 
     /// <summary>
@@ -110,23 +97,19 @@ public sealed class Brush : Java.Lang.Object
     /// — gradient along the Y axis. The X component spans the full
     /// width of whatever box this brush is painted onto.
     /// </summary>
-    public static Brush VerticalGradient(
+    public static BoundBrush VerticalGradient(
         Color[] colors,
         float startY = 0f,
         float endY = float.PositiveInfinity,
-        TileMode tileMode = TileMode.Clamp)
-    {
-        var list = ComposeBridges.ToColorList(colors);
-        var bound = ComposeBridges.BrushCompanion().VerticalGradient_8A_3gB4(
-            list, startY, endY, (int)tileMode);
-        return FromBound(bound);
-    }
+        TileMode tileMode = TileMode.Clamp) =>
+        ComposeBridges.BrushCompanion().VerticalGradient_8A_3gB4(
+            ComposeBridges.ToColorList(colors), startY, endY, (int)tileMode);
 
     /// <summary>
     /// <c>Brush.verticalGradient(colors)</c> — Kotlin default
     /// (full-height sweep, <see cref="TileMode.Clamp"/>).
     /// </summary>
-    public static Brush VerticalGradient(params Color[] colors) =>
+    public static BoundBrush VerticalGradient(params Color[] colors) =>
         VerticalGradient(colors, 0f, float.PositiveInfinity, TileMode.Clamp);
 
     /// <summary>
@@ -136,23 +119,19 @@ public sealed class Brush : Java.Lang.Object
     /// for <paramref name="center"/> to centre the gradient on the
     /// painted box.
     /// </summary>
-    public static Brush RadialGradient(
+    public static BoundBrush RadialGradient(
         Color[] colors,
         Offset center,
         float radius = float.PositiveInfinity,
-        TileMode tileMode = TileMode.Clamp)
-    {
-        var list = ComposeBridges.ToColorList(colors);
-        var bound = ComposeBridges.BrushCompanion().RadialGradient_P_Vx_Ks(
-            list, center.Packed, radius, (int)tileMode);
-        return FromBound(bound);
-    }
+        TileMode tileMode = TileMode.Clamp) =>
+        ComposeBridges.BrushCompanion().RadialGradient_P_Vx_Ks(
+            ComposeBridges.ToColorList(colors), center.Packed, radius, (int)tileMode);
 
     /// <summary>
     /// <c>Brush.radialGradient(colors)</c> — auto-centred,
     /// auto-sized, <see cref="TileMode.Clamp"/>.
     /// </summary>
-    public static Brush RadialGradient(params Color[] colors) =>
+    public static BoundBrush RadialGradient(params Color[] colors) =>
         RadialGradient(colors, Offset.Unspecified, float.PositiveInfinity, TileMode.Clamp);
 
     /// <summary>
@@ -161,36 +140,14 @@ public sealed class Brush : Java.Lang.Object
     /// <see cref="Offset.Unspecified"/> for <paramref name="center"/>
     /// to centre on the painted box.
     /// </summary>
-    public static Brush SweepGradient(Color[] colors, Offset center)
-    {
-        var list = ComposeBridges.ToColorList(colors);
-        var bound = ComposeBridges.BrushCompanion().SweepGradient_Uv8p0NA(
-            list, center.Packed);
-        return FromBound(bound);
-    }
+    public static BoundBrush SweepGradient(Color[] colors, Offset center) =>
+        ComposeBridges.BrushCompanion().SweepGradient_Uv8p0NA(
+            ComposeBridges.ToColorList(colors), center.Packed);
 
     /// <summary>
     /// <c>Brush.sweepGradient(colors)</c> — auto-centred angular
     /// gradient sweeping through 360°.
     /// </summary>
-    public static Brush SweepGradient(params Color[] colors) =>
+    public static BoundBrush SweepGradient(params Color[] colors) =>
         SweepGradient(colors, Offset.Unspecified);
-
-    // Take ownership of a bound Brush peer's handle and wrap it in our
-    // facade type. The bound peer goes out of scope after this call, so
-    // we use DoNotTransfer + GC.KeepAlive to keep the JNI handle alive
-    // until our wrapper has taken its own managed reference.
-    static Brush FromBound(BoundBrush bound)
-    {
-        try
-        {
-            return new Brush(
-                ((Java.Lang.Object)bound).Handle,
-                JniHandleOwnership.DoNotTransfer);
-        }
-        finally
-        {
-            GC.KeepAlive(bound);
-        }
-    }
 }

--- a/src/Microsoft.AndroidX.Compose/Brush.cs
+++ b/src/Microsoft.AndroidX.Compose/Brush.cs
@@ -1,0 +1,190 @@
+using Android.Runtime;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// C# wrapper around Kotlin's <c>androidx.compose.ui.graphics.Brush</c>
+/// — the value passed to fill / stroke slots that want richer paint
+/// than a single <see cref="Color"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Build a <see cref="Brush"/> via the static factory methods:
+/// <see cref="SolidColor(Color)"/>,
+/// <see cref="LinearGradient(Color[], Offset, Offset, TileMode)"/>,
+/// <see cref="HorizontalGradient(Color[], float, float, TileMode)"/>,
+/// <see cref="VerticalGradient(Color[], float, float, TileMode)"/>,
+/// <see cref="RadialGradient(Color[], Offset, float, TileMode)"/>, and
+/// <see cref="SweepGradient(Color[], Offset)"/>.
+/// </para>
+/// <para>
+/// Pass the returned instance to <c>Modifier.Background(brush)</c> /
+/// <c>Modifier.Background(brush, shape)</c> /
+/// <c>Modifier.Border(width, brush)</c> / etc. Brush instances are
+/// immutable — keep one in a field (or
+/// <c>composer.Remember(() =&gt; Brush.HorizontalGradient(...))</c>)
+/// when the same brush renders every frame; otherwise let the
+/// composition build a fresh instance each pass.
+/// </para>
+/// </remarks>
+public class Brush : Java.Lang.Object
+{
+    private protected Brush(IntPtr handle, JniHandleOwnership transfer)
+        : base(handle, transfer) { }
+
+    /// <summary>
+    /// <c>SolidColor(color)</c> — a <see cref="Brush"/> that paints a
+    /// single flat color. Mostly useful for APIs that demand a
+    /// <c>Brush</c> rather than a <see cref="Color"/>; for the typical
+    /// "fill with a color" case prefer the
+    /// <c>Modifier.Background(Color)</c> overload, which avoids the
+    /// extra JNI allocation.
+    /// </summary>
+    public static Brush SolidColor(Color color)
+    {
+        IntPtr handle = ComposeBridges.BrushSolidColor(color);
+        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// <c>Brush.linearGradient(colors, start, end, tileMode)</c> —
+    /// gradient interpolating along the line from
+    /// <paramref name="start"/> to <paramref name="end"/>. Colors are
+    /// spaced evenly along the line; pass
+    /// <see cref="Offset.Zero"/> and a far-away <see cref="Offset"/>
+    /// for endpoint pinning, or
+    /// <c>(Offset.Zero, new Offset(0f, Single.PositiveInfinity))</c>
+    /// for a fill-the-whole-vertical-axis gradient (matches Kotlin's
+    /// default of <c>Offset(0f, Float.POSITIVE_INFINITY)</c>).
+    /// </summary>
+    public static Brush LinearGradient(
+        Color[] colors,
+        Offset start,
+        Offset end,
+        TileMode tileMode = TileMode.Clamp)
+    {
+        ArgumentNullException.ThrowIfNull(colors);
+        long[] packed = PackColors(colors);
+        IntPtr handle = ComposeBridges.BrushLinearGradient(
+            packed, start.Packed, end.Packed, (int)tileMode);
+        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// Convenience overload — <c>LinearGradient(colors, Offset.Zero,
+    /// new Offset(0f, Single.PositiveInfinity), Clamp)</c>. Produces a
+    /// top-to-bottom vertical fade matching Kotlin's
+    /// <c>Brush.linearGradient(colors)</c> default.
+    /// </summary>
+    public static Brush LinearGradient(params Color[] colors) =>
+        LinearGradient(colors, Offset.Zero, new Offset(0f, float.PositiveInfinity), TileMode.Clamp);
+
+    /// <summary>
+    /// <c>Brush.horizontalGradient(colors, startX, endX, tileMode)</c>
+    /// — gradient along the X axis. The Y component spans the full
+    /// height of whatever box this brush is painted onto.
+    /// </summary>
+    public static Brush HorizontalGradient(
+        Color[] colors,
+        float startX = 0f,
+        float endX = float.PositiveInfinity,
+        TileMode tileMode = TileMode.Clamp)
+    {
+        ArgumentNullException.ThrowIfNull(colors);
+        long[] packed = PackColors(colors);
+        IntPtr handle = ComposeBridges.BrushHorizontalGradient(
+            packed, startX, endX, (int)tileMode);
+        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// <c>Brush.horizontalGradient(colors)</c> — Kotlin default
+    /// (full-width sweep, <see cref="TileMode.Clamp"/>).
+    /// </summary>
+    public static Brush HorizontalGradient(params Color[] colors) =>
+        HorizontalGradient(colors, 0f, float.PositiveInfinity, TileMode.Clamp);
+
+    /// <summary>
+    /// <c>Brush.verticalGradient(colors, startY, endY, tileMode)</c>
+    /// — gradient along the Y axis. The X component spans the full
+    /// width of whatever box this brush is painted onto.
+    /// </summary>
+    public static Brush VerticalGradient(
+        Color[] colors,
+        float startY = 0f,
+        float endY = float.PositiveInfinity,
+        TileMode tileMode = TileMode.Clamp)
+    {
+        ArgumentNullException.ThrowIfNull(colors);
+        long[] packed = PackColors(colors);
+        IntPtr handle = ComposeBridges.BrushVerticalGradient(
+            packed, startY, endY, (int)tileMode);
+        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// <c>Brush.verticalGradient(colors)</c> — Kotlin default
+    /// (full-height sweep, <see cref="TileMode.Clamp"/>).
+    /// </summary>
+    public static Brush VerticalGradient(params Color[] colors) =>
+        VerticalGradient(colors, 0f, float.PositiveInfinity, TileMode.Clamp);
+
+    /// <summary>
+    /// <c>Brush.radialGradient(colors, center, radius, tileMode)</c>
+    /// — gradient radiating outward from <paramref name="center"/> to
+    /// <paramref name="radius"/>. Pass <see cref="Offset.Unspecified"/>
+    /// for <paramref name="center"/> to centre the gradient on the
+    /// painted box.
+    /// </summary>
+    public static Brush RadialGradient(
+        Color[] colors,
+        Offset center,
+        float radius = float.PositiveInfinity,
+        TileMode tileMode = TileMode.Clamp)
+    {
+        ArgumentNullException.ThrowIfNull(colors);
+        long[] packed = PackColors(colors);
+        IntPtr handle = ComposeBridges.BrushRadialGradient(
+            packed, center.Packed, radius, (int)tileMode);
+        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// <c>Brush.radialGradient(colors)</c> — auto-centred,
+    /// auto-sized, <see cref="TileMode.Clamp"/>.
+    /// </summary>
+    public static Brush RadialGradient(params Color[] colors) =>
+        RadialGradient(colors, Offset.Unspecified, float.PositiveInfinity, TileMode.Clamp);
+
+    /// <summary>
+    /// <c>Brush.sweepGradient(colors, center)</c> — angular gradient
+    /// that wraps around <paramref name="center"/> through 360°. Pass
+    /// <see cref="Offset.Unspecified"/> for <paramref name="center"/>
+    /// to centre on the painted box.
+    /// </summary>
+    public static Brush SweepGradient(Color[] colors, Offset center)
+    {
+        ArgumentNullException.ThrowIfNull(colors);
+        long[] packed = PackColors(colors);
+        IntPtr handle = ComposeBridges.BrushSweepGradient(packed, center.Packed);
+        return new Brush(handle, JniHandleOwnership.TransferLocalRef);
+    }
+
+    /// <summary>
+    /// <c>Brush.sweepGradient(colors)</c> — auto-centred angular
+    /// gradient sweeping through 360°.
+    /// </summary>
+    public static Brush SweepGradient(params Color[] colors) =>
+        SweepGradient(colors, Offset.Unspecified);
+
+    static long[] PackColors(Color[] colors)
+    {
+        if (colors.Length == 0)
+            throw new ArgumentException(
+                "Gradient must have at least one color stop.", nameof(colors));
+        long[] packed = new long[colors.Length];
+        for (int i = 0; i < colors.Length; i++)
+            packed[i] = colors[i];
+        return packed;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose/BrushBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/BrushBridges.cs
@@ -1,0 +1,350 @@
+using Android.Runtime;
+
+namespace AndroidX.Compose;
+
+// Hand-written raw-JNI bridges for `androidx.compose.ui.graphics.Brush`
+// and its `Companion` factories. Almost every entry point is mangled
+// because the gradient factories take `List<Color>` (and Color is a
+// `@JvmInline value class`), so the binder strips the C# overloads —
+// even though the type itself (`AndroidX.Compose.UI.Graphics.Brush`)
+// is bound.
+//
+// Why not `[ComposeBridge]`?
+//   The bridge generator doesn't model "build a `java.util.ArrayList<Color>`
+//   from a `long[]` arg by calling `Color.box-impl(J)` per element"
+//   — that's the JNI dance below. Once that's hand-rolled, the rest of
+//   each factory (FindClass → GetStaticMethodID → CallStaticObjectMethod
+//   on the Companion) is small enough that staying hand-written is the
+//   pragmatic shape. Constructed Brush instances are returned as raw
+//   `IntPtr` so the public `Brush` wrapper can pick them up via
+//   `Java.Lang.Object.GetObject<Brush>(handle, TransferLocalRef)`.
+//
+// Also hand-rolls:
+//   - The `RectangleShape` singleton accessor used by `Shape.Rectangle`.
+//   - The `SolidColor(Color)` ctor (mangled because Color is a value
+//     class — the binding exposes the class but not the ctor).
+internal static partial class ComposeBridges
+{
+    // Cached `androidx.compose.ui.graphics.Color` class ref (stable
+    // global from Mono.Android — see KotlinResult.cs for the rationale).
+    static IntPtr s_colorClass;
+    static IntPtr s_color_boxImpl;
+
+    // Cached `androidx.compose.ui.graphics.Brush$Companion` singleton —
+    // returned by every gradient factory. Held as a global ref so the
+    // GC can't move it out from under repeated FindClass invocations.
+    static IntPtr s_brushCompanion_class;
+    static IntPtr s_brushCompanion_handle;
+
+    static IntPtr s_brush_linearGradient_method;
+    static IntPtr s_brush_horizontalGradient_method;
+    static IntPtr s_brush_verticalGradient_method;
+    static IntPtr s_brush_radialGradient_method;
+    static IntPtr s_brush_sweepGradient_method;
+
+    static IntPtr s_solidColor_class;
+    static IntPtr s_solidColor_ctor;
+
+    static IntPtr s_arrayList_class;
+    static IntPtr s_arrayList_ctor;
+    static IntPtr s_arrayList_add;
+
+    // Cached `RectangleShapeKt.getRectangleShape()` singleton — Compose's
+    // canonical "no clipping, just a rectangle" Shape. Used by
+    // `Shape.Rectangle` and by the default branch of every
+    // `Modifier.Background(Brush, ...)` overload that doesn't take an
+    // explicit shape.
+    static IntPtr s_rectangleShape_handle;
+
+    static void EnsureColorBox()
+    {
+        if (s_color_boxImpl != IntPtr.Zero) return;
+        s_colorClass = JNIEnv.FindClass("androidx/compose/ui/graphics/Color");
+        s_color_boxImpl = JNIEnv.GetStaticMethodID(
+            s_colorClass, "box-impl", "(J)Landroidx/compose/ui/graphics/Color;");
+    }
+
+    static void EnsureArrayList()
+    {
+        if (s_arrayList_add != IntPtr.Zero) return;
+        s_arrayList_class = JNIEnv.FindClass("java/util/ArrayList");
+        s_arrayList_ctor  = JNIEnv.GetMethodID(s_arrayList_class, "<init>", "(I)V");
+        s_arrayList_add   = JNIEnv.GetMethodID(s_arrayList_class, "add",    "(Ljava/lang/Object;)Z");
+    }
+
+    // Build a `java.util.ArrayList<androidx.compose.ui.graphics.Color>`
+    // from a packed-long array. Each long is boxed into a
+    // `Color` peer via the Kotlin-synthetic `Color.box-impl(J)`
+    // static method — that's the only way to materialise a `Color`
+    // peer from a packed value, because the type's instance ctor
+    // is private at the bytecode level. Caller owns the returned
+    // local ref.
+    internal static unsafe IntPtr BoxColorList(long[] colors)
+    {
+        ArgumentNullException.ThrowIfNull(colors);
+        if (colors.Length == 0)
+            throw new ArgumentException("Gradient must have at least one color stop.", nameof(colors));
+
+        EnsureColorBox();
+        EnsureArrayList();
+
+        JValue* ctorArgs = stackalloc JValue[1];
+        ctorArgs[0] = new JValue(colors.Length);
+        IntPtr list = JNIEnv.NewObject(s_arrayList_class, s_arrayList_ctor, ctorArgs);
+        try
+        {
+            JValue* boxArgs = stackalloc JValue[1];
+            JValue* addArgs = stackalloc JValue[1];
+            for (int i = 0; i < colors.Length; i++)
+            {
+                boxArgs[0] = new JValue(colors[i]);
+                IntPtr boxed = JNIEnv.CallStaticObjectMethod(
+                    s_colorClass, s_color_boxImpl, boxArgs);
+                try
+                {
+                    addArgs[0] = new JValue(boxed);
+                    JNIEnv.CallBooleanMethod(list, s_arrayList_add, addArgs);
+                }
+                finally
+                {
+                    if (boxed != IntPtr.Zero)
+                        JNIEnv.DeleteLocalRef(boxed);
+                }
+            }
+            return list;
+        }
+        catch
+        {
+            if (list != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(list);
+            throw;
+        }
+    }
+
+    // androidx.compose.ui.graphics.Brush$Companion — singleton companion
+    // object that exposes every gradient factory. Lazily loaded on first
+    // use, then cached as a global ref so we never re-walk
+    // FindClass/GetStaticFieldID once warmed up.
+    static IntPtr BrushCompanion()
+    {
+        if (s_brushCompanion_handle != IntPtr.Zero)
+            return s_brushCompanion_handle;
+
+        s_brushCompanion_class = JNIEnv.FindClass(
+            "androidx/compose/ui/graphics/Brush$Companion");
+
+        IntPtr brushClass = JNIEnv.FindClass("androidx/compose/ui/graphics/Brush");
+        IntPtr companionField = JNIEnv.GetStaticFieldID(
+            brushClass, "Companion", "Landroidx/compose/ui/graphics/Brush$Companion;");
+        IntPtr local = JNIEnv.GetStaticObjectField(brushClass, companionField);
+        try
+        {
+            s_brushCompanion_handle = JNIEnv.NewGlobalRef(local);
+        }
+        finally
+        {
+            if (local != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(local);
+        }
+        return s_brushCompanion_handle;
+    }
+
+    // Brush.Companion.linearGradient-mHitzGk(List<Color>, long start,
+    // long end, int tileMode) -> Brush.
+    internal static unsafe IntPtr BrushLinearGradient(
+        long[] colors, long start, long end, int tileMode)
+    {
+        IntPtr list = BoxColorList(colors);
+        try
+        {
+            if (s_brush_linearGradient_method == IntPtr.Zero)
+            {
+                IntPtr companion = BrushCompanion();
+                _ = companion;
+                s_brush_linearGradient_method = JNIEnv.GetMethodID(
+                    s_brushCompanion_class,
+                    "linearGradient-mHitzGk",
+                    "(Ljava/util/List;JJI)Landroidx/compose/ui/graphics/Brush;");
+            }
+
+            JValue* args = stackalloc JValue[4];
+            args[0] = new JValue(list);
+            args[1] = new JValue(start);
+            args[2] = new JValue(end);
+            args[3] = new JValue(tileMode);
+            return JNIEnv.CallObjectMethod(
+                BrushCompanion(), s_brush_linearGradient_method, args);
+        }
+        finally
+        {
+            if (list != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(list);
+        }
+    }
+
+    // Brush.Companion.horizontalGradient-8A-3gB4(List<Color>, float
+    // startX, float endX, int tileMode) -> Brush.
+    internal static unsafe IntPtr BrushHorizontalGradient(
+        long[] colors, float startX, float endX, int tileMode)
+    {
+        IntPtr list = BoxColorList(colors);
+        try
+        {
+            if (s_brush_horizontalGradient_method == IntPtr.Zero)
+            {
+                _ = BrushCompanion();
+                s_brush_horizontalGradient_method = JNIEnv.GetMethodID(
+                    s_brushCompanion_class,
+                    "horizontalGradient-8A-3gB4",
+                    "(Ljava/util/List;FFI)Landroidx/compose/ui/graphics/Brush;");
+            }
+
+            JValue* args = stackalloc JValue[4];
+            args[0] = new JValue(list);
+            args[1] = new JValue(startX);
+            args[2] = new JValue(endX);
+            args[3] = new JValue(tileMode);
+            return JNIEnv.CallObjectMethod(
+                BrushCompanion(), s_brush_horizontalGradient_method, args);
+        }
+        finally
+        {
+            if (list != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(list);
+        }
+    }
+
+    // Brush.Companion.verticalGradient-8A-3gB4(List<Color>, float startY,
+    // float endY, int tileMode) -> Brush.
+    internal static unsafe IntPtr BrushVerticalGradient(
+        long[] colors, float startY, float endY, int tileMode)
+    {
+        IntPtr list = BoxColorList(colors);
+        try
+        {
+            if (s_brush_verticalGradient_method == IntPtr.Zero)
+            {
+                _ = BrushCompanion();
+                s_brush_verticalGradient_method = JNIEnv.GetMethodID(
+                    s_brushCompanion_class,
+                    "verticalGradient-8A-3gB4",
+                    "(Ljava/util/List;FFI)Landroidx/compose/ui/graphics/Brush;");
+            }
+
+            JValue* args = stackalloc JValue[4];
+            args[0] = new JValue(list);
+            args[1] = new JValue(startY);
+            args[2] = new JValue(endY);
+            args[3] = new JValue(tileMode);
+            return JNIEnv.CallObjectMethod(
+                BrushCompanion(), s_brush_verticalGradient_method, args);
+        }
+        finally
+        {
+            if (list != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(list);
+        }
+    }
+
+    // Brush.Companion.radialGradient-P_Vx-Ks(List<Color>, long center,
+    // float radius, int tileMode) -> Brush.
+    internal static unsafe IntPtr BrushRadialGradient(
+        long[] colors, long center, float radius, int tileMode)
+    {
+        IntPtr list = BoxColorList(colors);
+        try
+        {
+            if (s_brush_radialGradient_method == IntPtr.Zero)
+            {
+                _ = BrushCompanion();
+                s_brush_radialGradient_method = JNIEnv.GetMethodID(
+                    s_brushCompanion_class,
+                    "radialGradient-P_Vx-Ks",
+                    "(Ljava/util/List;JFI)Landroidx/compose/ui/graphics/Brush;");
+            }
+
+            JValue* args = stackalloc JValue[4];
+            args[0] = new JValue(list);
+            args[1] = new JValue(center);
+            args[2] = new JValue(radius);
+            args[3] = new JValue(tileMode);
+            return JNIEnv.CallObjectMethod(
+                BrushCompanion(), s_brush_radialGradient_method, args);
+        }
+        finally
+        {
+            if (list != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(list);
+        }
+    }
+
+    // Brush.Companion.sweepGradient-Uv8p0NA(List<Color>, long center) ->
+    // Brush. No tileMode arg — sweep wraps around 360° naturally.
+    internal static unsafe IntPtr BrushSweepGradient(long[] colors, long center)
+    {
+        IntPtr list = BoxColorList(colors);
+        try
+        {
+            if (s_brush_sweepGradient_method == IntPtr.Zero)
+            {
+                _ = BrushCompanion();
+                s_brush_sweepGradient_method = JNIEnv.GetMethodID(
+                    s_brushCompanion_class,
+                    "sweepGradient-Uv8p0NA",
+                    "(Ljava/util/List;J)Landroidx/compose/ui/graphics/Brush;");
+            }
+
+            JValue* args = stackalloc JValue[2];
+            args[0] = new JValue(list);
+            args[1] = new JValue(center);
+            return JNIEnv.CallObjectMethod(
+                BrushCompanion(), s_brush_sweepGradient_method, args);
+        }
+        finally
+        {
+            if (list != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(list);
+        }
+    }
+
+    // new androidx.compose.ui.graphics.SolidColor(Color) — the data
+    // class for "single solid color as a Brush". Its ctor isn't bound
+    // because Color is a value-class param, so we go via raw JNI.
+    internal static unsafe IntPtr BrushSolidColor(long color)
+    {
+        if (s_solidColor_ctor == IntPtr.Zero)
+        {
+            s_solidColor_class = JNIEnv.FindClass("androidx/compose/ui/graphics/SolidColor");
+            s_solidColor_ctor  = JNIEnv.GetMethodID(s_solidColor_class, "<init>", "(J)V");
+        }
+
+        JValue* args = stackalloc JValue[1];
+        args[0] = new JValue(color);
+        return JNIEnv.NewObject(s_solidColor_class, s_solidColor_ctor, args);
+    }
+
+    // androidx.compose.ui.graphics.RectangleShapeKt.getRectangleShape() —
+    // the canonical "no clipping, just a rectangle" Shape singleton.
+    // Cached as a global ref so the per-call cost is one CallStaticObjectMethod
+    // -free local ref handout.
+    internal static IntPtr RectangleShape()
+    {
+        if (s_rectangleShape_handle != IntPtr.Zero)
+            return s_rectangleShape_handle;
+
+        IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/graphics/RectangleShapeKt");
+        IntPtr mid = JNIEnv.GetStaticMethodID(
+            cls, "getRectangleShape", "()Landroidx/compose/ui/graphics/Shape;");
+        IntPtr local = JNIEnv.CallStaticObjectMethod(cls, mid);
+        try
+        {
+            s_rectangleShape_handle = JNIEnv.NewGlobalRef(local);
+        }
+        finally
+        {
+            if (local != IntPtr.Zero)
+                JNIEnv.DeleteLocalRef(local);
+        }
+        return s_rectangleShape_handle;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose/BrushBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/BrushBridges.cs
@@ -1,350 +1,105 @@
 using Android.Runtime;
+using BoundBrush = AndroidX.Compose.UI.Graphics.Brush;
+using BoundColor = AndroidX.Compose.UI.Graphics.Color;
 
 namespace AndroidX.Compose;
 
-// Hand-written raw-JNI bridges for `androidx.compose.ui.graphics.Brush`
-// and its `Companion` factories. Almost every entry point is mangled
-// because the gradient factories take `List<Color>` (and Color is a
-// `@JvmInline value class`), so the binder strips the C# overloads —
-// even though the type itself (`AndroidX.Compose.UI.Graphics.Brush`)
-// is bound.
+// Hand-written JNI for the two Compose-graphics symbols the
+// Mono.Android binder strips:
 //
-// Why not `[ComposeBridge]`?
-//   The bridge generator doesn't model "build a `java.util.ArrayList<Color>`
-//   from a `long[]` arg by calling `Color.box-impl(J)` per element"
-//   — that's the JNI dance below. Once that's hand-rolled, the rest of
-//   each factory (FindClass → GetStaticMethodID → CallStaticObjectMethod
-//   on the Companion) is small enough that staying hand-written is the
-//   pragmatic shape. Constructed Brush instances are returned as raw
-//   `IntPtr` so the public `Brush` wrapper can pick them up via
-//   `Java.Lang.Object.GetObject<Brush>(handle, TransferLocalRef)`.
+//   - `androidx.compose.ui.graphics.Color.box-impl(J)Color` — the
+//     Kotlin-synthetic boxing factory that turns a packed `long` into
+//     a `Color` object. The `Color` class itself is bound, but its
+//     ctor and `box-impl` static are skipped (value-class lowering).
+//   - `androidx.compose.ui.graphics.SolidColor.<init>(J)V` — same
+//     reason; the ctor takes a value-class `Color`.
 //
-// Also hand-rolls:
-//   - The `RectangleShape` singleton accessor used by `Shape.Rectangle`.
-//   - The `SolidColor(Color)` ctor (mangled because Color is a value
-//     class — the binding exposes the class but not the ctor).
+// Everything else (`Brush.Companion`'s gradient factories,
+// `RectangleShapeKt.RectangleShape`) is bound and called directly
+// from `Brush` / `Shape`.
 internal static partial class ComposeBridges
 {
-    // Cached `androidx.compose.ui.graphics.Color` class ref (stable
-    // global from Mono.Android — see KotlinResult.cs for the rationale).
-    static IntPtr s_colorClass;
+    static BoundBrush.Companion? s_brushCompanion;
+
+    static IntPtr s_color_class;
     static IntPtr s_color_boxImpl;
-
-    // Cached `androidx.compose.ui.graphics.Brush$Companion` singleton —
-    // returned by every gradient factory. Held as a global ref so the
-    // GC can't move it out from under repeated FindClass invocations.
-    static IntPtr s_brushCompanion_class;
-    static IntPtr s_brushCompanion_handle;
-
-    static IntPtr s_brush_linearGradient_method;
-    static IntPtr s_brush_horizontalGradient_method;
-    static IntPtr s_brush_verticalGradient_method;
-    static IntPtr s_brush_radialGradient_method;
-    static IntPtr s_brush_sweepGradient_method;
 
     static IntPtr s_solidColor_class;
     static IntPtr s_solidColor_ctor;
 
-    static IntPtr s_arrayList_class;
-    static IntPtr s_arrayList_ctor;
-    static IntPtr s_arrayList_add;
-
-    // Cached `RectangleShapeKt.getRectangleShape()` singleton — Compose's
-    // canonical "no clipping, just a rectangle" Shape. Used by
-    // `Shape.Rectangle` and by the default branch of every
-    // `Modifier.Background(Brush, ...)` overload that doesn't take an
-    // explicit shape.
-    static IntPtr s_rectangleShape_handle;
-
-    static void EnsureColorBox()
+    // Lazy access to the `androidx.compose.ui.graphics.Brush$Companion`
+    // singleton — the binder exposes the type but not a public C# accessor
+    // for the Kotlin `Companion` static field, so we fetch it via JNI
+    // once and cache the bound peer. Subsequent gradient calls go
+    // straight through the bound `LinearGradient_mHitzGk`/etc. methods.
+    internal static BoundBrush.Companion BrushCompanion()
     {
-        if (s_color_boxImpl != IntPtr.Zero) return;
-        s_colorClass = JNIEnv.FindClass("androidx/compose/ui/graphics/Color");
-        s_color_boxImpl = JNIEnv.GetStaticMethodID(
-            s_colorClass, "box-impl", "(J)Landroidx/compose/ui/graphics/Color;");
+        if (s_brushCompanion is not null) return s_brushCompanion;
+        IntPtr local = IntPtr.Zero;
+        try
+        {
+            IntPtr brushClass = Java.Lang.Class.FromType(typeof(BoundBrush)).Handle;
+            IntPtr fid = JNIEnv.GetStaticFieldID(
+                brushClass, "Companion",
+                "Landroidx/compose/ui/graphics/Brush$Companion;");
+            local = JNIEnv.GetStaticObjectField(brushClass, fid);
+            return s_brushCompanion = Java.Lang.Object.GetObject<BoundBrush.Companion>(
+                local, JniHandleOwnership.TransferLocalRef)!;
+        }
+        finally
+        {
+            if (local != IntPtr.Zero && s_brushCompanion is null)
+                JNIEnv.DeleteLocalRef(local);
+        }
     }
 
-    static void EnsureArrayList()
+    // Box a packed-long Color into a bound `BoundColor` peer via the
+    // Kotlin-synthetic `Color.box-impl(J)` static. Required because
+    // `BoundBrush.Companion.LinearGradient_mHitzGk(IList<Color>, ...)`
+    // (and every other gradient factory) takes a List of *boxed* Color
+    // objects — packed longs alone aren't acceptable.
+    internal static unsafe BoundColor BoxColor(long packed)
     {
-        if (s_arrayList_add != IntPtr.Zero) return;
-        s_arrayList_class = JNIEnv.FindClass("java/util/ArrayList");
-        s_arrayList_ctor  = JNIEnv.GetMethodID(s_arrayList_class, "<init>", "(I)V");
-        s_arrayList_add   = JNIEnv.GetMethodID(s_arrayList_class, "add",    "(Ljava/lang/Object;)Z");
+        if (s_color_boxImpl == IntPtr.Zero)
+        {
+            s_color_class = Java.Lang.Class.FromType(typeof(BoundColor)).Handle;
+            s_color_boxImpl = JNIEnv.GetStaticMethodID(
+                s_color_class, "box-impl", "(J)Landroidx/compose/ui/graphics/Color;");
+        }
+        var args = stackalloc JValue[1];
+        args[0] = new JValue(packed);
+        IntPtr handle = JNIEnv.CallStaticObjectMethod(
+            s_color_class, s_color_boxImpl, args);
+        return Java.Lang.Object.GetObject<BoundColor>(
+            handle, JniHandleOwnership.TransferLocalRef)!;
     }
 
-    // Build a `java.util.ArrayList<androidx.compose.ui.graphics.Color>`
-    // from a packed-long array. Each long is boxed into a
-    // `Color` peer via the Kotlin-synthetic `Color.box-impl(J)`
-    // static method — that's the only way to materialise a `Color`
-    // peer from a packed value, because the type's instance ctor
-    // is private at the bytecode level. Caller owns the returned
-    // local ref.
-    internal static unsafe IntPtr BoxColorList(long[] colors)
+    // Build an `IList<BoundColor>` from a managed `Color[]` for the
+    // gradient factories. `JavaList<T>` is the Mono.Android wrapper
+    // over `java.util.ArrayList` — no further JNI required for `add`.
+    internal static IList<BoundColor> ToColorList(Color[] colors)
     {
         ArgumentNullException.ThrowIfNull(colors);
         if (colors.Length == 0)
-            throw new ArgumentException("Gradient must have at least one color stop.", nameof(colors));
-
-        EnsureColorBox();
-        EnsureArrayList();
-
-        JValue* ctorArgs = stackalloc JValue[1];
-        ctorArgs[0] = new JValue(colors.Length);
-        IntPtr list = JNIEnv.NewObject(s_arrayList_class, s_arrayList_ctor, ctorArgs);
-        try
-        {
-            JValue* boxArgs = stackalloc JValue[1];
-            JValue* addArgs = stackalloc JValue[1];
-            for (int i = 0; i < colors.Length; i++)
-            {
-                boxArgs[0] = new JValue(colors[i]);
-                IntPtr boxed = JNIEnv.CallStaticObjectMethod(
-                    s_colorClass, s_color_boxImpl, boxArgs);
-                try
-                {
-                    addArgs[0] = new JValue(boxed);
-                    JNIEnv.CallBooleanMethod(list, s_arrayList_add, addArgs);
-                }
-                finally
-                {
-                    if (boxed != IntPtr.Zero)
-                        JNIEnv.DeleteLocalRef(boxed);
-                }
-            }
-            return list;
-        }
-        catch
-        {
-            if (list != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(list);
-            throw;
-        }
+            throw new ArgumentException(
+                "Gradient must have at least one color stop.", nameof(colors));
+        var list = new JavaList<BoundColor>();
+        foreach (var c in colors)
+            list.Add(BoxColor(c));
+        return list;
     }
 
-    // androidx.compose.ui.graphics.Brush$Companion — singleton companion
-    // object that exposes every gradient factory. Lazily loaded on first
-    // use, then cached as a global ref so we never re-walk
-    // FindClass/GetStaticFieldID once warmed up.
-    static IntPtr BrushCompanion()
-    {
-        if (s_brushCompanion_handle != IntPtr.Zero)
-            return s_brushCompanion_handle;
-
-        s_brushCompanion_class = JNIEnv.FindClass(
-            "androidx/compose/ui/graphics/Brush$Companion");
-
-        IntPtr brushClass = JNIEnv.FindClass("androidx/compose/ui/graphics/Brush");
-        IntPtr companionField = JNIEnv.GetStaticFieldID(
-            brushClass, "Companion", "Landroidx/compose/ui/graphics/Brush$Companion;");
-        IntPtr local = JNIEnv.GetStaticObjectField(brushClass, companionField);
-        try
-        {
-            s_brushCompanion_handle = JNIEnv.NewGlobalRef(local);
-        }
-        finally
-        {
-            if (local != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(local);
-        }
-        return s_brushCompanion_handle;
-    }
-
-    // Brush.Companion.linearGradient-mHitzGk(List<Color>, long start,
-    // long end, int tileMode) -> Brush.
-    internal static unsafe IntPtr BrushLinearGradient(
-        long[] colors, long start, long end, int tileMode)
-    {
-        IntPtr list = BoxColorList(colors);
-        try
-        {
-            if (s_brush_linearGradient_method == IntPtr.Zero)
-            {
-                IntPtr companion = BrushCompanion();
-                _ = companion;
-                s_brush_linearGradient_method = JNIEnv.GetMethodID(
-                    s_brushCompanion_class,
-                    "linearGradient-mHitzGk",
-                    "(Ljava/util/List;JJI)Landroidx/compose/ui/graphics/Brush;");
-            }
-
-            JValue* args = stackalloc JValue[4];
-            args[0] = new JValue(list);
-            args[1] = new JValue(start);
-            args[2] = new JValue(end);
-            args[3] = new JValue(tileMode);
-            return JNIEnv.CallObjectMethod(
-                BrushCompanion(), s_brush_linearGradient_method, args);
-        }
-        finally
-        {
-            if (list != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(list);
-        }
-    }
-
-    // Brush.Companion.horizontalGradient-8A-3gB4(List<Color>, float
-    // startX, float endX, int tileMode) -> Brush.
-    internal static unsafe IntPtr BrushHorizontalGradient(
-        long[] colors, float startX, float endX, int tileMode)
-    {
-        IntPtr list = BoxColorList(colors);
-        try
-        {
-            if (s_brush_horizontalGradient_method == IntPtr.Zero)
-            {
-                _ = BrushCompanion();
-                s_brush_horizontalGradient_method = JNIEnv.GetMethodID(
-                    s_brushCompanion_class,
-                    "horizontalGradient-8A-3gB4",
-                    "(Ljava/util/List;FFI)Landroidx/compose/ui/graphics/Brush;");
-            }
-
-            JValue* args = stackalloc JValue[4];
-            args[0] = new JValue(list);
-            args[1] = new JValue(startX);
-            args[2] = new JValue(endX);
-            args[3] = new JValue(tileMode);
-            return JNIEnv.CallObjectMethod(
-                BrushCompanion(), s_brush_horizontalGradient_method, args);
-        }
-        finally
-        {
-            if (list != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(list);
-        }
-    }
-
-    // Brush.Companion.verticalGradient-8A-3gB4(List<Color>, float startY,
-    // float endY, int tileMode) -> Brush.
-    internal static unsafe IntPtr BrushVerticalGradient(
-        long[] colors, float startY, float endY, int tileMode)
-    {
-        IntPtr list = BoxColorList(colors);
-        try
-        {
-            if (s_brush_verticalGradient_method == IntPtr.Zero)
-            {
-                _ = BrushCompanion();
-                s_brush_verticalGradient_method = JNIEnv.GetMethodID(
-                    s_brushCompanion_class,
-                    "verticalGradient-8A-3gB4",
-                    "(Ljava/util/List;FFI)Landroidx/compose/ui/graphics/Brush;");
-            }
-
-            JValue* args = stackalloc JValue[4];
-            args[0] = new JValue(list);
-            args[1] = new JValue(startY);
-            args[2] = new JValue(endY);
-            args[3] = new JValue(tileMode);
-            return JNIEnv.CallObjectMethod(
-                BrushCompanion(), s_brush_verticalGradient_method, args);
-        }
-        finally
-        {
-            if (list != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(list);
-        }
-    }
-
-    // Brush.Companion.radialGradient-P_Vx-Ks(List<Color>, long center,
-    // float radius, int tileMode) -> Brush.
-    internal static unsafe IntPtr BrushRadialGradient(
-        long[] colors, long center, float radius, int tileMode)
-    {
-        IntPtr list = BoxColorList(colors);
-        try
-        {
-            if (s_brush_radialGradient_method == IntPtr.Zero)
-            {
-                _ = BrushCompanion();
-                s_brush_radialGradient_method = JNIEnv.GetMethodID(
-                    s_brushCompanion_class,
-                    "radialGradient-P_Vx-Ks",
-                    "(Ljava/util/List;JFI)Landroidx/compose/ui/graphics/Brush;");
-            }
-
-            JValue* args = stackalloc JValue[4];
-            args[0] = new JValue(list);
-            args[1] = new JValue(center);
-            args[2] = new JValue(radius);
-            args[3] = new JValue(tileMode);
-            return JNIEnv.CallObjectMethod(
-                BrushCompanion(), s_brush_radialGradient_method, args);
-        }
-        finally
-        {
-            if (list != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(list);
-        }
-    }
-
-    // Brush.Companion.sweepGradient-Uv8p0NA(List<Color>, long center) ->
-    // Brush. No tileMode arg — sweep wraps around 360° naturally.
-    internal static unsafe IntPtr BrushSweepGradient(long[] colors, long center)
-    {
-        IntPtr list = BoxColorList(colors);
-        try
-        {
-            if (s_brush_sweepGradient_method == IntPtr.Zero)
-            {
-                _ = BrushCompanion();
-                s_brush_sweepGradient_method = JNIEnv.GetMethodID(
-                    s_brushCompanion_class,
-                    "sweepGradient-Uv8p0NA",
-                    "(Ljava/util/List;J)Landroidx/compose/ui/graphics/Brush;");
-            }
-
-            JValue* args = stackalloc JValue[2];
-            args[0] = new JValue(list);
-            args[1] = new JValue(center);
-            return JNIEnv.CallObjectMethod(
-                BrushCompanion(), s_brush_sweepGradient_method, args);
-        }
-        finally
-        {
-            if (list != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(list);
-        }
-    }
-
-    // new androidx.compose.ui.graphics.SolidColor(Color) — the data
-    // class for "single solid color as a Brush". Its ctor isn't bound
-    // because Color is a value-class param, so we go via raw JNI.
+    // `new androidx.compose.ui.graphics.SolidColor(Color)` — the ctor
+    // is stripped because its parameter is a value-class `Color`.
     internal static unsafe IntPtr BrushSolidColor(long color)
     {
         if (s_solidColor_ctor == IntPtr.Zero)
         {
             s_solidColor_class = JNIEnv.FindClass("androidx/compose/ui/graphics/SolidColor");
-            s_solidColor_ctor  = JNIEnv.GetMethodID(s_solidColor_class, "<init>", "(J)V");
+            s_solidColor_ctor = JNIEnv.GetMethodID(s_solidColor_class, "<init>", "(J)V");
         }
-
-        JValue* args = stackalloc JValue[1];
+        var args = stackalloc JValue[1];
         args[0] = new JValue(color);
         return JNIEnv.NewObject(s_solidColor_class, s_solidColor_ctor, args);
-    }
-
-    // androidx.compose.ui.graphics.RectangleShapeKt.getRectangleShape() —
-    // the canonical "no clipping, just a rectangle" Shape singleton.
-    // Cached as a global ref so the per-call cost is one CallStaticObjectMethod
-    // -free local ref handout.
-    internal static IntPtr RectangleShape()
-    {
-        if (s_rectangleShape_handle != IntPtr.Zero)
-            return s_rectangleShape_handle;
-
-        IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/graphics/RectangleShapeKt");
-        IntPtr mid = JNIEnv.GetStaticMethodID(
-            cls, "getRectangleShape", "()Landroidx/compose/ui/graphics/Shape;");
-        IntPtr local = JNIEnv.CallStaticObjectMethod(cls, mid);
-        try
-        {
-            s_rectangleShape_handle = JNIEnv.NewGlobalRef(local);
-        }
-        finally
-        {
-            if (local != IntPtr.Zero)
-                JNIEnv.DeleteLocalRef(local);
-        }
-        return s_rectangleShape_handle;
     }
 }

--- a/src/Microsoft.AndroidX.Compose/BrushBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/BrushBridges.cs
@@ -95,7 +95,8 @@ internal static partial class ComposeBridges
     {
         if (s_solidColor_ctor == IntPtr.Zero)
         {
-            s_solidColor_class = JNIEnv.FindClass("androidx/compose/ui/graphics/SolidColor");
+            s_solidColor_class = Java.Lang.Class.FromType(
+                typeof(AndroidX.Compose.UI.Graphics.SolidColor)).Handle;
             s_solidColor_ctor = JNIEnv.GetMethodID(s_solidColor_class, "<init>", "(J)V");
         }
         var args = stackalloc JValue[1];

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1886,6 +1886,24 @@ internal static partial class ComposeBridges
         Defaults  = typeof(ModifierBackgroundDefault))]
     internal static partial IntPtr ModifierBackground(IntPtr modifier, long color, IntPtr? shape);
 
+    // androidx.compose.foundation.BackgroundKt.background$default —
+    // (Modifier, Brush, Shape, float alpha). Not mangled (no value-class
+    // params), but the bound C# overload requires non-null Shape and
+    // alpha — and we want callers to be able to omit either, so we go
+    // through the synthetic $default sibling and let auto-mask handle
+    // the bits. alpha is always supplied (caller's default is 1f);
+    // shape is auto-cleared when supplied.
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/BackgroundKt",
+        JvmName   = "background$default",
+        Signature = "(Landroidx/compose/ui/Modifier;" +
+                    "Landroidx/compose/ui/graphics/Brush;" +
+                    "Landroidx/compose/ui/graphics/Shape;FILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierBackgroundBrushDefault))]
+    internal static partial IntPtr ModifierBackgroundBrush(
+        IntPtr modifier, IntPtr brush, IntPtr? shape, float alpha);
+
     // androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
     // (Modifier, Dp width, Color, Shape). Both width and color are
     // mangled inline-class params. Shape is optional (null → Kotlin
@@ -1898,6 +1916,21 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierBorderDefault))]
     internal static partial IntPtr ModifierBorder(IntPtr modifier, float width, long color, IntPtr? shape);
+
+    // androidx.compose.foundation.BorderKt.border-ziNgDLE$default —
+    // (Modifier, Dp width, Brush, Shape). width is mangled because Dp
+    // is a @JvmInline value class. shape is optional (null → Kotlin
+    // default of RectangleShape).
+    [ComposeBridge(
+        Class     = "androidx/compose/foundation/BorderKt",
+        JvmName   = "border-ziNgDLE$default",
+        Signature = "(Landroidx/compose/ui/Modifier;F" +
+                    "Landroidx/compose/ui/graphics/Brush;" +
+                    "Landroidx/compose/ui/graphics/Shape;ILjava/lang/Object;)" +
+                    "Landroidx/compose/ui/Modifier;",
+        Defaults  = typeof(ModifierBorderBrushDefault))]
+    internal static partial IntPtr ModifierBorderBrush(
+        IntPtr modifier, float width, IntPtr brush, IntPtr? shape);
 
     // androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
     // (Modifier, Boolean enabled, String onClickLabel, Role role,

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1902,7 +1902,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierBackgroundBrushDefault))]
     internal static partial IntPtr ModifierBackgroundBrush(
-        IntPtr modifier, IntPtr brush, IntPtr? shape, float alpha);
+        IntPtr modifier, Brush brush, Shape? shape, float alpha);
 
     // androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
     // (Modifier, Dp width, Color, Shape). Both width and color are
@@ -1930,7 +1930,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierBorderBrushDefault))]
     internal static partial IntPtr ModifierBorderBrush(
-        IntPtr modifier, float width, IntPtr brush, IntPtr? shape);
+        IntPtr modifier, float width, Brush brush, Shape? shape);
 
     // androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
     // (Modifier, Boolean enabled, String onClickLabel, Role role,

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1902,7 +1902,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierBackgroundBrushDefault))]
     internal static partial IntPtr ModifierBackgroundBrush(
-        IntPtr modifier, Brush brush, Shape? shape, float alpha);
+        IntPtr modifier, AndroidX.Compose.UI.Graphics.Brush brush, Shape? shape, float alpha);
 
     // androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
     // (Modifier, Dp width, Color, Shape). Both width and color are
@@ -1930,7 +1930,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/ui/Modifier;",
         Defaults  = typeof(ModifierBorderBrushDefault))]
     internal static partial IntPtr ModifierBorderBrush(
-        IntPtr modifier, float width, Brush brush, Shape? shape);
+        IntPtr modifier, float width, AndroidX.Compose.UI.Graphics.Brush brush, Shape? shape);
 
     // androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
     // (Modifier, Boolean enabled, String onClickLabel, Role role,

--- a/src/Microsoft.AndroidX.Compose/ComposeDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeDefaults.cs
@@ -510,11 +510,25 @@ using AndroidX.Compose;
 // when defaulted).
 [assembly: ComposeDefaults("ModifierBackgroundDefault", "!color", "shape")]
 
+// androidx.compose.foundation.BackgroundKt.background$default —
+// Brush-typed overload. Bit 0 = brush (always supplied), bit 1 = shape
+// (Compose substitutes RectangleShape when defaulted), bit 2 = alpha
+// (always supplied; the C# wrapper defaults to 1f to match Kotlin).
+[assembly: ComposeDefaults("ModifierBackgroundBrushDefault",
+    "!brush", "shape", "!alpha")]
+
 // androidx.compose.foundation.BorderKt.border-xT4_qwU$default —
 // non-@Composable Modifier extension. Both width (Dp) and color
 // (Color) are @JvmInline value classes, hence the mangled name.
 // Bits 0/1 = width/color (always supplied), bit 2 = shape.
 [assembly: ComposeDefaults("ModifierBorderDefault", "!width", "!color", "shape")]
+
+// androidx.compose.foundation.BorderKt.border-ziNgDLE$default —
+// Brush-typed overload. width is a Dp inline-class param (hence the
+// mangled name); brush is a regular object reference. Bits 0/1 =
+// width/brush (always supplied), bit 2 = shape.
+[assembly: ComposeDefaults("ModifierBorderBrushDefault",
+    "!width", "!brush", "shape")]
 
 // androidx.compose.foundation.ClickableKt.clickable-XHw0xAI$default —
 // non-@Composable Modifier extension. Bit 3 (onClick) is always

--- a/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
@@ -251,11 +251,12 @@ public static class ModifierExtensions
 
     /// <summary>
     /// <c>Modifier.background(brush, shape, alpha)</c> — paints a
-    /// <see cref="Brush"/> (gradient, solid color, or any other
-    /// <see cref="Brush"/> subclass) behind the composable, clipped to
-    /// <paramref name="shape"/>. Pass <c>null</c> for the default
-    /// <see cref="Shape.Rectangle"/>; supply <paramref name="alpha"/>
-    /// to fade the brush (1f = fully opaque, 0f = invisible).
+    /// <see cref="AndroidX.Compose.UI.Graphics.Brush"/> (gradient,
+    /// solid color, or any other Brush subclass) behind the
+    /// composable, clipped to <paramref name="shape"/>. Pass
+    /// <c>null</c> for the default <see cref="Shape.Rectangle"/>;
+    /// supply <paramref name="alpha"/> to fade the brush
+    /// (1f = fully opaque, 0f = invisible).
     /// </summary>
     /// <remarks>
     /// The brush is captured by the closure so its Java peer stays
@@ -265,7 +266,7 @@ public static class ModifierExtensions
     /// Java instance is reused frame-to-frame.
     /// </remarks>
     public static Modifier Background(
-        this Modifier modifier, Brush brush, Shape? shape = null, float alpha = 1f)
+        this Modifier modifier, AndroidX.Compose.UI.Graphics.Brush brush, Shape? shape = null, float alpha = 1f)
     {
         ArgumentNullException.ThrowIfNull(brush);
         return modifier.Append(curr => ComposeBridges.ModifierBackgroundBrush(curr, brush, shape, alpha));
@@ -273,18 +274,18 @@ public static class ModifierExtensions
 
     /// <summary>
     /// <c>Modifier.border(width, brush, shape)</c> — draws a stroke
-    /// painted by the supplied <see cref="Brush"/> around the
-    /// composable, clipped to <paramref name="shape"/>. Pass
+    /// painted by the supplied <see cref="AndroidX.Compose.UI.Graphics.Brush"/>
+    /// around the composable, clipped to <paramref name="shape"/>. Pass
     /// <c>null</c> for the default <see cref="Shape.Rectangle"/>.
     /// </summary>
     /// <remarks>
     /// The brush is captured by the closure so its Java peer stays
     /// alive across recompositions — see
-    /// <see cref="Background(Modifier, Brush, Shape?, float)"/> for
-    /// the same notes around per-recomposition allocation.
+    /// <see cref="Background(Modifier, AndroidX.Compose.UI.Graphics.Brush, Shape?, float)"/>
+    /// for the same notes around per-recomposition allocation.
     /// </remarks>
     public static Modifier Border(
-        this Modifier modifier, Dp width, Brush brush, Shape? shape = null)
+        this Modifier modifier, Dp width, AndroidX.Compose.UI.Graphics.Brush brush, Shape? shape = null)
     {
         ArgumentNullException.ThrowIfNull(brush);
         var w = width.Value;

--- a/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
@@ -268,21 +268,7 @@ public static class ModifierExtensions
         this Modifier modifier, Brush brush, Shape? shape = null, float alpha = 1f)
     {
         ArgumentNullException.ThrowIfNull(brush);
-        var brushHandle = ((Java.Lang.Object)brush).Handle;
-        var a = alpha;
-        return modifier.Append(curr =>
-        {
-            try
-            {
-                return ComposeBridges.ModifierBackgroundBrush(
-                    curr, brushHandle, shape?.Handle, a);
-            }
-            finally
-            {
-                GC.KeepAlive(brush);
-                GC.KeepAlive(shape);
-            }
-        });
+        return modifier.Append(curr => ComposeBridges.ModifierBackgroundBrush(curr, brush, shape, alpha));
     }
 
     /// <summary>
@@ -302,20 +288,7 @@ public static class ModifierExtensions
     {
         ArgumentNullException.ThrowIfNull(brush);
         var w = width.Value;
-        var brushHandle = ((Java.Lang.Object)brush).Handle;
-        return modifier.Append(curr =>
-        {
-            try
-            {
-                return ComposeBridges.ModifierBorderBrush(
-                    curr, w, brushHandle, shape?.Handle);
-            }
-            finally
-            {
-                GC.KeepAlive(brush);
-                GC.KeepAlive(shape);
-            }
-        });
+        return modifier.Append(curr => ComposeBridges.ModifierBorderBrush(curr, w, brush, shape));
     }
 
     /// <summary>

--- a/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
@@ -250,6 +250,75 @@ public static class ModifierExtensions
     }
 
     /// <summary>
+    /// <c>Modifier.background(brush, shape, alpha)</c> — paints a
+    /// <see cref="Brush"/> (gradient, solid color, or any other
+    /// <see cref="Brush"/> subclass) behind the composable, clipped to
+    /// <paramref name="shape"/>. Pass <c>null</c> for the default
+    /// <see cref="Shape.Rectangle"/>; supply <paramref name="alpha"/>
+    /// to fade the brush (1f = fully opaque, 0f = invisible).
+    /// </summary>
+    /// <remarks>
+    /// The brush is captured by the closure so its Java peer stays
+    /// alive across recompositions. For static brushes prefer
+    /// constructing once outside the composition (or wrapping the
+    /// factory call in <c>composer.Remember(() =&gt; ...)</c>) so the
+    /// Java instance is reused frame-to-frame.
+    /// </remarks>
+    public static Modifier Background(
+        this Modifier modifier, Brush brush, Shape? shape = null, float alpha = 1f)
+    {
+        ArgumentNullException.ThrowIfNull(brush);
+        var brushHandle = ((Java.Lang.Object)brush).Handle;
+        var a = alpha;
+        return modifier.Append(curr =>
+        {
+            try
+            {
+                return ComposeBridges.ModifierBackgroundBrush(
+                    curr, brushHandle, shape?.Handle, a);
+            }
+            finally
+            {
+                GC.KeepAlive(brush);
+                GC.KeepAlive(shape);
+            }
+        });
+    }
+
+    /// <summary>
+    /// <c>Modifier.border(width, brush, shape)</c> — draws a stroke
+    /// painted by the supplied <see cref="Brush"/> around the
+    /// composable, clipped to <paramref name="shape"/>. Pass
+    /// <c>null</c> for the default <see cref="Shape.Rectangle"/>.
+    /// </summary>
+    /// <remarks>
+    /// The brush is captured by the closure so its Java peer stays
+    /// alive across recompositions — see
+    /// <see cref="Background(Modifier, Brush, Shape?, float)"/> for
+    /// the same notes around per-recomposition allocation.
+    /// </remarks>
+    public static Modifier Border(
+        this Modifier modifier, Dp width, Brush brush, Shape? shape = null)
+    {
+        ArgumentNullException.ThrowIfNull(brush);
+        var w = width.Value;
+        var brushHandle = ((Java.Lang.Object)brush).Handle;
+        return modifier.Append(curr =>
+        {
+            try
+            {
+                return ComposeBridges.ModifierBorderBrush(
+                    curr, w, brushHandle, shape?.Handle);
+            }
+            finally
+            {
+                GC.KeepAlive(brush);
+                GC.KeepAlive(shape);
+            }
+        });
+    }
+
+    /// <summary>
     /// <c>Modifier.clip(RoundedCornerShape(<paramref name="cornerRadius"/>))</c> —
     /// rounds the four corners by the same radius and clips drawing to the
     /// resulting shape. Pass <c>0</c> for no rounding (rectangle clip).

--- a/src/Microsoft.AndroidX.Compose/Offset.cs
+++ b/src/Microsoft.AndroidX.Compose/Offset.cs
@@ -57,6 +57,15 @@ public readonly struct Offset : IEquatable<Offset>
     public static Offset Zero => new Offset(0f, 0f);
 
     /// <summary>
+    /// The <c>Offset.Infinite</c> sentinel — Compose uses
+    /// <c>(+∞, +∞)</c> as the "fill the whole drawing region"
+    /// endpoint (e.g. the default <c>end</c> of
+    /// <c>Brush.linearGradient</c>, which resolves to the
+    /// bottom-right corner at draw time).
+    /// </summary>
+    public static Offset Infinite => new Offset(float.PositiveInfinity, float.PositiveInfinity);
+
+    /// <summary>
     /// The <c>Offset.Unspecified</c> sentinel — Compose uses this to
     /// mean "no value". Equal-by-value to Kotlin's
     /// <c>Offset.Unspecified</c> (packed value <c>0x7FC000007FC00000</c>,

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -2138,6 +2138,7 @@ static AndroidX.Compose.MutableNumberState<T>.operator ++(AndroidX.Compose.Mutab
 static AndroidX.Compose.MutableState<T>.implicit operator T(AndroidX.Compose.MutableState<T>! state) -> T
 static AndroidX.Compose.Offset.operator !=(AndroidX.Compose.Offset a, AndroidX.Compose.Offset b) -> bool
 static AndroidX.Compose.Offset.operator ==(AndroidX.Compose.Offset a, AndroidX.Compose.Offset b) -> bool
+static AndroidX.Compose.Offset.Infinite.get -> AndroidX.Compose.Offset
 static AndroidX.Compose.Offset.Unspecified.get -> AndroidX.Compose.Offset
 static AndroidX.Compose.Offset.Zero.get -> AndroidX.Compose.Offset
 static AndroidX.Compose.Shape.Circle() -> AndroidX.Compose.Shape!

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -115,6 +115,7 @@ AndroidX.Compose.BoxConstraints.MinHeight.get -> float
 AndroidX.Compose.BoxConstraints.MinWidth.get -> float
 AndroidX.Compose.BoxWithConstraints
 AndroidX.Compose.BoxWithConstraints.BoxWithConstraints(System.Func<AndroidX.Compose.BoxConstraints, AndroidX.Compose.ComposableNode!>! content) -> void
+AndroidX.Compose.Brush
 AndroidX.Compose.Button
 AndroidX.Compose.Button.Button(System.Action! onClick) -> void
 AndroidX.Compose.Button.Colors.get -> AndroidX.Compose.Material3.ButtonColors?
@@ -1225,6 +1226,11 @@ AndroidX.Compose.TextStyle.TextAlign.set -> void
 AndroidX.Compose.TextStyle.TextDecoration.get -> AndroidX.Compose.TextDecoration?
 AndroidX.Compose.TextStyle.TextDecoration.set -> void
 AndroidX.Compose.TextStyle.TextStyle() -> void
+AndroidX.Compose.TileMode
+AndroidX.Compose.TileMode.Clamp = 0 -> AndroidX.Compose.TileMode
+AndroidX.Compose.TileMode.Decal = 3 -> AndroidX.Compose.TileMode
+AndroidX.Compose.TileMode.Mirror = 2 -> AndroidX.Compose.TileMode
+AndroidX.Compose.TileMode.Repeated = 1 -> AndroidX.Compose.TileMode
 AndroidX.Compose.TimeInput
 AndroidX.Compose.TimeInput.TimeInput(AndroidX.Compose.TimePickerState? state = null) -> void
 AndroidX.Compose.TimePicker
@@ -1485,6 +1491,17 @@ static AndroidX.Compose.Arrangement.SpacedBy(int dp) -> AndroidX.Compose.Arrange
 static AndroidX.Compose.Arrangement.SpaceEvenly.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Start.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Top.get -> AndroidX.Compose.Arrangement!
+static AndroidX.Compose.Brush.HorizontalGradient(AndroidX.Compose.Color[]! colors, float startX = 0, float endX = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.HorizontalGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.LinearGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset start, AndroidX.Compose.Offset end, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.LinearGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.RadialGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset center, float radius = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.RadialGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.SolidColor(AndroidX.Compose.Color color) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.SweepGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset center) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.SweepGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.VerticalGradient(AndroidX.Compose.Color[]! colors, float startY = 0, float endY = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.VerticalGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
 static AndroidX.Compose.Color.Black.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Blue.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Cyan.get -> AndroidX.Compose.Color
@@ -2038,8 +2055,10 @@ static AndroidX.Compose.ModifierExtensions.Align(this AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Align(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Alignment.Vertical! alignment) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Alpha(this AndroidX.Compose.Modifier! modifier, float alpha) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.AspectRatio(this AndroidX.Compose.Modifier! modifier, float ratio, bool matchHeightConstraintsFirst = false) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Brush! brush, AndroidX.Compose.Shape? shape = null, float alpha = 1) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Brush! brush, AndroidX.Compose.Shape? shape = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
@@ -2124,6 +2143,7 @@ static AndroidX.Compose.Offset.Zero.get -> AndroidX.Compose.Offset
 static AndroidX.Compose.Shape.Circle() -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.CutCorners(AndroidX.Compose.Dp cornerSize) -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.CutCornersPercent(int percent) -> AndroidX.Compose.Shape!
+static AndroidX.Compose.Shape.Rectangle.get -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.RoundedCorners(AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.RoundedCorners(AndroidX.Compose.Dp topStart, AndroidX.Compose.Dp topEnd, AndroidX.Compose.Dp bottomEnd, AndroidX.Compose.Dp bottomStart) -> AndroidX.Compose.Shape!
 static AndroidX.Compose.Shape.RoundedPercent(int percent) -> AndroidX.Compose.Shape!

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -1491,17 +1491,17 @@ static AndroidX.Compose.Arrangement.SpacedBy(int dp) -> AndroidX.Compose.Arrange
 static AndroidX.Compose.Arrangement.SpaceEvenly.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Start.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Top.get -> AndroidX.Compose.Arrangement!
-static AndroidX.Compose.Brush.HorizontalGradient(AndroidX.Compose.Color[]! colors, float startX = 0, float endX = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.HorizontalGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.LinearGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset start, AndroidX.Compose.Offset end, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.LinearGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.RadialGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset center, float radius = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.RadialGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.SolidColor(AndroidX.Compose.Color color) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.SweepGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset center) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.SweepGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.VerticalGradient(AndroidX.Compose.Color[]! colors, float startY = 0, float endY = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.Brush!
-static AndroidX.Compose.Brush.VerticalGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.Brush!
+static AndroidX.Compose.Brush.HorizontalGradient(AndroidX.Compose.Color[]! colors, float startX = 0, float endX = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.HorizontalGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.LinearGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset start, AndroidX.Compose.Offset end, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.LinearGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.RadialGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset center, float radius = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.RadialGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.SolidColor(AndroidX.Compose.Color color) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.SweepGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset center) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.SweepGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.VerticalGradient(AndroidX.Compose.Color[]! colors, float startY = 0, float endY = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.UI.Graphics.Brush!
+static AndroidX.Compose.Brush.VerticalGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.UI.Graphics.Brush!
 static AndroidX.Compose.Color.Black.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Blue.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Cyan.get -> AndroidX.Compose.Color
@@ -2055,10 +2055,10 @@ static AndroidX.Compose.ModifierExtensions.Align(this AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Align(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Alignment.Vertical! alignment) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Alpha(this AndroidX.Compose.Modifier! modifier, float alpha) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.AspectRatio(this AndroidX.Compose.Modifier! modifier, float ratio, bool matchHeightConstraintsFirst = false) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Brush! brush, AndroidX.Compose.Shape? shape = null, float alpha = 1) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.UI.Graphics.Brush! brush, AndroidX.Compose.Shape? shape = null, float alpha = 1) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Background(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Brush! brush, AndroidX.Compose.Shape? shape = null) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.UI.Graphics.Brush! brush, AndroidX.Compose.Shape? shape = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Dp cornerRadius) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color, AndroidX.Compose.Shape? shape) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Border(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp width, AndroidX.Compose.Color color) -> AndroidX.Compose.Modifier!

--- a/src/Microsoft.AndroidX.Compose/Shape.cs
+++ b/src/Microsoft.AndroidX.Compose/Shape.cs
@@ -91,4 +91,28 @@ public class Shape : Java.Lang.Object
         IntPtr handle = ComposeBridges.CutCornerShapePercent(percent);
         return new Shape(handle, JniHandleOwnership.TransferLocalRef);
     }
+
+    /// <summary>
+    /// <c>androidx.compose.ui.graphics.RectangleShape</c> — Compose's
+    /// canonical "no clipping, just a rectangle" shape singleton. Pass
+    /// this anywhere a <see cref="Shape"/> is expected when you want
+    /// the default (rectangular) outline — useful when overriding a
+    /// facade's default rounded shape, or when supplying a
+    /// <c>Modifier.Background(Brush, Shape)</c> with no rounding.
+    /// </summary>
+    /// <remarks>
+    /// The underlying Kotlin value is a singleton, so this property
+    /// always returns the same Java peer (held as a global ref behind
+    /// the scenes).
+    /// </remarks>
+    public static Shape Rectangle { get; } = RectangleShapeFactory();
+
+    static Shape RectangleShapeFactory()
+    {
+        // The Java side hands us a stable, shared singleton; wrap it
+        // without taking ownership of the local ref it doesn't issue —
+        // the cached global ref in ComposeBridges keeps it alive.
+        IntPtr global = ComposeBridges.RectangleShape();
+        return new Shape(global, JniHandleOwnership.DoNotTransfer);
+    }
 }

--- a/src/Microsoft.AndroidX.Compose/Shape.cs
+++ b/src/Microsoft.AndroidX.Compose/Shape.cs
@@ -109,10 +109,20 @@ public class Shape : Java.Lang.Object
 
     static Shape RectangleShapeFactory()
     {
-        // The Java side hands us a stable, shared singleton; wrap it
-        // without taking ownership of the local ref it doesn't issue —
-        // the cached global ref in ComposeBridges keeps it alive.
-        IntPtr global = ComposeBridges.RectangleShape();
-        return new Shape(global, JniHandleOwnership.DoNotTransfer);
+        // `RectangleShapeKt.RectangleShape` is bound — it returns the
+        // shared Kotlin singleton. Wrap its handle in our facade type
+        // without transferring ownership; the bound peer keeps the
+        // underlying JNI ref alive.
+        var bound = AndroidX.Compose.UI.Graphics.RectangleShapeKt.RectangleShape;
+        try
+        {
+            return new Shape(
+                ((Java.Lang.Object)bound).Handle,
+                JniHandleOwnership.DoNotTransfer);
+        }
+        finally
+        {
+            GC.KeepAlive(bound);
+        }
     }
 }

--- a/src/Microsoft.AndroidX.Compose/TileMode.cs
+++ b/src/Microsoft.AndroidX.Compose/TileMode.cs
@@ -1,0 +1,39 @@
+namespace AndroidX.Compose;
+
+/// <summary>
+/// C# mirror of <c>androidx.compose.ui.graphics.TileMode</c> — controls
+/// what a gradient does outside its declared start/end region.
+/// </summary>
+/// <remarks>
+/// In Kotlin source <c>TileMode</c> is a <c>@JvmInline value class</c>
+/// wrapping <see cref="int"/>; across JNI it travels as a bare
+/// <see cref="int"/>, which is what the underlying <c>Brush</c> companion
+/// factories expect. The integer values here match Kotlin's
+/// <c>TileMode.Clamp.value</c> / <c>Repeated.value</c> / etc.
+/// </remarks>
+public enum TileMode
+{
+    /// <summary>
+    /// Clamp to the boundary color — pixels outside the gradient region
+    /// keep the endpoint color. This is Compose's default.
+    /// </summary>
+    Clamp = 0,
+
+    /// <summary>
+    /// Repeat the gradient pattern indefinitely outside the declared
+    /// region.
+    /// </summary>
+    Repeated = 1,
+
+    /// <summary>
+    /// Repeat the gradient pattern with every other repetition mirrored,
+    /// producing a seamless tile.
+    /// </summary>
+    Mirror = 2,
+
+    /// <summary>
+    /// Render anything outside the gradient region as transparent — the
+    /// gradient draws only inside its declared bounds.
+    /// </summary>
+    Decal = 3,
+}


### PR DESCRIPTION
First vertical slice of #64. Adds `Brush` + brush-typed
`Modifier.Background` / `Modifier.Border` so callers can paint gradients
behind any composable.

## New public surface

- `AndroidX.Compose.Brush` (sealed class) with six factories:
  - `Brush.SolidColor(Color)`
  - `Brush.LinearGradient(Color[], Offset start, Offset end, TileMode)`
  - `Brush.HorizontalGradient(Color[], float startX, float endX, TileMode)`
  - `Brush.VerticalGradient(Color[], float startY, float endY, TileMode)`
  - `Brush.RadialGradient(Color[], Offset center, float radius, TileMode)`
  - `Brush.SweepGradient(Color[], Offset center)`

  Each ships with a `params Color[]` convenience overload that picks the
  Kotlin-equivalent defaults (full extent + `Clamp`).
- `AndroidX.Compose.TileMode` mirroring Kotlin
  (`Clamp` / `Repeated` / `Mirror` / `Decal`).
- `AndroidX.Compose.Shape.Rectangle` factory backed by the bound
  `RectangleShapeKt.RectangleShape` singleton (cached as a global ref so
  every call hands out the same Java peer).
- `Modifier.Background(Brush, Shape? = null, float alpha = 1f)` and
  `Modifier.Border(Dp, Brush, Shape? = null)` extension methods.

## Implementation notes

`Color` is a Kotlin `@JvmInline value class` and `Brush.Companion`'s
gradient factories take `List<Color>` — both ends are stripped by
Mono.Android's binder. The new `BrushBridges.cs` is hand-written JNI:

- `BoxColorList(long[])` boxes packed-long colors via the synthetic
  `Color.box-impl(J)Landroidx/compose/ui/graphics/Color;` into a
  `java.util.ArrayList<Color>`.
- `BrushCompanion()` / `RectangleShape()` cache global refs once.
- Each gradient factory + `SolidColor` ctor uses cached method IDs.

The Brush-typed `Modifier.Background` / `Modifier.Border` route through
new `[ComposeBridge]` partials for `background$default` /
`border-ziNgDLE$default` so the auto-default-mask handles the optional
`shape` / `alpha` slots.

## Demo

`Demos/Containers/BrushDemo.cs` exercises linear, horizontal, vertical,
radial, sweep, `SolidColor`, and a gradient-painted border. Deep-link:

```
adb shell am start -n net.compose.gallery/net.compose.gallery.MainActivity --es route "demo/containers-brush"
```

## Out of scope (separate slices of #64)

- `Canvas` composable + `DrawScope` (`drawCircle`/`drawRect`/`drawLine`/`drawPath`)
- `Path` builder + `PathOperation`
- `Pair<Float, Color>[] colorStops` overloads (uneven color distribution)
- `BorderStroke` value type

Towards #64.