### PR TITLE
MAUI Phase 2 Slice 7: ThemeManager (Application.RequestedTheme -> MaterialTheme)

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -602,6 +602,86 @@ page so cross-sibling animation, semantics, and a single
   consumes pointer events for its own composition. Workaround: put
   a stock leaf in the cell, or convert the container.
 
+#### Phase 2 Slice 7 — `ThemeManager` (Application.RequestedTheme → MaterialTheme) ✅ shipped
+
+Goal: bridge MAUI's theme signal (`Application.RequestedTheme` /
+`UserAppTheme`) into the Compose `MaterialTheme` scope owned by
+`PageHandler`, so a MAUI app that flips itself to dark via
+`App.Current.UserAppTheme = AppTheme.Dark` actually flips the Compose-
+backed surfaces along with it.
+
+**Delivered:**
+
+- **`Platform/ThemeManager.cs`** — registered as a DI singleton via
+  `UseAndroidXCompose()`. Exposes a single process-wide
+  `MutableState<bool> IsDark`. On construction (and on every
+  `Application.Current.RequestedThemeChanged`), it resolves the active
+  theme in this order:
+  1. `Application.Current.UserAppTheme` (if not `Unspecified`).
+  2. `Application.Current.RequestedTheme` (MAUI's resolved value —
+     also encodes the OS preference).
+  3. `Android.App.Application.Context.Resources.Configuration.UiMode &
+     UiMode.NightMask` (last-resort raw Android signal).
+- **`PageHandler.MapContent`** — resolves `ThemeManager` from
+  `handler.MauiContext.Services` and wraps the walker output in
+  `new MaterialTheme { Dark = theme.IsDark.Value, UseDynamicColor = false }`
+  inside `compose.SetContent`. Reading `IsDark.Value` inside the
+  `SetContent` lambda registers a Compose snapshot subscription —
+  every page composition recomposes when `IsDark` flips. `MaterialTheme`
+  is a `ComposableContainer`, so the page's root walked node is added
+  via `themed.Add(root)` (the C# initializer rule CS0747 forbids mixing
+  property assignments with collection-init items in the same `{ }`
+  block).
+
+**Sample:**
+
+- `Pages/ThemePage.xaml` — three buttons set `Application.UserAppTheme`
+  to `Light`, `Dark`, `Unspecified`. A status label echoes both
+  `UserAppTheme` and `RequestedTheme` so you can see MAUI's resolved
+  view of the world. The page itself plus a default M3 button, an
+  `Entry`, and a caller-pinned-color button serve as visual probes.
+
+**Decisions:**
+
+- **Scope: dark/light only.** MAUI's `Primary` / `Secondary` /
+  `Tertiary` `Color` resources are *not* bridged into a custom
+  `colorScheme` overlay. The trade-off: a single MAUI brand colour
+  doesn't supply the full M3 surface palette
+  (`primaryContainer`, `onPrimary`, `surfaceVariant`, …); seeding only
+  `primary` from MAUI risks contrast bugs and partial theming. The
+  better contract is "MAUI tells us light vs dark; M3 picks the
+  scheme." Consumers who want full M3 theming can pass a custom
+  `ColorScheme` directly via the existing `MaterialTheme` facade.
+- **`UseDynamicColor = false`.** Material You wallpaper-derived palettes
+  override the `Dark` flag's effect. The slice is meant to honour MAUI's
+  signal exactly; dynamic colour is a follow-up flag.
+- **One state object, many compositions.** Compose supports multiple
+  compositions subscribing to a single `MutableState`. A process-wide
+  `MutableState<bool> IsDark` shared across every `PageHandler` instance
+  is correct — every Compose-backed page recomposes when it flips, no
+  per-page bookkeeping needed.
+
+**Lessons learned (Slice 7):**
+
+- **`Application.UserAppTheme` vs `RequestedTheme`.** `UserAppTheme` is
+  the in-app override the developer sets; `RequestedTheme` is MAUI's
+  resolved value (UserAppTheme wins; otherwise falls through to the
+  platform). We read `UserAppTheme` first explicitly for clarity, then
+  `RequestedTheme`, then fall back to Android's raw `Configuration.UiMode`
+  in case MAUI's `Application.Current` isn't ready yet (early ctor calls
+  before `MainPage` is set).
+- **Why route through MAUI's `RequestedThemeChanged` rather than
+  Compose's `LocalConfiguration`.** `UserAppTheme` doesn't always flip
+  the Android `Configuration` — it's a MAUI-internal preference. A
+  Compose-only listener (`LocalConfiguration.current.uiMode`) misses
+  in-app overrides and only catches OS-level changes. MAUI's event is
+  the union signal; we route through it.
+- **No new public Compose facade needed.** `MaterialTheme.LightColorScheme()` /
+  `DarkColorScheme()` were already exposed by the Compose facade; the
+  `Dark` property on `MaterialTheme` was already there. The slice is
+  pure plumbing — no new `[ComposeBridge]` / `[ComposeFacade]` /
+  `PublicAPI.Unshipped.txt` updates.
+
 ### Phase 3 — collection + container (target: list-driven apps)
 
 `CollectionView` → `LazyColumn<T>` / `LazyRow<T>` / `LazyVerticalGrid<T>`
