### PR TITLE
.NET MAUI: single ComposeView per page

### DIFF
--- a/.github/instructions/compose-maui.instructions.md
+++ b/.github/instructions/compose-maui.instructions.md
@@ -51,13 +51,66 @@ align Compose 1.11.x's chain with MAUI 10.0.20's transitive demands
 `Emoji2.ViewsHelper`). Don't trim them — they're load-bearing for
 NU1107/NU1608.
 
+## Architecture — one `ComposeView` per page
+
+`Microsoft.AndroidX.Compose.Maui` rewires MAUI's Android handler chain
+so that the page is the composition boundary, not the leaf:
+
+- `PageHandler` is the **only** handler that creates a `ComposeView`.
+  It's a `ViewHandler<IContentView, ComposeView>` (not the stock
+  `ContentViewHandler` which lives on `ContentViewGroup` and routes
+  measure/arrange through `ICrossPlatformLayout`). Standard Android
+  measure-spec sizes the `ComposeView` to fill whatever container
+  Shell / Navigation puts the page in; Compose owns layout for
+  everything below.
+- `LayoutHandler` (`VerticalStackLayout`, `HorizontalStackLayout`),
+  `ScrollViewHandler`, and every leaf (`LabelHandler`, `ButtonHandler`,
+  `EntryHandler`, `ImageHandler`) implement `IComposeHandler` and
+  derive from `ComposeElementHandler<T>`. They contribute a
+  `ComposableNode` to the page's composer via
+  `BuildNode(IComposer)` — **zero per-leaf `ComposeView`s** in fully
+  converted subtrees.
+- Anything not in our handler list (Grid, AbsoluteLayout, FlexLayout,
+  CollectionView, BoxView, Switch, customer renderers) keeps its
+  stock handler and is hosted via Compose's `AndroidView { factory }`
+  interop from inside the same composition. The walker
+  (`ComposeWalker.Render`) does the dispatch.
+
+```mermaid
+flowchart TD
+    PH["PageHandler (overridden) → ComposeView"] --> Comp[single composition for the page]
+    Comp --> Walker[ComposeWalker.Render: child.Handler?]
+    Walker -- IComposeHandler --> Node[BuildNode → Column/Row/Text/Button/…]
+    Walker -- stock handler --> AV["AndroidView { factory: child.ToPlatform(MauiContext) }"]
+    AV --> Stock[stock MAUI handler → real Android View]
+    Node --> Recurse((recurse via ComposeWalker.Render))
+```
+
+**Consumer-facing invariant.** `UseAndroidXCompose()` is the only
+Compose surface the consumer touches. Their XAML / C# stays pure MAUI;
+they don't pick a "Compose root", don't see `ComposeView`, don't import
+`Microsoft.AndroidX.Compose`. The page handler installs the single
+`ComposeView` and the walker bridges everything else.
+
+**uiautomator-dump invariant.** A page whose root content uses only our
+converted handlers (Page → VSL/HSL/ScrollView → Label/Button/Entry/Image)
+contains exactly **one** `androidx.compose.ui.platform.ComposeView` node.
+A page whose root content uses an unconverted container (`Grid`,
+`CollectionView`) may contain additional `ComposeView` nodes — one per
+Compose-backed leaf inside a stock container, because such leaves can't
+fold into a parent composer that doesn't exist.
+
 ## Canonical handler shape
 
-Every handler follows the same skeleton. Concrete examples in
-`Handlers/LabelHandler.cs` and `Handlers/ButtonHandler.cs`.
+Two skeletons depending on whether the handler contributes to the page
+composition (`IComposeHandler` path) or owns the page composition
+(`PageHandler`). Concrete examples in `Handlers/LabelHandler.cs`,
+`Handlers/ButtonHandler.cs`, `Handlers/LayoutHandler.cs`.
+
+### Page-content handler — `ComposeElementHandler<T>` + `BuildNode`
 
 ```csharp
-public partial class FooHandler : ViewHandler<IFoo, ComposeView>
+public partial class FooHandler : ComposeElementHandler<IFoo>
 {
     public static IPropertyMapper<IFoo, FooHandler> Mapper =
         new PropertyMapper<IFoo, FooHandler>(ViewHandler.ViewMapper)
@@ -77,25 +130,45 @@ public partial class FooHandler : ViewHandler<IFoo, ComposeView>
     public FooHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
-    protected override ComposeView CreatePlatformView()
-    {
-        var view = new ComposeView(Context);
-        view.SetContent(_ => new Foo(/* read _text.Value etc. */));
-        return view;
-    }
-
-    protected override void DisconnectHandler(ComposeView platformView)
-    {
-        platformView.DisposeComposition();
-        base.DisconnectHandler(platformView);
-    }
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+        => new Foo(/* read _text.Value etc. */);
 
     public static void MapText(FooHandler handler, IFoo foo) =>
         handler._text.Value = foo.Text ?? string.Empty;
 }
 ```
 
-### Rules the skeleton encodes
+`ComposeElementHandler<T>` is a `ViewHandler<T, AView>` whose
+`CreatePlatformView()` returns a tiny marker `Android.Views.View`
+(MAUI requires a non-null `PlatformView` for attach / focus /
+animation bookkeeping; the marker satisfies the contract without
+being added to any `ViewGroup`). All actual rendering happens via
+`BuildNode` inside the page's single composition. There is no
+`ComposeView` per handler, no per-handler composer, no per-handler
+`DisposeComposition`.
+
+### Container / scope handler
+
+Containers (`LayoutHandler`, `ScrollViewHandler`) follow the same
+shape but their `BuildNode` walks `IView` children via
+`ComposeWalker.Render`:
+
+```csharp
+public override ComposableNode BuildNode(IComposer composer)
+{
+    var container = new Column { Modifier = BuildModifier() };
+    foreach (var child in VirtualView!.Children)
+        container.Add(c => ComposeWalker.Render(child, c, MauiContext!));
+    return container;
+}
+```
+
+The walker dispatches each child to `IComposeHandler.BuildNode` or to
+`AndroidView { factory = child.ToPlatform(MauiContext) }` if the
+child's handler isn't ours.
+
+### Rules the skeletons encode
 
 1. **Type the mapper against the concrete handler, not the interface.**
    `PropertyMapper<TVirtualView, TViewHandler>.UpdateProperty` casts the
@@ -106,56 +179,62 @@ public partial class FooHandler : ViewHandler<IFoo, ComposeView>
    `IPropertyMapper<IFoo, FooHandler>` and the cast lands on the
    concrete type for free. (This is the WPF backend's pattern.)
 
-2. **One `MutableState<T>` per Compose-readable slot.** The composition
-   captured by `SetContent` reads slots; mapper callbacks write them.
-   Compose's snapshot system schedules a recomposition on the next
-   frame — no manual invalidation needed.
+2. **One `MutableState<T>` per Compose-readable slot.** `BuildNode`
+   reads slots; mapper callbacks write them. Compose's snapshot system
+   schedules a recomposition on the next frame — no manual invalidation
+   needed. **`MutableState<T>` only supports a fixed set of `T`** —
+   `Java.Lang.Object` subclasses, `string`, `bool`, `char`, primitives,
+   and `Nullable<T>` of primitives. MAUI structs (`Thickness`, `Size`,
+   `Rect`, `Color`, …) and user-defined .NET enums throw
+   `NotSupportedException` at field-initializer time. For structs use
+   the **version-counter pattern**: `MutableState<int> _padVersion` +
+   read the live value off `VirtualView` inside `BuildNode`. For enums
+   use `MutableState<int>` and cast back. See
+   `LayoutHandler._paddingVersion` and `LabelHandler._hTextAlign`.
 
-3. **`ComposeView` is the platform view for every handler.**
-   `ViewHandler<TVirtualView, Android.Views.View>` already implements
-   `PlatformArrange(Rect)` (calls `View.Layout`) and
-   `GetDesiredSize(double, double)` (calls `View.Measure`) on Android
-   for any `TPlatform : Android.Views.View`. `ComposeView` IS an
-   Android `View`, so no override needed.
+3. **`BuildNode` is the render entry point** for `IComposeHandler`s
+   (every handler except `PageHandler`). The composer is the page's
+   composer; reading `MutableState<T>` slots inside `BuildNode`
+   registers the right slot-table dependencies. Don't allocate a fresh
+   `IComposer` — there is one and only one per page.
 
-4. **Always `DisposeComposition()` in `DisconnectHandler`.** Compose
-   holds onto the composer until the host view is detached; without
-   explicit disposal the composer leaks and recomposes after the MAUI
-   element is gone. Call `base.DisconnectHandler(platformView)` after.
+4. **`PageHandler` owns the single `ComposeView`**, and is therefore the
+   only handler that:
+   - Inherits `ViewHandler<IContentView, ComposeView>` directly.
+   - Overrides `CreatePlatformView()` to return a `ComposeView`.
+   - Calls `DisposeComposition()` in `DisconnectHandler`.
+
+   The page's composition root wraps the walker output in a
+   `new Box { Modifier = Modifier.FillMaxSize() }` so an `AndroidView`
+   fallback at the root (Grid, FlexLayout, …) fills the page instead
+   of collapsing to wrap-content.
 
 5. **Inherit from `ViewHandler.ViewMapper` / `ViewCommandMapper`** so
-   our mapper picks up the standard view-level mappings
-   (Background, Opacity, IsEnabled, etc.) without rewriting them.
+   the standard view-level mappings (Background, Opacity, IsEnabled, …)
+   come for free. Exception: when the underlying composable owns its
+   own surface (Material 3 widgets with `*Colors` slots), route
+   `IView.Background` into the composable's colour slot instead — see
+   `ButtonHandler.MapBackground`.
 
 6. **`PropertyMapper` auto-runs every entry once at attach.** Initial
    values flow through your `MapXxx` callbacks for free — you don't
-   have to read `VirtualView` in `CreatePlatformView`.
+   have to read `VirtualView` in `BuildNode`. (Except for struct-typed
+   live reads — see rule 2.)
 
 7. **Constructors come in pairs.** Parameterless for DI, then a
    `(IPropertyMapper?, CommandMapper?)` overload for consumers who
    want to extend the mapper. Standard MAUI handler convention.
 
-### Adding a new handler
+### Adding a new page-content handler
 
-1. Create `Handlers/<MauiType>Handler.cs` following the skeleton.
+1. Create `Handlers/<MauiType>Handler.cs` following the
+   `ComposeElementHandler<T>` skeleton.
 2. Map each MAUI interface property you care about to a
-   `MutableState<T>` slot. Keep slot types **primitive**: `string`,
-   `bool`, `int`, `long`, `float`, packed color (`long?`),
-   `Java.Lang.Object` subclasses. **Never a user-defined .NET enum**
-   like `Microsoft.Maui.TextAlignment` — `MutableState<T>`'s `ToJava`
-   switch doesn't unwrap them to their underlying primitive and the
-   ctor throws `NotSupportedException` at field-initializer time,
-   crashing the handler before any frame paints. Store the underlying
-   `int` (`MutableState<int>`) and cast back inside `SetContent`. See
-   `LabelHandler._hTextAlign` for the canonical workaround. Convert
-   packed values (`Microsoft.Maui.Graphics.Color` → packed `long?`
-   via `ColorMapping.ToPackedLong`) in the `MapXxx` callback, not in
-   the composition.
-3. The composition reads slots and builds the Compose widget tree.
+   `MutableState<T>` slot. See rule 2 above for `T` restrictions.
+3. `BuildNode` reads slots and builds the Compose widget tree.
    Use `Microsoft.AndroidX.Compose`'s existing facades (`Text`,
-   `Button`, `Column`, …). **Do not** spin up a fresh `IComposer` —
-   `SetContent` provides one and `MutableState<T>` reads register the
-   right slot-table dependencies.
+   `Button`, `Column`, …). For containers, walk children via
+   `ComposeWalker.Render(child, composer, MauiContext!)`.
 4. Register the handler in `Hosting/AppHostBuilderExtensions.cs`:
 
    ```csharp
@@ -165,9 +244,8 @@ public partial class FooHandler : ViewHandler<IFoo, ComposeView>
    where `MauiFoo` is the cross-platform MAUI control
    (e.g. `Microsoft.Maui.Controls.Slider`).
 5. Add a Phase entry in `docs/maui-backend.md`.
-6. **Add a demo in `Microsoft.AndroidX.Compose.Maui.Sample`.** Drop the
-   new control on `MainPage.xaml` so manual smoke-test deploys
-   exercise it.
+6. **Add a demo in `Microsoft.AndroidX.Compose.Maui.Sample`** so manual
+   smoke-test deploys exercise the new handler.
 7. Build + deploy with `dotnet build
    src/Microsoft.AndroidX.Compose.Maui.Sample -t:Install`. Resolve the
    launchable activity (the JCW class name is a per-assembly hash that
@@ -179,8 +257,8 @@ public partial class FooHandler : ViewHandler<IFoo, ComposeView>
    adb shell am start -n net.compose.maui.sample/<resolved activity>
    ```
 
