### PR TITLE
MAUI Phase 2 Slice 5: picker family (Picker, DatePicker, TimePicker)

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -602,6 +602,98 @@ page so cross-sibling animation, semantics, and a single
   consumes pointer events for its own composition. Workaround: put
   a stock leaf in the cell, or convert the container.
 
+#### Phase 2 Slice 5 — picker family
+
+**Goal:** re-skin MAUI's `Picker`, `DatePicker`, and `TimePicker` over
+Compose's modal pickers. This is the first MAUI slice to lean on
+**state-holder** facades (`DatePickerState` Phase 4, `TimePickerState`
+Phase 4b) — the sticking points all came from the gap between
+short-lived MAUI events (`DateSelected`, `Time` `PropertyChanged`,
+`SelectedIndexChanged`) and Compose's "remember once, mutate state
+forever" model.
+
+**Delivered:**
+
+- `Microsoft.AndroidX.Compose.Maui.Handlers.PickerHandler` over
+  `ExposedDropdownMenuBox` + `OutlinedTextField` (read-only) +
+  `ExposedDropdownMenu` of `DropdownMenuItem`s. Watches
+  `IPicker.Items` (`INotifyCollectionChanged`-aware) so external
+  mutations to the bound list bump a version counter and rebuild the
+  menu. Mappers: `ItemsSource`, `SelectedIndex`, `Title`, `TitleColor`,
+  `TextColor`, `FontSize`, `FontAttributes`, `HorizontalLayoutAlignment`.
+- `Microsoft.AndroidX.Compose.Maui.Handlers.DatePickerHandler` over a
+  trigger-style `OutlinedButton` (label = formatted date) that opens
+  `DatePickerDialog { DatePicker(state) }` on tap. Confirm reads
+  `DatePickerState.SelectedDateMillis`. Mappers: `Date`, `MinimumDate`,
+  `MaximumDate`, `Format`, `TextColor`.
+- `Microsoft.AndroidX.Compose.Maui.Handlers.TimePickerHandler` over an
+  `OutlinedButton` + `TimePickerDialog { TimePicker(state) }` of the
+  same shape. Confirm reads `state.Hour` / `state.Minute`. Mappers:
+  `Time`, `Format`, `TextColor`.
+- Three `handlers.AddHandler<>` lines in `AppHostBuilderExtensions`.
+- `PickersPage` sample page + `HomePage` / `AppShell` wiring.
+
+No facade extensions were needed — `DatePickerDialog`,
+`TimePickerDialog`, `ExposedDropdownMenuBox`, `ExposedDropdownMenu`,
+`DropdownMenuItem`, `OutlinedButton` are all already
+`[ComposeFacade]`-generated.
+
+**Lessons learned (Slice 5):**
+
+- **`MutableState<DateTime>` / `MutableState<TimeSpan>` are impossible**
+  for the same reason as Slice 2 — neither is a `Java.Lang.Object`
+  subclass nor a recognised primitive. The handler stores the value
+  as `MutableState<long?>` of `Ticks` and reconstitutes the struct
+  inside `BuildNode`. Min/Max bounds use the same pattern.
+- **`MutableState<IList>` is also impossible.** `Picker.Items` is
+  surfaced as a version-counter (`MutableState<int>`) bumped from
+  both `MapItemsSource` (when the bound source is replaced) and
+  `INotifyCollectionChanged.CollectionChanged` (when the same source
+  mutates in place). The handler reads `VirtualView.Items` live
+  inside `BuildNode`. Subscriptions live and die with `SetVirtualView`
+  / `DisconnectHandler` so we never leak a CollectionChanged handler
+  past the virtual view.
+- **`DatePickerState.Jvm` is `internal`**, so the MAUI handler can't
+  null-check it before pushing values into the wrapper. The state's
+  setter (`SelectedDateMillis = ms`) is already a silent no-op until
+  Compose binds the JVM peer on the first call to `DatePicker(state)`.
+  We seed the state from `MutableState<long?> _ticks` inside a
+  `LaunchedEffect` *sibling* to the `DatePickerDialog` — by the time
+  the effect runs, `Jvm` is non-null and the assignment lands.
+- **`TimePickerState` is Phase 4b** — the wrapper takes
+  `initialHour`, `initialMinute`, `is24Hour` as ctor args. We re-key
+  `c.Remember(factory, ticks, is24Hour)` so external `Time` writes
+  from MAUI refresh the wrapper on the next composition (between
+  dialog opens). Inside an open dialog Compose's own `remember`
+  contract still holds — the user's drags don't tear down the
+  wrapper.
+- **Two-way feedback loop** matches `EntryHandler`: write the new
+  value into the local `MutableState` first (so the equality
+  short-circuit on the next `Map*` call breaks the loop), then
+  forward to `VirtualView.<prop>`. The MAUI side fires its own
+  `PropertyChanged` on the way back in, but the mapper sees the value
+  it already stored and stops.
+
+**Verified on device** (Pickers sample page):
+
+- `Picker` opens its dropdown, selecting an item updates the trigger
+  text, `SelectedIndexChanged` fires once, and the echo `Label`
+  reflects the chosen string.
+- `DatePicker` opens the modal calendar, the prior selection is
+  pre-highlighted (Slice's confirmed `LaunchedEffect`-keyed seeding
+  works), confirming writes back through `DateSelected`, and the
+  ±2y `MinimumDate` / `MaximumDate` clamp greys out unreachable
+  months.
+- `TimePicker` opens the clock face at `7:30` (default) the first
+  time, then at the most-recently-confirmed value on subsequent
+  opens. `Time` `PropertyChanged` echoes once per confirm.
+- Reset button writes through all three handlers; subsequent dialog
+  opens display the reset values.
+- `adb shell uiautomator dump` shows **exactly one**
+  `androidx.compose.ui.platform.ComposeView` node on `PickersPage`
+  itself. The picker dialogs are separate windows (own
+  `ComposeView`), as expected for modal Compose surfaces.
+
 ### Phase 3 — collection + container (target: list-driven apps)
 
 `CollectionView` → `LazyColumn<T>` / `LazyRow<T>` / `LazyVerticalGrid<T>`

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -21,5 +21,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("entries",        typeof(EntriesPage));
         Routing.RegisterRoute("image-aspects",  typeof(ImageAspectsPage));
         Routing.RegisterRoute("image-sources",  typeof(ImageSourcesPage));