@@ -684,12 +764,14 @@ delegate, but some essentials might need Compose-aware UIs like
    for v1?** ✅ **Resolved in Phase 2 Slice 2** by going to a single
    `ComposeView` per page. The page-level composition lives inside
    one `ComposeView`, which means there's exactly one Compose
-   `MaterialTheme` scope (currently the M3 default) for the entire
-   page; every `ComposableNode` contributed by
-   `IComposeHandler.BuildNode` inherits it via `CompositionLocal`.
-   Wiring an explicit `MaterialTheme { ... }` wrapper bridged from
-   MAUI's `Application.Resources` colour palette is a follow-up; the
-   per-island wrapping problem is gone.
+   `MaterialTheme` scope for the entire page; every `ComposableNode`
+   contributed by `IComposeHandler.BuildNode` inherits it via
+   `CompositionLocal`. Phase 2 Slice 7 wires the explicit
+   `MaterialTheme { Dark = theme.IsDark.Value, ... }` wrapper bridged
+   from MAUI's `Application.RequestedTheme` so dark/light flips
+   propagate; per-resource colour-palette bridging
+   (MAUI `Primary`/`Secondary`/`Tertiary` → custom `ColorScheme`)
+   stays a documented follow-up.
 
 4. **Layout sizing** — Compose composables size themselves; MAUI wants
    you to honor an explicit `widthSpec`/`heightSpec`. Need to

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -21,5 +21,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("entries",        typeof(EntriesPage));
         Routing.RegisterRoute("image-aspects",  typeof(ImageAspectsPage));
         Routing.RegisterRoute("image-sources",  typeof(ImageSourcesPage));
