### PR TITLE
MAUI Phase 2 Slice 3: toggle leaves (CheckBox, Switch, RadioButton)

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -614,10 +614,10 @@ leaves so a settings-style page is fully Compose-backed.
   [`Microsoft.AndroidX.Compose.Checkbox`](../src/Microsoft.AndroidX.Compose/Checkbox.cs)
   facade. Maps `IsChecked` (two-way) and `Foreground` (MAUI's
   `CheckBox.Color` lowers to a `SolidPaint` on `Foreground`; only
-  `SolidPaint` is forwarded). The single tint applies to every
-  `CheckboxColors` slot the user touches — `checkedBoxColor`,
-  `checkedBorderColor`, `checkedCheckmarkColor`, plus the matching
-  unchecked border — via `composer.CheckboxColors(...)`.
+  `SolidPaint` is forwarded). The single tint is forwarded as
+  `composer.CheckboxColors(checkedColor: …)`, which substitutes only
+  `checkedBoxColor` and `checkedBorderColor` (the ring + filled state);
+  the checkmark glyph and unchecked border keep their M3 defaults.
 - **`SwitchHandler`** ([`Handlers/SwitchHandler.cs`](../src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs))
   — `ComposeElementHandler<ISwitch>` over the
   [`Microsoft.AndroidX.Compose.Switch`](../src/Microsoft.AndroidX.Compose/Switch.cs)

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -602,6 +602,119 @@ page so cross-sibling animation, semantics, and a single
   consumes pointer events for its own composition. Workaround: put
   a stock leaf in the cell, or convert the container.
 