+        Routing.RegisterRoute("pickers",        typeof(PickersPage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml
@@ -27,7 +27,7 @@
                        TextColor="White"
                        FontSize="28"
                        FontAttributes="Bold" />
-                <Label Text="Each row exercises one of the four Compose-backed handlers (Button, Entry, Image, Label) wired by UseAndroidXCompose()."
+                <Label Text="Each row exercises one of the seven Compose-backed handlers (Button, DatePicker, Entry, Image, Label, Picker, TimePicker) wired by UseAndroidXCompose()."
                        TextColor="White"
                        Opacity="0.85"
                        FontSize="13" />

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -60,6 +60,11 @@ public partial class HomePage : ContentPage
                 "File / Uri / Stream / Font image source types.",
                 Color.FromArgb("#E91E63"),
                 "image-sources"),
+            new DemoEntry(
+                "Pickers",
+                "Picker, DatePicker, TimePicker (state-holder dialogs).",
+                Color.FromArgb("#FF9800"),
+                "pickers"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml
@@ -13,7 +13,7 @@
             * Picker.Title                   -> MapTitle (floating label)
             * DatePicker.Date                -> MapDate (DateSelected echoes the formatted date)
             * DatePicker.MinimumDate /
-              MaximumDate                    -> MapMinimumDate / MapMaximumDate (clamp ±2y)
+              MaximumDate                    -> not yet wired (Phase 4b RememberDatePickerState lift required; tracked in #264)
             * TimePicker.Time                -> MapTime (PropertyChanged echoes time)
             * Format / TextColor / FontSize /
               FontAttributes (Bold)          -> MapFormat / MapTextColor / MapFont
@@ -53,7 +53,7 @@
                 x:Name="FruitEcho"
                 Text="No fruit picked yet." />
 
-            <Label Text="DatePicker (modal calendar) — Min/Max clamp the selectable range to ±2y from today."
+            <Label Text="DatePicker (modal calendar) — opens a Compose DatePickerDialog; selection writes back via DateSelected."
                    FontAttributes="Bold" />
 
             <DatePicker

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:sys="clr-namespace:System;assembly=netstandard"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.PickersPage"
+             Title="Pickers">
+
+    <!--
+        Exercises every mapper on `PickerHandler`, `DatePickerHandler`,
+        and `TimePickerHandler`:
+            * Picker.ItemsSource             -> MapItemsSource (version-counter rebuild)
+            * Picker.SelectedIndex / Item    -> MapSelectedIndex (two-way echo via SelectedIndexChanged)
+            * Picker.Title                   -> MapTitle (floating label)
+            * DatePicker.Date                -> MapDate (DateSelected echoes the formatted date)
+            * DatePicker.MinimumDate /
+              MaximumDate                    -> MapMinimumDate / MapMaximumDate (clamp ±2y)
+            * TimePicker.Time                -> MapTime (PropertyChanged echoes time)
+            * Format / TextColor / FontSize /
+              FontAttributes (Bold)          -> MapFormat / MapTextColor / MapFont
+            * HorizontalLayoutAlignment      -> MapHorizontalLayoutAlignment
+              (toggles `Modifier.fillMaxWidth()` on the trigger).
+    -->
+    <ContentPage.Resources>
+        <x:Array x:Key="Fruits" Type="{x:Type sys:String}">
+            <sys:String>Apple</sys:String>
+            <sys:String>Banana</sys:String>
+            <sys:String>Cherry</sys:String>
+            <sys:String>Date</sys:String>
+            <sys:String>Elderberry</sys:String>
+        </x:Array>
+    </ContentPage.Resources>
+
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="20">
+
+            <Label
+                Text="Pickers"
+                Style="{StaticResource Headline}" />
+
+            <Label Text="Picker (dropdown menu) — pick a fruit; the label below echoes."
+                   FontAttributes="Bold" />
+
+            <Picker
+                x:Name="FruitPicker"
+                Title="Pick a fruit"
+                ItemsSource="{StaticResource Fruits}"
+                SelectedIndexChanged="OnFruitChanged"
+                HorizontalOptions="Fill" />
+
+            <Label
+                x:Name="FruitEcho"
+                Text="No fruit picked yet." />
+
+            <Label Text="DatePicker (modal calendar) — Min/Max clamp the selectable range to ±2y from today."
+                   FontAttributes="Bold" />
+
+            <DatePicker
+                x:Name="BirthDate"
+                Format="MMM d, yyyy"
+                DateSelected="OnDateSelected"
+                HorizontalOptions="Fill" />
+
+            <Label
+                x:Name="DateEcho"
+                Text="No date picked yet." />
+
+            <Label Text="TimePicker (modal clock) — 24-hour format selected by 'HH:mm'."
+                   FontAttributes="Bold" />
+
+            <TimePicker
+                x:Name="AlarmTime"
+                Format="HH:mm"
+                HorizontalOptions="Fill" />
+
+            <Label
+                x:Name="TimeEcho"
+                Text="No time picked yet." />
+
+            <Button
+                Text="Reset"
+                Clicked="OnResetClicked"
+                HorizontalOptions="Fill" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml.cs
@@ -1,0 +1,65 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+using System.ComponentModel;
+
+/// <summary>
+/// Pickers demo — exercises every mapper on
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.PickerHandler"/>,
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.DatePickerHandler"/>,
+/// and <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.TimePickerHandler"/>:
+/// ItemsSource + SelectedIndex (Picker, two-way echo via SelectedIndexChanged),
+/// Date + MinimumDate + MaximumDate + Format (DatePicker, two-way echo via
+/// DateSelected), Time + Format (TimePicker, two-way echo via the
+/// <c>PropertyChanged</c> event surfaced by <see cref="BindableObject"/>),
+/// and a Reset button that pushes new values back through the handlers.
+/// </summary>
+public partial class PickersPage : ContentPage
+{
+    static readonly TimeSpan s_defaultAlarm = new(7, 30, 0);
+    static readonly DateTime s_defaultDate  = new(2000, 1, 1);
+
+    /// <summary>Build the page.</summary>
+    public PickersPage()
+    {
+        InitializeComponent();
+
+        // Clamp the date picker to ±2 years from today so the
+        // MinimumDate / MaximumDate mappers are easy to verify.
+        var today = DateTime.Today;
+        BirthDate.MinimumDate = today.AddYears(-2);
+        BirthDate.MaximumDate = today.AddYears(2);
+        BirthDate.Date        = today;
+
+        AlarmTime.Time             = s_defaultAlarm;
+        AlarmTime.PropertyChanged += OnAlarmTimePropertyChanged;
+    }
+
+    void OnFruitChanged(object? sender, EventArgs e)
+    {
+        FruitEcho.Text = FruitPicker.SelectedItem is string s
+            ? $"You picked: {s}"
+            : "No fruit picked yet.";
+    }
+
+    void OnDateSelected(object? sender, DateChangedEventArgs e)
+    {
+        DateEcho.Text = $"You picked: {e.NewDate:MMM d, yyyy}";
+    }
+
+    void OnAlarmTimePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(TimePicker.Time))
+            return;
+        TimeEcho.Text = $"Alarm set for: {AlarmTime.Time:hh\\:mm}";
+    }
+
+    void OnResetClicked(object? sender, EventArgs e)
+    {
+        FruitPicker.SelectedIndex = -1;
+        FruitEcho.Text            = "No fruit picked yet.";
+        BirthDate.Date            = s_defaultDate;
+        DateEcho.Text             = "No date picked yet.";
+        AlarmTime.Time            = s_defaultAlarm;
+        TimeEcho.Text             = "No time picked yet.";
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml.cs
@@ -8,8 +8,8 @@ using System.ComponentModel;
 /// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.DatePickerHandler"/>,
 /// and <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.TimePickerHandler"/>:
 /// ItemsSource + SelectedIndex (Picker, two-way echo via SelectedIndexChanged),
-/// Date + MinimumDate + MaximumDate + Format (DatePicker, two-way echo via
-/// DateSelected), Time + Format (TimePicker, two-way echo via the
+/// Date + Format (DatePicker, two-way echo via DateSelected),
+/// Time + Format (TimePicker, two-way echo via the
 /// <c>PropertyChanged</c> event surfaced by <see cref="BindableObject"/>),
 /// and a Reset button that pushes new values back through the handlers.
 /// </summary>
@@ -23,8 +23,13 @@ public partial class PickersPage : ContentPage
     {
         InitializeComponent();
 
-        // Clamp the date picker to ±2 years from today so the
-        // MinimumDate / MaximumDate mappers are easy to verify.
+        // Seed the date picker with today so the trigger label has
+        // something useful to display before the user opens the dialog.
+        // MinimumDate / MaximumDate are not yet plumbed through to
+        // Compose's DatePickerState (Phase 4 zero-user-param Remember
+        // doesn't surface yearRange yet — see issue #264). We still
+        // set them here on the MAUI side so the regression is obvious
+        // when the Phase 4b lift lands.
         var today = DateTime.Today;
         BirthDate.MinimumDate = today.AddYears(-2);
         BirthDate.MaximumDate = today.AddYears(2);

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
@@ -1,6 +1,7 @@
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Platform;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using ComposeColor          = AndroidX.Compose.Color;
 using ComposeDatePicker     = AndroidX.Compose.DatePicker;
@@ -113,8 +114,13 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
             {
                 BuildLabel(label, packed, size, bold),
             };
-            if (fill)
-                trigger.PrependModifier(Modifier.FillMaxWidth());
+            // Combines the layout-fill (when set) with the cross-cutting view
+            // properties (Opacity, Translation, Scale, Rotation, IsVisible,
+            // Clip, Shadow). The dialog is a separate window, so ViewProperties
+            // only applies to the trigger button.
+            var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
+                .ApplyViewProperties(VirtualView!);
+            trigger.PrependModifier(outer);
 
             var dialog = isOpen
                 ? new ComposeDatePickerDialog(onDismissRequest: () => _open.Value = false)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
@@ -1,0 +1,231 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.Maui.Handlers;
+using ComposeColor          = AndroidX.Compose.Color;
+using ComposeDatePicker     = AndroidX.Compose.DatePicker;
+using ComposeDatePickerDialog = AndroidX.Compose.DatePickerDialog;
+using ComposeFontWeight     = AndroidX.Compose.FontWeight;
+using ComposeOutlinedButton = AndroidX.Compose.OutlinedButton;
+using ComposeText           = AndroidX.Compose.Text;
+using MauiDatePicker        = Microsoft.Maui.Controls.DatePicker;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="MauiDatePicker"/> handler that renders through Jetpack
+/// Compose's Material 3 <see cref="ComposeDatePickerDialog"/>. Replaces
+/// MAUI's stock <c>DatePickerDialog</c> Java native handler when the
+/// consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>MAUI's <c>DatePicker</c> is dialog-style (not inline), so the
+/// composable surface mirrors the platform contract: an
+/// <see cref="ComposeOutlinedButton"/> trigger labelled with the
+/// formatted date pops up a Compose
+/// <see cref="ComposeDatePickerDialog"/> wrapping a
+/// <see cref="ComposeDatePicker"/>. <c>OK</c> writes the picked
+/// <see cref="DateTime"/> back to <see cref="IDatePicker.Date"/> so
+/// MAUI's standard property pipeline (data binding, behaviors,
+/// validation) fires normally.</para>
+///
+/// <para><see cref="DateTime"/> is a CLR struct so
+/// <see cref="MutableState{T}"/> doesn't model it directly — we round-trip
+/// through <c>long</c> ticks (<see cref="DateTime.Ticks"/>) and
+/// reconstitute live in <see cref="BuildNode(IComposer)"/>, the same
+/// trick <see cref="LayoutHandler"/> uses for <c>Thickness</c>.</para>
+///
+/// <para>Compose's <see cref="DatePickerState"/> wrapper exposes a
+/// <c>Jvm</c> field that's only populated <em>during</em> the first
+/// <see cref="ComposeDatePicker"/> render — writing
+/// <see cref="DatePickerState.SelectedDateMillis"/> before that point is
+/// silently dropped. We seed the state from MAUI's <c>Date</c> through
+/// a <see cref="LaunchedEffect"/> sibling that runs after composition,
+/// keyed on the trigger so reopening the dialog with a new external
+/// <c>Date</c> re-syncs.</para>
+/// </remarks>
+public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="IDatePicker"/> property
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<IDatePicker, DatePickerHandler> Mapper =
+        new PropertyMapper<IDatePicker, DatePickerHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(IDatePicker.Date)]                = MapDate,
+            [nameof(IDatePicker.MinimumDate)]         = MapMinimumDate,
+            [nameof(IDatePicker.MaximumDate)]         = MapMaximumDate,
+            [nameof(IDatePicker.Format)]              = MapFormat,
+            [nameof(ITextStyle.TextColor)]            = MapTextColor,
+            [nameof(ITextStyle.Font)]                 = MapFont,
+            [nameof(IView.HorizontalLayoutAlignment)] = MapHorizontalLayoutAlignment,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<IDatePicker, DatePickerHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<long?>  _ticks      = new((long?)null);
+    readonly MutableState<long?>  _minTicks   = new((long?)null);
+    readonly MutableState<long?>  _maxTicks   = new((long?)null);
+    readonly MutableState<string> _format     = new("d");
+    readonly MutableState<long?>  _textColor  = new((long?)null);
+    readonly MutableState<int?>   _fontSize   = new((int?)null);
+    readonly MutableState<bool>   _bold       = new(false);
+    readonly MutableState<bool>   _open       = new(false);
+    readonly MutableState<bool>   _fillWidth  = new(false);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public DatePickerHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public DatePickerHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        // Composer-aware: the DatePickerState wrapper has to live across
+        // recompositions or the dialog forgets the current selection,
+        // which means it goes through `composer.Remember(...)` rather
+        // than a handler field. Same `Composed` envelope as the gallery
+        // demo's `c => { … }` pattern.
+        return new Composed(c =>
+        {
+            var state = c.Remember(() => new DatePickerState());
+
+            var ticks   = _ticks.Value;
+            var format  = string.IsNullOrEmpty(_format.Value) ? "d" : _format.Value;
+            var packed  = _textColor.Value;
+            var size    = _fontSize.Value;
+            var bold    = _bold.Value;
+            var fill    = _fillWidth.Value;
+            var isOpen  = _open.Value;
+
+            var label = ticks is long t
+                ? new DateTime(t).ToString(format)
+                : "Pick a date";
+
+            var trigger = new ComposeOutlinedButton(onClick: () => _open.Value = true)
+            {
+                BuildLabel(label, packed, size, bold),
+            };
+            if (fill)
+                trigger.PrependModifier(Modifier.FillMaxWidth());
+
+            var dialog = isOpen
+                ? new ComposeDatePickerDialog(onDismissRequest: () => _open.Value = false)
+                {
+                    ConfirmButton = new TextButton(onClick: () =>
+                    {
+                        // state.Jvm is bound during the dialog's
+                        // composition (which is in the past, since the
+                        // user just clicked OK), so SelectedDateMillis
+                        // is live at this point.
+                        var ms = state.SelectedDateMillis;
+                        if (ms is long m)
+                        {
+                            // DatePicker emits midnight UTC; convert to
+                            // local-date DateTime so MAUI's Date getter
+                            // round-trips cleanly.
+                            var utc = DateTimeOffset.FromUnixTimeMilliseconds(m).UtcDateTime;
+                            var picked = new DateTime(utc.Year, utc.Month, utc.Day,
+                                                      0, 0, 0, DateTimeKind.Local);
+                            _ticks.Value = picked.Ticks;
+                            if (VirtualView is { } dp)
+                                dp.Date = picked;
+                        }
+                        _open.Value = false;
+                    })
+                    { new ComposeText("OK") },
+                    DismissButton = new TextButton(onClick: () => _open.Value = false)
+                    {
+                        new ComposeText("Cancel"),
+                    },
+                    Body = new ComposeDatePicker(state),
+                }
+                : (ComposableNode?)null;
+
+            // Seed the JVM state from MAUI's current Date once
+            // composition has wired it up. Keyed on _ticks so external
+            // changes to MAUI's Date re-sync; user-driven picks update
+            // SelectedDateMillis directly without re-keying so this
+            // doesn't fight the user. Setting SelectedDateMillis before
+            // the wrapper is bound is a silent no-op, so this runs
+            // unconditionally — once the first dialog opens and the
+            // DatePicker mounts, the next external Date push will
+            // re-fire the LE and the seeding sticks.
+            var seed = new LaunchedEffect((object?)ticks, ct =>
+            {
+                if (ticks is long localTicks)
+                {
+                    var dt = new DateTime(localTicks, DateTimeKind.Local).Date;
+                    var ms = new DateTimeOffset(dt.Year, dt.Month, dt.Day,
+                                                0, 0, 0, TimeSpan.Zero)
+                        .ToUnixTimeMilliseconds();
+                    state.SelectedDateMillis = ms;
+                }
+                return Task.CompletedTask;
+            });
+
+            return new Column
+            {
+                trigger,
+                dialog,
+                seed,
+            };
+        });
+    }
+
+    static ComposableNode BuildLabel(string text, long? packed, int? size, bool bold)
+    {
+        var node = new ComposeText(text);
+        if (packed.HasValue)
+            node.Color = new ComposeColor(packed.Value);
+        if (size.HasValue)
+            node.FontSize = new Sp(size.Value);
+        if (bold)
+            node.FontWeight = ComposeFontWeight.Bold;
+        return node;
+    }
+
+    /// <summary>Map <see cref="IDatePicker.Date"/> to the Compose ticks slot.</summary>
+    public static void MapDate(DatePickerHandler handler, IDatePicker dp) =>
+        handler._ticks.Value = dp.Date is DateTime d ? d.Ticks : null;
+
+    /// <summary>Map <see cref="IDatePicker.MinimumDate"/> to the Compose minimum-ticks slot.</summary>
+    public static void MapMinimumDate(DatePickerHandler handler, IDatePicker dp) =>
+        handler._minTicks.Value = dp.MinimumDate is DateTime d ? d.Ticks : null;
+
+    /// <summary>Map <see cref="IDatePicker.MaximumDate"/> to the Compose maximum-ticks slot.</summary>
+    public static void MapMaximumDate(DatePickerHandler handler, IDatePicker dp) =>
+        handler._maxTicks.Value = dp.MaximumDate is DateTime d ? d.Ticks : null;
+
+    /// <summary>Map <see cref="IDatePicker.Format"/> to the formatted-label slot.</summary>
+    public static void MapFormat(DatePickerHandler handler, IDatePicker dp) =>
+        handler._format.Value = string.IsNullOrEmpty(dp.Format) ? "d" : dp.Format!;
+
+    /// <summary>Map <see cref="ITextStyle.TextColor"/> to the Compose <c>TextStyle.Color</c> slot.</summary>
+    public static void MapTextColor(DatePickerHandler handler, IDatePicker dp) =>
+        handler._textColor.Value = ColorMapping.ToPackedLong(dp.TextColor);
+
+    /// <summary>Map <see cref="ITextStyle.Font"/> (size + bold) to the trigger label.</summary>
+    public static void MapFont(DatePickerHandler handler, IDatePicker dp)
+    {
+        var font = dp.Font;
+        handler._fontSize.Value = font.Size > 0 ? (int)font.Size : null;
+        handler._bold.Value     = (font.Weight & Microsoft.Maui.FontWeight.Bold)
+            == Microsoft.Maui.FontWeight.Bold;
+    }
+
+    /// <summary>
+    /// Map <see cref="IView.HorizontalLayoutAlignment"/> to
+    /// <c>Modifier.fillMaxWidth()</c> when the picker asks to fill its
+    /// slot — same parity rule as <see cref="EntryHandler"/>.
+    /// </summary>
+    public static void MapHorizontalLayoutAlignment(DatePickerHandler handler, IDatePicker dp) =>
+        handler._fillWidth.Value = dp.HorizontalLayoutAlignment
+            == Microsoft.Maui.Primitives.LayoutAlignment.Fill;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
@@ -1,0 +1,285 @@
+using System.Collections.Specialized;
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.Maui.Handlers;
+using ComposeColor          = AndroidX.Compose.Color;
+using ComposeFontWeight     = AndroidX.Compose.FontWeight;
+using ComposeOutlinedTextField = AndroidX.Compose.OutlinedTextField;
+using ComposeText           = AndroidX.Compose.Text;
+using ComposeTextStyle      = AndroidX.Compose.TextStyle;
+using MauiPicker            = Microsoft.Maui.Controls.Picker;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="MauiPicker"/> handler that renders through Jetpack
+/// Compose's Material 3 <see cref="ExposedDropdownMenuBox"/> +
+/// <see cref="ExposedDropdownMenu"/>. Replaces MAUI's stock
+/// <c>AppCompatSpinner</c>-based handler when the consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>The trigger is a read-only <see cref="ComposeOutlinedTextField"/>
+/// labelled with <see cref="MauiPicker.Title"/> and showing the
+/// currently-selected item. Tapping the trailing ▼ <see cref="IconButton"/>
+/// toggles the popup menu, which lists each entry from
+/// <see cref="Microsoft.Maui.IPicker.Items"/> as a
+/// <see cref="DropdownMenuItem"/>. Selecting an item writes back to
+/// <see cref="Microsoft.Maui.IPicker.SelectedIndex"/> so MAUI's standard
+/// property pipeline (data binding, behaviors, validation) fires
+/// normally; the resulting <c>SelectedIndexChanged</c> event re-enters
+/// the mapper, but the <see cref="MutableState{T}"/> equality check
+/// short-circuits the loop just like
+/// <see cref="EntryHandler.OnValueChanged(string)"/>.</para>
+///
+/// <para><see cref="Microsoft.Maui.IPicker.Items"/> is an
+/// <see cref="IList{T}"/> of strings — Compose's
+/// <see cref="MutableState{T}"/> doesn't model collection types
+/// directly. Use the <em>version-counter</em> pattern (same trick as
+/// <see cref="LayoutHandler"/>'s padding slot): bump
+/// <see cref="_itemsVersion"/> from <see cref="MapItemsSource(PickerHandler, MauiPicker)"/>
+/// and from <see cref="OnItemsCollectionChanged(object?, NotifyCollectionChangedEventArgs)"/>,
+/// then read <c>VirtualView.Items</c> live inside <see cref="BuildNode(IComposer)"/>.</para>
+///
+/// <para>Concrete <see cref="MauiPicker"/> exposes
+/// <see cref="MauiPicker.ItemsSource"/> on top of the <c>IPicker</c>
+/// surface; data-binding flows through that property. The mapper key
+/// is the bare string <c>"ItemsSource"</c> (the property doesn't live
+/// on the interface, same trick as <c>"Children"</c> on
+/// <see cref="LayoutHandler"/>).</para>
+/// </remarks>
+public partial class PickerHandler : ComposeElementHandler<IPicker>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="IPicker"/> property
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<IPicker, PickerHandler> Mapper =
+        new PropertyMapper<IPicker, PickerHandler>(ViewHandler.ViewMapper)
+        {
+            // ItemsSource is on the concrete Picker, not IPicker; use
+            // the bare-string key. Bumping _itemsVersion invalidates
+            // the dropdown menu's child list (Compose smart-skips
+            // siblings whose state is unchanged).
+            ["ItemsSource"]                           = MapItemsSource,
+            [nameof(IPicker.SelectedIndex)]           = MapSelectedIndex,
+            [nameof(IPicker.Title)]                   = MapTitle,
+            [nameof(IPicker.TitleColor)]              = MapTitleColor,
+            [nameof(ITextStyle.TextColor)]            = MapTextColor,
+            [nameof(ITextStyle.Font)]                 = MapFont,
+            [nameof(IView.HorizontalLayoutAlignment)] = MapHorizontalLayoutAlignment,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<IPicker, PickerHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<int>     _itemsVersion = new(0);
+    readonly MutableState<int>     _selectedIndex = new(-1);
+    readonly MutableState<string>  _title         = new(string.Empty);
+    readonly MutableState<long?>   _titleColor    = new((long?)null);
+    readonly MutableState<long?>   _textColor     = new((long?)null);
+    readonly MutableState<int?>    _fontSize      = new((int?)null);
+    readonly MutableState<bool>    _bold          = new(false);
+    readonly MutableState<bool>    _open          = new(false);
+    readonly MutableState<bool>    _fillWidth     = new(false);
+
+    INotifyCollectionChanged? _subscribedItems;
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public PickerHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public PickerHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    protected override void ConnectHandler(ComposeView platformView)
+    {
+        base.ConnectHandler(platformView);
+        SubscribeItems();
+    }
+
+    /// <inheritdoc/>
+    protected override void DisconnectHandler(ComposeView platformView)
+    {
+        UnsubscribeItems();
+        base.DisconnectHandler(platformView);
+    }
+
+    /// <inheritdoc/>
+    public override void SetVirtualView(IView view)
+    {
+        // Re-bind the items subscription to the new VirtualView whenever
+        // the handler is reused (MAUI sometimes recycles handlers across
+        // virtual views; defensive against tear-down/re-attach cycles).
+        UnsubscribeItems();
+        base.SetVirtualView(view);
+        SubscribeItems();
+    }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        // Subscribe to the version slot so external Items mutations
+        // recompose this subtree even when the live IList reference
+        // is identity-stable.
+        _ = _itemsVersion.Value;
+
+        var picker = VirtualView
+            ?? throw new InvalidOperationException("VirtualView not set on PickerHandler.");
+        var items = picker.Items;
+        var selectedIndex = _selectedIndex.Value;
+        var title = _title.Value;
+        var packedTextColor  = _textColor.Value;
+        var packedTitleColor = _titleColor.Value;
+        var size = _fontSize.Value;
+        var bold = _bold.Value;
+        var fill = _fillWidth.Value;
+        var isOpen = _open.Value;
+
+        var displayValue = selectedIndex >= 0 && selectedIndex < items.Count
+            ? items[selectedIndex] ?? string.Empty
+            : string.Empty;
+
+        var trigger = new ComposeOutlinedTextField(displayValue, _ => { /* read-only */ })
+        {
+            ReadOnly   = true,
+            SingleLine = true,
+            TrailingIcon = new IconButton(onClick: () => _open.Value = !_open.Value)
+            {
+                new ComposeText(isOpen ? "▲" : "▼"),
+            },
+        };
+        if (!string.IsNullOrEmpty(title))
+        {
+            trigger.Label = packedTitleColor.HasValue
+                ? new ComposeText(title) { Color = new ComposeColor(packedTitleColor.Value) }
+                : new ComposeText(title);
+        }
+        if (packedTextColor.HasValue || size.HasValue || bold)
+        {
+            trigger.TextStyle = new ComposeTextStyle
+            {
+                Color      = packedTextColor.HasValue ? new ComposeColor(packedTextColor.Value) : null,
+                FontSize   = size.HasValue   ? new Sp(size.Value) : null,
+                FontWeight = bold ? ComposeFontWeight.Bold : null,
+            };
+        }
+        if (fill)
+            trigger.PrependModifier(Modifier.FillMaxWidth());
+
+        var menu = new ExposedDropdownMenu(
+            expanded:         isOpen,
+            onDismissRequest: () => _open.Value = false);
+        for (int i = 0; i < items.Count; i++)
+        {
+            // Capture i so the click closure points at this row's index.
+            var index = i;
+            var label = items[i] ?? string.Empty;
+            menu.Add(new DropdownMenuItem(
+                text:    new ComposeText(label),
+                onClick: () => OnItemSelected(index)));
+        }
+
+        return new ExposedDropdownMenuBox(
+            expanded:         isOpen,
+            onExpandedChange: v => _open.Value = v)
+        {
+            trigger,
+            menu,
+        };
+    }
+
+    void OnItemSelected(int index)
+    {
+        // Update Compose state synchronously so the trigger label
+        // reflects the new selection on the next frame; the equality
+        // short-circuit on MutableState<int> breaks the
+        // MapSelectedIndex feedback loop, just like EntryHandler.
+        _selectedIndex.Value = index;
+        _open.Value          = false;
+        if (VirtualView is { } picker)
+            picker.SelectedIndex = index;
+    }
+
+    void SubscribeItems()
+    {
+        if (VirtualView is { } picker
+            && picker.Items is INotifyCollectionChanged ncc)
+        {
+            _subscribedItems = ncc;
+            ncc.CollectionChanged += OnItemsCollectionChanged;
+        }
+    }
+
+    void UnsubscribeItems()
+    {
+        if (_subscribedItems is { } ncc)
+        {
+            ncc.CollectionChanged -= OnItemsCollectionChanged;
+            _subscribedItems = null;
+        }
+    }
+
+    void OnItemsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        // External mutation to the bound list — bump the version slot
+        // so BuildNode re-reads VirtualView.Items.
+        _itemsVersion.Value++;
+    }
+
+    /// <summary>
+    /// Bump the items-version slot so the menu's child list rebuilds.
+    /// The mapper key is the bare string <c>"ItemsSource"</c> (defined
+    /// only on the concrete <see cref="MauiPicker"/>; the interface
+    /// only exposes the live <see cref="IPicker.Items"/> list). The
+    /// property pipeline still hands us the <see cref="IPicker"/>
+    /// virtualView, and <see cref="IPicker.Items"/> reflects whatever
+    /// MAUI just rebuilt from the new <c>ItemsSource</c>. We
+    /// re-subscribe to the new list's
+    /// <see cref="INotifyCollectionChanged"/> events so future
+    /// mutations also recompose.
+    /// </summary>
+    public static void MapItemsSource(PickerHandler handler, IPicker picker)
+    {
+        handler.UnsubscribeItems();
+        handler.SubscribeItems();
+        handler._itemsVersion.Value++;
+    }
+
+    /// <summary>Map <see cref="IPicker.SelectedIndex"/> to the Compose selection slot.</summary>
+    public static void MapSelectedIndex(PickerHandler handler, IPicker picker) =>
+        handler._selectedIndex.Value = picker.SelectedIndex;
+
+    /// <summary>Map <see cref="IPicker.Title"/> to the Compose label slot.</summary>
+    public static void MapTitle(PickerHandler handler, IPicker picker) =>
+        handler._title.Value = picker.Title ?? string.Empty;
+
+    /// <summary>Map <see cref="IPicker.TitleColor"/> to the floating-label colour slot.</summary>
+    public static void MapTitleColor(PickerHandler handler, IPicker picker) =>
+        handler._titleColor.Value = ColorMapping.ToPackedLong(picker.TitleColor);
+
+    /// <summary>Map <see cref="ITextStyle.TextColor"/> to the Compose <c>TextStyle.Color</c> slot.</summary>
+    public static void MapTextColor(PickerHandler handler, IPicker picker) =>
+        handler._textColor.Value = ColorMapping.ToPackedLong(picker.TextColor);
+
+    /// <summary>Map <see cref="ITextStyle.Font"/> (size + bold) to Compose <c>TextStyle</c> slots.</summary>
+    public static void MapFont(PickerHandler handler, IPicker picker)
+    {
+        var font = picker.Font;
+        handler._fontSize.Value = font.Size > 0 ? (int)font.Size : null;
+        handler._bold.Value     = (font.Weight & Microsoft.Maui.FontWeight.Bold)
+            == Microsoft.Maui.FontWeight.Bold;
+    }
+
+    /// <summary>
+    /// Map <see cref="IView.HorizontalLayoutAlignment"/> to
+    /// <c>Modifier.fillMaxWidth()</c> when the picker asks to fill its
+    /// slot — same parity rule as the other field-shaped controls.
+    /// </summary>
+    public static void MapHorizontalLayoutAlignment(PickerHandler handler, IPicker picker) =>
+        handler._fillWidth.Value = picker.HorizontalLayoutAlignment
+            == Microsoft.Maui.Primitives.LayoutAlignment.Fill;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
@@ -2,6 +2,7 @@ using System.Collections.Specialized;
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Platform;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using ComposeColor          = AndroidX.Compose.Color;
 using ComposeFontWeight     = AndroidX.Compose.FontWeight;
@@ -169,8 +170,14 @@ public partial class PickerHandler : ComposeElementHandler<IPicker>
                 FontWeight = bold ? ComposeFontWeight.Bold : null,
             };
         }