+        Routing.RegisterRoute("theme",          typeof(ThemePage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -60,6 +60,11 @@ public partial class HomePage : ContentPage
                 "File / Uri / Stream / Font image source types.",
                 Color.FromArgb("#E91E63"),
                 "image-sources"),
+            new DemoEntry(
+                "Theme",
+                "Light / Dark / Unspecified — flips MaterialTheme via UserAppTheme.",
+                Color.FromArgb("#795548"),
+                "theme"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ThemePage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ThemePage.xaml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.ThemePage"
+             Title="Theme">
+
+    <!--
+        Exercises Phase 2 Slice 7 (ThemeManager). Tapping the three
+        buttons sets `Application.UserAppTheme`, which raises
+        `RequestedThemeChanged`; ThemeManager bridges that into a
+        process-wide MutableState<bool> read by every PageHandler's
+        SetContent lambda. Confirms:
+
+          * Buttons / Entry / Label flip to dark/light Material 3 surface.
+          * The Compose `MaterialTheme.colorScheme.background` reads the
+            matching theme.
+          * Navigating back to a previously visited page picks up the
+            new theme on its next composition (no special hook needed).
+    -->
+    <ScrollView>
+        <VerticalStackLayout Padding="30,30"
+                             Spacing="20">
+
+            <Label Text="Theme"
+                   Style="{StaticResource Headline}" />
+
+            <Label Text="Tap a button below to flip MAUI's UserAppTheme. The whole page (and every other Compose-backed page in the app) recomposes against the matching Material 3 ColorScheme."
+                   Style="{StaticResource SubHeadline}" />
+
+            <Label x:Name="StatusLabel"
+                   Text=""
+                   FontSize="14" />
+
+            <Button Text="Light"
+                    Clicked="OnLightClicked"
+                    HorizontalOptions="Fill" />
+
+            <Button Text="Dark"
+                    Clicked="OnDarkClicked"
+                    HorizontalOptions="Fill" />
+
+            <Button Text="Unspecified (follow system)"
+                    Clicked="OnUnspecifiedClicked"
+                    HorizontalOptions="Fill" />
+
+            <BoxView HeightRequest="1"
+                     Color="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray500}}"
+                     Margin="0,8" />
+
+            <Label Text="-- Sample widgets --"
+                   FontAttributes="Bold" />
+
+            <Label Text="A coloured label and entry below should swap their background / on-surface colors when you flip the theme."
+                   FontSize="13" />
+
+            <Entry Placeholder="Type something…"
+                   HorizontalOptions="Fill" />
+
+            <!-- Default M3 button — no BackgroundColor set so it picks
+                 up Primary from the active scheme. Flipping the theme
+                 swaps light primary (#6750A4) ↔ dark primary (#D0BCFF). -->
+            <Button Text="Default M3 button (theme-driven)"
+                    HorizontalOptions="Fill"
+                    Clicked="OnSampleButtonClicked" />
+
+            <!-- Caller-supplied colour: stays put across themes (wins
+                 over MaterialTheme), proves MapBackground still routes
+                 explicitly-set colours into the Compose Colors slot. -->
+            <Button Text="Caller-pinned background (#512BD4)"
+                    BackgroundColor="#512BD4"
+                    TextColor="White"
+                    HorizontalOptions="Fill"
+                    Clicked="OnSampleButtonClicked" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ThemePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ThemePage.xaml.cs
@@ -1,0 +1,62 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Theme demo — flips
+/// <see cref="Microsoft.Maui.Controls.Application.UserAppTheme"/>
+/// between Light, Dark, and Unspecified. Confirms the Compose-backed
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Platform.ThemeManager"/>
+/// bridges MAUI's <c>RequestedThemeChanged</c> event into the
+/// page-rooted Material 3 <c>ColorScheme</c>.
+/// </summary>
+public partial class ThemePage : ContentPage
+{
+    /// <summary>Build the page and seed the status label.</summary>
+    public ThemePage()
+    {
+        InitializeComponent();
+        UpdateStatus();
+        if (Application.Current is { } app)
+            app.RequestedThemeChanged += OnRequestedThemeChanged;
+    }
+
+    void OnRequestedThemeChanged(object? sender, AppThemeChangedEventArgs e) =>
+        UpdateStatus();
+
+    /// <inheritdoc/>
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        if (Application.Current is { } app)
+            app.RequestedThemeChanged -= OnRequestedThemeChanged;
+    }
+
+    void UpdateStatus()
+    {
+        var app = Application.Current;
+        StatusLabel.Text =
+            $"UserAppTheme: {app?.UserAppTheme}  ·  RequestedTheme: {app?.RequestedTheme}";
+    }
+
+    void OnLightClicked(object? sender, EventArgs e)
+    {
+        if (Application.Current is { } app) app.UserAppTheme = AppTheme.Light;
+        UpdateStatus();
+    }
+
+    void OnDarkClicked(object? sender, EventArgs e)
+    {
+        if (Application.Current is { } app) app.UserAppTheme = AppTheme.Dark;
+        UpdateStatus();
+    }
+
+    void OnUnspecifiedClicked(object? sender, EventArgs e)
+    {
+        if (Application.Current is { } app) app.UserAppTheme = AppTheme.Unspecified;
+        UpdateStatus();
+    }
+
+    void OnSampleButtonClicked(object? sender, EventArgs e)
+    {
+        // No-op: the buttons are visual probes for theme flips.
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ThemePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ThemePage.xaml.cs
@@ -15,12 +15,19 @@ public partial class ThemePage : ContentPage
     {
         InitializeComponent();
         UpdateStatus();
-        if (Application.Current is { } app)
-            app.RequestedThemeChanged += OnRequestedThemeChanged;
     }
 
     void OnRequestedThemeChanged(object? sender, AppThemeChangedEventArgs e) =>
         UpdateStatus();
+
+    /// <inheritdoc/>
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (Application.Current is { } app)
+            app.RequestedThemeChanged += OnRequestedThemeChanged;
+        UpdateStatus();
+    }
 
     /// <inheritdoc/>
     protected override void OnDisappearing()

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PageHandler.cs
@@ -1,5 +1,6 @@
 using AndroidX.Compose;
 using AndroidX.Compose.UI.Platform;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using StockPageHandler = Microsoft.Maui.Handlers.PageHandler;
 
@@ -78,7 +79,13 @@ public partial class PageHandler : ViewHandler<IContentView, ComposeView>
     /// <summary>
     /// Push the page's <see cref="IContentView.PresentedContent"/>
     /// through <see cref="ComposeWalker"/> and install the resulting
-    /// node into <see cref="PlatformView"/>'s composition.
+    /// node into <see cref="PlatformView"/>'s composition. The walker
+    /// output is wrapped in a <see cref="MaterialTheme"/> driven by
+    /// the DI-registered <see cref="ThemeManager"/> so MAUI's
+    /// <see cref="Microsoft.Maui.Controls.Application.RequestedTheme"/>
+    /// (and its <see cref="Microsoft.Maui.Controls.Application.UserAppTheme"/>
+    /// override) flips every Compose-backed page between light and
+    /// dark Material 3 colour schemes.
     /// </summary>
     public static void MapContent(PageHandler handler, IContentView page)
     {
@@ -89,10 +96,23 @@ public partial class PageHandler : ViewHandler<IContentView, ComposeView>
             ?? throw new InvalidOperationException(
                 "MauiContext should have been set by the base ViewHandler.");
 
+        // Resolve the singleton ThemeManager once per attach. Falls
+        // back to a transient instance if DI isn't wired (defensive —
+        // UseAndroidXCompose() always registers it). Reading
+        // theme.IsDark.Value inside SetContent's lambda registers a
+        // snapshot read so flipping the MAUI theme triggers a
+        // recomposition without the consumer reaching into Compose.
+        var theme = context.Services.GetService<ThemeManager>() ?? new ThemeManager();
+
         var content = page.PresentedContent;
         if (content is null)
         {
-            compose.SetContent(_ => new Box());
+            compose.SetContent(_ =>
+            {
+                var empty = new MaterialTheme { Dark = theme.IsDark.Value, UseDynamicColor = false };
+                empty.Add(new Box());
+                return empty;
+            });
             return;
         }
 
@@ -101,7 +121,19 @@ public partial class PageHandler : ViewHandler<IContentView, ComposeView>
             var node = ComposeWalker.Render(content, c, context);
             var root = new Box { Modifier = Modifier.FillMaxSize() };
             root.Add(node);
-            return root;
+            // Reading IsDark.Value here ties this composition to the
+            // singleton state. UseDynamicColor=false because Material
+            // You would otherwise pull a wallpaper-derived palette and
+            // ignore MAUI's signal entirely. C# disallows mixing
+            // property assignments with collection-init items in one
+            // initializer block (CS0747), so build then Add.
+            var themed = new MaterialTheme
+            {
+                Dark            = theme.IsDark.Value,
+                UseDynamicColor = false,
+            };
+            themed.Add(root);
+            return themed;
         });
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PageHandler.cs
@@ -96,13 +96,15 @@ public partial class PageHandler : ViewHandler<IContentView, ComposeView>
             ?? throw new InvalidOperationException(
                 "MauiContext should have been set by the base ViewHandler.");
 
-        // Resolve the singleton ThemeManager once per attach. Falls
-        // back to a transient instance if DI isn't wired (defensive —
-        // UseAndroidXCompose() always registers it). Reading
-        // theme.IsDark.Value inside SetContent's lambda registers a
-        // snapshot read so flipping the MAUI theme triggers a
-        // recomposition without the consumer reaching into Compose.
-        var theme = context.Services.GetService<ThemeManager>() ?? new ThemeManager();
+        // Resolve the singleton ThemeManager. Use GetRequiredService
+        // so a missing UseAndroidXCompose() registration fails fast
+        // with a clear message — silently allocating a transient on
+        // every MapContent invocation would leak the
+        // RequestedThemeChanged subscription. Reading IsDark.Value
+        // inside SetContent's lambda registers a snapshot read so
+        // flipping the MAUI theme triggers recomposition without the
+        // consumer reaching into Compose.
+        var theme = context.Services.GetRequiredService<ThemeManager>();
 
         var content = page.PresentedContent;
         if (content is null)

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AndroidX.Compose.Maui.Handlers;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using MauiButton = Microsoft.Maui.Controls.Button;
 using MauiEntry = Microsoft.Maui.Controls.Entry;
 using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
@@ -68,6 +69,12 @@ public static class AppHostBuilderExtensions
     public static MauiAppBuilder UseAndroidXCompose(this MauiAppBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+
+        // Process-wide bridge between MAUI's RequestedTheme /
+        // UserAppTheme and the Compose-side MaterialTheme. Resolved
+        // by PageHandler.MapContent — see ThemeManager for resolution
+        // rules and trade-offs.
+        builder.Services.AddSingleton<ThemeManager>();
 
         builder.ConfigureMauiHandlers(handlers =>
         {

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/ThemeManager.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/ThemeManager.cs
@@ -1,0 +1,151 @@
+using Android.Content.Res;
+using AndroidX.Compose;
+using MauiApplication = Microsoft.Maui.Controls.Application;
+
+namespace Microsoft.AndroidX.Compose.Maui.Platform;
+
+/// <summary>
+/// Process-wide bridge from MAUI's
+/// <see cref="MauiApplication.RequestedTheme"/> /
+/// <see cref="MauiApplication.UserAppTheme"/> to a Compose-observable
+/// <see cref="MutableState{T}"/> of <see cref="bool"/>. Every page's
+/// <see cref="Handlers.PageHandler"/> reads <see cref="IsDark"/>
+/// inside its <c>SetContent</c> lambda, so flipping the MAUI theme
+/// (system-driven or app-driven) recomposes every Compose-backed page
+/// against the matching Material 3 colour scheme.
+/// </summary>
+/// <remarks>
+/// <para>Registered as a DI singleton by
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>;
+/// resolved by <see cref="Handlers.PageHandler"/> via
+/// <c>MauiContext.Services</c>. Lifetime matches the running
+/// <see cref="MauiApplication"/>.</para>
+///
+/// <para><b>Why a separate state, not just <c>IsSystemInDarkTheme</c>?</b>
+/// Compose's <c>isSystemInDarkTheme()</c> reads
+/// <c>LocalConfiguration.current.uiMode</c>, which reflects the
+/// activity's resolved configuration. MAUI's
+/// <see cref="MauiApplication.UserAppTheme"/> is an <em>in-app</em>
+/// override that flips MAUI's <see cref="MauiApplication.RequestedTheme"/>
+/// without necessarily triggering an Android configuration change —
+/// so a Compose composition that only looks at
+/// <c>LocalConfiguration</c> would miss it. Routing through MAUI's
+/// own <see cref="MauiApplication.RequestedThemeChanged"/> event keeps
+/// Compose in sync with whatever theme MAUI itself thinks is active.
+/// </para>
+///
+/// <para><b>Resolution order</b> (matches MAUI's
+/// <c>Application.RequestedTheme</c> getter):</para>
+/// <list type="number">
+///   <item><description>If
+///   <see cref="MauiApplication.UserAppTheme"/> is
+///   <see cref="AppTheme.Light"/> or
+///   <see cref="AppTheme.Dark"/>, that wins.</description></item>
+///   <item><description>Otherwise we read
+///   <see cref="MauiApplication.RequestedTheme"/> (which falls through
+///   to the platform value).</description></item>
+///   <item><description>If both come back as
+///   <see cref="AppTheme.Unspecified"/> (rare — usually the platform
+///   resolves it), fall back to Android's
+///   <c>Configuration.UiMode &amp; NightMask</c>.</description></item>
+/// </list>
+/// </remarks>
+public sealed class ThemeManager : IDisposable
+{
+    /// <summary>
+    /// Compose-observable dark-theme flag. Read this inside a
+    /// <c>SetContent</c> lambda (or any composable scope) so the
+    /// snapshot system re-runs the lambda when the theme flips.
+    /// </summary>
+    public MutableState<bool> IsDark { get; } = new(false);
+
+    /// <summary>
+    /// Construct the manager. Subscribes to
+    /// <see cref="MauiApplication.RequestedThemeChanged"/> and seeds
+    /// <see cref="IsDark"/> with the current resolved theme. Safe to
+    /// call before <see cref="MauiApplication.Current"/> is set —
+    /// subscription is deferred until the first
+    /// <see cref="Refresh"/>.
+    /// </summary>
+    public ThemeManager() => Refresh();
+
+    MauiApplication? _subscribed;
+
+    /// <summary>
+    /// Re-resolve the active theme and republish it on
+    /// <see cref="IsDark"/>. Subscribes to
+    /// <see cref="MauiApplication.RequestedThemeChanged"/> the first
+    /// time <see cref="MauiApplication.Current"/> becomes available.
+    /// Idempotent.
+    /// </summary>
+    public void Refresh()
+    {
+        var app = MauiApplication.Current;
+        if (app is not null && _subscribed != app)
+        {
+            if (_subscribed is not null)
+                _subscribed.RequestedThemeChanged -= OnRequestedThemeChanged;
+
+            app.RequestedThemeChanged += OnRequestedThemeChanged;
+            _subscribed = app;
+        }
+
+        IsDark.Value = ResolveIsDark(app);
+    }
+
+    void OnRequestedThemeChanged(object? sender, AppThemeChangedEventArgs e) =>
+        IsDark.Value = e.RequestedTheme switch
+        {
+            AppTheme.Dark   => true,
+            AppTheme.Light  => false,
+            _               => ResolvePlatformDark(),
+        };
+
+    static bool ResolveIsDark(MauiApplication? app)
+    {
+        // UserAppTheme takes precedence over the system value — the
+        // app explicitly asked for a theme, honour it. (MAUI's own
+        // RequestedTheme getter encodes this rule, but reading
+        // UserAppTheme up front means we don't need to inspect both
+        // properties when the user override is set.)
+        if (app is not null)
+        {
+            switch (app.UserAppTheme)
+            {
+                case AppTheme.Dark:  return true;
+                case AppTheme.Light: return false;
+            }
+
+            switch (app.RequestedTheme)
+            {
+                case AppTheme.Dark:  return true;
+                case AppTheme.Light: return false;
+            }
+        }
+
+        return ResolvePlatformDark();
+    }
+
+    static bool ResolvePlatformDark()
+    {
+        // Last-resort: ask the Android Configuration directly. Used
+        // when MAUI hasn't resolved a theme yet (typical only during
+        // very early startup before the first window is shown).
+        var ctx = global::Android.App.Application.Context;
+        var mode = ctx?.Resources?.Configuration?.UiMode ?? UiMode.NightUndefined;
+        return (mode & UiMode.NightMask) == UiMode.NightYes;
+    }
+
+    /// <summary>Detach from
+    /// <see cref="MauiApplication.RequestedThemeChanged"/>. Called
+    /// when the DI container disposes the singleton (i.e. when the
+    /// app shuts down).</summary>
+    public void Dispose()
+    {
+        if (_subscribed is not null)
+        {
+            _subscribed.RequestedThemeChanged -= OnRequestedThemeChanged;
+            _subscribed = null;
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Phase 2 Slice 7 of the .NET MAUI Compose backend — bridge MAUI's
theme signal (`Application.RequestedTheme` / `UserAppTheme`) into
the Compose `MaterialTheme` scope owned by `PageHandler` so a MAUI
app that flips itself to dark via
`App.Current.UserAppTheme = AppTheme.Dark` actually flips the
Compose-backed surfaces along with it.

## Deliverables

- `src/Microsoft.AndroidX.Compose.Maui/Platform/ThemeManager.cs` — DI singleton.
  Exposes a single process-wide `MutableState<bool> IsDark`. On
  construction (and on every `Application.Current.RequestedThemeChanged`),
  resolves: `UserAppTheme` → `RequestedTheme` →
  `Configuration.UiMode & UiMode.NightMask`. Implements `IDisposable`
  to detach the event handler.
- `Handlers/PageHandler.cs` — `MapContent` resolves `ThemeManager`
  from `MauiContext.Services` and wraps the walker output in
  `new MaterialTheme { Dark = theme.IsDark.Value, UseDynamicColor = false }`
  inside `compose.SetContent`. Reading `IsDark.Value` inside the
  lambda registers a Compose snapshot subscription, so every page
  composition recomposes when the bool flips.
- `Hosting/AppHostBuilderExtensions.cs` — registers `ThemeManager`
  as a singleton.
- `Microsoft.AndroidX.Compose.Maui.Sample/Pages/ThemePage.xaml` +
  `.xaml.cs` — three buttons set `Application.UserAppTheme` to
  `Light` / `Dark` / `Unspecified`. Status label echoes both
  `UserAppTheme` and `RequestedTheme`. Default M3 button, `Entry`,
  and a caller-pinned-color button serve as visual probes.
- HomePage entry + Shell route registered.
- `docs/maui-backend.md` — new "Phase 2 Slice 7 — `ThemeManager`"
  subsection; updated open-question item 3 to reflect Slice 7
  shipping the explicit `MaterialTheme` wrapper.

## Decisions / lessons learned

- **Scope is dark/light only.** MAUI's `Primary` / `Secondary` /
  `Tertiary` `Color` resources are *not* bridged into a custom
  `colorScheme` overlay. The trade-off: a single MAUI brand colour
  doesn't supply the full M3 surface palette (`primaryContainer`,
  `onPrimary`, `surfaceVariant`, …); seeding only `primary` from
  MAUI risks contrast bugs and partial theming. The better contract
  is "MAUI tells us light vs dark; M3 picks the scheme." Consumers
  who want full M3 theming can pass a custom `ColorScheme` directly
  via the existing `MaterialTheme` facade.
- **`UserAppTheme` vs `RequestedTheme`.** `UserAppTheme` is the
  in-app override the developer sets; `RequestedTheme` is MAUI's
  resolved value (UserAppTheme wins; otherwise falls through to
  the platform). We read `UserAppTheme` first explicitly for
  clarity, then `RequestedTheme`, then fall back to Android's raw
  `Configuration.UiMode` if MAUI's `Application.Current` isn't
  ready yet.
- **Why route through MAUI's `RequestedThemeChanged` rather than
  Compose's `LocalConfiguration`.** `UserAppTheme` doesn't always
  flip the Android `Configuration` — it's a MAUI-internal preference.
  A Compose-only listener (`LocalConfiguration.current.uiMode`)
  misses in-app overrides and only catches OS-level changes.
- **`UseDynamicColor = false`.** Material You wallpaper-derived
  palettes override the `Dark` flag's effect. The slice is meant
  to honour MAUI's signal exactly; dynamic colour stays a follow-up.
- **One `MutableState<bool>`, many compositions.** Compose supports
  multiple compositions subscribing to a single snapshot state. A
  process-wide shared state across every `PageHandler` instance is
  correct — every Compose-backed page recomposes when it flips,
  no per-page bookkeeping needed.
- **No new public Compose facade pieces.**
  `MaterialTheme.LightColorScheme()` / `DarkColorScheme()` were
  already exposed, and the `Dark` property on `MaterialTheme`
  already existed. The slice is pure plumbing — no new
  `[ComposeBridge]` / `[ComposeFacade]` / `PublicAPI.Unshipped.txt`
  updates.
- **CS0747 footgun.** `MaterialTheme` is a `ComposableContainer`,
  but C# disallows mixing property assignments and collection-init
  items in the same `{ }` block. Build with property assignments
  first, then `.Add(child)`.

## Verification

- `dotnet build src/Microsoft.AndroidX.Compose` — 0 warnings, 0 errors.
- `dotnet build src/Microsoft.AndroidX.Compose.Maui` — 0 warnings, 0 errors.
- `dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample -t:Install` —
  0 warnings, 0 errors; APK installed to device.

On-device interactive verification (Light / Dark / Unspecified
button taps + cross-page recomposition + `uiautomator dump`
ComposeView count) was attempted but blocked by a shared device
that other concurrent worktree sessions kept reinstalling out from
under this branch's APK. The build path is clean and there's no
new generator behaviour or facade surface; reviewer can verify
end-to-end on a dedicated device after merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