+#### Phase 2 Slice 3 — toggle leaves ✅ shipped
+
+Goal: extend Phase 2 input coverage with the three boolean / selected
+leaves so a settings-style page is fully Compose-backed.
+
+**Delivered:**
+
+- **`CheckBoxHandler`** ([`Handlers/CheckBoxHandler.cs`](../src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs))
+  — `ComposeElementHandler<ICheckBox>` over the
+  [`Microsoft.AndroidX.Compose.Checkbox`](../src/Microsoft.AndroidX.Compose/Checkbox.cs)
+  facade. Maps `IsChecked` (two-way) and `Foreground` (MAUI's
+  `CheckBox.Color` lowers to a `SolidPaint` on `Foreground`; only
+  `SolidPaint` is forwarded). The single tint applies to every
+  `CheckboxColors` slot the user touches — `checkedBoxColor`,
+  `checkedBorderColor`, `checkedCheckmarkColor`, plus the matching
+  unchecked border — via `composer.CheckboxColors(...)`.
+- **`SwitchHandler`** ([`Handlers/SwitchHandler.cs`](../src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs))
+  — `ComposeElementHandler<ISwitch>` over the
+  [`Microsoft.AndroidX.Compose.Switch`](../src/Microsoft.AndroidX.Compose/Switch.cs)
+  facade. Maps `IsOn` (two-way), `TrackColor` (drives
+  `checkedTrackColor` + `uncheckedTrackColor`), `ThumbColor` (drives
+  `checkedThumbColor` + `uncheckedThumbColor`). Same colour applies in
+  both states to mirror MAUI's stock `SwitchHandler` rendering.
+- **`RadioButtonHandler`** ([`Handlers/RadioButtonHandler.cs`](../src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs))
+  — `ComposeElementHandler<IRadioButton>` over the
+  [`Microsoft.AndroidX.Compose.RadioButton`](../src/Microsoft.AndroidX.Compose/RadioButton.cs)
+  facade. Maps `IsChecked` (two-way), `Content` (string-only — read
+  off `Microsoft.Maui.Controls.RadioButton` since `IRadioButton`
+  doesn't expose `Content`), `TextColor`, `Font` (size + bold). Builds
+  `Row { RadioButton(selected, onClick), Text(label) }` so the visual
+  matches MAUI's stock `AppCompatRadioButton`. `RadioButtonGroup`
+  semantics are *not* reimplemented — MAUI's
+  `RadioButtonGroupController` automatically raises
+  `CheckedChanged(false)` on the previous selection when one in a
+  group flips on; the handler just surfaces `IsChecked` honestly.
+- **Compose facades extended** — added `Colors { get; set; }` slot to
+  `Checkbox` and `Switch` mirroring `Button.Colors`. New
+  [`composer.CheckboxColors(...)`](../src/Microsoft.AndroidX.Compose/ComposeExtensions.CheckboxDefaults.cs)
+  / [`composer.SwitchColors(...)`](../src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs)
+  factories build the per-control colour state-holder. `Checkbox`
+  routes through `CheckboxDefaults.Colors(composer, 0)` + `.Copy(...)`
+  because the parameterised 12-arg factory is binder-stripped (mangled
+  `colors-Q...`); `Switch`'s 16-arg parameterised factory IS bound, so
+  builds the `$default` mask directly.
+- **`UseAndroidXCompose()`** registers the three new handlers under
+  the existing leaves block ([`AppHostBuilderExtensions.cs`](../src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs)).
+- **`TogglesPage`** in the sample
+  ([`Pages/TogglesPage.xaml`](../src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/TogglesPage.xaml))
+  exercises every mapper: default + tinted CheckBox, default + tinted
+  Switch, RadioButton group with three options. Each section has an
+  echo `Label` updated from `CheckedChanged` / `Toggled` so manual
+  taps verify the Compose → MAUI write-back round-trips.
+
+**Verified on device:**
+
+- `TogglesPage` renders with exactly **one**
+  `androidx.compose.ui.platform.ComposeView` per `adb shell
+  uiautomator dump`. All three control kinds are exposed with
+  semantic `clickable=true checkable=true` so accessibility services
+  see them as toggles, not opaque views.
+- Echo labels flip on tap, confirming the two-way `MutableState<bool>`
+  feedback loop short-circuits without a `_suppressMauiWrite` guard
+  flag (matches `EntryHandler`'s pattern).
+
+**Lessons learned (Slice 3):**
+
+- **Two-way binding for `bool` state needs no guard flag.**
+  `MutableState<bool>` short-circuits on equality (`SnapshotMutationPolicy.StructuralEquality`),
+  so the round-trip `Compose onCheckedChange → write VirtualView.IsChecked
+  → MapIsChecked → set MutableState.Value` settles in one cycle. Same
+  pattern as `EntryHandler.OnValueChanged` — copied verbatim.
+- **`ICheckBox.Foreground` (not `Color`).** MAUI's `CheckBox.Color`
+  XAML attribute lowers to a `Paint` on the
+  [`IShape.Foreground`](https://learn.microsoft.com/dotnet/api/microsoft.maui.ishape.foreground)
+  interface property. Map `Foreground` and forward only `SolidPaint`
+  through `ColorMapping.ToPackedLong`; gradients fall back to default
+  M3 chrome.
+- **`ISwitch.IsOn` (not `IsToggled`).** `IsToggled` is the property
+  name on the concrete `Microsoft.Maui.Controls.Switch` control;
+  `ISwitch` (the handler interface) exposes it as `IsOn`. The mapper
+  key uses `nameof(ISwitch.IsOn)`.
+- **Kotlin `CheckboxColors.Copy(...)` is the only path for partial
+  override.** The parameterised 12-arg `CheckboxDefaults.colors(...)`
+  factory ships in Material3 but is binder-stripped because every
+  param is a `Color` (`@JvmInline value class` lowers to a mangled
+  JVM name like `colors-rGdcdEs`). Workaround: call the bound zero-arg
+  `Colors(composer, 0)` to get a defaulted instance, then thread
+  through `.Copy(...)` reading every default and substituting any
+  non-null overrides. `SwitchColors`'s 16-arg factory IS bound — `long`
+  packs `Color` into a primitive — so it builds the `$default` mask
+  directly. Documented the difference in the two extension factories.
+- **`IRadioButton.Content` lives on the concrete control, not the
+  interface.** `Microsoft.Maui.Controls.RadioButton.Content` is
+  `BindableProperty.Create(typeof(object), …)`. The mapper casts
+  `VirtualView` to `Microsoft.Maui.Controls.RadioButton` and forwards
+  `Content?.ToString()`; `View`-typed content (`ContentPresenter`-style)
+  isn't supported in this slice — pass a string.
+- **Don't reimplement `RadioButtonGroup` semantics.** MAUI's
+  `RadioButtonGroupController` handles unchecking the previous
+  selection automatically when one radio in a `GroupName` flips on;
+  the handler just surfaces `IsChecked`. The Compose `RadioButton`
+  composable's `onClick` only fires for unselected → selected (the
+  Kotlin contract), so a tap on an already-checked radio is a no-op
+  and the controller never sees a spurious `false` round-trip.
+- **Stale `Generated/` folder bites the facade generator.** A previous
+  `EmitCompilerGeneratedFiles=true` build wrote `Microsoft.AndroidX.Compose/Generated/`
+  with stale facade ctor bodies that compiled alongside the regenerated
+  `obj/Debug/.../Generated/...` files. Symptom: `bool enabled = true`
+  default silently dropped from `Checkbox` / `Switch` ctors. Fix:
+  `Remove-Item -Recurse Generated/ obj/` then rebuild without the flag.
+  Lesson: don't enable `EmitCompilerGeneratedFiles` in a working tree
+  while iterating on generators.
+
 ### Phase 3 — collection + container (target: list-driven apps)
 
 `CollectionView` → `LazyColumn<T>` / `LazyRow<T>` / `LazyVerticalGrid<T>`

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -21,5 +21,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("entries",        typeof(EntriesPage));
         Routing.RegisterRoute("image-aspects",  typeof(ImageAspectsPage));
         Routing.RegisterRoute("image-sources",  typeof(ImageSourcesPage));
+        Routing.RegisterRoute("toggles",        typeof(TogglesPage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml
@@ -27,7 +27,7 @@
                        TextColor="White"
                        FontSize="28"
                        FontAttributes="Bold" />
-                <Label Text="Each row exercises one of the four Compose-backed handlers (Button, Entry, Image, Label) wired by UseAndroidXCompose()."
+                <Label Text="Each row exercises one of the seven Compose-backed handlers (Button, Entry, Image, Label, CheckBox, Switch, RadioButton) wired by UseAndroidXCompose()."
                        TextColor="White"
                        Opacity="0.85"
                        FontSize="13" />

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -60,6 +60,11 @@ public partial class HomePage : ContentPage
                 "File / Uri / Stream / Font image source types.",
                 Color.FromArgb("#E91E63"),
                 "image-sources"),
+            new DemoEntry(
+                "Toggles",
+                "CheckBox / Switch / RadioButton with two-way binding.",
+                Color.FromArgb("#FF9800"),
+                "toggles"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/TogglesPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/TogglesPage.xaml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.TogglesPage"
+             Title="Toggles">
+
+    <!--
+        Exercises every mapper on the three new toggle handlers:
+            * CheckBoxHandler    -> IsChecked, Color (-> Foreground -> CheckboxColors)
+            * SwitchHandler      -> IsOn, OnColor (-> SwitchColors checkedTrack),
+                                    ThumbColor (-> SwitchColors checkedThumb)
+            * RadioButtonHandler -> IsChecked, Content (-> Compose Text inside a Row),
+                                    TextColor, FontSize.
+
+        Each section has an echo Label updated from the control's
+        CheckedChanged / Toggled event so manual taps verify the
+        Compose -> MAUI write-back round-trips.
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="20">
+
+            <Label
+                Text="Toggles"
+                Style="{StaticResource Headline}" />
+
+            <Label Text="CheckBox — default + colored."
+                   FontAttributes="Bold" />
+
+            <HorizontalStackLayout Spacing="12">
+                <CheckBox
+                    x:Name="DefaultCheck"
+                    IsChecked="True"
+                    CheckedChanged="OnDefaultCheckChanged" />
+                <Label Text="Default" VerticalOptions="Center" />
+            </HorizontalStackLayout>
+
+            <HorizontalStackLayout Spacing="12">
+                <CheckBox
+                    x:Name="ColoredCheck"
+                    Color="#E91E63"
+                    CheckedChanged="OnColoredCheckChanged" />
+                <Label Text="Pink" VerticalOptions="Center" />
+            </HorizontalStackLayout>
+
+            <Label
+                x:Name="CheckEcho"
+                Text="Default: True · Pink: False" />
+
+            <Label Text="Switch — default + tinted on/off."
+                   FontAttributes="Bold" />
+
+            <HorizontalStackLayout Spacing="12">
+                <Switch
+                    x:Name="DefaultSwitch"
+                    IsToggled="True"
+                    Toggled="OnDefaultSwitchToggled" />
+                <Label Text="Default" VerticalOptions="Center" />
+            </HorizontalStackLayout>
+
+            <HorizontalStackLayout Spacing="12">
+                <Switch
+                    x:Name="TintedSwitch"
+                    OnColor="#4CAF50"
+                    ThumbColor="#FFEB3B"
+                    Toggled="OnTintedSwitchToggled" />
+                <Label Text="Tinted" VerticalOptions="Center" />
+            </HorizontalStackLayout>
+
+            <Label
+                x:Name="SwitchEcho"
+                Text="Default: True · Tinted: False" />
+
+            <Label Text="RadioButton — three options in a group."
+                   FontAttributes="Bold" />
+
+            <RadioButton
+                Content="Apple"
+                Value="apple"
+                GroupName="fruit"
+                IsChecked="True"
+                CheckedChanged="OnFruitChanged" />
+            <RadioButton
+                Content="Banana"
+                Value="banana"
+                GroupName="fruit"
+                CheckedChanged="OnFruitChanged" />
+            <RadioButton
+                Content="Cherry"
+                Value="cherry"
+                GroupName="fruit"
+                TextColor="#C2185B"
+                FontSize="18"
+                FontAttributes="Bold"
+                CheckedChanged="OnFruitChanged" />
+
+            <Label
+                x:Name="FruitEcho"
+                Text="Selected: apple" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/TogglesPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/TogglesPage.xaml.cs
@@ -1,0 +1,53 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Toggles demo — exercises every mapper on the three new
+/// Phase 2 Slice 3 handlers
+/// (<see cref="Microsoft.AndroidX.Compose.Maui.Handlers.CheckBoxHandler"/>,
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.SwitchHandler"/>,
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.RadioButtonHandler"/>).
+/// </summary>
+/// <remarks>
+/// The echo labels are updated from each control's
+/// <c>CheckedChanged</c> / <c>Toggled</c> event handler — toggling a
+/// CheckBox / Switch / RadioButton on the device flips the bound
+/// virtual-view property, which the event surfaces back into the
+/// labels here.
+/// </remarks>
+public partial class TogglesPage : ContentPage
+{
+    /// <summary>Build the page.</summary>
+    public TogglesPage()
+    {
+        InitializeComponent();
+    }
+
+    void OnDefaultCheckChanged(object? sender, CheckedChangedEventArgs e) =>
+        UpdateCheckEcho();
+
+    void OnColoredCheckChanged(object? sender, CheckedChangedEventArgs e) =>
+        UpdateCheckEcho();
+
+    void UpdateCheckEcho() =>
+        CheckEcho.Text = $"Default: {DefaultCheck.IsChecked} · Pink: {ColoredCheck.IsChecked}";
+
+    void OnDefaultSwitchToggled(object? sender, ToggledEventArgs e) =>
+        UpdateSwitchEcho();
+
+    void OnTintedSwitchToggled(object? sender, ToggledEventArgs e) =>
+        UpdateSwitchEcho();
+
+    void UpdateSwitchEcho() =>
+        SwitchEcho.Text = $"Default: {DefaultSwitch.IsToggled} · Tinted: {TintedSwitch.IsToggled}";
+
+    void OnFruitChanged(object? sender, CheckedChangedEventArgs e)
+    {
+        // RadioButton fires CheckedChanged on every member of the group
+        // when one flips — the previous selection's event also fires
+        // (with Value=false). Only update the echo when *this* radio
+        // became the selected one.
+        if (!e.Value || sender is not RadioButton rb)
+            return;
+        FruitEcho.Text = $"Selected: {rb.Value}";
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs
@@ -1,0 +1,100 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ComposeCheckbox = AndroidX.Compose.Checkbox;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.CheckBox"/> handler that
+/// renders through Jetpack Compose's Material 3 <c>Checkbox</c>
+/// composable. Replaces MAUI's stock <c>AppCompatCheckBox</c>-based
+/// handler when the consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>. Two-way binding mirrors
+/// <see cref="EntryHandler"/>: Compose's <c>onCheckedChange</c> writes
+/// the new value back to <see cref="ICheckBox.IsChecked"/>, which
+/// re-enters <see cref="MapIsChecked"/> — that's a no-op against the
+/// already-updated <see cref="MutableState{T}"/> so the loop
+/// short-circuits without a guard flag.</para>
+///
+/// <para><see cref="Microsoft.Maui.Graphics.IElement.Color"/> is
+/// surfaced as Compose's <see cref="CheckboxColors"/> <c>checkedColor</c>
+/// slot via <see cref="ComposeExtensions.CheckboxColors"/>. MAUI's
+/// stock checkbox tints the box and the checkmark together; we map
+/// the same colour onto the box fill + border so the rendered chrome
+/// stays internally consistent. Alpha-only colour overrides are
+/// dropped as <c>0L</c>.</para>
+/// </remarks>
+public partial class CheckBoxHandler : ComposeElementHandler<ICheckBox>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="ICheckBox"/>
+    /// property changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<ICheckBox, CheckBoxHandler> Mapper =
+        new PropertyMapper<ICheckBox, CheckBoxHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(ICheckBox.IsChecked)] = MapIsChecked,
+            [nameof(ICheckBox.Foreground)] = MapForeground,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<ICheckBox, CheckBoxHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<bool>  _checked = new(false);
+    readonly MutableState<long?> _color   = new((long?)null);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public CheckBoxHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public CheckBoxHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        var color = _color.Value;
+        var box   = new ComposeCheckbox(@checked: _checked.Value,
+                                        onCheckedChange: OnCheckedChanged);
+        if (color is not null)
+            box.Colors = composer.CheckboxColors(checkedColor: color);
+        return box;
+    }
+
+    void OnCheckedChanged(bool newValue)
+    {
+        // Compose state must be flipped synchronously so the rendered
+        // box reflects the user's tap; lagging here drops the tick.
+        // Writing back to `VirtualView.IsChecked` re-enters MapIsChecked
+        // with the same bool — `MutableState<bool>` short-circuits on
+        // equality so there's no recompose-loop.
+        _checked.Value = newValue;
+        if (VirtualView is { } v)
+            v.IsChecked = newValue;
+    }
+
+    /// <summary>Map <see cref="ICheckBox.IsChecked"/> to the Compose <c>checked</c> slot.</summary>
+    public static void MapIsChecked(CheckBoxHandler handler, ICheckBox checkBox) =>
+        handler._checked.Value = checkBox.IsChecked;
+
+    /// <summary>
+    /// Map <see cref="ICheckBox.Foreground"/> to the Compose
+    /// <see cref="CheckboxColors"/> <c>checkedColor</c> slot. ICheckBox
+    /// surfaces its tint through <c>Foreground</c> (the
+    /// <see cref="Microsoft.Maui.Controls.CheckBox.Color"/> XAML
+    /// property maps to it). Only solid paints participate; gradients
+    /// / images / nulls fall back to the M3 theme default.
+    /// </summary>
+    public static void MapForeground(CheckBoxHandler handler, ICheckBox checkBox) =>
+        handler._color.Value = checkBox.Foreground is SolidPaint solid
+            ? ColorMapping.ToPackedLong(solid.Color)
+            : null;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
@@ -110,11 +110,14 @@ public partial class RadioButtonHandler : ComposeElementHandler<IRadioButton>
     {
         // The Compose `onClick` only fires for unselected → selected;
         // a tap on an already-checked radio is a no-op (matches Kotlin
-        // `RadioButton`'s own behaviour). Surfacing IsChecked = true
-        // re-enters MapIsChecked via VirtualView, and MAUI's
-        // `RadioButtonGroupController` raises CheckedChanged(false) on
-        // the previous selection automatically — we don't reimplement
-        // group semantics here.
+        // `RadioButton`'s own behaviour). Pin Compose state synchronously
+        // so the rendered ring reflects the user's tap immediately —
+        // matches `CheckBoxHandler.OnCheckedChanged` and
+        // `SwitchHandler.OnCheckedChanged`. Then surface IsChecked = true
+        // so MAUI's `RadioButtonGroupController` raises
+        // CheckedChanged(false) on the previous selection automatically;
+        // we don't reimplement group semantics here.
+        _checked.Value = true;
         if (VirtualView is { } v)
             v.IsChecked = true;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
@@ -1,0 +1,155 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ComposeColor      = AndroidX.Compose.Color;
+using ComposeFontWeight = AndroidX.Compose.FontWeight;
+using ComposeRadioButton = AndroidX.Compose.RadioButton;
+using ComposeText       = AndroidX.Compose.Text;
+using MauiRadioButton   = Microsoft.Maui.Controls.RadioButton;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.RadioButton"/> handler that
+/// renders through Jetpack Compose's Material 3 <c>RadioButton</c>
+/// composable — paired in a Compose <see cref="Row"/> with a
+/// <see cref="ComposeText"/> label so the rendered chrome matches
+/// MAUI's stock <c>AppCompatRadioButton</c>. Replaces MAUI's stock
+/// handler when the consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>. Two-way binding mirrors
+/// <see cref="EntryHandler"/>: the Compose <c>onClick</c> writes
+/// <see cref="IRadioButton.IsChecked"/><c> = true</c> on the tapped
+/// virtual view, which re-enters <see cref="MapIsChecked"/> — equality
+/// on <see cref="MutableState{T}"/> short-circuits the loop without a
+/// guard flag.</para>
+///
+/// <para>Group semantics
+/// (<see cref="Microsoft.Maui.Controls.RadioButtonGroup"/> /
+/// <see cref="Microsoft.Maui.Controls.RadioButton.GroupName"/>) are
+/// already enforced by MAUI's <c>RadioButtonGroupController</c> — when
+/// one radio in a group flips to <c>true</c>, the controller raises
+/// <c>CheckedChanged(false)</c> on the previous selection through the
+/// virtual view's normal property pipeline. The handler doesn't
+/// reimplement any of that; it simply surfaces
+/// <see cref="IRadioButton.IsChecked"/> faithfully.</para>
+///
+/// <para><see cref="MauiRadioButton.Content"/> is read off the
+/// concrete control type (it isn't on <see cref="IRadioButton"/>) and
+/// rendered as a <see cref="ComposeText"/> next to the radio circle.
+/// String content uses the value verbatim; anything else lowers
+/// through <c>ToString()</c> matching MAUI's stock platform handler.
+/// View-typed <c>Content</c> isn't supported here — pass a string or
+/// build a custom Compose-rendered control.</para>
+/// </remarks>
+public partial class RadioButtonHandler : ComposeElementHandler<IRadioButton>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="IRadioButton"/>
+    /// property changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<IRadioButton, RadioButtonHandler> Mapper =
+        new PropertyMapper<IRadioButton, RadioButtonHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(IRadioButton.IsChecked)]      = MapIsChecked,
+            [nameof(MauiRadioButton.Content)]     = MapContent,
+            [nameof(ITextStyle.TextColor)]        = MapTextColor,
+            [nameof(ITextStyle.Font)]             = MapFont,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<IRadioButton, RadioButtonHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<bool>   _checked  = new(false);
+    readonly MutableState<string> _label    = new(string.Empty);
+    readonly MutableState<long?>  _color    = new((long?)null);
+    readonly MutableState<int?>   _fontSize = new((int?)null);
+    readonly MutableState<bool>   _bold     = new(false);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public RadioButtonHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public RadioButtonHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        var packed = _color.Value;
+        var size   = _fontSize.Value;
+        var bold   = _bold.Value;
+        var label  = _label.Value;
+
+        var radio = new ComposeRadioButton(selected: _checked.Value, onClick: OnSelected);
+        if (string.IsNullOrEmpty(label))
+            return radio;
+
+        var text = new ComposeText(label);
+        if (packed.HasValue)
+            text.Color = new ComposeColor(packed.Value);
+        if (size.HasValue)
+            text.FontSize = new Sp(size.Value);
+        if (bold)
+            text.FontWeight = ComposeFontWeight.Bold;
+
+        return new Row(horizontalArrangement: null,
+                       verticalAlignment: Alignment.Vertical.CenterVertically)
+        {
+            radio,
+            text,
+        };
+    }
+
+    void OnSelected()
+    {
+        // The Compose `onClick` only fires for unselected → selected;
+        // a tap on an already-checked radio is a no-op (matches Kotlin
+        // `RadioButton`'s own behaviour). Surfacing IsChecked = true
+        // re-enters MapIsChecked via VirtualView, and MAUI's
+        // `RadioButtonGroupController` raises CheckedChanged(false) on
+        // the previous selection automatically — we don't reimplement
+        // group semantics here.
+        if (VirtualView is { } v)
+            v.IsChecked = true;
+    }
+
+    /// <summary>Map <see cref="IRadioButton.IsChecked"/> to the Compose <c>selected</c> slot.</summary>
+    public static void MapIsChecked(RadioButtonHandler handler, IRadioButton rb) =>
+        handler._checked.Value = rb.IsChecked;
+
+    /// <summary>
+    /// Map <see cref="MauiRadioButton.Content"/> to the Compose label
+    /// slot. Read off the concrete control type because
+    /// <see cref="IRadioButton"/> exposes content only as
+    /// <see cref="IContentView.PresentedContent"/>, which is null when
+    /// the binding holds a string. <see langword="null"/> /
+    /// <see cref="View"/>-typed content lowers to the empty string —
+    /// the radio circle is rendered without a sibling label.
+    /// </summary>
+    public static void MapContent(RadioButtonHandler handler, IRadioButton rb)
+    {
+        if (rb is MauiRadioButton concrete && concrete.Content is { } content && content is not Microsoft.Maui.Controls.View)
+            handler._label.Value = content.ToString() ?? string.Empty;
+        else
+            handler._label.Value = string.Empty;
+    }
+
+    /// <summary>Map <see cref="ITextStyle.TextColor"/> to the Compose label colour.</summary>
+    public static void MapTextColor(RadioButtonHandler handler, IRadioButton rb) =>
+        handler._color.Value = ColorMapping.ToPackedLong(rb.TextColor);
+
+    /// <summary>Map <see cref="ITextStyle.Font"/> (size + bold) to the Compose label slots.</summary>
+    public static void MapFont(RadioButtonHandler handler, IRadioButton rb)
+    {
+        var font = rb.Font;
+        handler._fontSize.Value = font.Size > 0 ? (int)font.Size : null;
+        handler._bold.Value     = (font.Weight & Microsoft.Maui.FontWeight.Bold)
+            == Microsoft.Maui.FontWeight.Bold;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs
@@ -1,0 +1,108 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ComposeSwitch = AndroidX.Compose.Switch;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.Switch"/> handler that
+/// renders through Jetpack Compose's Material 3 <c>Switch</c>
+/// composable. Replaces MAUI's stock <c>SwitchCompat</c>-based
+/// handler when the consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>. Two-way binding mirrors
+/// <see cref="EntryHandler"/>: Compose's <c>onCheckedChange</c> writes
+/// the new value back to <see cref="ISwitch.IsOn"/>, which re-enters
+/// <see cref="MapIsOn"/> — that's a no-op against the already-updated
+/// <see cref="MutableState{T}"/> so the loop short-circuits.</para>
+///
+/// <para>MAUI's <see cref="Microsoft.Maui.Controls.Switch.OnColor"/>
+/// (a.k.a. <see cref="ISwitch.TrackColor"/>) tints the track when the
+/// switch is on; MAUI's <see cref="ISwitch.ThumbColor"/> tints the
+/// thumb. Both are forwarded to Compose's
+/// <see cref="SwitchColors"/> via
+/// <see cref="ComposeExtensions.SwitchColors"/>. Because MAUI doesn't
+/// distinguish a "checked" vs "unchecked" thumb tint we apply the
+/// same tint to both states, matching the stock MAUI rendering.</para>
+/// </remarks>
+public partial class SwitchHandler : ComposeElementHandler<ISwitch>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="ISwitch"/>
+    /// property changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<ISwitch, SwitchHandler> Mapper =
+        new PropertyMapper<ISwitch, SwitchHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(ISwitch.IsOn)]       = MapIsOn,
+            [nameof(ISwitch.TrackColor)] = MapTrackColor,
+            [nameof(ISwitch.ThumbColor)] = MapThumbColor,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<ISwitch, SwitchHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<bool>  _on         = new(false);
+    readonly MutableState<long?> _trackColor = new((long?)null);
+    readonly MutableState<long?> _thumbColor = new((long?)null);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public SwitchHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public SwitchHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        var track = _trackColor.Value;
+        var thumb = _thumbColor.Value;
+        var sw = new ComposeSwitch(@checked: _on.Value,
+                                   onCheckedChange: OnCheckedChanged);
+        if (track is not null || thumb is not null)
+            sw.Colors = composer.SwitchColors(
+                checkedThumbColor:   thumb,
+                checkedTrackColor:   track,
+                uncheckedThumbColor: thumb,
+                uncheckedTrackColor: track);
+        return sw;
+    }
+
+    void OnCheckedChanged(bool newValue)
+    {
+        // Sync Compose state synchronously so the rendered thumb stays
+        // pinned where the user dragged it. Re-entrant write through
+        // VirtualView.IsOn lands in MapIsOn — equality on MutableState
+        // short-circuits the second pass.
+        _on.Value = newValue;
+        if (VirtualView is { } v)
+            v.IsOn = newValue;
+    }
+
+    /// <summary>Map <see cref="ISwitch.IsOn"/> to the Compose <c>checked</c> slot.</summary>
+    public static void MapIsOn(SwitchHandler handler, ISwitch sw) =>
+        handler._on.Value = sw.IsOn;
+
+    /// <summary>
+    /// Map <see cref="ISwitch.TrackColor"/> (MAUI <c>OnColor</c>) to
+    /// Compose's <see cref="SwitchColors"/> <c>checkedTrackColor</c>
+    /// slot.
+    /// </summary>
+    public static void MapTrackColor(SwitchHandler handler, ISwitch sw) =>
+        handler._trackColor.Value = ColorMapping.ToPackedLong(sw.TrackColor);
+
+    /// <summary>
+    /// Map <see cref="ISwitch.ThumbColor"/> to Compose's
+    /// <see cref="SwitchColors"/> <c>checkedThumbColor</c> slot.
+    /// </summary>
+    public static void MapThumbColor(SwitchHandler handler, ISwitch sw) =>
+        handler._thumbColor.Value = ColorMapping.ToPackedLong(sw.ThumbColor);
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -1,11 +1,14 @@
 using Microsoft.AndroidX.Compose.Maui.Handlers;
 using MauiButton = Microsoft.Maui.Controls.Button;
+using MauiCheckBox = Microsoft.Maui.Controls.CheckBox;
 using MauiEntry = Microsoft.Maui.Controls.Entry;
 using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
 using MauiImage = Microsoft.Maui.Controls.Image;
 using MauiLabel = Microsoft.Maui.Controls.Label;
 using MauiPage = Microsoft.Maui.Controls.Page;
+using MauiRadioButton = Microsoft.Maui.Controls.RadioButton;
 using MauiScrollView = Microsoft.Maui.Controls.ScrollView;
+using MauiSwitch = Microsoft.Maui.Controls.Switch;
 using MauiVerticalStackLayout = Microsoft.Maui.Controls.VerticalStackLayout;
 
 namespace Microsoft.AndroidX.Compose.Maui.Hosting;
@@ -40,8 +43,10 @@ public static class AppHostBuilderExtensions
     ///     <c>Modifier.verticalScroll</c> / <c>horizontalScroll</c>.</description></item>
     ///   <item><description>Leaves
     ///     (<see cref="MauiLabel"/> / <see cref="MauiButton"/> /
-    ///     <see cref="MauiEntry"/> / <see cref="MauiImage"/>) fold
-    ///     into the enclosing composition via
+    ///     <see cref="MauiEntry"/> / <see cref="MauiImage"/> /
+    ///     <see cref="MauiCheckBox"/> / <see cref="MauiSwitch"/> /
+    ///     <see cref="MauiRadioButton"/>) fold into the enclosing
+    ///     composition via
     ///     <see cref="IComposeHandler"/>.</description></item>
     /// </list>
     ///
@@ -84,6 +89,9 @@ public static class AppHostBuilderExtensions
             handlers.AddHandler<MauiButton,                 ButtonHandler>();
             handlers.AddHandler<MauiEntry,                  EntryHandler>();
             handlers.AddHandler<MauiImage,                  ImageHandler>();
+            handlers.AddHandler<MauiCheckBox,               CheckBoxHandler>();
+            handlers.AddHandler<MauiSwitch,                 SwitchHandler>();
+            handlers.AddHandler<MauiRadioButton,            RadioButtonHandler>();
         });
 
         return builder;

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -58,7 +58,7 @@ public static class AppHostBuilderExtensions
     /// (the leaf creates its own composition because there's no parent
     /// composer to fold into). When they appear <i>below</i> a
     /// converted parent — or anywhere a non-converted control surfaces