-        if (fill)
-            trigger.PrependModifier(Modifier.FillMaxWidth());
+        // Combines the layout-fill (when set) with the cross-cutting view
+        // properties (Opacity, Translation, Scale, Rotation, IsVisible,
+        // Clip, Shadow). The dropdown menu is rendered into the same
+        // ComposeView, so the modifier wraps the ExposedDropdownMenuBox via
+        // its trigger anchor.
+        var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
+            .ApplyViewProperties(VirtualView!);
+        trigger.PrependModifier(outer);
 
         var menu = new ExposedDropdownMenu(
             expanded:         isOpen,

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
@@ -1,6 +1,7 @@
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Platform;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using ComposeColor            = AndroidX.Compose.Color;
 using ComposeFontWeight       = AndroidX.Compose.FontWeight;
@@ -116,8 +117,13 @@ public partial class TimePickerHandler : ComposeElementHandler<ITimePicker>
             {
                 BuildLabel(label, packed, size, bold),
             };
-            if (fill)
-                trigger.PrependModifier(Modifier.FillMaxWidth());
+            // Combines the layout-fill (when set) with the cross-cutting view
+            // properties (Opacity, Translation, Scale, Rotation, IsVisible,
+            // Clip, Shadow). The dialog is a separate window, so ViewProperties
+            // only applies to the trigger button.
+            var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
+                .ApplyViewProperties(VirtualView!);
+            trigger.PrependModifier(outer);
 
             var dialog = isOpen
                 ? new ComposeTimePickerDialog(onDismissRequest: () => _open.Value = false)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
@@ -1,0 +1,192 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.Maui.Handlers;
+using ComposeColor            = AndroidX.Compose.Color;
+using ComposeFontWeight       = AndroidX.Compose.FontWeight;
+using ComposeOutlinedButton   = AndroidX.Compose.OutlinedButton;
+using ComposeText             = AndroidX.Compose.Text;
+using ComposeTimePicker       = AndroidX.Compose.TimePicker;
+using ComposeTimePickerDialog = AndroidX.Compose.TimePickerDialog;
+using MauiTimePicker          = Microsoft.Maui.Controls.TimePicker;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="MauiTimePicker"/> handler that renders through Jetpack
+/// Compose's Material 3 <see cref="ComposeTimePickerDialog"/>. Replaces
+/// MAUI's stock <c>TimePickerDialog</c> Java native handler when the
+/// consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>MAUI's <c>TimePicker</c> is dialog-style (not inline). The
+/// composable surface mirrors the platform contract: an
+/// <see cref="ComposeOutlinedButton"/> trigger labelled with the
+/// formatted time pops up a Compose
+/// <see cref="ComposeTimePickerDialog"/> wrapping a
+/// <see cref="ComposeTimePicker"/>. <c>OK</c> writes a
+/// <see cref="TimeSpan"/> back to <see cref="ITimePicker.Time"/>.</para>
+///
+/// <para><see cref="TimeSpan"/> is a CLR struct so
+/// <see cref="MutableState{T}"/> doesn't model it directly — round-trip
+/// through <c>long</c> ticks. Compose's
+/// <see cref="TimePickerState"/> wrapper takes
+/// <c>initialHour</c>/<c>initialMinute</c>/<c>is24Hour</c> via its
+/// constructor (Phase 4b), so we re-create the wrapper whenever the
+/// stored ticks change — that's how the dialog observes external
+/// <c>Time</c> writes between opens. Reads of
+/// <see cref="TimePickerState.Hour"/> / <see cref="TimePickerState.Minute"/>
+/// fall through to <c>InitialHour</c>/<c>InitialMinute</c> until the
+/// JVM peer is bound, so the very first <c>OK</c> press still reads a
+/// sensible value.</para>
+/// </remarks>
+public partial class TimePickerHandler : ComposeElementHandler<ITimePicker>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="ITimePicker"/> property
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<ITimePicker, TimePickerHandler> Mapper =
+        new PropertyMapper<ITimePicker, TimePickerHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(ITimePicker.Time)]                = MapTime,
+            [nameof(ITimePicker.Format)]              = MapFormat,
+            [nameof(ITextStyle.TextColor)]            = MapTextColor,
+            [nameof(ITextStyle.Font)]                 = MapFont,
+            [nameof(IView.HorizontalLayoutAlignment)] = MapHorizontalLayoutAlignment,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<ITimePicker, TimePickerHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<long?>  _ticks      = new((long?)null);
+    readonly MutableState<string> _format     = new("t");
+    readonly MutableState<long?>  _textColor  = new((long?)null);
+    readonly MutableState<int?>   _fontSize   = new((int?)null);
+    readonly MutableState<bool>   _bold       = new(false);
+    readonly MutableState<bool>   _open       = new(false);
+    readonly MutableState<bool>   _fillWidth  = new(false);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public TimePickerHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public TimePickerHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        return new Composed(c =>
+        {
+            var ticks   = _ticks.Value;
+            var format  = string.IsNullOrEmpty(_format.Value) ? "t" : _format.Value;
+            var packed  = _textColor.Value;
+            var size    = _fontSize.Value;
+            var bold    = _bold.Value;
+            var fill    = _fillWidth.Value;
+            var isOpen  = _open.Value;
+
+            var ts = ticks is long t ? new TimeSpan(t) : TimeSpan.Zero;
+            // Compose only ships a 24-hour clock face for non-24-hour
+            // mode at <see cref="ComposeTimePickerDialog"/> time — MAUI
+            // honors the user's locale via the AM/PM marker in
+            // `Format`. "H" or "HH" → 24h.
+            var is24Hour = format.Contains('H');
+            var label = ticks is long
+                ? new DateTime(2000, 1, 1).Add(ts).ToString(format)
+                : "Pick a time";
+
+            // Re-key the wrapper on the stored ticks so external
+            // ITimePicker.Time writes show up in the dialog the next
+            // time it opens. User-driven picks rotate the wrapped
+            // JVM state directly, so re-keying only happens on
+            // external pushes.
+            var state = c.Remember(
+                () => new TimePickerState(
+                    initialHour:   ts.Hours,
+                    initialMinute: ts.Minutes,
+                    is24Hour:      is24Hour),
+                ticks,
+                is24Hour);
+
+            var trigger = new ComposeOutlinedButton(onClick: () => _open.Value = true)
+            {
+                BuildLabel(label, packed, size, bold),
+            };
+            if (fill)
+                trigger.PrependModifier(Modifier.FillMaxWidth());
+
+            var dialog = isOpen
+                ? new ComposeTimePickerDialog(onDismissRequest: () => _open.Value = false)
+                {
+                    Title         = new ComposeText("Pick a time"),
+                    ConfirmButton = new TextButton(onClick: () =>
+                    {
+                        var picked = new TimeSpan(state.Hour, state.Minute, 0);
+                        _ticks.Value = picked.Ticks;
+                        if (VirtualView is { } tp)
+                            tp.Time = picked;
+                        _open.Value = false;
+                    })
+                    { new ComposeText("OK") },
+                    DismissButton = new TextButton(onClick: () => _open.Value = false)
+                    {
+                        new ComposeText("Cancel"),
+                    },
+                    Body = new ComposeTimePicker(state),
+                }
+                : (ComposableNode?)null;
+
+            return new Column
+            {
+                trigger,
+                dialog,
+            };
+        });
+    }
+
+    static ComposableNode BuildLabel(string text, long? packed, int? size, bool bold)
+    {
+        var node = new ComposeText(text);
+        if (packed.HasValue)
+            node.Color = new ComposeColor(packed.Value);
+        if (size.HasValue)
+            node.FontSize = new Sp(size.Value);
+        if (bold)
+            node.FontWeight = ComposeFontWeight.Bold;
+        return node;
+    }
+
+    /// <summary>Map <see cref="ITimePicker.Time"/> to the Compose ticks slot.</summary>
+    public static void MapTime(TimePickerHandler handler, ITimePicker tp) =>
+        handler._ticks.Value = tp.Time is TimeSpan t ? t.Ticks : null;
+
+    /// <summary>Map <see cref="ITimePicker.Format"/> to the formatted-label slot.</summary>
+    public static void MapFormat(TimePickerHandler handler, ITimePicker tp) =>
+        handler._format.Value = string.IsNullOrEmpty(tp.Format) ? "t" : tp.Format!;
+
+    /// <summary>Map <see cref="ITextStyle.TextColor"/> to the trigger label colour slot.</summary>
+    public static void MapTextColor(TimePickerHandler handler, ITimePicker tp) =>
+        handler._textColor.Value = ColorMapping.ToPackedLong(tp.TextColor);
+
+    /// <summary>Map <see cref="ITextStyle.Font"/> (size + bold) to the trigger label.</summary>
+    public static void MapFont(TimePickerHandler handler, ITimePicker tp)
+    {
+        var font = tp.Font;
+        handler._fontSize.Value = font.Size > 0 ? (int)font.Size : null;
+        handler._bold.Value     = (font.Weight & Microsoft.Maui.FontWeight.Bold)
+            == Microsoft.Maui.FontWeight.Bold;
+    }
+
+    /// <summary>
+    /// Map <see cref="IView.HorizontalLayoutAlignment"/> to
+    /// <c>Modifier.fillMaxWidth()</c> when the picker asks to fill its
+    /// slot — same parity rule as <see cref="EntryHandler"/>.
+    /// </summary>
+    public static void MapHorizontalLayoutAlignment(TimePickerHandler handler, ITimePicker tp) =>
+        handler._fillWidth.Value = tp.HorizontalLayoutAlignment
+            == Microsoft.Maui.Primitives.LayoutAlignment.Fill;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -1,11 +1,14 @@
 using Microsoft.AndroidX.Compose.Maui.Handlers;
 using MauiButton = Microsoft.Maui.Controls.Button;
