### PR TITLE
samples: refresh #64 row to reflect Brush gradient slice landed

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -40,7 +40,7 @@ that needs the same primitive.
 
 | Issue | Area                        | Blocks (in samples) |
 |------:|-----------------------------|--------------------|
-| [#64](https://github.com/jonathanpeppers/Microsoft.AndroidX.Compose/issues/64)  | Drawing primitives — `Canvas`, `drawBehind`, `Brush`, `Path`, `Shape` factories | Custom visuals in **JetLagged**; asymmetric `RoundedCornerShape(topStart, topEnd, …)` on **Jetchat** bubbles. |
+| [#64](https://github.com/jonathanpeppers/Microsoft.AndroidX.Compose/issues/64)  | Drawing primitives — `Canvas`, `drawBehind`, `Path`, asymmetric `RoundedCornerShape(topStart, topEnd, …)` factories (gradient `Brush` factories already shipped — see closed gaps) | Custom visuals in **JetLagged**; asymmetric `RoundedCornerShape(topStart, topEnd, …)` on **Jetchat** bubbles. |
 | [#20](https://github.com/jonathanpeppers/Microsoft.AndroidX.Compose/issues/20)  | Edge-to-edge bootstrapping | Status/nav-bar overlap on every sample. |
 | [#144](https://github.com/jonathanpeppers/Microsoft.AndroidX.Compose/issues/144) | Custom `Layout {}` primitive — Measurable / Placeable / MeasureScope | `InterestsAdaptiveContentLayout` in **JetNews**, custom carousels in **Jetsnack**, asymmetric chat bubbles in **Jetchat**. |
 | [#168](https://github.com/jonathanpeppers/Microsoft.AndroidX.Compose/issues/168) | `TwoPane` / `NavigableListDetailPaneScaffold` + Jetpack `WindowManager` (`WindowLayoutInfo`/`FoldingFeature`) | Adaptive list-detail with fold avoidance in **Reply**. |
@@ -53,6 +53,7 @@ Closed gaps that previously appeared here (now usable in samples):
 **#61** Theming reads + `Color` value type + parameterized `MaterialTheme`,
 **#62** State primitives (`RememberSaveable` / `mutableStateListOf` / `mutableStateMapOf` / `derivedStateOf`),
 **#63** Modifier surface (Background/Border/Clickable/Size/Width/Height/AspectRatio/Offset/Alpha/Clip/Weight + scroll + focus + semantics + Draggable),
+**#64 (partial)** `Brush` gradient factories + brush-typed `Modifier.Background` / `Border` + `Offset` / `TileMode` (`Canvas` / `drawBehind` / `Path` / asymmetric `RoundedCornerShape` still pending — see open gaps above),
 **#65** Compose value types (`Color`/`Dp`/`Sp`/`FontWeight`/`TextAlign`),
 **#69** WindowInsets padding modifiers (`imePadding` / `navigationBarsPadding` / `statusBarsPadding` / `displayCutoutPadding` / …),
 **#70** Row/Column `Arrangement`,


### PR DESCRIPTION
Tiny follow-up to #251. Stacked on `jonathanpeppers/fix-facade-gaps` —
will rebase onto `main` once #251 merges.

Updates `samples/README.md` to reflect the Brush gradient sub-slice of
#64 that shipped in #251:

- Refines the open **#64** row in the gaps table to drop `Brush` from
  the list of pending primitives. The remaining open work narrows to
  `Canvas`, `drawBehind`, `Path`, and asymmetric
  `RoundedCornerShape(topStart, topEnd, …)` factories, with a pointer
  back to the closed-gaps section for the brush slice.
- Adds a new `**#64 (partial)**` entry to the closed-gaps list:
  > `Brush` gradient factories + brush-typed `Modifier.Background` /
  > `Border` + `Offset` / `TileMode`

## Why no sample changes

I surveyed the three ported apps (Jetchat, JetNews, Reply) for places
to faithfully consume the new gradient brushes. None of the three
upstream Kotlin sources in
[android/compose-samples](https://github.com/android/compose-samples)
use `Brush.linearGradient` / `verticalGradient` / `horizontalGradient`
/ `radialGradient` / `sweepGradient`. The only places `Brush` appears
upstream are in **Jetsnack** (`Gradient.kt`, `SnackDetail.kt`) and
**JetLagged** (`JetLaggedTimeGraph.kt`) — neither sample is ported
yet.

The remaining placeholder in our JetNews port is per-post hero PNGs
copied verbatim from upstream (already shipped before this PR). There
is no surface where adding a gradient would faithfully match upstream
or replace a placeholder, so per the task's "valid outcome" carve-out
this PR is README-only.

The `BrushDemo` deep-link demo on the gallery side still ships with
#251 and exercises the new factories on-device.

Closes a sub-task spawned from #64; #251 is the upstream code change
this row tracks.