-    /// (CollectionView, BoxView, Switch, customer renderers) — they're
+    /// (CollectionView, BoxView, customer renderers) — they're
     /// hosted via <c>AndroidView { factory = child.ToPlatform(MauiContext) }</c>
     /// inside the page composition, so MAUI's normal handler resolution
     /// keeps working.</para>

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeReferenceTypes.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeReferenceTypes.cs
@@ -41,6 +41,8 @@ internal static class ComposeReferenceTypes
         "AndroidX.Compose.PaddingValues",
         "AndroidX.Compose.Material3.ITopAppBarScrollBehavior",
         "AndroidX.Compose.Material3.ButtonColors",
+        "AndroidX.Compose.Material3.CheckboxColors",
+        "AndroidX.Compose.Material3.SwitchColors",
         "AndroidX.Compose.UI.Text.TextStyle",
         "AndroidX.Compose.UI.Text.Input.IVisualTransformation",
         "AndroidX.Compose.Foundation.Text.KeyboardOptions",

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -3591,16 +3591,17 @@ internal static partial class ComposeBridges
         IFunction1                 onCheckedChange,
         IModifier?                 modifier,
         bool                       enabled  = true,
+        AndroidX.Compose.Material3.CheckboxColors? colors = null,
         int                        defaults = 0,
         IComposer                  composer = null!);
 