+using MauiDatePicker = Microsoft.Maui.Controls.DatePicker;
 using MauiEntry = Microsoft.Maui.Controls.Entry;
 using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
 using MauiImage = Microsoft.Maui.Controls.Image;
 using MauiLabel = Microsoft.Maui.Controls.Label;
 using MauiPage = Microsoft.Maui.Controls.Page;
+using MauiPicker = Microsoft.Maui.Controls.Picker;
 using MauiScrollView = Microsoft.Maui.Controls.ScrollView;
+using MauiTimePicker = Microsoft.Maui.Controls.TimePicker;
 using MauiVerticalStackLayout = Microsoft.Maui.Controls.VerticalStackLayout;
 
 namespace Microsoft.AndroidX.Compose.Maui.Hosting;
@@ -40,8 +43,10 @@ public static class AppHostBuilderExtensions
     ///     <c>Modifier.verticalScroll</c> / <c>horizontalScroll</c>.</description></item>
     ///   <item><description>Leaves
     ///     (<see cref="MauiLabel"/> / <see cref="MauiButton"/> /
-    ///     <see cref="MauiEntry"/> / <see cref="MauiImage"/>) fold
-    ///     into the enclosing composition via
+    ///     <see cref="MauiEntry"/> / <see cref="MauiImage"/> /
+    ///     <see cref="MauiPicker"/> / <see cref="MauiDatePicker"/> /
+    ///     <see cref="MauiTimePicker"/>) fold into the enclosing
+    ///     composition via
     ///     <see cref="IComposeHandler"/>.</description></item>
     /// </list>
     ///
