### PR TITLE
MAUI Image: apply Modifier.FillMaxSize() so Aspect modes work

### DIFF
--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
@@ -98,13 +98,23 @@ public partial class ImageHandler : ComposeElementHandler<MauiIImage>
     /// <inheritdoc/>
     public override ComposableNode BuildNode(IComposer composer)
     {
+        var cs = _contentScale.Value;
+        // Without a sizing modifier, Compose's `Image` measures itself
+        // against the painter's intrinsic size and `ContentScale` has
+        // no visible effect (the layout box exactly matches the
+        // scaled painter, so Fit / Crop / FillBounds all produce the
+        // same result). `Modifier.fillMaxSize()` makes the Image
+        // honour the layout box MAUI sized for the platform view —
+        // which is what `HeightRequest`/`WidthRequest` on the
+        // `<Image>` virtual view feed in to.
+        var modifier = Modifier.FillMaxSize();
         // Painter wins over the resource id so a freshly-loaded
         // BitmapPainter immediately replaces any stale fast-path
         // drawable. Both null => empty placeholder.
         if (_painter.Value is { } painter)
-            return new ComposeImage(painter) { ContentScale = _contentScale.Value };
+            return new ComposeImage(painter) { ContentScale = cs, Modifier = modifier };
         if (_drawableResourceId.Value is int id)
-            return new ComposeImage(id) { ContentScale = _contentScale.Value };
+            return new ComposeImage(id) { ContentScale = cs, Modifier = modifier };
         return new Box();
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
@@ -95,26 +95,29 @@ public partial class ImageHandler : ComposeElementHandler<MauiIImage>
     public ImageHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
+    // Without a sizing modifier, Compose's `Image` measures itself
+    // against the painter's intrinsic size and `ContentScale` has no
+    // visible effect (the layout box exactly matches the scaled
+    // painter, so Fit / Crop / FillBounds all produce the same
+    // result). `Modifier.fillMaxSize()` makes the Image honour the
+    // layout box MAUI sized for the platform view — which is what
+    // `HeightRequest` / `WidthRequest` on the `<Image>` virtual view
+    // feed into. The `Modifier` chain itself is an immutable POCO
+    // (just an op array); we cache one instance and share it across
+    // every handler / Render pass.
+    static readonly Modifier s_fillMaxSize = Modifier.FillMaxSize();
+
     /// <inheritdoc/>
     public override ComposableNode BuildNode(IComposer composer)
     {
         var cs = _contentScale.Value;
-        // Without a sizing modifier, Compose's `Image` measures itself
-        // against the painter's intrinsic size and `ContentScale` has
-        // no visible effect (the layout box exactly matches the
-        // scaled painter, so Fit / Crop / FillBounds all produce the
-        // same result). `Modifier.fillMaxSize()` makes the Image
-        // honour the layout box MAUI sized for the platform view —
-        // which is what `HeightRequest`/`WidthRequest` on the
-        // `<Image>` virtual view feed in to.
-        var modifier = Modifier.FillMaxSize();
         // Painter wins over the resource id so a freshly-loaded
         // BitmapPainter immediately replaces any stale fast-path
         // drawable. Both null => empty placeholder.
         if (_painter.Value is { } painter)
-            return new ComposeImage(painter) { ContentScale = cs, Modifier = modifier };
+            return new ComposeImage(painter) { ContentScale = cs, Modifier = s_fillMaxSize };
         if (_drawableResourceId.Value is int id)
-            return new ComposeImage(id) { ContentScale = cs, Modifier = modifier };
+            return new ComposeImage(id) { ContentScale = cs, Modifier = s_fillMaxSize };
         return new Box();
     }
 


### PR DESCRIPTION
Without a sizing `Modifier`, Compose's `Image` measures itself against the
painter's intrinsic size and `ContentScale` has no visible effect — the
layout box is sized to match the painter at `ContentScale.Fit`, so
`Crop` / `FillBounds` produce the same result.

The MAUI `Image: Aspects` sample showed this off perfectly: all four tiles
(`AspectFit` / `AspectFill` / `Fill` / `Center`) rendered identically
because the layout box was always painter‑intrinsic × Fit.

Fix: apply `Modifier.FillMaxSize()` in `ImageHandler.BuildNode` so the
Compose `Image` honours the layout box MAUI sized for the platform view —
which is what `HeightRequest` / `WidthRequest` on the `<Image>` virtual
view feed into via `ComposeView`'s measure pass.

### Result

After the fix each `Aspect` mode produces a visibly different layout on
the sample page:

- **AspectFit** — full image, gray letterbox bars top/bottom (image is
  wider than the tile).
- **AspectFill** — fills the tile edge‑to‑edge; bot/letters at the
  edges of the painter clipped.
- **Fill** — stretched/squished to the tile dimensions, ignoring
  aspect ratio.
- **Center** — falls back to Fit (handler already documents the
  fallback in the sample page comments).

### Investigation notes

- Initial hypothesis (JNI / peer collision on `ContentScale`) was disproved
  with logcat instrumentation: each handler instance receives its own
  distinct `ContentScale` JNI handle.
- The Kotlin signature for `ImageKt.Image(Painter, …)` matches the bridge
  exactly (verified via `javap` on `ImageKt.class`).
- Root cause is a layout problem, not a bridge problem.