-    public static partial void Checkbox(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, bool enabled, int defaults, IComposer composer)
+    public static partial void Checkbox(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, bool enabled, AndroidX.Compose.Material3.CheckboxColors? colors, int defaults, IComposer composer)
         => CheckboxKt.Checkbox(
             @checked:          @checked,
             onCheckedChange:   onCheckedChange,
             modifier:          modifier,
             enabled:           enabled,
-            colors:            null,
+            colors:            colors,
             interactionSource: null,
             _composer:         composer,
             p7:                0,
@@ -3613,17 +3614,18 @@ internal static partial class ComposeBridges
         IFunction1                 onCheckedChange,
         IModifier?                 modifier,
         bool                       enabled  = true,
+        AndroidX.Compose.Material3.SwitchColors? colors = null,
         int                        defaults = 0,
         IComposer                  composer = null!);
 
-    public static partial void Switch(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, bool enabled, int defaults, IComposer composer)
+    public static partial void Switch(bool @checked, IFunction1 onCheckedChange, IModifier? modifier, bool enabled, AndroidX.Compose.Material3.SwitchColors? colors, int defaults, IComposer composer)
         => SwitchKt.Switch(
             @checked:          @checked,
             onCheckedChange:   onCheckedChange,
             modifier:          modifier,
             thumbContent:      null,
             enabled:           enabled,
-            colors:            null,
+            colors:            colors,
             interactionSource: null,
             _composer:         composer,
             p8:                0,

--- a/src/Microsoft.AndroidX.Compose/ComposeDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeDefaults.cs
@@ -843,6 +843,23 @@ using AndroidX.Compose;
     "!checked", "!onCheckedChange", "modifier", "thumbContent",
     "enabled", "colors", "interactionSource")]
 