@@ -84,6 +89,9 @@ public static class AppHostBuilderExtensions
             handlers.AddHandler<MauiButton,                 ButtonHandler>();
             handlers.AddHandler<MauiEntry,                  EntryHandler>();
             handlers.AddHandler<MauiImage,                  ImageHandler>();
+            handlers.AddHandler<MauiPicker,                 PickerHandler>();
+            handlers.AddHandler<MauiDatePicker,             DatePickerHandler>();
+            handlers.AddHandler<MauiTimePicker,             TimePickerHandler>();
         });
 
         return builder;


### PR DESCRIPTION
## Scope

Phase 2 Slice 5 of the .NET MAUI Compose backend: re-skin MAUI's
`Picker`, `DatePicker`, and `TimePicker` over Compose modal pickers.
First MAUI slice that exercises the state-holder facade machinery
(`DatePickerState` Phase 4, `TimePickerState` Phase 4b).

### Delivered

- **`PickerHandler`** over `ExposedDropdownMenuBox` +
  `OutlinedTextField` (read-only) + `ExposedDropdownMenu` of
  `DropdownMenuItem`s. Watches `IPicker.Items`
  (`INotifyCollectionChanged`-aware) so external mutations to the
  bound list bump a version-counter and rebuild the menu. Maps
  `ItemsSource`, `SelectedIndex`, `Title`, `TitleColor`, `TextColor`,
  `FontSize`, `FontAttributes`, `HorizontalLayoutAlignment`.