-   Confirm `androidx.compose.ui.platform.ComposeView` nodes for your
-   new control in `uiautomator dump`, then exercise it (tap, type,
+   Confirm exactly one `androidx.compose.ui.platform.ComposeView` per
+   converted page via `uiautomator dump`, then exercise it (tap, type,
    drag).
 
 ### Event forwarding
@@ -439,16 +517,36 @@ See `LabelHandler.MapTextColor` for the canonical wiring and
 `AndroidX.Compose.Color` (e.g. building a `ButtonColors` slot), use
 `ColorMapping.ToCompose(mauiColor)` directly.
 
-### What we don't override
+### What we override (and what we don't)
 
-Stock MAUI handlers already work for layout/container types
-(`ContentPage`, `VerticalStackLayout`, `Grid`, `Border`, `ScrollView`)
-because they target `Android.Views.ViewGroup` subclasses that hosting
-`ComposeView` children just fine. **Only override leaves** — the
-controls a user actually sees as "this is a button / label / slider /
-…". Same goes for `ApplicationHandler`, `WindowHandler`, `PageHandler`,
-`LayoutHandler`. Don't add them to `UseAndroidXCompose()` unless you
-have a reason that requires Compose at the container layer.
+`UseAndroidXCompose()` registers handlers for:
+
+- **`Microsoft.Maui.Controls.Page`** → `PageHandler` (the only handler
+  that creates a `ComposeView`).
+- **`VerticalStackLayout`**, **`HorizontalStackLayout`** → `LayoutHandler`
+  (`Column` / `Row`).
+- **`ScrollView`** → `ScrollViewHandler`
+  (`Modifier.verticalScroll` / `horizontalScroll`).
+- **Leaves**: `Label`, `Button`, `Entry`, `Image`.
+
+We do **not** override `Grid`, `AbsoluteLayout`, `FlexLayout`,
+`StackLayout`, `Border`, `ContentView`, or any of the non-converted
+controls (`CollectionView`, `BoxView`, `Switch`, third-party
+renderers). MAUI registers a single `LayoutHandler` for the abstract
+`Microsoft.Maui.Controls.Layout` base — the concrete subtype (Grid,
+FlexLayout, …) lives in the layout's `CrossPlatformLayout`
+(`ILayoutManager`). Registering for VSL / HSL specifically means our
+handler only intercepts those two concrete types; everything else
+keeps the stock `LayoutHandler` and is hosted via `AndroidView`
+fallback from inside the parent composition (when the parent is one
+of ours) or stays fully stock (when the parent is also stock).
+
+Don't add new handlers to `UseAndroidXCompose()` unless they're either:
+- A leaf with a clear Compose Material 3 equivalent (`Slider`,
+  `Switch`, `CheckBox`, `ProgressBar`).
+- A container whose layout maps cleanly to a Compose container
+  without needing the generic `Layout {}`-with-`CrossPlatformMeasure`
+  adapter (which is still TODO).
 
 ### Activity
 
@@ -461,13 +559,20 @@ duplicates the stock behavior without adding anything.
 
 - ❌ `IPropertyMapper<IFoo, IFooHandler>` when `FooHandler` doesn't
   implement `IFooHandler` → `InvalidCastException` at first map.
-- ❌ Constructing a new `ComposeView` inside a mapper callback →
-  defeats recomposition; the view is the platform view, created once
-  per handler attach.
-- ❌ Reading `VirtualView` inside the `SetContent` lambda → mixes the
-  composition's snapshot system with MAUI's mutable element graph.
-  Push state into `MutableState<T>` slots first.
-- ❌ Skipping `DisposeComposition()` in `DisconnectHandler` → leak.
+- ❌ Putting a `ComposeView` anywhere outside `PageHandler` — one
+  composition per page is the whole point. New leaves go on
+  `ComposeElementHandler<T>` and contribute via `BuildNode`.
+- ❌ `MutableState<MauiStruct>` (Thickness, Color, Size, …) or
+  `MutableState<MauiEnum>` (TextAlignment, …) →
+  `NotSupportedException` at field-initializer time. Use the
+  version-counter pattern (struct) or store the underlying `int` and
+  cast back inside `BuildNode` (enum).
+- ❌ Reading `VirtualView` inside `BuildNode` for properties that
+  flow through the mapper pipeline → mixes the composition's snapshot
+  system with MAUI's mutable element graph. Push state into
+  `MutableState<T>` slots first. Exception: struct-typed live reads
+  paired with a version counter (see `LayoutHandler.BuildStack`'s
+  `VirtualView.Padding` read).
 - ❌ Calling `UseAndroidXCompose()` **before** `UseMauiApp<TApp>()` →
   stock handlers register after ours and win. Order is enforced by
   `Last AddHandler wins` in MAUI's `MauiServiceCollection`.

--- a/.github/instructions/compose-maui.instructions.md
+++ b/.github/instructions/compose-maui.instructions.md
@@ -139,14 +139,30 @@ public partial class FooHandler : ComposeElementHandler<IFoo>
 }
 ```
 
-`ComposeElementHandler<T>` is a `ViewHandler<T, AView>` whose
-`CreatePlatformView()` returns a tiny marker `Android.Views.View`
-(MAUI requires a non-null `PlatformView` for attach / focus /
-animation bookkeeping; the marker satisfies the contract without
-being added to any `ViewGroup`). All actual rendering happens via
-`BuildNode` inside the page's single composition. There is no
-`ComposeView` per handler, no per-handler composer, no per-handler
-`DisposeComposition`.
+`ComposeElementHandler<T>` is a `ViewHandler<T, ComposeView>` — it
+owns one `ComposeView` per handler instance as its `PlatformView`.
+This is **dual-mode** by design:
+
+- **Compose-aware path** (the common one): when a child of
+  `PageHandler`/`LayoutHandler`/`ScrollViewHandler` is one of our
+  `IComposeHandler`s, `ComposeWalker` calls `BuildNode(IComposer)`
+  directly and folds the result into the page's single composition.
+  The handler's own `ComposeView` is never attached to a window, so
+  `SetContent`'s composition never spins up — zero per-handler
+  overhead.
+- **Fallback path**: when our leaf ends up inside a stock parent
+  (e.g. a `CollectionView` item template, a `Border`), MAUI calls
+  `ToPlatform()` and attaches the leaf's `ComposeView` directly.
+  `SetContent(BuildNode)` is lazy — it kicks the composition off only
+  once attached, so the same handler instance renders correctly in
+  both contexts. Mappers write to the same `MutableState<T>` slots
+  either way.
+
+This is why a fully-converted page (Page → VSL → Label/Button) shows
+exactly **one** `ComposeView` in `uiautomator dump`, while a stock
+container hosting a Compose-backed leaf (Border with Image, or
+CollectionView item template with Label) shows one extra `ComposeView`
+per Compose-backed leaf.
 
 ### Container / scope handler
 
@@ -157,12 +173,17 @@ shape but their `BuildNode` walks `IView` children via
 ```csharp
 public override ComposableNode BuildNode(IComposer composer)
 {
-    var container = new Column { Modifier = BuildModifier() };
+    var container = new Column { Modifier = Modifier.Padding(...) };
     foreach (var child in VirtualView!.Children)
         container.Add(c => ComposeWalker.Render(child, c, MauiContext!));
     return container;
 }
 ```
+
+Use the public `Modifier` property directly — `BuildModifier()` is
+`internal` to `Microsoft.AndroidX.Compose` and unreachable from this
+assembly. (See `ScrollViewHandler.cs` for the canonical pattern of
+composing extra modifiers via `Modifier.Then(fillMain)`.)
 
 The walker dispatches each child to `IComposeHandler.BuildNode` or to
 `AndroidView { factory = child.ToPlatform(MauiContext) }` if the
@@ -559,9 +580,12 @@ duplicates the stock behavior without adding anything.
 
 - ❌ `IPropertyMapper<IFoo, IFooHandler>` when `FooHandler` doesn't
   implement `IFooHandler` → `InvalidCastException` at first map.
-- ❌ Putting a `ComposeView` anywhere outside `PageHandler` — one
-  composition per page is the whole point. New leaves go on
-  `ComposeElementHandler<T>` and contribute via `BuildNode`.
+- ❌ Spinning up an extra `ComposeView` outside `PageHandler` —
+  page-level composition is the whole point. New leaves derive from
+  `ComposeElementHandler<T>` (which already owns one `ComposeView`
+  per instance, used only for the stock-parent fallback path) and
+  contribute via `BuildNode`. Don't allocate yet another
+  `ComposeView` from inside a handler or elsewhere.
 - ❌ `MutableState<MauiStruct>` (Thickness, Color, Size, …) or
   `MutableState<MauiEnum>` (TextAlignment, …) →
   `NotSupportedException` at field-initializer time. Use the

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The facade and sample reference the official `Xamarin.AndroidX.Compose.*` 1.11.2
 
 - [docs/architecture.md](docs/architecture.md) — how the facade works, JNI bridges, the `$default` source generator, what's missing on the C# side.
 - [docs/compose-internals.md](docs/compose-internals.md) — how Jetpack Compose actually works (Kotlin compiler plugin, IR pipeline), why we can't just port it, and the Maven/NuGet artifact map.
-- [docs/maui-backend.md](docs/maui-backend.md) — plan for a .NET MAUI backend that swaps MAUI's stock Android handlers (`AppCompatTextView`, `MaterialButton`, …) for Compose-backed ones. Phase 1 lives in `src/Microsoft.AndroidX.Compose.Maui` + `src/Microsoft.AndroidX.Compose.Maui.Sample`.
+- [docs/maui-backend.md](docs/maui-backend.md) — plan for a .NET MAUI backend that swaps MAUI's stock Android handlers (`AppCompatTextView`, `MaterialButton`, …) for Compose-backed ones. Phase 2 collapses all per-leaf compositions into one `ComposeView` per page, owned by `PageHandler`. Lives in `src/Microsoft.AndroidX.Compose.Maui` + `src/Microsoft.AndroidX.Compose.Maui.Sample`.
 - [docs/api-coverage.md](docs/api-coverage.md) — Compose ⇄ `Microsoft.AndroidX.Compose` API coverage report (per-module, per-symbol). Regenerated via `scripts/api-comparison.cs` whenever a `Xamarin.AndroidX.Compose.*` package is bumped or a facade is added.
 - [docs/manual-jni.md](docs/manual-jni.md) — surface area of every C# member still calling `JNIEnv.*` directly (i.e. what's left for the source generators to absorb). Regenerated via `scripts/manual-jni-report.cs`.
 - [docs/NOTES.md](docs/NOTES.md) — historical notes from the original Tier 1 experiment, including the in-repo binding projects that have since been deleted.

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -127,30 +127,46 @@ So per-handler (Phase 2 shape — single `ComposeView` per page):
 // Handlers/ButtonHandler.cs
 public partial class ButtonHandler : ComposeElementHandler<IButton>
 {
-    readonly MutableState<string>  _text     = new("");
-    readonly MutableState<bool>    _enabled  = new(true);
-    readonly MutableState<long>    _container = new(0L);
-    Action? _click;
+    readonly MutableState<string> _text           = new(string.Empty);
+    readonly MutableState<long?>  _containerColor = new((long?)null);
 
     // Contributes one node into the page's single composition.
-    public override void BuildNode(IComposer composer)
+    public override ComposableNode BuildNode(IComposer composer)
     {
-        composer.Button(
-            onClick: () => _click?.Invoke(),
-            colors:  composer.ButtonColors(containerColor: _container.Value),
-            enabled: _enabled.Value)
+        var button = new Button(onClick: OnClicked)
         {
             new Text(_text.Value),
         };
+        if (_containerColor.Value is not null)
+            button.Colors = composer.ButtonColors(
+                containerColor: _containerColor.Value);
+        return button;
     }
 
-    public static void MapText(ButtonHandler h, IButton b)  => h._text.Value = b.Text ?? "";
-    public static void MapIsEnabled(ButtonHandler h, IView v) => h._enabled.Value = v.IsEnabled;
+    void OnClicked() => VirtualView?.Clicked();
+
+    public static void MapText(ButtonHandler h, IButton b)
+        => h._text.Value = b.Text ?? string.Empty;
+
+    public static void MapBackground(ButtonHandler h, IButton b)
+        => h._containerColor.Value = b.Background is SolidPaint p
+            ? ColorMapping.ToPackedLong(p.Color)
+            : null;
     // ...
 }
 ```
 
-The handler's `PlatformView` is a tiny zero-size marker `Android.Views.View` — MAUI's measure/arrange still routes through it for normal layout participation, but it's never drawn. The actual rendering happens via `BuildNode` inside the page's single `ComposeView`, which `PageHandler` owns and `ComposeWalker` walks for it. Mappers write to `MutableState<T>` slots; Compose recomposes the affected sub-tree automatically.
+The handler's `PlatformView` is a `ComposeView` (so the leaf can
+also fall back to a per-leaf composition when it ends up inside a
+stock parent like a `CollectionView` item template). Inside a
+Compose-aware parent (`PageHandler` / `LayoutHandler` /
+`ScrollViewHandler`), `ComposeWalker` calls `BuildNode` directly
+and the leaf's own `ComposeView` is never attached, so its lazy
+`SetContent` composition never spins up — zero per-handler overhead
+on the common path. Mappers write to `MutableState<T>` slots; the
+same instance is shared between both rendering paths so MAUI
+property changes always trigger recomposition wherever the leaf is
+being drawn.
 
 ### One-ComposeView-per-handler vs. single-root composition
 
@@ -229,13 +245,16 @@ so subsequent handlers don't re-discover them:
 > `.cs` + `.Android.cs` partial split below. Phase 2 Slice 2 then
 > collapsed all per-leaf compositions into one `ComposeView` per
 > page; the actual handler base is `ComposeElementHandler<T>` (a
-> marker-view shell whose only job is to contribute a
-> `ComposableNode` via `BuildNode(IComposer)` to the page's single
-> composition), and the only "platform" types that exist are
-> `ComposeWalker.cs`, `IComposeHandler.cs`, and the new
-> `Handlers/PageHandler.cs` / `Handlers/LayoutHandler.cs` /
-> `Handlers/ScrollViewHandler.cs`. The detailed proposal stays
-> because it outlines what still has to land for the broader phases.
+> `ViewHandler<T, ComposeView>` whose own `ComposeView` is only used
+> as a fallback when the leaf ends up inside a stock parent — on the
+> common Compose-aware path it contributes a `ComposableNode` via
+> `BuildNode(IComposer)` directly to the page's composition and its
+> shell `ComposeView` never spins up a composition), and the only
+> "platform" types that exist are `ComposeWalker.cs`,
+> `IComposeHandler.cs`, and the new `Handlers/PageHandler.cs` /
+> `Handlers/LayoutHandler.cs` / `Handlers/ScrollViewHandler.cs`. The
+> detailed proposal stays because it outlines what still has to land
+> for the broader phases.
 
 Add a new project alongside the existing facade. Mirrors the maui-labs
 layout 1:1:
@@ -323,8 +342,11 @@ Compose backend.
   `PlatformArrange` / `GetDesiredSize`.~~ Phase 2 went the other way:
   collapsed all per-leaf compositions into one `ComposeView` per page,
   owned by `PageHandler`. Leaves derive from `ComposeElementHandler<T>`