+// androidx.compose.material3.SwitchDefaults.colors(...): 16-slot
+// $default mask covering thumb/track/border/icon for each of the
+// checked, unchecked, disabled-checked, and disabled-unchecked
+// states. Used by `composer.SwitchColors(...)` to flip individual
+// bits as caller-supplied overrides arrive. Order matches the
+// bytecode lowering (every parameter is a `@JvmInline value class
+// Color` lowered to `long`, so the 16-slot factory is fully bound).
+[assembly: ComposeDefaults("SwitchColorsDefault",
+    "checkedThumbColor", "checkedTrackColor",
+    "checkedBorderColor", "checkedIconColor",
+    "uncheckedThumbColor", "uncheckedTrackColor",
+    "uncheckedBorderColor", "uncheckedIconColor",
+    "disabledCheckedThumbColor", "disabledCheckedTrackColor",
+    "disabledCheckedBorderColor", "disabledCheckedIconColor",
+    "disabledUncheckedThumbColor", "disabledUncheckedTrackColor",
+    "disabledUncheckedBorderColor", "disabledUncheckedIconColor")]
+
 // androidx.compose.material3.SliderKt.Slider (simple float overload):
 // 9 user params; bits 0 (value) and 1 (onValueChange) always provided.
 // The longer overload with Function3 thumb/track slots has non-null

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.CheckboxDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.CheckboxDefaults.cs
@@ -1,0 +1,72 @@
+using System.Runtime.CompilerServices;
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// Static factories mirroring Kotlin's
+/// <c>androidx.compose.material3.CheckboxDefaults</c> singleton —
+/// returns a <see cref="CheckboxColors"/> configured for a particular
+/// override pattern. Surfaced as <see cref="IComposer"/> extensions so
+/// call sites read <c>composer.CheckboxColors(checkedColor: ...)</c>.
+/// </summary>
+public static partial class ComposeExtensions
+{
+    /// <summary>
+    /// Mirrors Kotlin's
+    /// <c>CheckboxDefaults.colors(checkedColor = …, uncheckedColor = …,
+    /// checkmarkColor = …)</c> for the three slots most consumers want
+    /// to override.
+    ///
+    /// <para>The Kotlin <c>colors(...)</c> factory takes a
+    /// <c>$default</c> bitmask, but the C# binder strips it because
+    /// every parameter is the <c>@JvmInline value class Color</c>. We
+    /// therefore call the parameterless <c>colors(composer, _changed)</c>
+    /// to obtain the theme defaults and build the result via the bound
+    /// <c>CheckboxColors.copy(...)</c> overload — which is the only
+    /// twelve-<c>long</c> entry point that survives the binder strip.</para>
+    ///
+    /// <para>Each non-<c>null</c> argument substitutes for the
+    /// corresponding default; <c>null</c> falls back to the value from
+    /// the current <c>MaterialTheme</c>. <paramref name="checkedColor"/>
+    /// applies to both the box fill and the box border so the checked
+    /// chrome stays internally consistent.</para>
+    /// </summary>
+    public static CheckboxColors CheckboxColors(
+        this IComposer composer,
+        long? checkedColor = null,
+        long? uncheckedColor = null,
+        long? checkmarkColor = null,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+    {
+        ArgumentNullException.ThrowIfNull(composer);
+
+        composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
+        try
+        {
+            var d = AndroidX.Compose.Material3.CheckboxDefaults.Instance.Colors(composer, 0);
+            if (checkedColor is null && uncheckedColor is null && checkmarkColor is null)
+                return d;
+
+            return d.Copy(
+                checkedCheckmarkColor:            checkmarkColor ?? d.CheckedCheckmarkColor,
+                uncheckedCheckmarkColor:          d.UncheckedCheckmarkColor,
+                checkedBoxColor:                  checkedColor   ?? d.CheckedBoxColor,
+                uncheckedBoxColor:                uncheckedColor ?? d.UncheckedBoxColor,
+                disabledCheckedBoxColor:          d.DisabledCheckedBoxColor,
+                disabledUncheckedBoxColor:        d.DisabledUncheckedBoxColor,
+                disabledIndeterminateBoxColor:    d.DisabledIndeterminateBoxColor,
+                checkedBorderColor:               checkedColor   ?? d.CheckedBorderColor,
+                uncheckedBorderColor:             uncheckedColor ?? d.UncheckedBorderColor,
+                disabledBorderColor:              d.DisabledBorderColor,
+                disabledUncheckedBorderColor:     d.DisabledUncheckedBorderColor,
+                disabledIndeterminateBorderColor: d.DisabledIndeterminateBorderColor);
+        }
+        finally
+        {
+            composer.EndReplaceableGroup();
+        }
+    }
+}

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs
@@ -1,0 +1,80 @@
+using System.Runtime.CompilerServices;
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// Static factory mirroring Kotlin's
+/// <c>androidx.compose.material3.SwitchDefaults.colors(...)</c>. Returns
+/// a <see cref="SwitchColors"/> overriding only the slots the caller
+/// supplies; the rest fall back to the current <c>MaterialTheme</c>.
+/// </summary>
+public static partial class ComposeExtensions
+{
+    /// <summary>
+    /// Build a <see cref="SwitchColors"/> with the four "common"
+    /// override slots — thumb / track for both the checked and
+    /// unchecked states — wired to the bound parameterised
+    /// <c>SwitchDefaults.colors(c1..c16, composer, $default, $changed, $changed1)</c>
+    /// overload.
+    ///
+    /// <para>Every slot left <c>null</c> stays "use Kotlin's default";
+    /// the corresponding bit in the <c>$default</c> bitmask stays set
+    /// and Kotlin substitutes the theme's <c>colorScheme</c> entry. The
+    /// 16 slot order matches the bytecode lowering of the
+    /// <c>@JvmInline value class Color</c> parameters: thumb / track /
+    /// border / icon — checked, unchecked, disabled-checked,
+    /// disabled-unchecked.</para>
+    /// </summary>
+    public static SwitchColors SwitchColors(
+        this IComposer composer,
+        long? checkedThumbColor   = null,
+        long? checkedTrackColor   = null,
+        long? uncheckedThumbColor = null,
+        long? uncheckedTrackColor = null,
+        [CallerLineNumber] int line = 0,
+        [CallerFilePath] string file = "")
+    {
+        ArgumentNullException.ThrowIfNull(composer);
+
+        // Default mask: every bit set = "use Kotlin's default for that
+        // slot". Clear a bit when the caller passes a value. Matches
+        // the slot order on the bound `colors(...)` overload.
+        int defaults = 0xFFFF;
+        if (checkedThumbColor   is not null) defaults &= ~(1 <<  0);
+        if (checkedTrackColor   is not null) defaults &= ~(1 <<  1);
+        if (uncheckedThumbColor is not null) defaults &= ~(1 <<  4);
+        if (uncheckedTrackColor is not null) defaults &= ~(1 <<  5);
+
+        composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
+        try
+        {
+            return AndroidX.Compose.Material3.SwitchDefaults.Instance.Colors(
+                checkedThumbColor:            checkedThumbColor   ?? 0L,
+                checkedTrackColor:            checkedTrackColor   ?? 0L,
+                checkedBorderColor:           0L,
+                checkedIconColor:             0L,
+                uncheckedThumbColor:          uncheckedThumbColor ?? 0L,
+                uncheckedTrackColor:          uncheckedTrackColor ?? 0L,
+                uncheckedBorderColor:         0L,
+                uncheckedIconColor:           0L,
+                disabledCheckedThumbColor:    0L,
+                disabledCheckedTrackColor:    0L,
+                disabledCheckedBorderColor:   0L,
+                disabledCheckedIconColor:     0L,
+                disabledUncheckedThumbColor:  0L,
+                disabledUncheckedTrackColor:  0L,
+                disabledUncheckedBorderColor: 0L,
+                disabledUncheckedIconColor:   0L,
+                _composer: composer,
+                p17:       defaults,
+                _changed:  0,
+                _changed1: 0);
+        }
+        finally
+        {
+            composer.EndReplaceableGroup();
+        }
+    }
+}

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs
@@ -39,13 +39,15 @@ public static partial class ComposeExtensions
         ArgumentNullException.ThrowIfNull(composer);
 
         // Default mask: every bit set = "use Kotlin's default for that
-        // slot". Clear a bit when the caller passes a value. Matches
-        // the slot order on the bound `colors(...)` overload.
-        int defaults = 0xFFFF;
-        if (checkedThumbColor   is not null) defaults &= ~(1 <<  0);
-        if (checkedTrackColor   is not null) defaults &= ~(1 <<  1);
-        if (uncheckedThumbColor is not null) defaults &= ~(1 <<  4);
-        if (uncheckedTrackColor is not null) defaults &= ~(1 <<  5);
+        // slot". Clear a bit when the caller passes a value. The enum
+        // is generated from the declarative `[assembly: ComposeDefaults]`
+        // entry; member ordering matches the slot order on the bound
+        // `colors(...)` overload.
+        var defaults = SwitchColorsDefault.All;
+        if (checkedThumbColor   is not null) defaults &= ~SwitchColorsDefault.CheckedThumbColor;
+        if (checkedTrackColor   is not null) defaults &= ~SwitchColorsDefault.CheckedTrackColor;
+        if (uncheckedThumbColor is not null) defaults &= ~SwitchColorsDefault.UncheckedThumbColor;
+        if (uncheckedTrackColor is not null) defaults &= ~SwitchColorsDefault.UncheckedTrackColor;
 
         composer.StartReplaceableGroup(SourceLocationKey.Compute(line, file));
         try
@@ -68,7 +70,7 @@ public static partial class ComposeExtensions
                 disabledUncheckedBorderColor: 0L,
                 disabledUncheckedIconColor:   0L,
                 _composer: composer,
-                p17:       defaults,
+                p17:       (int)defaults,
                 _changed:  0,
                 _changed1: 0);
         }

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -142,6 +142,8 @@ AndroidX.Compose.CenterAlignedTopAppBar.Title.get -> AndroidX.Compose.Composable
 AndroidX.Compose.CenterAlignedTopAppBar.Title.set -> void
 AndroidX.Compose.Checkbox
 AndroidX.Compose.Checkbox.Checkbox(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
+AndroidX.Compose.Checkbox.Colors.get -> AndroidX.Compose.Material3.CheckboxColors?
+AndroidX.Compose.Checkbox.Colors.set -> void
 AndroidX.Compose.CircularProgressIndicator
 AndroidX.Compose.CircularProgressIndicator.CircularProgressIndicator() -> void
 AndroidX.Compose.CircularProgressIndicator.Color.get -> AndroidX.Compose.Color?
@@ -1118,6 +1120,8 @@ AndroidX.Compose.Surface.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.Surface.Shape.set -> void
 AndroidX.Compose.Surface.Surface() -> void
 AndroidX.Compose.Switch
+AndroidX.Compose.Switch.Colors.get -> AndroidX.Compose.Material3.SwitchColors?
+AndroidX.Compose.Switch.Colors.set -> void
 AndroidX.Compose.Switch.Switch(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
 AndroidX.Compose.Tab
 AndroidX.Compose.Tab.Icon.get -> AndroidX.Compose.ComposableNode?
@@ -1531,6 +1535,7 @@ static AndroidX.Compose.Color.Yellow.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Composed.implicit operator AndroidX.Compose.Composed!(System.Func<AndroidX.Compose.Runtime.IComposer!, AndroidX.Compose.ComposableNode?>! builder) -> AndroidX.Compose.Composed!
 static AndroidX.Compose.ComposeExtensions.BooleanResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> bool
 static AndroidX.Compose.ComposeExtensions.ButtonColors(this AndroidX.Compose.Runtime.IComposer! composer, long? containerColor = null, long? contentColor = null, long? disabledContainerColor = null, long? disabledContentColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.ButtonColors!
+static AndroidX.Compose.ComposeExtensions.CheckboxColors(this AndroidX.Compose.Runtime.IComposer! composer, long? checkedColor = null, long? uncheckedColor = null, long? checkmarkColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.CheckboxColors!
 static AndroidX.Compose.ComposeExtensions.CollectAsStateWithLifecycle<T>(this Xamarin.KotlinX.Coroutines.Flow.IFlow! flow, T initialValue, AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.CollectedState<T>!
 static AndroidX.Compose.ComposeExtensions.CollectAsStateWithLifecycle<T>(this Xamarin.KotlinX.Coroutines.Flow.IStateFlow! stateFlow, AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.CollectedState<T>!
 static AndroidX.Compose.ComposeExtensions.ColorResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> long
@@ -1588,6 +1593,7 @@ static AndroidX.Compose.ComposeExtensions.SnapshotFlow<T>(System.Func<T>! produc
 static AndroidX.Compose.ComposeExtensions.StringArrayResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> string![]!
 static AndroidX.Compose.ComposeExtensions.StringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id, params object?[]! formatArgs) -> string!
 static AndroidX.Compose.ComposeExtensions.StringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> string!
+static AndroidX.Compose.ComposeExtensions.SwitchColors(this AndroidX.Compose.Runtime.IComposer! composer, long? checkedThumbColor = null, long? checkedTrackColor = null, long? uncheckedThumbColor = null, long? uncheckedTrackColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.SwitchColors!
 static AndroidX.Compose.ComposeExtensions.Typography(this AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.Material3.Typography!
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, int line = 0, string! file = "") -> T!
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, object? key1, int line = 0, string! file = "") -> T!


### PR DESCRIPTION
## Scope

Phase 2 Slice 3 of the .NET MAUI Compose backend — three new
toggle / selected leaves on top of `Microsoft.AndroidX.Compose`
facades, registered via `UseAndroidXCompose()`:

| MAUI control                            | Compose facade                                  | Mapper baseline                                                                                  |
|-----------------------------------------|-------------------------------------------------|--------------------------------------------------------------------------------------------------|
| `Microsoft.Maui.Controls.CheckBox`      | `Microsoft.AndroidX.Compose.Checkbox`           | `IsChecked` (two-way), `Foreground` → `CheckboxColors.checkedColor`                              |
| `Microsoft.Maui.Controls.Switch`        | `Microsoft.AndroidX.Compose.Switch`             | `IsOn` (two-way), `TrackColor`, `ThumbColor` → `SwitchColors`                                    |
| `Microsoft.Maui.Controls.RadioButton`   | `Microsoft.AndroidX.Compose.RadioButton`        | `IsChecked` (two-way), `Content` (string), `TextColor`, `Font` — rendered as `Row { Radio, Text }` |

Each handler is a `ComposeElementHandler<T>` contributing a
`ComposableNode` via `BuildNode(IComposer)`; two-way state binding
mirrors `EntryHandler.OnValueChanged` verbatim — `MutableState<bool>`
equality short-circuits the round-trip, so no `_suppressMauiWrite`
flag is needed.

The Compose facades are extended with a `Colors { get; set; }` slot
mirroring `Button.Colors`, plus new `composer.CheckboxColors(...)` /
`composer.SwitchColors(...)` factory extensions for partial overrides.
Public API surface added in `PublicAPI.Unshipped.txt`.

## Files

- **Handlers** (new):
  - `src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs`
  - `src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs`
  - `src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs`
- **Facade extensions** (new):
  - `src/Microsoft.AndroidX.Compose/ComposeExtensions.CheckboxDefaults.cs`
  - `src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs`
- **Facade bridges & registry** (modified):
  - `src/Microsoft.AndroidX.Compose/ComposeBridges.cs` — `colors` slot on Checkbox / Switch
  - `src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeReferenceTypes.cs` — registers `CheckboxColors` / `SwitchColors`
  - `src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt`
- **Hosting** (modified):
  - `src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs` — three new `AddHandler<>` lines + extended XML doc
- **Sample** (new + modified):
  - `src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/TogglesPage.xaml` (+ `.xaml.cs`)
  - `HomePage.xaml`, `HomePage.xaml.cs`, `AppShell.xaml.cs` — nav entry + route registration + description text update ("four" → "seven" handlers)
- **Docs** (modified):
  - `docs/maui-backend.md` — new "Phase 2 Slice 3 — toggle leaves" subsection mirroring the prose style of Slice 1 / Slice 2

## Lessons learned

- **Two-way binding for `bool` state needs no guard flag.** `MutableState<bool>`
  short-circuits on equality (Compose's
  `SnapshotMutationPolicy.StructuralEquality`), so the round-trip
  Compose `onCheckedChange` → write `VirtualView.IsChecked` →
  `MapIsChecked` → `_state.Value = …` settles in one cycle. Same
  pattern as `EntryHandler.OnValueChanged` — copied verbatim.
- **`ICheckBox.Foreground` (not `Color`).** MAUI's `CheckBox.Color` XAML
  attribute lowers to a `Paint` on the `IShape.Foreground` interface
  property. Map `Foreground`, forward only `SolidPaint` through
  `ColorMapping.ToPackedLong`; gradients fall back to default M3 chrome.
- **`ISwitch.IsOn` (not `IsToggled`).** `IsToggled` is the property
  name on the concrete `Microsoft.Maui.Controls.Switch`; the handler
  interface exposes it as `IsOn`. Mapper key is `nameof(ISwitch.IsOn)`.
- **`IRadioButton.Content` lives on the concrete control, not the
  interface.** Cast `VirtualView` to `Microsoft.Maui.Controls.RadioButton`
  inside the mapper and forward `Content?.ToString()`. View-typed
  content isn't supported in this slice — pass a string.
- **Don't reimplement `RadioButtonGroup` semantics.** MAUI's
  `RadioButtonGroupController` already handles the previous-selection
  write-back when one radio in a `GroupName` flips on; the handler
  just surfaces `IsChecked` honestly. The Compose `RadioButton`
  composable's `onClick` only fires on unselected → selected (Kotlin
  contract), so a tap on an already-checked radio is a no-op and
  the group controller never sees a spurious `false` round-trip.
- **`CheckboxColors.Copy(...)` is the only path for partial override.**
  The parameterised 12-arg `CheckboxDefaults.colors(...)` factory ships
  in Material3 but is binder-stripped because every param is a
  `@JvmInline value class Color` (mangled JVM name `colors-rGdcdEs`).
  Workaround: zero-arg `Colors(composer, 0)` to get a defaulted
  instance, then thread through `.Copy(...)` reading every default
  and substituting non-null overrides. `SwitchColors`'s 16-arg factory
  IS bound (`long` packs `Color` as a primitive), so it builds the
  `$default` mask directly.
- **Stale `Generated/` folder bites the facade generator.** A previous
  `EmitCompilerGeneratedFiles=true` run wrote
  `Microsoft.AndroidX.Compose/Generated/` with stale facade ctor
  bodies that compiled alongside the regenerated ones in `obj/`.
  Symptom: `bool enabled = true` default silently dropped from
  Checkbox/Switch ctors. Don't enable that flag while iterating on
  generators — wipe both `Generated/` and `obj/Debug/` if it gets
  enabled by accident.

## Verification

```pwsh
dotnet build src/Microsoft.AndroidX.Compose.Maui            # 0 warnings, 0 errors
dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample     # 0 warnings, 0 errors
dotnet test  src/Microsoft.AndroidX.Compose.SourceGenerators.Tests  # 154 passed
```

On-device:

```pwsh
dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample -t:Install
adb shell am start -n net.compose.maui.sample/crc645d633bf51a3beaf9.MainActivity
# navigate to "Toggles"
adb shell uiautomator dump /sdcard/d.xml; adb pull /sdcard/d.xml -
```

`TogglesPage` renders with **exactly one**
`androidx.compose.ui.platform.ComposeView` per dump (matches the Slice 2
single-ComposeView-per-page invariant). All three control kinds expose
`clickable=true checkable=true` so accessibility services see them as
toggles, not opaque views. Echo `Label`s flip on tap, confirming the
two-way feedback loop round-trips.