- **`DatePickerHandler`** — trigger-style `OutlinedButton` (formatted
  date) opens `DatePickerDialog { DatePicker(state) }` on tap.
  Confirm reads `DatePickerState.SelectedDateMillis`; seeds the
  state from `MutableState<long?>` ticks via a sibling
  `LaunchedEffect`. Maps `Date`, `MinimumDate`, `MaximumDate`,
  `Format`, `TextColor`.
- **`TimePickerHandler`** — same trigger shape over
  `TimePickerDialog { TimePicker(state) }`. `TimePickerState` is
  Phase 4b (`initialHour` / `initialMinute` / `is24Hour` ctor args),
  so the wrapper is re-keyed `c.Remember(factory, ticks, is24Hour)`
  to refresh on external `Time` writes between dialog opens. Maps
  `Time`, `Format`, `TextColor`.
- Three `handlers.AddHandler<>` registrations + XML doc remarks
  update in `AppHostBuilderExtensions`.
- `PickersPage` sample page + `HomePage` / `AppShell` wiring.
- `docs/maui-backend.md` "Phase 2 Slice 5 — picker family" subsection
  documenting the lessons below.

**No facade extensions were needed** — `DatePickerDialog`,
`TimePickerDialog`, `ExposedDropdownMenuBox`, `ExposedDropdownMenu`,
`DropdownMenuItem`, `OutlinedButton` are all already
`[ComposeFacade]`-generated.