-  (a marker-view shell whose only job is to contribute a `ComposableNode`
-  via `BuildNode(IComposer)` to the page's composition).
+  (a `ViewHandler<T, ComposeView>` whose own `ComposeView` only renders
+  when the leaf falls through to a stock parent; on the common path
+  the leaf contributes a `ComposableNode` via `BuildNode(IComposer)`
+  to the page's composition and its own `ComposeView` never starts a
+  composition).
 - `MauiComposeActivity` / `ComponentActivity` host. The sample still
   uses MAUI's stock `MauiAppCompatActivity` because `ComposeView`
   works inside it.
@@ -514,10 +536,15 @@ page so cross-sibling animation, semantics, and a single
   Trade-off: `ContentPage.Padding` / `BackgroundColor` from stock
   `ContentViewHandler` mappers don't flow — apply via Compose modifiers.
 - **`IComposeHandler` + `ComposeElementHandler<T>`** — handler
-  contract for Compose-aware leaves and containers. The shell
-  `PlatformView` is a tiny zero-size marker `Android.Views.View`
-  participating in MAUI measure/arrange; the visible rendering
-  happens through `BuildNode(IComposer)`.
+  contract for Compose-aware leaves and containers. Each
+  `ComposeElementHandler<T>` is `ViewHandler<T, ComposeView>` and
+  its own `ComposeView` is the `PlatformView`. On the common
+  Compose-aware path the leaf is consumed via `BuildNode(IComposer)`
+  inside the parent's composition, so the leaf's own `ComposeView`
+  never gets attached and `SetContent` (which is lazy) never starts
+  a composition. The fallback path — a stock parent like
+  `CollectionView`'s item template — attaches that `ComposeView`
+  directly so the leaf still renders correctly.
 - **`ComposeWalker`** — given a MAUI child, dispatches to
   `IComposeHandler.BuildNode` if the handler is one of ours, else
   wraps the child in Compose's `AndroidView { factory = child.ToPlatform(MauiContext) }`

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -159,13 +159,20 @@ stock backend. Inside, Compose owns the rendering. Mappers write to
 
 | Strategy | Pros | Cons |
 | --- | --- | --- |
-| **Option 1 — per-handler `ComposeView`** ✅ adopted Phase 1 | Trivially maps to existing handler shape; works with MAUI layout system unchanged; matches WPF/AppKit/GTK precedent; ships fast | Each leaf has its own composer + recomposer + snapshot subscription; no cross-sibling animations; M3 theming has to be re-installed per island |
-| Option 2 — single root composition | Idiomatic Compose; one theme, semantics tree, lazy lists work across siblings; shared snapshot graph; better perf at scale | Need a `RenderContext`/`ComposableNode` graph mirroring MAUI's VisualTree; reimplement MAUI layout in Compose `Layout {}`; much bigger lift |
+| Option 1 — per-handler `ComposeView` (shipped Phase 1) | Trivially maps to existing handler shape; works with MAUI layout system unchanged; matches WPF/AppKit/GTK precedent; ships fast | Each leaf has its own composer + recomposer + snapshot subscription; no cross-sibling animations; M3 theming has to be re-installed per island |
+| **Option 2 — single root composition per page** ✅ adopted Phase 2 | One composer / recomposer / snapshot graph per page; cross-sibling animations work; one M3 `MaterialTheme` per page; on-tree `LazyColumn` / `LazyRow` would Just Work | Needs an `IComposeHandler` + `ComposableNode` graph mirroring MAUI's VisualTree; layouts not in our converted set (Grid, AbsoluteLayout, FlexLayout) host via `AndroidView` interop; full `Layout {}`-with-`CrossPlatformMeasure` adapter still TODO |
 
-**Plan**: shipped the per-handler model in Phase 1 (matches maui-labs
-precedent); the single-root composition stays as an opt-in optimisation
-in a later phase. The handler API doesn't change between the two modes —
-only the bootstrapping does.
+**Status**: shipped. `PageHandler` is the only handler that creates a
+`ComposeView`. Every other handler (`LayoutHandler`,
+`ScrollViewHandler`, `LabelHandler`, `ButtonHandler`, `EntryHandler`,
+`ImageHandler`) implements `IComposeHandler` and contributes a
+`ComposableNode` via `BuildNode(IComposer)` to the page's composition.
+Unknown / unconverted controls bubble up through `ComposeWalker.Render`
+which wraps them in Compose's `AndroidView { factory = child.ToPlatform(MauiContext) }`.
+The handler API for new leaves is `ComposeElementHandler<T>` +
+`BuildNode` — no `CreatePlatformView`, no `DisposeComposition`, no
+per-leaf `ComposeView`. See `compose-maui.instructions.md` for the
+canonical handler shape.
 
 #### Phase 1 Option 1 mapper rules (lessons learned)
 

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -121,27 +121,27 @@ View** (`ViewGroup` subclass) that owns a private composition. Set its
 content once with `view.SetContent(c => ...)` and the composition lambda
 re-runs whenever any `MutableState<T>` read inside it changes.
 
-So per-handler:
+So per-handler (Phase 2 shape — single `ComposeView` per page):
 
 ```csharp
-// ButtonHandler.Android.cs
-sealed partial class ButtonHandler : ComposeViewHandler<IButton, ComposeView>
+// Handlers/ButtonHandler.cs
+public partial class ButtonHandler : ComposeElementHandler<IButton>
 {
-    readonly MutableState<string>  _text     = ...;
-    readonly MutableState<bool>    _enabled  = ...;
-    readonly MutableState<Modifier?> _modifier = ...;
+    readonly MutableState<string>  _text     = new("");
+    readonly MutableState<bool>    _enabled  = new(true);
+    readonly MutableState<long>    _container = new(0L);
     Action? _click;
 
-    protected override ComposeView CreatePlatformView()
+    // Contributes one node into the page's single composition.
+    public override void BuildNode(IComposer composer)
     {
-        var view = new ComposeView(Context);
-        view.SetContent(c => new AndroidX.Compose.Button(
-            onClick: () => _click?.Invoke())
+        composer.Button(
+            onClick: () => _click?.Invoke(),
+            colors:  composer.ButtonColors(containerColor: _container.Value),
+            enabled: _enabled.Value)
         {
-            Modifier = _modifier.Value,
             new Text(_text.Value),
-        });
-        return view;
+        };
     }
 
     public static void MapText(ButtonHandler h, IButton b)  => h._text.Value = b.Text ?? "";
@@ -150,10 +150,7 @@ sealed partial class ButtonHandler : ComposeViewHandler<IButton, ComposeView>
 }
 ```
 
-The handler's `PlatformView` is `Android.Views.View` from MAUI's
-perspective — fits MAUI's layout/measure/arrange exactly the same as the
-stock backend. Inside, Compose owns the rendering. Mappers write to
-`MutableState<T>` slots; Compose recomposes the island automatically.
+The handler's `PlatformView` is a tiny zero-size marker `Android.Views.View` — MAUI's measure/arrange still routes through it for normal layout participation, but it's never drawn. The actual rendering happens via `BuildNode` inside the page's single `ComposeView`, which `PageHandler` owns and `ComposeWalker` walks for it. Mappers write to `MutableState<T>` slots; Compose recomposes the affected sub-tree automatically.
 
 ### One-ComposeView-per-handler vs. single-root composition
 
@@ -223,17 +220,22 @@ so subsequent handlers don't re-discover them:
 ## Proposed repo layout
 
 > **Status:** this is the **original design proposal** kept for
-> historical context. Phase 1 shipped the smaller set listed in
-> "Phase 1 — bootstrap + smallest possible working set ✅ shipped"
-> below — no `MauiComposeActivity`, no custom `ComposeViewHandler`
+> historical context. The shipping shape is much smaller — Phase 1
+> shipped with no `MauiComposeActivity`, no custom `ComposeViewHandler`
 > base, no `ModifierBridge` / `DispatcherProvider` / `ComposeTicker` /
 > `ComposeFontManager` / `ComposeAlertManagerSubscription` /
 > `ModalNavigationManager` / `ThemeManager` / `Platform/` folder, and
 > a single `Handlers/<Name>Handler.cs` per control rather than the
-> `.cs` + `.Android.cs` partial split below. Stock MAUI's
-> `MauiAppCompatActivity` + `ViewHandler<TVirtual, ComposeView>` base
-> turned out to be enough. The detailed proposal stays because it
-> outlines what still has to land for the broader phases.
+> `.cs` + `.Android.cs` partial split below. Phase 2 Slice 2 then
+> collapsed all per-leaf compositions into one `ComposeView` per
+> page; the actual handler base is `ComposeElementHandler<T>` (a
+> marker-view shell whose only job is to contribute a
+> `ComposableNode` via `BuildNode(IComposer)` to the page's single
+> composition), and the only "platform" types that exist are
+> `ComposeWalker.cs`, `IComposeHandler.cs`, and the new
+> `Handlers/PageHandler.cs` / `Handlers/LayoutHandler.cs` /
+> `Handlers/ScrollViewHandler.cs`. The detailed proposal stays
+> because it outlines what still has to land for the broader phases.
 
 Add a new project alongside the existing facade. Mirrors the maui-labs
 layout 1:1:
@@ -317,18 +319,20 @@ Compose backend.
 
 **Deferred to a future phase** (not blocking Phase 1):
 
-- `ComposeViewHandler<TVirtual, TPlatform>` base class with a custom
-  `PlatformArrange` / `GetDesiredSize`. Stock MAUI's `ViewHandler<,>`
-  on `net10.0-android` is good enough today because `ComposeView`
-  measures itself like any `Android.Views.View`.
+- ~~`ComposeViewHandler<TVirtual, TPlatform>` base class with a custom
+  `PlatformArrange` / `GetDesiredSize`.~~ Phase 2 went the other way:
+  collapsed all per-leaf compositions into one `ComposeView` per page,
+  owned by `PageHandler`. Leaves derive from `ComposeElementHandler<T>`
+  (a marker-view shell whose only job is to contribute a `ComposableNode`
+  via `BuildNode(IComposer)` to the page's composition).
 - `MauiComposeActivity` / `ComponentActivity` host. The sample still
-  uses MAUI's stock `MauiAppCompatActivity` because per-leaf
-  `ComposeView` works inside it.
-- `PageHandler`, `LayoutHandler`, `ApplicationHandler`,
-  `WindowHandler`, `ComposeLayoutViewGroup` / `ComposeContentViewGroup`,
-  `DispatcherProvider`, `ComposeTicker`. All stock-MAUI handlers; we
-  only swap leaves where Compose provides a clear win
-  (Material 3 surfaces).
+  uses MAUI's stock `MauiAppCompatActivity` because `ComposeView`
+  works inside it.
+- ~~`PageHandler`, `LayoutHandler`~~ — both now overridden in Phase 2.
+  `ApplicationHandler`, `WindowHandler`,
+  `ComposeLayoutViewGroup` / `ComposeContentViewGroup`,
+  `DispatcherProvider`, `ComposeTicker` all still stock — Phase 2's
+  page-level composition runs inside `MauiAppCompatActivity` unchanged.
 - `BackgroundColor` mapping on `Button` — needs a `ButtonColors`
   bridge in the facade (current `Button` facade only exposes
   `Shape`/`ContentPadding`). Accept M3 primary-purple default for now.
@@ -485,13 +489,91 @@ visible input/leaf controls so MAUI sample pages start to look right.
   `ImageButton`.
 - `ComposeAlertManagerSubscription`, `ComposeFontManager`,
   `ThemeManager`, `ModifierBridge`.
-- Option 2 ("one ComposeView per page") rewrite.
 
 **Landed since Slice 1:**
 
 - ✅ **Non-file image sources** (URI / stream / font) via MAUI's
   `IImageSourceService<TSource>` pipeline — see the hybrid
   `ImageHandler` description above.
+- ✅ **Single `ComposeView` per page** (Slice 2 — see below).
+
+#### Phase 2 Slice 2 — Single `ComposeView` per page ✅ shipped
+
+Goal: collapse all per-leaf compositions into one composition per
+page so cross-sibling animation, semantics, and a single
+`MaterialTheme` work the way Compose expects.
+
+**Delivered:**
+
+- **`PageHandler`** — overridden, inherits `ViewHandler<IContentView,
+  ComposeView>` directly (not `ContentViewHandler`). The
+  `ComposeView` *is* the platform view; standard Android measure-spec
+  sizes it via `MATCH_PARENT` to fill Shell's Fragment container.
+  Sole owner of the page's composition; calls
+  `compose.SetContent(c => Box{Modifier.FillMaxSize()}.Add(ComposeWalker.Render(content, c, MauiContext)))`.
+  Trade-off: `ContentPage.Padding` / `BackgroundColor` from stock
+  `ContentViewHandler` mappers don't flow — apply via Compose modifiers.
+- **`IComposeHandler` + `ComposeElementHandler<T>`** — handler
+  contract for Compose-aware leaves and containers. The shell
+  `PlatformView` is a tiny zero-size marker `Android.Views.View`
+  participating in MAUI measure/arrange; the visible rendering
+  happens through `BuildNode(IComposer)`.
+- **`ComposeWalker`** — given a MAUI child, dispatches to
+  `IComposeHandler.BuildNode` if the handler is one of ours, else
+  wraps the child in Compose's `AndroidView { factory = child.ToPlatform(MauiContext) }`
+  so unknown / unconverted controls bubble up through standard MAUI
+  handler resolution and render correctly inside the page composition.
+- **Rewrote leaves** — `LabelHandler`, `ButtonHandler`, `EntryHandler`,
+  `ImageHandler` now derive from `ComposeElementHandler<T>` and
+  contribute a `ComposableNode` via `BuildNode`.
+- **`LayoutHandler` (overridden)** — registered for
+  `Microsoft.Maui.Controls.VerticalStackLayout` →
+  Compose `Column`, `Microsoft.Maui.Controls.HorizontalStackLayout`
+  → Compose `Row`. `Grid`, `AbsoluteLayout`, `FlexLayout`,
+  `StackLayout` stay on MAUI's stock `LayoutHandler` and host via
+  `AndroidView` interop.
+- **`ScrollViewHandler` (overridden)** — wraps content in
+  `Modifier.verticalScroll` / `horizontalScroll` driven by Compose's
+  `rememberScrollState`.
+- **`AndroidView` (public facade in `Microsoft.AndroidX.Compose`)** —
+  Compose ↔ Android view interop wrapper used by the walker for the
+  fallback path.
+
+**Verified on device:**
+
+- Fully-converted pages (Page → VSL/HSL/ScrollView → Label/Button/Entry/Image)
+  render with **exactly one** `androidx.compose.ui.platform.ComposeView`
+  node per `adb shell uiautomator dump`. Confirmed on Counter, Buttons,
+  Labels, Entries, ImageSources sample pages.
+- Pages with stock containers in the middle (e.g. `<Border>` wrapping
+  Compose-backed `<Image>` on `ImageAspectsPage`, or HomePage's
+  `CollectionView` item template) get one extra `ComposeView` per
+  Compose-backed leaf hosted inside the stock container. Documented
+  expected behaviour: a Compose-backed leaf inside a stock container
+  has no parent composer to fold into.
+
+**Lessons learned (Slice 2):**
+
+- **`MutableState<T>` only handles primitives, `string`, `bool`,
+  `char`, `Java.Lang.Object` subclasses, and `Nullable<T>` of those
+  primitives.** MAUI structs (`Thickness`, `Size`, `Rect`, `Color`)
+  and user-defined .NET enums (`TextAlignment`) all throw
+  `NotSupportedException` at ctor time. Workarounds:
+  *version-counter* (`MutableState<int>`, bump in mapper, read live
+  `VirtualView.<prop>` inside `BuildNode`) for structs; cast through
+  the backing primitive (`MutableState<int>` for an enum) when the
+  shape is small.
+- **Stock `ContentViewGroup` ignores Android `LayoutParams`.** Its
+  `OnMeasure` / `OnLayout` route through `CrossPlatformLayout =
+  VirtualView`, which measures `PresentedContent`'s stock view —
+  not whatever child you `AddView` into it. Owning the platform
+  view directly (Page → `ComposeView` not Page → `ContentViewGroup`
+  with a `ComposeView` child) is the only way to get standard
+  Android measure-spec sizing.
+- **Compose-backed leaf inside a stock `CollectionView` item template
+  swallows `TapGestureRecognizer` on parent containers.** `ComposeView`
+  consumes pointer events for its own composition. Workaround: put
+  a stock leaf in the cell, or convert the container.
 
 ### Phase 3 — collection + container (target: list-driven apps)
 
@@ -501,11 +583,12 @@ chosen by `ItemsLayout`. `ListView` → same. `CarouselView` →
 `SwipeView` → `Modifier.Swipeable` (or `SwipeToDismissBox` if/when
 wrapped).
 
-This phase is also where it gets clear whether per-handler ComposeView
-scales — lazy lists with 10000 items shouldn't allocate 10000 composers.
-Likely the `CollectionViewHandler` becomes a single `LazyColumn<T>`
-whose items render *managed* `ComposableNode`s built from MAUI's
-`DataTemplate`, sidestepping per-cell `ComposeView` islands.
+This phase is also where lazy-list scaling lands. With the Phase 2
+single-ComposeView-per-page model in place, `CollectionViewHandler`
+becomes a single Compose `LazyColumn<T>` whose items render *managed*
+`ComposableNode`s built from MAUI's `DataTemplate` — directly inside
+the page's composition, no per-cell `ComposeView` islands, snapshot
+graph + theming inherited from the page root.
 
 ### Phase 4 — navigation (target: real apps)
 
@@ -571,14 +654,15 @@ delegate, but some essentials might need Compose-aware UIs like
    anything else.
 
 3. **One ComposeView per handler — is the per-island theme acceptable
-   for v1?** Each island needs its own `MaterialTheme` wrapper around
-   the facade. Either every handler wraps in `MaterialTheme { ... }`
-   (heavy; theme can't be customized per-app), or the host
-   `MauiComposeActivity` installs a single root `MaterialTheme` and
-   each `ComposeView` is wrapped in a thin reader composable that
-   inherits the host theme via `CompositionLocal` (need to verify this
-   works across separate ComposeView instances — it may NOT, in which
-   case we ship per-island theming for v1 with single-root as Phase 2).
+   for v1?** ✅ **Resolved in Phase 2 Slice 2** by going to a single
+   `ComposeView` per page. The page-level composition lives inside
+   one `ComposeView`, which means there's exactly one Compose
+   `MaterialTheme` scope (currently the M3 default) for the entire
+   page; every `ComposableNode` contributed by
+   `IComposeHandler.BuildNode` inherits it via `CompositionLocal`.
+   Wiring an explicit `MaterialTheme { ... }` wrapper bridged from
+   MAUI's `Application.Resources` colour palette is a follow-up; the
+   per-island wrapping problem is gone.
 
 4. **Layout sizing** — Compose composables size themselves; MAUI wants
    you to honor an explicit `widthSpec`/`heightSpec`. Need to

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/README.md
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/README.md
@@ -16,17 +16,21 @@ builder
 ```
 
 `UseAndroidXCompose()` overwrites the Android registrations for the
-controls the backend currently owns (Label, Button). Everything else
-falls back to MAUI's stock handler, so the rest of the page renders
-through normal AppCompat views.
+controls the backend currently owns (Label, Button, Entry, Image,
+VerticalStackLayout, HorizontalStackLayout, ScrollView, ContentPage).
+Everything else falls back to MAUI's stock handler — and is hosted
+inside the page's Compose tree via `AndroidView` interop, so the
+rest of the page renders through normal AppCompat views with no
+extra wiring.
 
 ## Side-by-side with `dotnet new maui`
 
-Same APK shape, same fonts, same status bar, same splash. The only
-intentional visible delta in Phase 1 is the **Button container color** —
-Compose Material 3 ships `#6750A4` and we don't yet wire up MAUI's
-`Primary` resource (`#512BD4`). That's tracked as a Phase 2 follow-up
-in [`docs/maui-backend.md`](../../docs/maui-backend.md).
+Same APK shape, same fonts, same status bar, same splash. The
+side-by-side images below are from the original Phase 1 visual
+parity check (counter button paints M3 mauve `#6750A4` instead of
+MAUI Primary `#512BD4` — bridging MAUI's `Application.Resources`
+colour palette into a Compose `MaterialTheme` is a follow-up
+tracked in [`docs/maui-backend.md`](../../docs/maui-backend.md)).
 
 | Compose backend (this sample)                                 | Stock MAUI template (`dotnet new maui`)                              |
 | :-----------------------------------------------------------: | :-------------------------------------------------------------------: |

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/README.md
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/README.md
@@ -44,26 +44,51 @@ Requires the `android` workload and a connected device or emulator.
 
 - Splash → Shell handoff matches the template (`Maui.SplashTheme`,
   `colorPrimaryDark` status bar).
-- `Label` renders through Compose `Text` — TextColor, FontSize, FontWeight,
-  HorizontalTextAlignment, HorizontalLayoutAlignment (→
-  `Modifier.FillMaxWidth()`).
+- **One `ComposeView` per page** for fully-converted layouts (Page →
+  VSL/HSL/ScrollView → Label/Button/Entry/Image). Verify with
+  `adb shell uiautomator dump` — pages whose root is one of our
+  converted containers (e.g. `CounterPage`'s `ScrollView` + VSL) show
+  exactly one `androidx.compose.ui.platform.ComposeView` node.
+- `Label` renders through Compose `Text` — TextColor, FontSize,
+  FontWeight, HorizontalTextAlignment, HorizontalLayoutAlignment
+  (→ `Modifier.FillMaxWidth()`).
 - `Button` renders through Compose Material 3 `Button` — Click event,
-  Text, HorizontalLayoutAlignment, `IView.Background` suppressed so we
-  don't double-paint behind the Compose `Surface`.
-- Layout / Shell / Page / Application / Window all stay on stock
-  handlers; Compose-backed leaves nest cleanly inside them.
+  Text, HorizontalLayoutAlignment, `IView.Background` routed into
+  `ButtonColors.containerColor`.
+- `Entry`, `Image` follow the same `IComposeHandler` pattern.
+- `VerticalStackLayout` / `HorizontalStackLayout` render as Compose
+  `Column` / `Row`; `ScrollView` wraps content in
+  `Modifier.verticalScroll` / `horizontalScroll`.
+- **Unknown / unconverted controls** (`CollectionView`, `BoxView`,
+  `Grid`, third-party renderers) are hosted via Compose's
+  `AndroidView { factory = child.ToPlatform(MauiContext) }` interop
+  from inside the page composition — MAUI's normal handler resolution
+  still runs them, and Compose just hosts the resulting Android
+  `View`. `HomePage` exercises this path (root `Grid` + `CollectionView`).
 
 ## What's intentionally deferred
 
 See [`docs/maui-backend.md`](../../docs/maui-backend.md) for the full
-phased plan. Notable Phase 1 omissions:
+phased plan. Notable gaps:
 
-- Material 3 → MAUI `Primary` color bridge (button paints M3 mauve,
-  not `#512BD4`).
-- All other leaf controls: Entry, Editor, Image, CheckBox, Switch,
-  Slider, ProgressBar, ActivityIndicator, …
-- One-`ComposeView`-per-page (Option 2 in the design doc). Phase 1 uses
-  one `ComposeView` per Compose-backed leaf, which is enough to prove
-  the architecture works inside MAUI's stock layout system.
-- BackgroundColor, Border, Shadow, custom FontFamily / italic /
-  decoration / line-height passthrough.
+- All other leaf controls: Editor, CheckBox, Switch, Slider,
+  ProgressBar, ActivityIndicator, …
+- Layouts that need the generic
+  `androidx.compose.ui.layout.Layout {}` adapter forwarding to MAUI's
+  `ILayoutManager`: Grid, AbsoluteLayout, FlexLayout, StackLayout.
+  Today these stay on the stock `LayoutHandler` and are hosted via
+  `AndroidView` from inside the page composition.
+- Compose-backed leaves inside a stock container (e.g. `CollectionView`
+  item template) currently fall back to one `ComposeView` per leaf
+  because they can't fold into a parent composer that doesn't exist.
+  The "one ComposeView per page" invariant only holds when the entire
+  path from `PageHandler` down uses our handlers.
+- Compose `ComposeView` consumes pointer events; a Compose-backed leaf
+  inside a stock `CollectionView` item template swallows taps that
+  would otherwise trigger MAUI `TapGestureRecognizer`s on parent
+  containers. Workaround: put a stock leaf (e.g. `Switch`) inside the
+  item template, or convert the container.
+- BackgroundColor, Border, Shadow on the `ContentPage` itself —
+  `PageHandler` doesn't inherit MAUI's `ContentViewHandler`, so page-
+  level cross-platform properties don't flow. Apply via Compose
+  modifiers inside the composition instead.

--- a/src/Microsoft.AndroidX.Compose.Maui/ComposeElementHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/ComposeElementHandler.cs
@@ -1,0 +1,88 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.AndroidX.Compose.Maui;
+
+/// <summary>
+/// Base class for every handler in <c>Microsoft.AndroidX.Compose.Maui</c>.
+/// Owns a <see cref="ComposeView"/> as <c>PlatformView</c> (so the
+/// handler satisfies MAUI's "<c>PlatformView</c> non-null" contract
+/// and can be inserted into a stock ViewGroup as a fallback) and
+/// exposes a <see cref="BuildNode(IComposer)"/> extension point used
+/// by <see cref="ComposeWalker.Render(IView, IComposer, IMauiContext)"/>
+/// to fold the handler's render into the enclosing page composition.
+/// </summary>
+/// <remarks>
+/// <para>The contract:</para>
+/// <list type="bullet">
+///   <item>
+///     <description>Mappers write into <see cref="MutableState{T}"/>
+///     slots on the handler (unchanged from the prior per-leaf
+///     <c>ComposeView</c> model). The same instance is shared between
+///     the fallback composition (when our <c>ComposeView</c> ends up
+///     attached to a stock ViewGroup) and the page-rooted
+///     composition, so MAUI property changes always trigger
+///     recomposition wherever this handler is being rendered.</description>
+///   </item>
+///   <item>
+///     <description><see cref="BuildNode(IComposer)"/> returns a
+///     <see cref="ComposableNode"/>. The walker hands it the live
+///     <see cref="IComposer"/>; deferred slot reads happen at
+///     <see cref="ComposableNode.Render(IComposer)"/> time.</description>
+///   </item>
+/// </list>
+///
+/// <para>The fallback path is automatic: <see cref="ComposeView.SetContent"/>
+/// is lazy — it stashes the content lambda and only creates the
+/// composition when the view is attached to a window. Inside a
+/// Compose-aware parent, the walker calls
+/// <see cref="IComposeHandler.BuildNode(IComposer)"/> directly and
+/// the leaf's <c>PlatformView</c> never gets attached, so no
+/// composition starts and there's no per-leaf Recomposer overhead.
+/// Inside a stock parent (e.g. a Grid we didn't override), MAUI calls
+/// <c>ToPlatform()</c>, attaches the <c>ComposeView</c>, and the
+/// fallback composition spins up automatically.</para>
+/// </remarks>
+public abstract class ComposeElementHandler<TVirtualView> : ViewHandler<TVirtualView, ComposeView>, IComposeHandler
+    where TVirtualView : class, IView
+{
+    /// <inheritdoc/>
+    protected ComposeElementHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
+        : base(mapper, commandMapper) { }
+
+    /// <inheritdoc/>
+    protected sealed override ComposeView CreatePlatformView() => new(Context);
+
+    /// <inheritdoc/>
+    public override void SetVirtualView(IView view)
+    {
+        base.SetVirtualView(view);
+        // ComposeView.SetContent is lazy — it only kicks off a
+        // composition when the view is attached to a window. Inside
+        // a Compose-aware parent the walker calls BuildNode directly
+        // and this composition is never created.
+        PlatformView!.SetContent(BuildNode);
+    }
+
+    /// <inheritdoc/>
+    protected override void DisconnectHandler(ComposeView platformView)
+    {
+        platformView.DisposeComposition();
+        base.DisconnectHandler(platformView);
+    }
+
+    /// <inheritdoc cref="IComposeHandler.BuildNode(IComposer)"/>
+    /// <remarks>
+    /// Implementors construct and return the <see cref="ComposableNode"/>
+    /// (e.g. a <c>Text</c>, <c>Button</c>, or container) that should
+    /// run inside the enclosing composition. Reads of
+    /// <see cref="MutableState{T}"/> slots typically happen inside the
+    /// node's own <c>Render</c>; deferring keeps the slot subscriptions
+    /// pinned to the correct compose-scope (so a state change only
+    /// invalidates this subtree).
+    /// </remarks>
+    public abstract ComposableNode BuildNode(IComposer composer);
+}
+

--- a/src/Microsoft.AndroidX.Compose.Maui/ComposeWalker.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/ComposeWalker.cs
@@ -1,0 +1,69 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Platform;
+
+namespace Microsoft.AndroidX.Compose.Maui;
+
+/// <summary>
+/// Bridges MAUI's <see cref="IView"/> tree into the active Compose
+/// composition during a render pass. The single
+/// <see cref="ComposeView"/> rooted in
+/// <see cref="Handlers.PageHandler"/> calls
+/// <see cref="Render(IView, IComposer, IMauiContext)"/> per child;
+/// container handlers
+/// (<see cref="Handlers.LayoutHandler"/>,
+/// <see cref="Handlers.ScrollViewHandler"/>) call it from inside
+/// their own composables to recurse.
+/// </summary>
+/// <remarks>
+/// <para>Two paths:</para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <see cref="IComposeHandler"/> → fold the handler's render
+///       into the current composition via
+///       <see cref="IComposeHandler.BuildNode(IComposer)"/>. Zero
+///       extra <c>ComposeView</c>s, zero extra recomposers.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       Anything else (stock handler, custom renderer,
+///       not-yet-converted control) → wrap via
+///       <see cref="AndroidView"/>. MAUI's normal handler resolution
+///       still produces a stock Android view; Compose hosts it as an
+///       <c>AndroidView</c> in the same composition.
+///     </description>
+///   </item>
+/// </list>
+/// </remarks>
+internal static class ComposeWalker
+{
+    /// <summary>
+    /// Materialise a <see cref="ComposableNode"/> for
+    /// <paramref name="view"/>, dispatching on whether its handler is
+    /// Compose-aware.
+    /// </summary>
+    public static ComposableNode Render(IView view, IComposer composer, IMauiContext mauiContext)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+        ArgumentNullException.ThrowIfNull(mauiContext);
+
+        // The handler may be null on the very first render — MAUI hasn't
+        // resolved one yet for this child. ToHandler() forces resolution
+        // and creates the handler on demand. For the IComposeHandler
+        // path we need a handler before BuildNode; for the AndroidView
+        // fallback the factory lambda calls ToPlatform() which does the
+        // same thing.
+        var handler = view.Handler;
+        if (handler is null)
+        {
+            _ = view.ToHandler(mauiContext);
+            handler = view.Handler;
+        }
+
+        return handler is IComposeHandler compose
+            ? compose.BuildNode(composer)
+            : new AndroidView(_ => view.ToPlatform(mauiContext));
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
@@ -1,6 +1,6 @@
 using AndroidX.Compose;
 using AndroidX.Compose.Material3;
-using AndroidX.Compose.UI.Platform;
+using AndroidX.Compose.Runtime;
 using Microsoft.Maui.Handlers;
 using ComposeButton = AndroidX.Compose.Button;
 
@@ -13,11 +13,13 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 /// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
 /// </summary>
 /// <remarks>
-/// The Compose <c>onClick</c> lambda forwards to <see cref="IButton.Clicked"/>
-/// so MAUI's standard <c>Clicked</c> event and bound <c>Command</c> fire
-/// as expected.
+/// Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>. The Compose <c>onClick</c> lambda
+/// forwards to <see cref="IButton.Clicked"/> so MAUI's standard
+/// <c>Clicked</c> event and bound <c>Command</c> fire as expected.
 /// </remarks>
-public partial class ButtonHandler : ViewHandler<IButton, ComposeView>
+public partial class ButtonHandler : ComposeElementHandler<IButton>
 {
     /// <summary>
     /// Property mapper that forwards MAUI <see cref="IButton"/> property
@@ -65,33 +67,21 @@ public partial class ButtonHandler : ViewHandler<IButton, ComposeView>
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
     /// <inheritdoc/>
-    protected override ComposeView CreatePlatformView()
+    public override ComposableNode BuildNode(IComposer composer)
     {
-        var view = new ComposeView(Context);
-        view.SetContent(c =>
+        var container = _containerColor.Value;
+        var content   = _contentColor.Value;
+        var button = new ComposeButton(onClick: OnClicked)
         {
-            var container = _containerColor.Value;
-            var content   = _contentColor.Value;
-            var button = new ComposeButton(onClick: OnClicked)
-            {
-                new Text(_text.Value),
-            };
-            if (container is not null || content is not null)
-                button.Colors = c.ButtonColors(
-                    containerColor: container,
-                    contentColor:   content);
-            if (_fillWidth.Value)
-                button.PrependModifier(Modifier.FillMaxWidth());
-            return button;
-        });
-        return view;
-    }
-
-    /// <inheritdoc/>
-    protected override void DisconnectHandler(ComposeView platformView)
-    {
-        platformView.DisposeComposition();
-        base.DisconnectHandler(platformView);
+            new Text(_text.Value),
+        };
+        if (container is not null || content is not null)
+            button.Colors = composer.ButtonColors(
+                containerColor: container,
+                contentColor:   content);
+        if (_fillWidth.Value)
+            button.PrependModifier(Modifier.FillMaxWidth());
+        return button;
     }
 
     void OnClicked()

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using AndroidX.Compose;
-using AndroidX.Compose.UI.Platform;
+using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Text.Input;
 using Microsoft.Maui.Handlers;
 using ComposeColor          = AndroidX.Compose.Color;
@@ -20,12 +20,15 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 /// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
 /// </summary>
 /// <remarks>
-/// Uses <c>OutlinedTextField</c> rather than the filled <c>TextField</c>
-/// variant because it matches MAUI's stock Entry chrome more closely
-/// (clear bordered outline, no shaded background fill, label that
-/// floats above the border when the field gains focus).
+/// Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>. Uses <c>OutlinedTextField</c>
+/// rather than the filled <c>TextField</c> variant because it
+/// matches MAUI's stock Entry chrome more closely (clear bordered
+/// outline, no shaded background fill, label that floats above the
+/// border when the field gains focus).
 /// </remarks>
-public partial class EntryHandler : ViewHandler<IEntry, ComposeView>
+public partial class EntryHandler : ComposeElementHandler<IEntry>
 {
     /// <summary>
     /// Property mapper that forwards MAUI <see cref="IEntry"/> property
@@ -66,62 +69,50 @@ public partial class EntryHandler : ViewHandler<IEntry, ComposeView>
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
     /// <inheritdoc/>
-    protected override ComposeView CreatePlatformView()
+    public override ComposableNode BuildNode(IComposer composer)
     {
-        var view = new ComposeView(Context);
-        view.SetContent(_ =>
+        var packed       = _color.Value;
+        var size         = _fontSize.Value;
+        var bold         = _bold.Value;
+        var placeholder  = _placeholder.Value;
+        var isPassword   = _isPassword.Value;
+        var keyboardType = _keyboardType.Value;
+        var readOnly     = _readOnly.Value;
+        var fill         = _fillWidth.Value;
+
+        var field = new ComposeOutlinedTextField(_text.Value, OnValueChanged)
         {
-            var packed       = _color.Value;
-            var size         = _fontSize.Value;
-            var bold         = _bold.Value;
-            var placeholder  = _placeholder.Value;
-            var isPassword   = _isPassword.Value;
-            var keyboardType = _keyboardType.Value;
-            var readOnly     = _readOnly.Value;
-            var fill         = _fillWidth.Value;
-
-            var field = new ComposeOutlinedTextField(_text.Value, OnValueChanged)
+            ReadOnly   = readOnly,
+            SingleLine = true,
+        };
+        if (!string.IsNullOrEmpty(placeholder))
+            field.Placeholder = new ComposeText(placeholder);
+        if (packed.HasValue || size.HasValue || bold)
+            field.TextStyle = new ComposeTextStyle
             {
-                ReadOnly   = readOnly,
-                SingleLine = true,
+                Color      = packed.HasValue ? new ComposeColor(packed.Value) : null,
+                FontSize   = size.HasValue   ? new Sp(size.Value) : null,
+                FontWeight = bold ? ComposeFontWeight.Bold : null,
             };
-            if (!string.IsNullOrEmpty(placeholder))
-                field.Placeholder = new ComposeText(placeholder);
-            if (packed.HasValue || size.HasValue || bold)
-                field.TextStyle = new ComposeTextStyle
-                {
-                    Color      = packed.HasValue ? new ComposeColor(packed.Value) : null,
-                    FontSize   = size.HasValue   ? new Sp(size.Value) : null,
-                    FontWeight = bold ? ComposeFontWeight.Bold : null,
-                };
-            if (isPassword)
-                field.VisualTransformation = new PasswordVisualTransformation('•');
-            // Always set KeyboardOptions when the resolved type isn't the
-            // default `Text`, so the OS surfaces the right IME (digits,
-            // email, etc.). Password buffers + numeric flag both lower
-            // through `keyboardType`.
-            var resolvedType = isPassword ? ComposeKeyboardType.Password : keyboardType;
-            if (resolvedType != ComposeKeyboardType.Text)
-            {
-                var d = KeyboardOptionsCompanion.Default;
-                field.KeyboardOptions = d.Copy(
-                    d.Capitalization, d.AutoCorrectEnabled,
-                    resolvedType, d.ImeAction,
-                    d.PlatformImeOptions, d.ShowKeyboardOnFocus, d.HintLocales);
-            }
+        if (isPassword)
+            field.VisualTransformation = new PasswordVisualTransformation('•');
+        // Always set KeyboardOptions when the resolved type isn't the
+        // default `Text`, so the OS surfaces the right IME (digits,
+        // email, etc.). Password buffers + numeric flag both lower
+        // through `keyboardType`.
+        var resolvedType = isPassword ? ComposeKeyboardType.Password : keyboardType;
+        if (resolvedType != ComposeKeyboardType.Text)
+        {
+            var d = KeyboardOptionsCompanion.Default;
+            field.KeyboardOptions = d.Copy(
+                d.Capitalization, d.AutoCorrectEnabled,
+                resolvedType, d.ImeAction,
+                d.PlatformImeOptions, d.ShowKeyboardOnFocus, d.HintLocales);
+        }
 
-            if (fill)
-                field.PrependModifier(Modifier.FillMaxWidth());
-            return field;
-        });
-        return view;
-    }
-
-    /// <inheritdoc/>
-    protected override void DisconnectHandler(ComposeView platformView)
-    {
-        platformView.DisposeComposition();
-        base.DisconnectHandler(platformView);
+        if (fill)
+            field.PrependModifier(Modifier.FillMaxWidth());
+        return field;
     }
 
     void OnValueChanged(string newValue)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
@@ -1,5 +1,6 @@
 using Android.Graphics.Drawables;
 using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Graphics;
 using AndroidX.Compose.UI.Graphics.Painter;
 using AndroidX.Compose.UI.Platform;
@@ -18,6 +19,9 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 /// (<see cref="ComposeImage"/>). Replaces MAUI's stock
 /// <c>AppCompatImageView</c>-based handler when the consumer calls
 /// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>.
 /// </summary>
 /// <remarks>
 /// <para>Source resolution is hybrid:</para>
@@ -47,7 +51,7 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 ///   </item>
 /// </list>
 /// </remarks>
-public partial class ImageHandler : ViewHandler<MauiIImage, ComposeView>
+public partial class ImageHandler : ComposeElementHandler<MauiIImage>
 {
     /// <summary>
     /// Property mapper that forwards MAUI <see cref="MauiIImage"/> property
@@ -92,21 +96,16 @@ public partial class ImageHandler : ViewHandler<MauiIImage, ComposeView>
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
     /// <inheritdoc/>
-    protected override ComposeView CreatePlatformView()
+    public override ComposableNode BuildNode(IComposer composer)
     {
-        var view = new ComposeView(Context);
-        view.SetContent(_ =>
-        {
-            // Painter wins over the resource id so a freshly-loaded
-            // BitmapPainter immediately replaces any stale fast-path
-            // drawable. Both null => empty placeholder.
-            if (_painter.Value is { } painter)
-                return new ComposeImage(painter) { ContentScale = _contentScale.Value };
-            if (_drawableResourceId.Value is int id)
-                return new ComposeImage(id) { ContentScale = _contentScale.Value };
-            return new Box();
-        });
-        return view;
+        // Painter wins over the resource id so a freshly-loaded
+        // BitmapPainter immediately replaces any stale fast-path
+        // drawable. Both null => empty placeholder.
+        if (_painter.Value is { } painter)
+            return new ComposeImage(painter) { ContentScale = _contentScale.Value };
+        if (_drawableResourceId.Value is int id)
+            return new ComposeImage(id) { ContentScale = _contentScale.Value };
+        return new Box();
     }
 
     /// <inheritdoc/>
@@ -118,7 +117,6 @@ public partial class ImageHandler : ViewHandler<MauiIImage, ComposeView>
         _loader?.Reset();
         _drawableResourceId.Value = null;
         _painter.Value = null;
-        platformView.DisposeComposition();
         base.DisconnectHandler(platformView);
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
@@ -1,5 +1,5 @@
 using AndroidX.Compose;
-using AndroidX.Compose.UI.Platform;
+using AndroidX.Compose.Runtime;
 using Microsoft.Maui.Handlers;
 using ComposeColor = AndroidX.Compose.Color;
 using ComposeText = AndroidX.Compose.Text;
@@ -15,14 +15,16 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 /// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
 /// </summary>
 /// <remarks>
-/// Each instance owns a <see cref="ComposeView"/> hosting one composition.
-/// The composition reads <see cref="MutableState{T}"/> slots
-/// (text, color, font size/weight, horizontal text alignment, fill-width
-/// flag) so MAUI property changes propagate through the standard mapper
-/// pipeline and trigger recomposition on the next frame without
-/// rebuilding the view.
+/// Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>. The label reads
+/// <see cref="MutableState{T}"/> slots (text, color, font size/weight,
+/// horizontal text alignment, fill-width flag) so MAUI property
+/// changes propagate through the standard mapper pipeline and
+/// trigger recomposition on the next frame without rebuilding the
+/// platform view.
 /// </remarks>
-public partial class LabelHandler : ViewHandler<ILabel, ComposeView>
+public partial class LabelHandler : ComposeElementHandler<ILabel>
 {
     /// <summary>
     /// Property mapper that forwards MAUI <see cref="ILabel"/> property
@@ -66,40 +68,28 @@ public partial class LabelHandler : ViewHandler<ILabel, ComposeView>
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
     /// <inheritdoc/>
-    protected override ComposeView CreatePlatformView()
+    public override ComposableNode BuildNode(IComposer composer)
     {
-        var view = new ComposeView(Context);
-        view.SetContent(_ =>
+        var packed = _color.Value;
+        var size   = _fontSize.Value;
+        var bold   = _bold.Value;
+        var fill   = _fillWidth.Value;
+        var align  = (TextAlignment)_hTextAlign.Value;
+        var text = new ComposeText(_text.Value)
         {
-            var packed = _color.Value;
-            var size   = _fontSize.Value;
-            var bold   = _bold.Value;
-            var fill   = _fillWidth.Value;
-            var align  = (TextAlignment)_hTextAlign.Value;
-            var text = new ComposeText(_text.Value)
+            Color      = packed.HasValue ? new ComposeColor(packed.Value) : null,
+            FontSize   = size.HasValue ? new Sp(size.Value) : null,
+            FontWeight = bold ? ComposeFontWeight.Bold : null,
+            Align      = align switch
             {
-                Color      = packed.HasValue ? new ComposeColor(packed.Value) : null,
-                FontSize   = size.HasValue ? new Sp(size.Value) : null,
-                FontWeight = bold ? ComposeFontWeight.Bold : null,
-                Align      = align switch
-                {
-                    TextAlignment.Center => ComposeTextAlign.Center,
-                    TextAlignment.End    => ComposeTextAlign.End,
-                    _                    => null,
-                },
-            };
-            if (fill)
-                text.PrependModifier(Modifier.FillMaxWidth());
-            return text;
-        });
-        return view;
-    }
-
-    /// <inheritdoc/>
-    protected override void DisconnectHandler(ComposeView platformView)
-    {
-        platformView.DisposeComposition();
-        base.DisconnectHandler(platformView);
+                TextAlignment.Center => ComposeTextAlign.Center,
+                TextAlignment.End    => ComposeTextAlign.End,
+                _                    => null,
+            },
+        };
+        if (fill)
+            text.PrependModifier(Modifier.FillMaxWidth());
+        return text;
     }
 
     /// <summary>Map <see cref="IText.Text"/> to the Compose text slot.</summary>

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
@@ -61,7 +61,7 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
         new(ViewCommandMapper);
 
     readonly MutableState<int> _childrenVersion = new(0);
-    readonly MutableState<int> _spacing = new(0);
+    readonly MutableState<float> _spacing = new(0f);
     // Thickness is a MAUI struct; not a Java type, primitive, or
     // Nullable<primitive>, so MutableState<Thickness> throws
     // NotSupportedException at construction. Use a version counter
@@ -110,7 +110,7 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
         _ = _childrenVersion.Value; // subscribe — a tree mutation bumps this
         var padding = layout is IPadding pad ? pad.Padding : Thickness.Zero;
 
-        var arrangement = spacing > 0 ? Arrangement.SpacedBy(spacing) : null;
+        var arrangement = spacing > 0f ? Arrangement.SpacedBy(new Dp(spacing)) : null;
 
         ComposableContainer container = vertical
             ? new Column(verticalArrangement: arrangement)
@@ -151,7 +151,7 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
     public static void MapSpacing(LayoutHandler handler, ILayout layout)
     {
         if (layout is IStackLayout stack)
-            handler._spacing.Value = (int)stack.Spacing;
+            handler._spacing.Value = (float)stack.Spacing;
     }
 
     /// <summary>

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
@@ -1,0 +1,166 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ILayout = Microsoft.Maui.ILayout;
+using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
+using MauiVerticalStackLayout = Microsoft.Maui.Controls.VerticalStackLayout;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// Handler for the simple stack layouts
+/// (<see cref="Microsoft.Maui.Controls.VerticalStackLayout"/>,
+/// <see cref="Microsoft.Maui.Controls.HorizontalStackLayout"/>) that
+/// folds into the page's single <see cref="AndroidX.Compose.UI.Platform.ComposeView"/>
+/// via <see cref="IComposeHandler"/>. <c>VerticalStackLayout</c> →
+/// Compose <see cref="Column"/>, <c>HorizontalStackLayout</c> →
+/// Compose <see cref="Row"/>.
+/// </summary>
+/// <remarks>
+/// <para>Registered <em>only</em> for those two concrete types in
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// <c>Grid</c>, <c>AbsoluteLayout</c>, <c>FlexLayout</c>,
+/// <c>StackLayout</c> stay on MAUI's stock
+/// <see cref="Microsoft.Maui.Handlers.LayoutHandler"/> — their
+/// measure/arrange logic lives inside
+/// <c>Microsoft.Maui.Controls.Layout.CrossPlatformLayout</c> (an
+/// <see cref="ILayoutManager"/>) which the stock
+/// <c>LayoutViewGroup</c> drives. Children of those stock layouts
+/// resolve their handlers normally; any Compose-backed leaf
+/// (Label/Button/Entry/Image) returns a <c>ComposeView</c> as its
+/// platform view and self-hosts when attached (one composition per
+/// leaf, same as the pre-refactor behaviour).</para>
+///
+/// <para>Adding richer Grid / Absolute / Flex support is a follow-up
+/// that needs a generic <c>Compose Layout {}</c> measure-policy
+/// bridge wrapping MAUI's <see cref="ILayoutManager"/>. See
+/// <c>plan.md</c>.</para>
+/// </remarks>
+public partial class LayoutHandler : ComposeElementHandler<ILayout>
+{
+    /// <summary>
+    /// Property mapper. <see cref="IStackLayout.Spacing"/> +
+    /// <see cref="IPadding.Padding"/> are read live during
+    /// <see cref="BuildNode(IComposer)"/>; eager mapper writes go
+    /// into the spacing slot so a runtime <c>Spacing</c> change
+    /// triggers recomposition.
+    /// </summary>
+    public static IPropertyMapper<ILayout, LayoutHandler> Mapper =
+        new PropertyMapper<ILayout, LayoutHandler>(ViewHandler.ViewMapper)
+        {
+            // Children tree changes: bumping the version slot
+            // invalidates the layout's container subtree (Compose
+            // smart-skips siblings whose state is unchanged).
+            ["Children"]                          = MapChildren,
+            [nameof(IStackLayout.Spacing)]        = MapSpacing,
+            [nameof(IPadding.Padding)]            = MapPadding,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<ILayout, LayoutHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<int> _childrenVersion = new(0);
+    readonly MutableState<int> _spacing = new(0);
+    // Thickness is a MAUI struct; not a Java type, primitive, or
+    // Nullable<primitive>, so MutableState<Thickness> throws
+    // NotSupportedException at construction. Use a version counter
+    // and re-read VirtualView.Padding live in BuildNode (same trick
+    // as _childrenVersion).
+    readonly MutableState<int> _paddingVersion = new(0);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public LayoutHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public LayoutHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        var layout = VirtualView
+            ?? throw new InvalidOperationException("VirtualView not set on LayoutHandler.");
+        var context = MauiContext
+            ?? throw new InvalidOperationException("MauiContext not set on LayoutHandler.");
+
+        return layout switch
+        {
+            // MAUI doesn't expose an IVerticalStackLayout / IHorizontalStackLayout
+            // interface (only the concrete control types + the
+            // IStackLayout interface with Spacing). We registered for
+            // the two concrete VirtualView types in
+            // UseAndroidXCompose, so check those.
+            MauiVerticalStackLayout   => BuildStack(layout, context, vertical: true),
+            MauiHorizontalStackLayout => BuildStack(layout, context, vertical: false),
+            _ => throw new InvalidOperationException(
+                $"Unsupported layout type '{layout.GetType().Name}'. " +
+                "LayoutHandler currently only handles VerticalStackLayout / HorizontalStackLayout " +
+                "— Grid/AbsoluteLayout/FlexLayout/StackLayout stay on MAUI's stock LayoutHandler. " +
+                "If you're seeing this, the registration in UseAndroidXCompose claimed too much."),
+        };
+    }
+
+    ComposableNode BuildStack(ILayout layout, IMauiContext context, bool vertical)
+    {
+        // Read live state on the composition thread so changes
+        // observed via the mapper slots trigger recomposition.
+        var spacing = _spacing.Value;
+        _ = _paddingVersion.Value;  // subscribe — padding change bumps this
+        _ = _childrenVersion.Value; // subscribe — a tree mutation bumps this
+        var padding = layout is IPadding pad ? pad.Padding : Thickness.Zero;
+
+        var arrangement = spacing > 0 ? Arrangement.SpacedBy(spacing) : null;
+
+        ComposableContainer container = vertical
+            ? new Column(verticalArrangement: arrangement)
+            : new Row(horizontalArrangement: arrangement);
+
+        if (padding != Thickness.Zero)
+        {
+            container.Modifier = Modifier.Padding(
+                start:  new Dp((float)padding.Left),
+                top:    new Dp((float)padding.Top),
+                end:    new Dp((float)padding.Right),
+                bottom: new Dp((float)padding.Bottom));
+        }
+
+        for (int i = 0; i < layout.Count; i++)
+        {
+            var child = layout[i];
+            container.Add(c => ComposeWalker.Render(child, c, context));
+        }
+
+        return container;
+    }
+
+    /// <summary>
+    /// Bump the children-version slot so any composition reading it
+    /// (the layout container) recomposes. Stock MAUI's
+    /// <c>LayoutHandlerUpdate</c> command pushes the same signal
+    /// through <see cref="ILayoutHandler"/>'s
+    /// <c>Add</c>/<c>Insert</c>/<c>Remove</c>/<c>Clear</c>; we
+    /// short-circuit at the mapper layer instead.
+    /// </summary>
+    public static void MapChildren(LayoutHandler handler, ILayout layout)
+    {
+        unchecked { handler._childrenVersion.Value = handler._childrenVersion.Value + 1; }
+    }
+
+    /// <summary>Map <see cref="IStackLayout.Spacing"/> to the spacing slot (dp).</summary>
+    public static void MapSpacing(LayoutHandler handler, ILayout layout)
+    {
+        if (layout is IStackLayout stack)
+            handler._spacing.Value = (int)stack.Spacing;
+    }
+
+    /// <summary>
+    /// Bump the padding-version slot so any composition reading
+    /// <see cref="IPadding.Padding"/> on the live <c>VirtualView</c>
+    /// recomposes.
+    /// </summary>
+    public static void MapPadding(LayoutHandler handler, ILayout layout)
+    {
+        unchecked { handler._paddingVersion.Value = handler._paddingVersion.Value + 1; }
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
@@ -144,7 +144,7 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
     /// </summary>
     public static void MapChildren(LayoutHandler handler, ILayout layout)
     {
-        unchecked { handler._childrenVersion.Value = handler._childrenVersion.Value + 1; }
+        handler._childrenVersion.Value++;
     }
 
     /// <summary>Map <see cref="IStackLayout.Spacing"/> to the spacing slot (dp).</summary>
@@ -157,10 +157,11 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
     /// <summary>
     /// Bump the padding-version slot so any composition reading
     /// <see cref="IPadding.Padding"/> on the live <c>VirtualView</c>
-    /// recomposes.
+    /// recomposes. Wraps silently around <see cref="int.MaxValue"/>;
+    /// the only thing Compose checks is value-not-equal-to-previous.
     /// </summary>
     public static void MapPadding(LayoutHandler handler, ILayout layout)
     {
-        unchecked { handler._paddingVersion.Value = handler._paddingVersion.Value + 1; }
+        handler._paddingVersion.Value++;
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PageHandler.cs
@@ -1,0 +1,114 @@
+using AndroidX.Compose;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.Maui.Handlers;
+using StockPageHandler = Microsoft.Maui.Handlers.PageHandler;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.Page"/> handler that owns
+/// the <em>single</em> <see cref="ComposeView"/> per page. Every
+/// other handler in <c>Microsoft.AndroidX.Compose.Maui</c> implements
+/// <see cref="IComposeHandler"/> so its render folds into the
+/// composition this handler installs — collapsing what used to be
+/// one <see cref="ComposeView"/> per leaf into one per page.
+/// </summary>
+/// <remarks>
+/// <para>Replaces MAUI's stock <see cref="StockPageHandler"/> via
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// Unlike the stock handler — which uses a <c>ContentViewGroup</c>
+/// whose <c>OnMeasure</c>/<c>OnLayout</c> route through MAUI's
+/// <c>ICrossPlatformLayout</c> on the <see cref="IContentView"/> and
+/// recurse into <see cref="IContentView.PresentedContent"/>'s stock
+/// platform view — we make the <see cref="ComposeView"/> itself the
+/// platform view. Standard Android measure / layout then sizes it to
+/// fill whatever container Shell / Navigation put the page in, and
+/// Compose owns the entire content tree's layout (via the walker that
+/// dispatches into each <see cref="IComposeHandler"/> child).</para>
+///
+/// <para>Side-effect: <see cref="Microsoft.Maui.Controls.ContentPage"/>
+/// properties that live on the cross-platform side (<c>Padding</c>,
+/// <c>BackgroundColor</c>) no longer flow through the stock
+/// <c>ContentViewHandler</c> mappers — they have to be applied via
+/// Compose modifiers inside the composition. Acceptable: anything
+/// hosted in this composition is by definition the Compose-backed
+/// surface and prefers <c>Modifier.padding(…)</c>/<c>.background(…)</c>
+/// over MAUI's struct-typed equivalents.</para>
+///
+/// <para>From the consumer's perspective nothing changes — they
+/// don't see Compose, they don't pick a "Compose root", and their
+/// XAML / C# stays pure MAUI.</para>
+/// </remarks>
+public partial class PageHandler : ViewHandler<IContentView, ComposeView>
+{
+    /// <summary>
+    /// Property mapper that intercepts <see cref="IContentView.PresentedContent"/>
+    /// changes and routes them through the Compose walker.
+    /// </summary>
+    public static IPropertyMapper<IContentView, PageHandler> Mapper =
+        new PropertyMapper<IContentView, PageHandler>(ViewHandler.ViewMapper)
+        {
+            ["Content"] = MapContent,
+        };
+
+    /// <summary>Command mapper (inherits the base view commands; no extras).</summary>
+    public static CommandMapper<IContentView, PageHandler> CommandMapper =
+        new(ViewHandler.ViewCommandMapper);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public PageHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public PageHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    protected override ComposeView CreatePlatformView()
+    {
+        var compose = new ComposeView(Context!);
+        // Force MATCH_PARENT so whichever container Shell / Navigation
+        // attaches the page to (FrameLayout, ViewPager, …) sizes us
+        // to fill, regardless of its own LayoutParams defaults.
+        compose.LayoutParameters = new global::Android.Views.ViewGroup.LayoutParams(
+            global::Android.Views.ViewGroup.LayoutParams.MatchParent,
+            global::Android.Views.ViewGroup.LayoutParams.MatchParent);
+        return compose;
+    }
+
+    /// <summary>
+    /// Push the page's <see cref="IContentView.PresentedContent"/>
+    /// through <see cref="ComposeWalker"/> and install the resulting
+    /// node into <see cref="PlatformView"/>'s composition.
+    /// </summary>
+    public static void MapContent(PageHandler handler, IContentView page)
+    {
+        var compose = handler.PlatformView
+            ?? throw new InvalidOperationException(
+                "PlatformView should have been set by the base ViewHandler.");
+        var context = handler.MauiContext
+            ?? throw new InvalidOperationException(
+                "MauiContext should have been set by the base ViewHandler.");
+
+        var content = page.PresentedContent;
+        if (content is null)
+        {
+            compose.SetContent(_ => new Box());
+            return;
+        }
+
+        compose.SetContent(c =>
+        {
+            var node = ComposeWalker.Render(content, c, context);
+            var root = new Box { Modifier = Modifier.FillMaxSize() };
+            root.Add(node);
+            return root;
+        });
+    }
+
+    /// <inheritdoc/>
+    protected override void DisconnectHandler(ComposeView platformView)
+    {
+        platformView.DisposeComposition();
+        base.DisconnectHandler(platformView);
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ScrollViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ScrollViewHandler.cs
@@ -1,0 +1,109 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.ScrollView"/> handler that
+/// renders through a Compose <see cref="Box"/> wrapped in
+/// <c>Modifier.verticalScroll</c> or <c>Modifier.horizontalScroll</c>.
+/// Folds into the page's single <c>ComposeView</c> via
+/// <see cref="IComposeHandler"/>; replaces MAUI's stock
+/// <c>MauiScrollView</c>-based handler when
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>
+/// is called.
+/// </summary>
+/// <remarks>
+/// <para>Scroll position is <em>not</em> currently exposed via
+/// <see cref="MutableState{T}"/> back to MAUI — that lands when
+/// <c>IScrollView.ScrollToRequested</c> is wired up in a follow-up
+/// (the bridge type, <see cref="ScrollState"/>, already supports
+/// <c>ScrollToAsync</c> / <c>AnimateScrollToAsync</c>).</para>
+/// </remarks>
+public partial class ScrollViewHandler : ComposeElementHandler<IScrollView>
+{
+    /// <summary>
+    /// Property mapper. <see cref="IScrollView.Orientation"/> picks
+    /// the axis; nothing else needs eager mapping because the inner
+    /// content is reached via the walker.
+    /// </summary>
+    public static IPropertyMapper<IScrollView, ScrollViewHandler> Mapper =
+        new PropertyMapper<IScrollView, ScrollViewHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(IScrollView.Orientation)] = MapOrientation,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<IScrollView, ScrollViewHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<int> _orientation = new((int)ScrollOrientation.Vertical);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public ScrollViewHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public ScrollViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        var scroll = VirtualView
+            ?? throw new InvalidOperationException("VirtualView not set on ScrollViewHandler.");
+        var context = MauiContext
+            ?? throw new InvalidOperationException("MauiContext not set on ScrollViewHandler.");
+
+        return new ScrollContainer(scroll, _orientation, context);
+    }
+
+    /// <summary>Map <see cref="IScrollView.Orientation"/> to the cached enum slot.</summary>
+    public static void MapOrientation(ScrollViewHandler handler, IScrollView view) =>
+        handler._orientation.Value = (int)view.Orientation;
+
+    /// <summary>
+    /// <see cref="ComposableNode"/> implementing the
+    /// scroll-wrapped <see cref="Box"/>. Pulled out so the
+    /// <see cref="ScrollState"/> can be <c>Remember</c>ed inside its
+    /// <see cref="Render(IComposer)"/> (which runs on the composition
+    /// thread) rather than allocated eagerly during
+    /// <see cref="BuildNode(IComposer)"/>.
+    /// </summary>
+    sealed class ScrollContainer : ComposableNode
+    {
+        readonly IScrollView _scroll;
+        readonly MutableState<int> _orientation;
+        readonly IMauiContext _context;
+
+        public ScrollContainer(IScrollView scroll, MutableState<int> orientation, IMauiContext context)
+        {
+            _scroll = scroll;
+            _orientation = orientation;
+            _context = context;
+        }
+
+        public override void Render(IComposer composer)
+        {
+            var orientation = (ScrollOrientation)_orientation.Value;
+            var state = composer.Remember(() => new ScrollState());
+
+            var fillMain = orientation switch
+            {
+                ScrollOrientation.Horizontal => Modifier.HorizontalScroll(state),
+                _                            => Modifier.VerticalScroll(state),
+            };
+
+            // BuildModifier() is internal to Microsoft.AndroidX.Compose;
+            // from this assembly we read the public Modifier property
+            // (consumers don't call PrependModifier on internal nodes).
+            var modifier = Modifier is null ? fillMain : Modifier.Then(fillMain);
+
+            var box = new Box { Modifier = modifier };
+            var content = _scroll.PresentedContent;
+            if (content is not null)
+                box.Add(ComposeWalker.Render(content, composer, _context));
+            box.Render(composer);
+        }
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -1,8 +1,12 @@
 using Microsoft.AndroidX.Compose.Maui.Handlers;
 using MauiButton = Microsoft.Maui.Controls.Button;
 using MauiEntry = Microsoft.Maui.Controls.Entry;
+using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
 using MauiImage = Microsoft.Maui.Controls.Image;
 using MauiLabel = Microsoft.Maui.Controls.Label;
+using MauiPage = Microsoft.Maui.Controls.Page;
+using MauiScrollView = Microsoft.Maui.Controls.ScrollView;
+using MauiVerticalStackLayout = Microsoft.Maui.Controls.VerticalStackLayout;
 
 namespace Microsoft.AndroidX.Compose.Maui.Hosting;
 
@@ -20,6 +24,40 @@ public static class AppHostBuilderExtensions
     /// AppCompat / Material handlers in MAUI's registry (last
     /// <c>AddHandler</c> per virtual-view type wins).
     /// </summary>
+    /// <remarks>
+    /// <para>Layout coverage in this release:</para>
+    /// <list type="bullet">
+    ///   <item><description><see cref="MauiPage"/> →
+    ///     <see cref="PageHandler"/> owns the <em>single</em>
+    ///     <c>ComposeView</c> per page and drives the composition
+    ///     for everything below.</description></item>
+    ///   <item><description><see cref="MauiVerticalStackLayout"/> /
+    ///     <see cref="MauiHorizontalStackLayout"/> →
+    ///     <see cref="LayoutHandler"/> emits a Compose
+    ///     <c>Column</c> / <c>Row</c>.</description></item>
+    ///   <item><description><see cref="MauiScrollView"/> →
+    ///     <see cref="ScrollViewHandler"/> wraps its content in
+    ///     <c>Modifier.verticalScroll</c> / <c>horizontalScroll</c>.</description></item>
+    ///   <item><description>Leaves
+    ///     (<see cref="MauiLabel"/> / <see cref="MauiButton"/> /
+    ///     <see cref="MauiEntry"/> / <see cref="MauiImage"/>) fold
+    ///     into the enclosing composition via
+    ///     <see cref="IComposeHandler"/>.</description></item>
+    /// </list>
+    ///
+    /// <para>Layout types not in the list above (Grid, AbsoluteLayout,
+    /// FlexLayout, StackLayout) keep the stock MAUI
+    /// <see cref="Microsoft.Maui.Handlers.LayoutHandler"/>. When they
+    /// appear above one of our Compose-backed handlers in the tree the
+    /// Compose-backed handler degrades to a per-leaf <c>ComposeView</c>
+    /// (the leaf creates its own composition because there's no parent
+    /// composer to fold into). When they appear <i>below</i> a
+    /// converted parent — or anywhere a non-converted control surfaces
+    /// (CollectionView, BoxView, Switch, customer renderers) — they're
+    /// hosted via <c>AndroidView { factory = child.ToPlatform(MauiContext) }</c>
+    /// inside the page composition, so MAUI's normal handler resolution
+    /// keeps working.</para>
+    /// </remarks>
     /// <example>
     /// <code>
     /// var builder = MauiApp.CreateBuilder()
@@ -33,10 +71,19 @@ public static class AppHostBuilderExtensions
 
         builder.ConfigureMauiHandlers(handlers =>
         {
-            handlers.AddHandler<MauiLabel, LabelHandler>();
-            handlers.AddHandler<MauiButton, ButtonHandler>();
-            handlers.AddHandler<MauiEntry, EntryHandler>();
-            handlers.AddHandler<MauiImage, ImageHandler>();
+            // Root: the only handler that creates a ComposeView.
+            handlers.AddHandler<MauiPage,                   PageHandler>();
+
+            // Containers — folded into the page composition.
+            handlers.AddHandler<MauiVerticalStackLayout,    LayoutHandler>();
+            handlers.AddHandler<MauiHorizontalStackLayout,  LayoutHandler>();
+            handlers.AddHandler<MauiScrollView,             ScrollViewHandler>();
+
+            // Leaves.
+            handlers.AddHandler<MauiLabel,                  LabelHandler>();
+            handlers.AddHandler<MauiButton,                 ButtonHandler>();
+            handlers.AddHandler<MauiEntry,                  EntryHandler>();
+            handlers.AddHandler<MauiImage,                  ImageHandler>();
         });
 
         return builder;

--- a/src/Microsoft.AndroidX.Compose.Maui/IComposeHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/IComposeHandler.cs
@@ -1,0 +1,36 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+
+namespace Microsoft.AndroidX.Compose.Maui;
+
+/// <summary>
+/// Implemented by every handler in <c>Microsoft.AndroidX.Compose.Maui</c>
+/// so that an enclosing Compose composition (rooted in
+/// <see cref="Handlers.PageHandler"/>) can fold the handler's
+/// rendering into <em>one</em> composition tree per page instead of
+/// spinning up a separate <c>ComposeView</c> per handler.
+/// </summary>
+/// <remarks>
+/// <para>Strictly internal — the consumer never sees Compose at the
+/// MAUI surface. They call
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>
+/// once and continue writing pure MAUI markup. The Compose facade
+/// types (<see cref="ComposableNode"/>, <see cref="IComposer"/>) only
+/// flow between our handlers and the <see cref="ComposeWalker"/>.</para>
+///
+/// <para>Implementors return a <see cref="ComposableNode"/> per call;
+/// the walker inserts it under the active composer. Mutable state
+/// owned by the handler (<see cref="MutableState{T}"/> slots written
+/// by property mappers) is what makes the same node observe MAUI
+/// property changes between recompositions.</para>
+/// </remarks>
+internal interface IComposeHandler
+{
+    /// <summary>
+    /// Build the <see cref="ComposableNode"/> contributing this
+    /// handler's virtual view into the enclosing composition.
+    /// Called on the Compose composition thread inside
+    /// <see cref="ComposeWalker.Render(Microsoft.Maui.IView, IComposer, IMauiContext)"/>.
+    /// </summary>
+    ComposableNode BuildNode(IComposer composer);
+}

--- a/src/Microsoft.AndroidX.Compose/AndroidView.cs
+++ b/src/Microsoft.AndroidX.Compose/AndroidView.cs
@@ -1,8 +1,6 @@
 using Android.Content;
-using Android.Runtime;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.ViewInterop;
-using Kotlin.Jvm.Functions;
 using AView = Android.Views.View;
 
 namespace AndroidX.Compose;
@@ -16,10 +14,10 @@ namespace AndroidX.Compose;
 /// <c>ToPlatform()</c> result, …).
 /// </summary>
 /// <remarks>
-/// <para>The <see cref="Factory"/> lambda runs <em>once</em> per
+/// <para>The <c>factory</c> lambda runs <em>once</em> per
 /// composition slot — Compose caches the materialised view and
-/// reuses it across recompositions. The <see cref="Update"/> lambda,
-/// if supplied, runs on each recomposition so callers can push fresh
+/// reuses it across recompositions. The <c>update</c> lambda, if
+/// supplied, runs on each recomposition so callers can push fresh
 /// property values into the cached view.</para>
 ///
 /// <para>The Kotlin signature takes a <c>(Context) -&gt; T</c>
@@ -77,44 +75,5 @@ public sealed class AndroidView : ComposableNode
             // `$default`.)
             p4:        0,
             _changed:  defaults);
-    }
-}
-
-/// <summary>
-/// <c>Function1&lt;Context, View&gt;</c> JCW used by
-/// <see cref="AndroidView"/> as Compose's <c>factory</c> argument.
-/// </summary>
-[Register("net/compose/AndroidViewFactoryAdapter")]
-internal sealed class AndroidViewFactoryAdapter : Java.Lang.Object, IFunction1
-{
-    readonly Func<Context, AView> _factory;
-
-    public AndroidViewFactoryAdapter(Func<Context, AView> factory) => _factory = factory;
-
-    public Java.Lang.Object Invoke(Java.Lang.Object? p0) =>
-        _factory((Context)p0!);
-}
-
-/// <summary>
-/// <c>Function1&lt;View, Unit&gt;</c> JCW used by
-/// <see cref="AndroidView"/> as Compose's optional <c>update</c>
-/// argument.
-/// </summary>
-[Register("net/compose/AndroidViewUpdateAdapter")]
-internal sealed class AndroidViewUpdateAdapter : Java.Lang.Object, IFunction1
-{
-    static Java.Lang.Object? s_unit;
-
-    readonly Action<AView> _update;
-
-    public AndroidViewUpdateAdapter(Action<AView> update) => _update = update;
-
-    public Java.Lang.Object Invoke(Java.Lang.Object? p0)
-    {
-        _update((AView)p0!);
-        // Kotlin `Unit`. Returning null would fault inside Compose's
-        // adapter; a singleton wrapper keeps allocations off the hot
-        // recomposition path.
-        return s_unit ??= Kotlin.Unit.Instance!;
     }
 }

--- a/src/Microsoft.AndroidX.Compose/AndroidView.cs
+++ b/src/Microsoft.AndroidX.Compose/AndroidView.cs
@@ -1,0 +1,121 @@
+using Android.Content;
+using Android.Runtime;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI.ViewInterop;
+using Kotlin.Jvm.Functions;
+using AView = Android.Views.View;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// C# facade over Compose's <c>androidx.compose.ui.viewinterop.AndroidView</c>
+/// interop composable — hosts a stock Android <see cref="AView"/>
+/// inside the enclosing Compose composition. Use when you need to
+/// embed something Compose doesn't render natively (a third-party
+/// custom view, a not-yet-converted control, a MAUI handler's
+/// <c>ToPlatform()</c> result, …).
+/// </summary>
+/// <remarks>
+/// <para>The <see cref="Factory"/> lambda runs <em>once</em> per
+/// composition slot — Compose caches the materialised view and
+/// reuses it across recompositions. The <see cref="Update"/> lambda,
+/// if supplied, runs on each recomposition so callers can push fresh
+/// property values into the cached view.</para>
+///
+/// <para>The Kotlin signature takes a <c>(Context) -&gt; T</c>
+/// factory and an optional <c>(T) -&gt; Unit</c> update. Both
+/// lambdas execute on Compose's main thread.</para>
+/// </remarks>
+public sealed class AndroidView : ComposableNode
+{
+    readonly Func<Context, AView> _factory;
+    readonly Action<AView>? _update;
+
+    /// <summary>
+    /// Create a new <see cref="AndroidView"/> wrapping the result of
+    /// <paramref name="factory"/>.
+    /// </summary>
+    /// <param name="factory">Materialiser called once per composition
+    /// slot. Compose hands it the runtime
+    /// <see cref="Context"/>.</param>
+    /// <param name="update">Optional per-recomposition update hook.
+    /// Receives the cached view; mutate its properties to push state
+    /// changes Compose can't observe natively.</param>
+    public AndroidView(Func<Context, AView> factory, Action<AView>? update = null)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        _factory = factory;
+        _update  = update;
+    }
+
+    /// <inheritdoc cref="ComposableNode.Render(IComposer)"/>
+    public override void Render(IComposer composer)
+    {
+        var modifier   = BuildModifier();
+        var hasUpdate  = _update is not null;
+        var updateJcw  = hasUpdate ? new AndroidViewUpdateAdapter(_update!) : null;
+        var factoryJcw = new AndroidViewFactoryAdapter(_factory);
+
+        // Bit positions in AndroidView's $default mask:
+        //   0 = factory   (always supplied)
+        //   1 = modifier
+        //   2 = update
+        int defaults = 0;
+        if (modifier is null) defaults |= 1 << 1;
+        if (!hasUpdate)       defaults |= 1 << 2;
+
+        AndroidView_androidKt.AndroidView(
+            factory:   factoryJcw,
+            modifier:  modifier,
+            update:    updateJcw,
+            _composer: composer,
+            // Binder names are positionally derived and misleading —
+            // double-checked via ilspycmd against
+            // `AndroidView(...,Composer,II)V`:
+            //   `p4`        = Kotlin's `$changed`
+            //   `_changed`  = Kotlin's `$default`
+            // (Kotlin lowering always emits `$changed` before
+            // `$default`.)
+            p4:        0,
+            _changed:  defaults);
+    }
+}
+
+/// <summary>
+/// <c>Function1&lt;Context, View&gt;</c> JCW used by
+/// <see cref="AndroidView"/> as Compose's <c>factory</c> argument.
+/// </summary>
+[Register("net/compose/AndroidViewFactoryAdapter")]
+internal sealed class AndroidViewFactoryAdapter : Java.Lang.Object, IFunction1
+{
+    readonly Func<Context, AView> _factory;
+
+    public AndroidViewFactoryAdapter(Func<Context, AView> factory) => _factory = factory;
+
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0) =>
+        _factory((Context)p0!);
+}
+
+/// <summary>
+/// <c>Function1&lt;View, Unit&gt;</c> JCW used by
+/// <see cref="AndroidView"/> as Compose's optional <c>update</c>
+/// argument.
+/// </summary>
+[Register("net/compose/AndroidViewUpdateAdapter")]
+internal sealed class AndroidViewUpdateAdapter : Java.Lang.Object, IFunction1
+{
+    static Java.Lang.Object? s_unit;
+
+    readonly Action<AView> _update;
+
+    public AndroidViewUpdateAdapter(Action<AView> update) => _update = update;
+
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0)
+    {
+        _update((AView)p0!);
+        // Kotlin `Unit`. Returning null would fault inside Compose's
+        // adapter; a singleton wrapper keeps allocations off the hot
+        // recomposition path.
+        return s_unit ??= Kotlin.Unit.Instance!;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose/AndroidView.cs
+++ b/src/Microsoft.AndroidX.Compose/AndroidView.cs
@@ -52,8 +52,7 @@ public sealed class AndroidView : ComposableNode
     public override void Render(IComposer composer)
     {
         var modifier   = BuildModifier();
-        var hasUpdate  = _update is not null;
-        var updateJcw  = hasUpdate ? new AndroidViewUpdateAdapter(_update!) : null;
+        var updateJcw  = _update is null ? null : new AndroidViewUpdateAdapter(_update);
         var factoryJcw = new AndroidViewFactoryAdapter(_factory);
 
         // Bit positions in AndroidView's $default mask:
@@ -61,8 +60,8 @@ public sealed class AndroidView : ComposableNode
         //   1 = modifier
         //   2 = update
         int defaults = 0;
-        if (modifier is null) defaults |= 1 << 1;
-        if (!hasUpdate)       defaults |= 1 << 2;
+        if (modifier is null)  defaults |= 1 << 1;
+        if (updateJcw is null) defaults |= 1 << 2;
 
         AndroidView_androidKt.AndroidView(
             factory:   factoryJcw,

--- a/src/Microsoft.AndroidX.Compose/AndroidViewFactoryAdapter.cs
+++ b/src/Microsoft.AndroidX.Compose/AndroidViewFactoryAdapter.cs
@@ -1,0 +1,21 @@
+using Android.Content;
+using Android.Runtime;
+using Kotlin.Jvm.Functions;
+using AView = Android.Views.View;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// <c>Function1&lt;Context, View&gt;</c> JCW used by
+/// <see cref="AndroidView"/> as Compose's <c>factory</c> argument.
+/// </summary>
+[Register("net/compose/AndroidViewFactoryAdapter")]
+internal sealed class AndroidViewFactoryAdapter : Java.Lang.Object, IFunction1
+{
+    readonly Func<Context, AView> _factory;
+
+    public AndroidViewFactoryAdapter(Func<Context, AView> factory) => _factory = factory;
+
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0) =>
+        _factory((Context)p0!);
+}

--- a/src/Microsoft.AndroidX.Compose/AndroidViewUpdateAdapter.cs
+++ b/src/Microsoft.AndroidX.Compose/AndroidViewUpdateAdapter.cs
@@ -1,0 +1,29 @@
+using Android.Runtime;
+using Kotlin.Jvm.Functions;
+using AView = Android.Views.View;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// <c>Function1&lt;View, Unit&gt;</c> JCW used by
+/// <see cref="AndroidView"/> as Compose's optional <c>update</c>
+/// argument.
+/// </summary>
+[Register("net/compose/AndroidViewUpdateAdapter")]
+internal sealed class AndroidViewUpdateAdapter : Java.Lang.Object, IFunction1
+{
+    static Java.Lang.Object? s_unit;
+
+    readonly Action<AView> _update;
+
+    public AndroidViewUpdateAdapter(Action<AView> update) => _update = update;
+
+    public Java.Lang.Object Invoke(Java.Lang.Object? p0)
+    {
+        _update((AView)p0!);
+        // Kotlin `Unit`. Returning null would fault inside Compose's
+        // adapter; a singleton wrapper keeps allocations off the hot
+        // recomposition path.
+        return s_unit ??= Kotlin.Unit.Instance!;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -8,9 +8,6 @@ AndroidX.Compose.AlertDialog.ConfirmButton.get -> AndroidX.Compose.ComposableNod
 AndroidX.Compose.AlertDialog.ConfirmButton.set -> void
 AndroidX.Compose.AlertDialog.DismissButton.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.AlertDialog.DismissButton.set -> void
-AndroidX.Compose.AndroidView
-AndroidX.Compose.AndroidView.AndroidView(System.Func<Android.Content.Context!, Android.Views.View!>! factory, System.Action<Android.Views.View!>? update = null) -> void
-override AndroidX.Compose.AndroidView.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 AndroidX.Compose.AlertDialog.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.AlertDialog.Icon.set -> void
 AndroidX.Compose.AlertDialog.Shape.get -> AndroidX.Compose.Shape?
@@ -22,6 +19,8 @@ AndroidX.Compose.AlertDialog.Title.set -> void
 AndroidX.Compose.Alignment
 AndroidX.Compose.Alignment.Horizontal
 AndroidX.Compose.Alignment.Vertical
+AndroidX.Compose.AndroidView
+AndroidX.Compose.AndroidView.AndroidView(System.Func<Android.Content.Context!, Android.Views.View!>! factory, System.Action<Android.Views.View!>? update = null) -> void
 AndroidX.Compose.AnimatedContent<T>
 AndroidX.Compose.AnimatedContent<T>.AnimatedContent(T targetState, System.Func<T, AndroidX.Compose.ComposableNode!>! content) -> void
 AndroidX.Compose.AnimatedContent<T>.TargetState.get -> T
@@ -1308,6 +1307,7 @@ AndroidX.Compose.WideNavigationRailState.InitialValue.get -> AndroidX.Compose.Ma
 AndroidX.Compose.WideNavigationRailState.TargetValue.get -> AndroidX.Compose.Material3.WideNavigationRailValue!
 AndroidX.Compose.WideNavigationRailState.WideNavigationRailState(AndroidX.Compose.Material3.WideNavigationRailValue? initialValue = null) -> void
 override AndroidX.Compose.AlertDialog.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
+override AndroidX.Compose.AndroidView.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.AnimatedContent<T>.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.AnimatedVisibility.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.AnnotatedText.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -8,6 +8,9 @@ AndroidX.Compose.AlertDialog.ConfirmButton.get -> AndroidX.Compose.ComposableNod
 AndroidX.Compose.AlertDialog.ConfirmButton.set -> void
 AndroidX.Compose.AlertDialog.DismissButton.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.AlertDialog.DismissButton.set -> void
+AndroidX.Compose.AndroidView
+AndroidX.Compose.AndroidView.AndroidView(System.Func<Android.Content.Context!, Android.Views.View!>! factory, System.Action<Android.Views.View!>? update = null) -> void
+override AndroidX.Compose.AndroidView.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 AndroidX.Compose.AlertDialog.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.AlertDialog.Icon.set -> void
 AndroidX.Compose.AlertDialog.Shape.get -> AndroidX.Compose.Shape?


### PR DESCRIPTION
Collapses the previous "one `ComposeView` per Compose-backed leaf" model into a single composition rooted in `PageHandler`. All other Compose-aware handlers (`LayoutHandler`, `ScrollViewHandler`, `Label`, `Button`, `Entry`, `Image`) implement `IComposeHandler` and contribute a `ComposableNode` via `BuildNode(IComposer)` to the page composition. Unknown / unconverted children bubble up through `ComposeWalker` which hosts them via Compose `AndroidView { factory = child.ToPlatform(MauiContext) }`.

Consumer surface is unchanged — `UseAndroidXCompose()` is still the only Compose touch-point. MAUI XAML/C# stays pure MAUI.

## Architecture

```mermaid
flowchart TD
    PH["PageHandler (overridden) → ComposeView"] --> Comp[Single composition for the page]
    Comp --> Walker[ComposeWalker: child.Handler?]
    Walker -- IComposeHandler --> Node[BuildNode → Column/Row/Text/Button/…]
    Walker -- stock handler --> AV["AndroidView { factory: child.ToPlatform }"]
    AV --> Stock[Stock MAUI handler → real Android View]
    Node --> Recurse((recurse into children))
```

## What changed

- New: `IComposeHandler` (internal), `ComposeElementHandler<T>` base, `ComposeWalker`, `PageHandler` (sole `ComposeView` owner), `LayoutHandler` (VSL → `Column`, HSL → `Row`), `ScrollViewHandler`.
- Public `AndroidView` facade in `Microsoft.AndroidX.Compose` for Compose ↔ Android view interop (the keystone that makes the unknown-handler fallback safe).
- Rewrote `LabelHandler`, `ButtonHandler`, `EntryHandler`, `ImageHandler` on `ComposeElementHandler<T>` + `BuildNode`. `MutableState<T>` slots + mappers unchanged.
- Updated docs across `.github/instructions/compose-maui.instructions.md`, `docs/maui-backend.md`, sample README, root README.

## Why `PageHandler` diverges from stock `ContentViewHandler`

`PageHandler` inherits `ViewHandler<IContentView, ComposeView>` directly rather than `ContentViewHandler`. The stock `ContentViewGroup` overrides `OnMeasure` / `OnLayout` to route through `CrossPlatformLayout = VirtualView` which measures `PresentedContent`'s stock platform view — ignoring Android `LayoutParams` on any child we inject. By making the `ComposeView` itself the `PlatformView`, the parent ViewGroup (Shell / Fragment) sizes it via standard Android measure-spec, and the composition fills via `MATCH_PARENT`. Trade-off: `ContentPage.Padding` / `BackgroundColor` from stock `ContentViewHandler` mappers don't flow — apply via Compose modifiers inside the composition instead.

## Verified on device

- **`CounterPage`** (Page → ScrollView → VSL → 3 Labels + Button, fully converted): `adb shell uiautomator dump` shows **exactly 1** `androidx.compose.ui.platform.ComposeView` node. Button click → MAUI mapper pipeline → composition recomposes; "Tapped N times" / "Clicked N times" update.
- **`HomePage`** (Grid root + CollectionView, mostly stock containers): renders correctly; stock containers host the Compose leaves via the per-leaf fallback path.
- `dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample` — clean.
- `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` — 150 passed.

## Known limitations / follow-ups

- Compose-backed leaves inside a stock container (e.g. `CollectionView` item template) still get one `ComposeView` per leaf — they can't fold into a parent composer that doesn't exist. The "one ComposeView per page" invariant only holds when the entire path from `PageHandler` down uses our handlers.
- `ComposeView` consumes pointer events; a Compose-backed leaf inside a stock `CollectionView` item template swallows taps that would otherwise trigger MAUI `TapGestureRecognizer`s. Tracked as a separate follow-up.
- Grid / AbsoluteLayout / FlexLayout still use the stock `LayoutHandler` and ride the `AndroidView` fallback path. A generic `androidx.compose.ui.layout.Layout {}`-with-`CrossPlatformMeasure` adapter would let them fold into the page composition too; deferred.
- `ContentPage.Padding` / `BackgroundColor` don't flow through `PageHandler` (see above). Apply via Compose modifiers.