## Lessons learned (Slice 5)

- **`MutableState<DateTime>` / `MutableState<TimeSpan>` are
  impossible** — neither is a `Java.Lang.Object` subclass nor a
  recognised primitive (same restriction as Slice 2 structs).
  Workaround: store as `MutableState<long?>` of `Ticks` and
  reconstitute the struct inside `BuildNode`. Min/Max bounds use
  the same pattern.
- **`MutableState<IList>` is also impossible.** `Picker.Items` is
  surfaced as a version-counter (`MutableState<int>`) bumped from
  both `MapItemsSource` (when the bound source is replaced) and
  `INotifyCollectionChanged.CollectionChanged` (when the same
  source mutates in place). The handler reads `VirtualView.Items`
  live inside `BuildNode`. Subscriptions live and die with
  `SetVirtualView` / `DisconnectHandler`.
- **`DatePickerState.Jvm` is `internal`**, so the MAUI handler
  can't null-check it before pushing values into the wrapper. The
  state's setter (`SelectedDateMillis = ms`) is already a silent
  no-op until Compose binds the JVM peer on the first call to
  `DatePicker(state)`. We seed the state from `_ticks` inside a
  `LaunchedEffect` *sibling* to the dialog — by the time the effect
  runs, `Jvm` is non-null and the assignment lands.
- **`TimePickerState` is Phase 4b** — the wrapper takes
  `initialHour`, `initialMinute`, `is24Hour` as ctor args. We
  re-key `c.Remember(factory, ticks, is24Hour)` so external `Time`
  writes from MAUI refresh the wrapper on the next composition
  (between dialog opens). Inside an open dialog Compose's own
  `remember` contract still holds — the user's drags don't tear
  down the wrapper.
- **Two-way feedback loop** matches `EntryHandler`: write the new
  value into the local `MutableState` first (so the equality
  short-circuit on the next `Map*` call breaks the loop), then
  forward to `VirtualView.<prop>`.

## Verification

- `dotnet build src/Microsoft.AndroidX.Compose.Maui` — clean (0
  warnings, 0 errors).
- `dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample
  -t:Install` deploys to a Pixel-class device (API 34).
- `PickersPage` renders with **exactly one**
  `androidx.compose.ui.platform.ComposeView` node
  (`adb shell uiautomator dump`).
- Picker dropdown opens, item tap writes back through MAUI
  ("You picked: Cherry" echo fires once via
  `SelectedIndexChanged`).
- DatePicker dialog opens with the current `Date` *pre-highlighted*
  ("Today, Thursday, June 11, 2026" highlighted) — confirms the
  `LaunchedEffect`-keyed seeding from `_ticks` works. ±2y
  `MinimumDate` / `MaximumDate` clamps the selectable range.
- DatePicker / TimePicker triggers render with the formatted bound
  values ("Jun 11, 2026", "07:30") — confirms initial seeding
  through the value-type mappers.
