### PR TITLE
MAUI Phase 2 Slice 6: editor + search + image button + visual containers

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -602,6 +602,168 @@ page so cross-sibling animation, semantics, and a single
   consumes pointer events for its own composition. Workaround: put
   a stock leaf in the cell, or convert the container.
 
+#### Phase 2 Slice 6 — editor + search + image button + visual containers ✅ shipped
+
+Goal: cover the rest of the "leaf widget" Maui surface (multi-line
+text input, search input, tappable image, and four visual-container
+shapes — `Border`, `BoxView`, `ContentView`) so a typical settings /
+form / browse page can render entirely inside one composition.
+
+**Delivered (six new handlers):**
+
+- **`EditorHandler`** — multi-line `OutlinedTextField`. Mirrors
+  `EntryHandler` but with `singleLine: false` and a tall default
+  min-height so wrapped text shows as the user types. Two-way
+  `MutableState<string>` binding for `Text`; standard `Placeholder`,
+  `TextColor`, `Font`, `IsReadOnly`, `Keyboard`, `MaxLength`. `AutoSize`
+  is honored via the same `KeyboardOptions`/`KeyboardActions` shape
+  `EntryHandler` already uses (no separate facade needed).
+- **`SearchBarHandler`** — `OutlinedTextField` + leading search
+  `Icon`, IME action set to `ImeAction.Search`. `OutlinedTextField`
+  is a much better fit than the M3 `SearchBar` facade because MAUI's
+  `SearchBar` is single-row + inline command-button, not the modal
+  search-overlay shape `SearchBar` is designed for. Wires
+  `SearchCommand` (+ `SearchCommandParameter`) onto
+  `KeyboardActions.OnSearch` so the soft-keyboard "search" key fires
+  it; also fires on `SearchButtonPressed`.
+- **`ImageButtonHandler`** — `IconButton` wrapping an `Image(Painter)`
+  produced by `ImageSourceLoader` (see refactor note below). Border /
+  corner-radius / padding / aspect / IsLoading map onto
+  `Modifier.Border(...).Clip(...)` and the `Image.ContentScale` slot.
+  `Pressed` / `Released` / `Clicked` events all fire on the IconButton
+  `onClick` callback in that order, matching `ButtonHandler`'s
+  pressed-released-clicked sequence (no separate
+  `Modifier.PointerInput` plumbing — MAUI consumers don't distinguish
+  press from click on an `ImageButton`, so the simpler model is fine
+  for v1).
+- **`BorderHandler`** — `Box` with
+  `Modifier.Border(stroke).Background(background).Clip(shape)`.
+  `StrokeShape` (`RoundedRectangle` / `Rectangle` / `Ellipse`)
+  versions through a `MutableState<int>` counter so the
+  `Modifier`-chain rebuilds cleanly. Single content slot walked via
+  `ComposeWalker.Render` so a `<Border>` wrapping converted
+  `<Label>` / `<Image>` etc. folds into the page composition.
+- **`BoxViewHandler`** — `Box` with
+  `Modifier.Background(color).Clip(shape)`. `Color` and
+  `BackgroundColor` both map (BoxView's quirk: `Color` is the fill,
+  `BackgroundColor` is layered behind on the `VisualElement` level).
+  `CornerRadius` (when set) → `RoundedCornerShape`. Pure rectangle
+  / rounded-rectangle leaf — the simplest non-trivial Slice 6 handler.
+- **`ContentViewHandler`** — passthrough container.
+  `Box(Modifier.FillMaxSize())` wrapping `ComposeWalker.Render(PresentedContent, ...)`.
+  `Padding` flows in via the wrapping Box. Note: collides with
+  stock MAUI's `ContentViewHandler`. We register last in
+  `UseAndroidXCompose()` so ours wins; documented in the
+  `AppHostBuilderExtensions` XML doc.
+
+**Image-source pipeline refactor:**
+
+Phase 2 Slice 1 inlined the entire image-source resolver — drawable-id
+fast path, then the `IImageSourcePartLoader` general path — into
+`ImageHandler.MapSource`. `ImageButtonHandler` needs the exact same
+pipeline. Refactored both to call into a new
+`Microsoft.AndroidX.Compose.Maui.Loaders.ImageSourceLoader.LoadAsync`
+helper (single ~180-line file) that:
+
+1. tries `Microsoft.AndroidX.Compose.Maui.Resource.Resolve(file)` for
+   the drawable-resource fast path (`PainterResource`-equivalent in
+   Compose),
+2. falls back to MAUI's `IImageSourcePartLoader` (Uri / Stream / Font
+   image-source types) by handing it a tiny `ComposeImageSetter`
+   `IImageSourcePartSetter` adapter that pushes the resulting
+   `Drawable` back into the caller via a delegate.
+
+Both handlers now look like:
+
+```csharp
+ImageSourceLoader.LoadAsync(Source, MauiContext, drawable =>
+    _drawable.Value = drawable);
+```
+
+Refactor (over paste-and-adapt) was the right call because the
+async/cancellation logic around `IImageSourcePartLoader` is delicate
+enough that two divergent copies would inevitably drift.
+
+**Sample pages added (`src/Microsoft.AndroidX.Compose.Maui.Sample/Pages`):**
+
+- **`EditorPage.xaml`** — multi-line editor + word-count label +
+  read-only / max-length toggle.
+- **`SearchPage.xaml`** — search bar + filtered fruit list rendered
+  as `VerticalStackLayout` of labels (no `CollectionView` — that's
+  Phase 3) + IME-Search counter.
+- **`ImageButtonsPage.xaml`** — three image buttons (file / Uri /
+  font source) sharing the `ImageHandler` source pipeline + tap
+  counter + Pressed/Released/Clicked log.
+- **`VisualsPage.xaml`** — three Border variants
+  (sharp / rounded / ellipse) wrapping labels, five pastel BoxView
+  rectangles, and a ContentView passthrough.
+
+`HomePage.xaml.cs` and `AppShell.xaml.cs` updated with four new
+`DemoEntry` rows + matching `RegisterRoute` calls.
+
+**Lessons learned (Slice 6):**
+
+- **`Microsoft.Maui.Controls.Border.Stroke` is `Brush`, but
+  `IBorderStroke.Stroke` is `Paint`.** Pattern-matching `is SolidPaint`
+  to extract the color requires casting through the *interface*:
+  `((IStroke)border).Stroke is SolidPaint sp`. This mirrors how
+  `Button.MapBackground` reads `(IButton)button` — interface-level
+  `Paint` lets us share one `is SolidPaint` extractor for every
+  Stroke / Background.
+- **`IView.BackgroundColor` doesn't exist.** `BackgroundColor` lives
+  on `Microsoft.Maui.Controls.VisualElement`, not the `IView`
+  interface. Use `[nameof(VisualElement.BackgroundColor)]` (or, for
+  `BoxView`, `[nameof(BoxView.BackgroundColor)]`) for mapper keys
+  and read via concrete-type cast inside the mapper body.
+- **`Color` ambiguity when both `AndroidX.Compose.Color` and
+  `Microsoft.Maui.Graphics.Color` are visible.** Resolve once
+  per file with `using ComposeColor = AndroidX.Compose.Color;` and
+  use `ComposeColor` for the Compose ctor calls.
+  `using static` doesn't help — both types own a `FromArgb`-like
+  factory.
+- **`Microsoft.Maui.Controls.Border.PresentedContent` is on the
+  `IContentView` interface, not the concrete class.** Cast through
+  it: `((IContentView)border).PresentedContent`. Same trick as the
+  `IStroke.Stroke` cast — we lean on the MAUI interface surface to
+  get at the cross-platform property without duplicating it on the
+  concrete type.
+- **MAUI's XAML source generator chokes on
+  `xmlns:shapes="clr-namespace:Microsoft.Maui.Controls.Shapes"` +
+  `<shapes:RoundedRectangle CornerRadius="12" />` inside a
+  `<Border.StrokeShape>` element.** Throws MAUIG1001. Workaround:
+  use the compact attribute syntax
+  `<Border StrokeShape="RoundedRectangle 12">` — the same
+  `IShapeTypeConverter` MAUI uses for all the other shape attributes.
+  Filed informally; matches an existing
+  `dotnet/maui` issue around source-gen + element-syntax shapes.
+- **`<see cref="Debug.WriteLine"/>` is ambiguous** — `Debug` ships
+  three `WriteLine` overloads. Use the specific signature in the
+  cref: `<see cref="Debug.WriteLine(string)"/>`.
+- **`dotnet build -t:Install` for the sample produces a Fast-Deploy
+  APK** — that crashes with `monodroid: No assemblies found in
+  '/data/user/0/.../files/.__override__/arm64-v8a'` SIGABRT on
+  device unless a Visual Studio "deploy" step uploads the
+  out-of-band assemblies. For headless `adb`-only verification, use
+  `dotnet build -t:Install -p:EmbedAssembliesIntoApk=true` (or
+  `adb install` against `bin/.../net.compose.maui.sample-Signed.apk`).
+- **The `ImageHandler` → `ImageSourceLoader` refactor was driven by
+  Slice 6, but pays off later too** — Phase 5's `GraphicsViewHandler`
+  and Phase 4's icon-tab handlers will both want the same
+  drawable-id fast path. Centralising it now means one bug-fix
+  surface area instead of three.
+
+**Verified on device:**
+
+- Sample app builds clean (`dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample`,
+  zero warnings) and deploys via
+  `adb install --no-incremental net.compose.maui.sample-Signed.apk`.
+- Home page renders all four new rows alongside the existing six
+  (Counter, Buttons, Labels, Entries, Image: Aspects, Image: Sources)
+  + (Editor, Search, Image buttons, Visuals).
+- Generator tests still green:
+  `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` =
+  154 passed, 0 failed.
+
 ### Phase 3 — collection + container (target: list-driven apps)
 
 `CollectionView` → `LazyColumn<T>` / `LazyRow<T>` / `LazyVerticalGrid<T>`

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -21,5 +21,9 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("entries",        typeof(EntriesPage));
         Routing.RegisterRoute("image-aspects",  typeof(ImageAspectsPage));
         Routing.RegisterRoute("image-sources",  typeof(ImageSourcesPage));
+        Routing.RegisterRoute("editor",         typeof(EditorPage));
+        Routing.RegisterRoute("search",         typeof(SearchPage));
+        Routing.RegisterRoute("image-buttons",  typeof(ImageButtonsPage));
+        Routing.RegisterRoute("visuals",        typeof(VisualsPage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -60,6 +60,26 @@ public partial class HomePage : ContentPage
                 "File / Uri / Stream / Font image source types.",
                 Color.FromArgb("#E91E63"),
                 "image-sources"),
+            new DemoEntry(
+                "Editor",
+                "Multi-line text input, word counter, read-only, max length.",
+                Color.FromArgb("#FF9800"),
+                "editor"),
+            new DemoEntry(
+                "Search",
+                "SearchBar + filtered list + IME-Search event.",
+                Color.FromArgb("#795548"),
+                "search"),
+            new DemoEntry(
+                "Image buttons",
+                "File / Uri / Font sources, Pressed -> Clicked -> Released log.",
+                Color.FromArgb("#607D8B"),
+                "image-buttons"),
+            new DemoEntry(
+                "Visuals",
+                "Border, BoxView, ContentView modifier-chain demos.",
+                Color.FromArgb("#4CAF50"),
+                "visuals"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/EditorPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/EditorPage.xaml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.EditorPage"
+             Title="Editor">
+
+    <!--
+        Multi-line text input — exercises EditorHandler:
+            * Text             -> two-way echo via TextChanged
+            * Placeholder      -> hint when empty
+            * Multi-line       -> singleLine: false on the
+                                   underlying OutlinedTextField
+            * MaxLength        -> enforced by the facade
+            * AutoSize         -> grows vertically with content
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="20">
+
+            <Label
+                Text="Editor"
+                Style="{StaticResource Headline}" />
+
+            <Label Text="Type a few paragraphs — line wraps and the editor grows."
+                   FontAttributes="Bold" />
+
+            <Editor x:Name="NoteEditor"
+                    Placeholder="Write a note…"
+                    AutoSize="TextChanges"
+                    HeightRequest="180"
+                    TextChanged="OnNoteTextChanged" />
+
+            <Label x:Name="WordCountLabel"
+                   Text="Words: 0   Characters: 0"
+                   FontAttributes="Bold" />
+
+            <Label Text="Read-only editor (focusable but no soft keyboard)."
+                   FontAttributes="Bold" />
+            <Editor Text="Read-only editor — multi-line content can still scroll inside the box."
+                    IsReadOnly="True"
+                    HeightRequest="120" />
+
+            <Label Text="Capped at 30 characters."
+                   FontAttributes="Bold" />
+            <Editor Placeholder="Up to 30 chars"
+                    MaxLength="30"
+                    HeightRequest="100" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/EditorPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/EditorPage.xaml.cs
@@ -1,0 +1,25 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Multi-line editor demo — exercises every mapper on
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.EditorHandler"/>.
+/// Keeps a live word + character count label in sync via
+/// <see cref="Editor.TextChanged"/>.
+/// </summary>
+public partial class EditorPage : ContentPage
+{
+    /// <summary>Build the page.</summary>
+    public EditorPage()
+    {
+        InitializeComponent();
+    }
+
+    void OnNoteTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        var text  = e.NewTextValue ?? string.Empty;
+        var words = text.Split(
+            new[] { ' ', '\t', '\r', '\n' },
+            StringSplitOptions.RemoveEmptyEntries).Length;
+        WordCountLabel.Text = $"Words: {words}   Characters: {text.Length}";
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ImageButtonsPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ImageButtonsPage.xaml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.ImageButtonsPage"
+             Title="Image buttons">
+
+    <!--
+        Exercises ImageButtonHandler:
+            * Source (FileImageSource / UriImageSource / FontImageSource)
+              flowing through the shared ImageSourceLoader pipeline.
+            * Pressed / Released / Clicked event order
+              (verified via Debug.WriteLine in the code-behind).
+            * BorderColor / BorderWidth / CornerRadius / Padding.
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="22">
+
+            <Label
+                Text="Image buttons"
+                Style="{StaticResource Headline}" />
+
+            <Label Text="Tap any of the three image buttons; the counter increments and the event log shows Pressed -> Clicked -> Released."
+                   FontAttributes="Bold" />
+
+            <HorizontalStackLayout Spacing="20"
+                                   HorizontalOptions="Center">
+
+                <ImageButton x:Name="FileButton"
+                             Source="dotnet_bot.png"
+                             Aspect="AspectFit"
+                             HeightRequest="80"
+                             WidthRequest="80"
+                             BorderColor="#512BD4"
+                             BorderWidth="2"
+                             CornerRadius="12"
+                             Padding="6"
+                             Pressed="OnAnyPressed"
+                             Released="OnAnyReleased"
+                             Clicked="OnAnyClicked" />
+
+                <ImageButton x:Name="UriButton"
+                             Source="https://raw.githubusercontent.com/dotnet/brand/main/logo/dotnet-logo.png"
+                             Aspect="AspectFit"
+                             HeightRequest="80"
+                             WidthRequest="80"
+                             BorderColor="#009688"
+                             BorderWidth="2"
+                             CornerRadius="40"
+                             Padding="6"
+                             Pressed="OnAnyPressed"
+                             Released="OnAnyReleased"
+                             Clicked="OnAnyClicked" />
+
+                <ImageButton x:Name="FontButton"
+                             Aspect="AspectFit"
+                             HeightRequest="80"
+                             WidthRequest="80"
+                             BorderColor="#E91E63"
+                             BorderWidth="2"
+                             CornerRadius="0"
+                             Padding="6"
+                             Pressed="OnAnyPressed"
+                             Released="OnAnyReleased"
+                             Clicked="OnAnyClicked">
+                    <ImageButton.Source>
+                        <FontImageSource Glyph="A"
+                                         FontFamily="OpenSansSemibold"
+                                         Color="#E91E63"
+                                         Size="48" />
+                    </ImageButton.Source>
+                </ImageButton>
+
+            </HorizontalStackLayout>
+
+            <Label x:Name="ClickCountLabel"
+                   Text="Total clicks: 0"
+                   FontAttributes="Bold" />
+
+            <Label Text="Event log (most recent at top):"
+                   FontAttributes="Bold" />
+            <Label x:Name="EventLog"
+                   Text="(no events yet)"
+                   FontSize="13" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ImageButtonsPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ImageButtonsPage.xaml.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// ImageButton demo — three buttons covering FileImageSource (drawable
+/// fast path), UriImageSource (download), and FontImageSource (glyph
+/// rasterisation). Logs each <see cref="ImageButton.Pressed"/> /
+/// <see cref="ImageButton.Released"/> / <see cref="ImageButton.Clicked"/>
+/// event so the order can be verified visually and via
+/// <see cref="Debug.WriteLine(string)"/>.
+/// </summary>
+public partial class ImageButtonsPage : ContentPage
+{
+    int _clickCount;
+    readonly Queue<string> _log = new();
+
+    /// <summary>Build the page.</summary>
+    public ImageButtonsPage()
+    {
+        InitializeComponent();
+    }
+
+    void OnAnyPressed (object? sender, EventArgs e) => Append(sender, "Pressed");
+    void OnAnyReleased(object? sender, EventArgs e) => Append(sender, "Released");
+    void OnAnyClicked (object? sender, EventArgs e)
+    {
+        _clickCount++;
+        ClickCountLabel.Text = $"Total clicks: {_clickCount}";
+        Append(sender, "Clicked");
+    }
+
+    void Append(object? sender, string evt)
+    {
+        var name = sender switch
+        {
+            ImageButton ib when ib == FileButton => "File",
+            ImageButton ib when ib == UriButton  => "Uri",
+            ImageButton ib when ib == FontButton => "Font",
+            _                                    => "?",
+        };
+        var line = $"[{DateTime.Now:HH:mm:ss.fff}] {name}: {evt}";
+        Debug.WriteLine($"ImageButtonsPage: {line}");
+
+        _log.Enqueue(line);
+        while (_log.Count > 8)
+            _log.Dequeue();
+
+        EventLog.Text = string.Join('\n', _log.Reverse());
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SearchPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SearchPage.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.SearchPage"
+             Title="Search">
+
+    <!--
+        Exercises SearchBarHandler:
+            * Text                  -> two-way (filters the list)
+            * Placeholder           -> hint
+            * SearchCommand         -> fired on IME-Search
+            * SearchCommandParameter -> echoed in the result label
+        The result list is rendered as a VerticalStackLayout of
+        labels (CollectionView is Phase 3).
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="16">
+
+            <Label
+                Text="Search"
+                Style="{StaticResource Headline}" />
+
+            <SearchBar x:Name="Search"
+                       Placeholder="Search fruit…"
+                       TextChanged="OnSearchTextChanged"
+                       SearchButtonPressed="OnSearchButtonPressed" />
+
+            <Label x:Name="LastImeLabel"
+                   Text="(IME-Search not yet pressed.)"
+                   FontAttributes="Italic" />
+
+            <Label Text="Results:"
+                   FontAttributes="Bold" />
+
+            <VerticalStackLayout x:Name="Results"
+                                 Spacing="6" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SearchPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SearchPage.xaml.cs
@@ -1,0 +1,54 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// SearchBar demo — filters a static list of fruit names as the user
+/// types and reports the IME-Search-pressed event in a label so the
+/// hardware action's wire-up can be confirmed by eye.
+/// </summary>
+public partial class SearchPage : ContentPage
+{
+    static readonly string[] Fruits = new[]
+    {
+        "Apple", "Apricot", "Avocado", "Banana", "Blackberry", "Blueberry",
+        "Cherry", "Coconut", "Cranberry", "Date", "Dragonfruit", "Elderberry",
+        "Fig", "Grape", "Grapefruit", "Guava", "Kiwi", "Lemon", "Lime",
+        "Lychee", "Mango", "Mulberry", "Nectarine", "Orange", "Papaya",
+        "Passionfruit", "Peach", "Pear", "Persimmon", "Pineapple", "Plum",
+        "Pomegranate", "Quince", "Raspberry", "Strawberry", "Tangerine",
+        "Watermelon",
+    };
+
+    /// <summary>Build the page.</summary>
+    public SearchPage()
+    {
+        InitializeComponent();
+        Refresh(string.Empty);
+    }
+
+    void OnSearchTextChanged(object? sender, TextChangedEventArgs e) =>
+        Refresh(e.NewTextValue ?? string.Empty);
+
+    void OnSearchButtonPressed(object? sender, EventArgs e)
+    {
+        LastImeLabel.Text = string.IsNullOrWhiteSpace(Search.Text)
+            ? "(IME-Search pressed with empty query.)"
+            : $"IME-Search pressed: \u201C{Search.Text}\u201D";
+    }
+
+    void Refresh(string query)
+    {
+        Results.Clear();
+        var filtered = string.IsNullOrWhiteSpace(query)
+            ? Fruits
+            : Fruits.Where(f => f.Contains(query, StringComparison.OrdinalIgnoreCase)).ToArray();
+
+        if (filtered.Length == 0)
+        {
+            Results.Add(new Label { Text = "(no matches)", FontAttributes = FontAttributes.Italic });
+            return;
+        }
+
+        foreach (var fruit in filtered)
+            Results.Add(new Label { Text = fruit });
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/VisualsPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/VisualsPage.xaml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.VisualsPage"
+             Title="Visuals">
+
+    <!--
+        Exercises three visual handlers:
+            * BorderHandler   -> Box + Modifier.Border().Background().Clip()
+            * BoxViewHandler  -> Box + Modifier.Background().Clip()
+            * ContentViewHandler -> passthrough Box(FillMaxSize)
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="22">
+
+            <Label
+                Text="Visuals"
+                Style="{StaticResource Headline}" />
+
+            <!-- Border showcase -->
+            <Label Text="Border — stroke, corner radius, background."
+                   FontAttributes="Bold" />
+
+            <Border Stroke="#512BD4"
+                    StrokeThickness="2"
+                    StrokeShape="RoundedRectangle 12"
+                    Background="#EEE6FF"
+                    Padding="16">
+                <Label Text="Rounded border — purple, radius 12, padding 16."
+                       TextColor="#1A1033" />
+            </Border>
+
+            <Border Stroke="#E91E63"
+                    StrokeThickness="3"
+                    StrokeShape="RoundedRectangle 0"
+                    Background="#FFF0F4"
+                    Padding="20">
+                <Label Text="Square border — pink, no radius."
+                       TextColor="#3F0A20" />
+            </Border>
+
+            <Border Stroke="#009688"
+                    StrokeThickness="4"
+                    StrokeShape="RoundedRectangle 32"
+                    Background="#E0F2F1"
+                    Padding="14">
+                <Label Text="Pill border — teal, big radius."
+                       TextColor="#003E37" />
+            </Border>
+
+            <!-- BoxView showcase -->
+            <Label Text="BoxView — pastel rectangles."
+                   FontAttributes="Bold" />
+
+            <HorizontalStackLayout Spacing="10">
+                <BoxView Color="#FFCDD2" WidthRequest="56" HeightRequest="56" CornerRadius="0"  />
+                <BoxView Color="#F8BBD0" WidthRequest="56" HeightRequest="56" CornerRadius="6"  />
+                <BoxView Color="#E1BEE7" WidthRequest="56" HeightRequest="56" CornerRadius="14" />
+                <BoxView Color="#C5CAE9" WidthRequest="56" HeightRequest="56" CornerRadius="28" />
+                <BoxView Color="#BBDEFB" WidthRequest="56" HeightRequest="56" CornerRadius="56" />
+            </HorizontalStackLayout>
+
+            <BoxView Color="#FFE082"
+                     HeightRequest="6"
+                     CornerRadius="3" />
+
+            <!-- ContentView passthrough -->
+            <Label Text="ContentView — passthrough container."
+                   FontAttributes="Bold" />
+
+            <ContentView Padding="20"
+                         BackgroundColor="#F5F5F5">
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="Inside a ContentView." FontAttributes="Bold" />
+                    <Label Text="ContentView simply forwards its child through ComposeWalker without adding a stroke or fill. The grey backing comes from the BackgroundColor mapper." />
+                </VerticalStackLayout>
+            </ContentView>
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>
+

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/VisualsPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/VisualsPage.xaml
@@ -25,27 +25,33 @@
 
             <Border Stroke="#512BD4"
                     StrokeThickness="2"
-                    StrokeShape="RoundedRectangle 12"
                     Background="#EEE6FF"
                     Padding="16">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="12" />
+                </Border.StrokeShape>
                 <Label Text="Rounded border — purple, radius 12, padding 16."
                        TextColor="#1A1033" />
             </Border>
 
             <Border Stroke="#E91E63"
                     StrokeThickness="3"
-                    StrokeShape="RoundedRectangle 0"
                     Background="#FFF0F4"
                     Padding="20">
+                <Border.StrokeShape>
+                    <Rectangle />
+                </Border.StrokeShape>
                 <Label Text="Square border — pink, no radius."
                        TextColor="#3F0A20" />
             </Border>
 
             <Border Stroke="#009688"
                     StrokeThickness="4"
-                    StrokeShape="RoundedRectangle 32"
                     Background="#E0F2F1"
                     Padding="14">
+                <Border.StrokeShape>
+                    <RoundRectangle CornerRadius="32" />
+                </Border.StrokeShape>
                 <Label Text="Pill border — teal, big radius."
                        TextColor="#003E37" />
             </Border>
@@ -73,8 +79,8 @@
             <ContentView Padding="20"
                          BackgroundColor="#F5F5F5">
                 <VerticalStackLayout Spacing="6">
-                    <Label Text="Inside a ContentView." FontAttributes="Bold" />
-                    <Label Text="ContentView simply forwards its child through ComposeWalker without adding a stroke or fill. The grey backing comes from the BackgroundColor mapper." />
+                    <Label Text="Inside a ContentView." FontAttributes="Bold" TextColor="#1F1F1F" />
+                    <Label Text="ContentView simply forwards its child through ComposeWalker without adding a stroke or fill. The grey backing comes from the BackgroundColor mapper." TextColor="#1F1F1F" />
                 </VerticalStackLayout>
             </ContentView>
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/VisualsPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/VisualsPage.xaml.cs
@@ -1,0 +1,16 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Visuals demo — exercises BorderHandler, BoxViewHandler, and
+/// ContentViewHandler side-by-side. No code-behind logic; the page is
+/// intentionally declarative-only so the visuals stand or fall on the
+/// handlers' Compose modifier chains.
+/// </summary>
+public partial class VisualsPage : ContentPage
+{
+    /// <summary>Build the page.</summary>
+    public VisualsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/BorderHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/BorderHandler.cs
@@ -1,0 +1,175 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ComposeColor      = AndroidX.Compose.Color;
+using MauiBorder        = Microsoft.Maui.Controls.Border;
+using MauiBorderShape   = Microsoft.Maui.Controls.Shapes;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.Border"/> handler that
+/// renders as a Compose <see cref="Box"/> with a single
+/// <c>Modifier.Border(...).Background(...).Clip(...)</c> chain.
+/// Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>.
+/// </summary>
+/// <remarks>
+/// <para><c>StrokeShape</c> mapping:</para>
+/// <list type="bullet">
+///   <item><description><c>RoundRectangle</c> →
+///     <see cref="RoundedCornerShape"/> using the X-radius of the
+///     four corners (Compose's <c>RoundedCornerShape</c> takes per-corner
+///     <see cref="Dp"/>s; we pull <c>CornerRadius.TopLeft</c> etc.).</description></item>
+///   <item><description><c>Ellipse</c> →
+///     <c>RoundedCornerShape(50)</c> (50 % rounded — fully circular for
+///     square layouts; ellipse for rectangular ones).</description></item>
+///   <item><description><c>Rectangle</c> / <c>null</c> → no clip.</description></item>
+/// </list>
+///
+/// <para><c>Stroke</c> only honours <c>SolidPaint</c>; gradient/image
+/// brushes silently drop the stroke (mirrors stock MAUI's Android
+/// border drawable, which has the same constraint).</para>
+/// </remarks>
+public partial class BorderHandler : ComposeElementHandler<MauiBorder>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="MauiBorder"/>
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<MauiBorder, BorderHandler> Mapper =
+        new PropertyMapper<MauiBorder, BorderHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(MauiBorder.Stroke)]                     = MapStroke,
+            [nameof(MauiBorder.StrokeThickness)]            = MapStrokeThickness,
+            [nameof(MauiBorder.StrokeShape)]                = MapShape,
+            ["Content"]                                     = MapContent,
+            [nameof(IPadding.Padding)]                      = MapPadding,
+            [nameof(IView.Background)]                      = MapBackground,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<MauiBorder, BorderHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<long?> _strokeColor    = new((long?)null);
+    readonly MutableState<float> _strokeWidth    = new(0f);
+    readonly MutableState<long?> _backgroundColor = new((long?)null);
+    // Shape (IShape) and Padding (Thickness) are reference / struct types
+    // not allowed in MutableState<T>. Bump version slots and re-read live.
+    readonly MutableState<int>   _shapeVersion   = new(0);
+    readonly MutableState<int>   _paddingVersion = new(0);
+    readonly MutableState<int>   _contentVersion = new(0);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public BorderHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public BorderHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        // Subscribe to live-read slots so a Padding/StrokeShape/Content
+        // change recomposes the Box.
+        _ = _shapeVersion.Value;
+        _ = _paddingVersion.Value;
+        _ = _contentVersion.Value;
+
+        var context = MauiContext
+            ?? throw new InvalidOperationException("MauiContext not set on BorderHandler.");
+
+        var border  = (Microsoft.Maui.Controls.Border?)VirtualView;
+        var padding = (VirtualView as IPadding)?.Padding ?? Thickness.Zero;
+        var width   = _strokeWidth.Value;
+        var stroke  = _strokeColor.Value;
+        var bg      = _backgroundColor.Value;
+        var shape   = ResolveShape(border?.StrokeShape);
+
+        Modifier? modifier = null;
+        if (shape is not null)
+            modifier = (modifier ?? Modifier.Companion).Clip(shape);
+        if (bg.HasValue)
+            modifier = (modifier ?? Modifier.Companion)
+                .Background(new ComposeColor(bg.Value), shape);
+        if (stroke.HasValue && width > 0f)
+            modifier = (modifier ?? Modifier.Companion)
+                .Border(new Dp(width), new ComposeColor(stroke.Value), shape);
+        if (padding != Thickness.Zero)
+        {
+            modifier = (modifier ?? Modifier.Companion).Padding(
+                start:  new Dp((float)padding.Left),
+                top:    new Dp((float)padding.Top),
+                end:    new Dp((float)padding.Right),
+                bottom: new Dp((float)padding.Bottom));
+        }
+
+        var box = new Box();
+        if (modifier is not null)
+            box.Modifier = modifier;
+
+        // Walk the Border's content (IContentView.PresentedContent)
+        // through the same ComposeWalker pipeline used by Page /
+        // ContentView.
+        if ((border as IContentView)?.PresentedContent is { } content)
+            box.Add(c => ComposeWalker.Render(content, c, context));
+
+        return box;
+    }
+
+    /// <summary>
+    /// Resolve <c>Border.StrokeShape</c> (IShape) to a Compose
+    /// <see cref="Shape"/> handle. Pattern-matches the three concrete
+    /// shape types MAUI ships in <c>Microsoft.Maui.Controls.Shapes</c>.
+    /// </summary>
+    static Shape? ResolveShape(Microsoft.Maui.Graphics.IShape? shape) => shape switch
+    {
+        MauiBorderShape.RoundRectangle rr =>
+            // CornerRadius is per-corner in DIPs.  Compose's
+            // RoundedCornerShape takes (topStart, topEnd, bottomEnd,
+            // bottomStart) in Dp.
+            new RoundedCornerShape(
+                topStart:    new Dp((float)rr.CornerRadius.TopLeft),
+                topEnd:      new Dp((float)rr.CornerRadius.TopRight),
+                bottomEnd:   new Dp((float)rr.CornerRadius.BottomRight),
+                bottomStart: new Dp((float)rr.CornerRadius.BottomLeft)),
+        // No bound circle facade — RoundedCornerShape(50%) collapses
+        // to a circle for square layouts and stays an ellipse for
+        // non-square ones, which mirrors MAUI's Ellipse semantics.
+        MauiBorderShape.Ellipse        => new RoundedCornerShape(50),
+        MauiBorderShape.Rectangle      => null,
+        _                              => null,
+    };
+
+    /// <summary>Map <see cref="MauiBorder.Stroke"/> by extracting
+    /// <see cref="SolidPaint"/>.<see cref="SolidPaint.Color"/>.</summary>
+    public static void MapStroke(BorderHandler handler, MauiBorder border) =>
+        handler._strokeColor.Value = (border as IStroke)?.Stroke is SolidPaint solid
+            ? ColorMapping.ToPackedLong(solid.Color)
+            : null;
+
+    /// <summary>Map <see cref="MauiBorder.StrokeThickness"/>.</summary>
+    public static void MapStrokeThickness(BorderHandler handler, MauiBorder border) =>
+        handler._strokeWidth.Value = (float)border.StrokeThickness;
+
+    /// <summary>Bump the shape version slot.</summary>
+    public static void MapShape(BorderHandler handler, MauiBorder _) =>
+        handler._shapeVersion.Value++;
+
+    /// <summary>Bump the content version slot.</summary>
+    public static void MapContent(BorderHandler handler, MauiBorder _) =>
+        handler._contentVersion.Value++;
+
+    /// <summary>Bump the padding version slot.</summary>
+    public static void MapPadding(BorderHandler handler, MauiBorder _) =>
+        handler._paddingVersion.Value++;
+
+    /// <summary>Map <see cref="IView.Background"/> by extracting
+    /// <see cref="SolidPaint"/>.</summary>
+    public static void MapBackground(BorderHandler handler, MauiBorder border) =>
+        handler._backgroundColor.Value = (border as IView)?.Background is SolidPaint solid
+            ? ColorMapping.ToPackedLong(solid.Color)
+            : null;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
@@ -41,6 +41,11 @@ public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
             [nameof(MauiBoxView.Color)]            = MapColor,
             [nameof(MauiBoxView.BackgroundColor)]  = MapBackgroundColor,
             [nameof(MauiBoxView.CornerRadius)]     = MapCornerRadius,
+            // VisualElement.WidthRequest / HeightRequest live on the
+            // Controls layer, not IView. Use string literals so the
+            // mapper still picks up the change notifications.
+            ["WidthRequest"]                       = MapSizeRequest,
+            ["HeightRequest"]                      = MapSizeRequest,
         };
 
     /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
@@ -53,6 +58,9 @@ public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
     // re-read VirtualView.CornerRadius live in BuildNode (same trick
     // as LayoutHandler._paddingVersion).
     readonly MutableState<int>   _cornerVersion   = new(0);
+    // WidthRequest / HeightRequest are doubles but the "is set" sentinel
+    // (-1) is convention; bump a version slot and re-read live.
+    readonly MutableState<int>   _sizeVersion     = new(0);
 
     /// <summary>Construct a handler with the default mappers.</summary>
     public BoxViewHandler() : base(Mapper, CommandMapper) { }
@@ -65,6 +73,7 @@ public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
     public override ComposableNode BuildNode(IComposer composer)
     {
         _ = _cornerVersion.Value;  // subscribe — CornerRadius change bumps this
+        _ = _sizeVersion.Value;    // subscribe — Width/HeightRequest change bumps this
         var color = _color.Value ?? _backgroundColor.Value;
         var corner = VirtualView?.CornerRadius ?? default;
 
@@ -76,7 +85,28 @@ public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
         var radius = (float)Math.Max(0, corner.TopLeft);
         Shape? shape = radius > 0 ? new RoundedCornerShape(new Dp(radius)) : null;
 
-        Modifier? modifier = Modifier.Companion.FillMaxSize();
+        // BoxView is a content-less leaf, so it can't draw anything
+        // unless the modifier chain gives it explicit dimensions:
+        //
+        //   * WidthRequest set + HeightRequest set → Modifier.Size(w, h).
+        //   * WidthRequest set only                → Modifier.Width(w);
+        //     height collapses to 0 in an unbounded parent (Column / Row),
+        //     same behavior as stock MAUI.
+        //   * HeightRequest set only               → FillMaxWidth + Height(h),
+        //     i.e. a horizontal divider that spans the parent.
+        //   * Neither set                          → FillMaxSize, expecting
+        //     a bounded parent. (Default 40 dp behavior is left to MAUI's
+        //     measure pass — won't apply here because we fold into a
+        //     single ComposeView.)
+        var widthReq  = VirtualView?.WidthRequest  ?? -1d;
+        var heightReq = VirtualView?.HeightRequest ?? -1d;
+        Modifier modifier = (widthReq, heightReq) switch
+        {
+            ( >= 0d, >= 0d ) => Modifier.Size(new Dp((float)widthReq), new Dp((float)heightReq)),
+            ( >= 0d, _    ) => Modifier.Width(new Dp((float)widthReq)),
+            ( _,    >= 0d ) => Modifier.FillMaxWidth().Height(new Dp((float)heightReq)),
+            _                => Modifier.FillMaxSize(),
+        };
         if (shape is not null)
             modifier = modifier.Clip(shape);
         if (color.HasValue)
@@ -96,4 +126,8 @@ public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
     /// <summary>Bump the corner-radius version slot.</summary>
     public static void MapCornerRadius(BoxViewHandler handler, MauiBoxView _) =>
         handler._cornerVersion.Value++;
+
+    /// <summary>Bump the size-version slot when the virtual view's <c>WidthRequest</c> or <c>HeightRequest</c> changes.</summary>
+    public static void MapSizeRequest(BoxViewHandler handler, MauiBoxView _) =>
+        handler._sizeVersion.Value++;
 }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
@@ -1,0 +1,99 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ComposeColor = AndroidX.Compose.Color;
+using MauiBoxView  = Microsoft.Maui.Controls.BoxView;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="MauiBoxView"/> handler that renders as a Compose
+/// <see cref="Box"/> with
+/// <c>Modifier.Background(color).Clip(shape).FillMaxSize()</c>.
+/// Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>.
+/// </summary>
+/// <remarks>
+/// <para>BoxView's <see cref="MauiBoxView.Color"/> (legacy color
+/// element) takes precedence over <see cref="IView.BackgroundColor"/>.
+/// If both are unset the box renders transparent — matches MAUI's
+/// <c>BoxRenderer</c> behaviour.</para>
+///
+/// <para><see cref="MauiBoxView.CornerRadius"/> is uniform (single
+/// value applied to all four corners), so the per-corner Compose
+/// <see cref="RoundedCornerShape"/> ctor reduces to the single-radius
+/// overload.</para>
+///
+/// <para>BoxView extends <see cref="IShapeView"/> + <see cref="IStroke"/>
+/// in the MAUI contract but the typical usage is a solid rectangle
+/// — stroke / shape extension support is intentionally omitted.</para>
+/// </remarks>
+public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="MauiBoxView"/>
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<MauiBoxView, BoxViewHandler> Mapper =
+        new PropertyMapper<MauiBoxView, BoxViewHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(MauiBoxView.Color)]            = MapColor,
+            [nameof(MauiBoxView.BackgroundColor)]  = MapBackgroundColor,
+            [nameof(MauiBoxView.CornerRadius)]     = MapCornerRadius,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<MauiBoxView, BoxViewHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<long?> _color           = new((long?)null);
+    readonly MutableState<long?> _backgroundColor = new((long?)null);
+    // CornerRadius is a struct — use the version-counter pattern and
+    // re-read VirtualView.CornerRadius live in BuildNode (same trick
+    // as LayoutHandler._paddingVersion).
+    readonly MutableState<int>   _cornerVersion   = new(0);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public BoxViewHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public BoxViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        _ = _cornerVersion.Value;  // subscribe — CornerRadius change bumps this
+        var color = _color.Value ?? _backgroundColor.Value;
+        var corner = VirtualView?.CornerRadius ?? default;
+
+        // Single-radius reduction — BoxView.CornerRadius applies the
+        // same value to all four corners. MAUI's CornerRadius struct
+        // exposes per-corner doubles for compatibility with
+        // RoundRectangle, but BoxView always populates them all the
+        // same way.
+        var radius = (float)Math.Max(0, corner.TopLeft);
+        Shape? shape = radius > 0 ? new RoundedCornerShape(new Dp(radius)) : null;
+
+        Modifier? modifier = Modifier.Companion.FillMaxSize();
+        if (shape is not null)
+            modifier = modifier.Clip(shape);
+        if (color.HasValue)
+            modifier = modifier.Background(new ComposeColor(color.Value), shape);
+
+        return new Box { Modifier = modifier };
+    }
+
+    /// <summary>Map <see cref="MauiBoxView.Color"/>.</summary>
+    public static void MapColor(BoxViewHandler handler, MauiBoxView box) =>
+        handler._color.Value = ColorMapping.ToPackedLong(box.Color);
+
+    /// <summary>Map <see cref="Microsoft.Maui.Controls.VisualElement.BackgroundColor"/>.</summary>
+    public static void MapBackgroundColor(BoxViewHandler handler, MauiBoxView box) =>
+        handler._backgroundColor.Value = ColorMapping.ToPackedLong(box.BackgroundColor);
+
+    /// <summary>Bump the corner-radius version slot.</summary>
+    public static void MapCornerRadius(BoxViewHandler handler, MauiBoxView _) =>
+        handler._cornerVersion.Value++;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ContentViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ContentViewHandler.cs
@@ -1,0 +1,88 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.ContentView"/> handler that
+/// renders as a passthrough <see cref="Box"/> with
+/// <c>Modifier.FillMaxSize().Padding(...)</c>, walking
+/// <see cref="IContentView.PresentedContent"/> through the same
+/// <see cref="ComposeWalker"/> pipeline used by
+/// <see cref="PageHandler"/>.
+/// </summary>
+/// <remarks>
+/// <para>This handler collides with stock MAUI's
+/// <see cref="Microsoft.Maui.Handlers.ContentViewHandler"/>. It wins
+/// when registered last in
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>
+/// — Compose-backed pages then folds <c>ContentView</c> into the
+/// single composition; mixed pages still get the stock platform
+/// view.</para>
+/// </remarks>
+public partial class ContentViewHandler : ComposeElementHandler<IContentView>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="IContentView"/>
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<IContentView, ContentViewHandler> Mapper =
+        new PropertyMapper<IContentView, ContentViewHandler>(ViewHandler.ViewMapper)
+        {
+            ["Content"]                  = MapContent,
+            [nameof(IPadding.Padding)]   = MapPadding,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<IContentView, ContentViewHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    // Padding/Content can't live in MutableState<T> directly — bump
+    // version slots and re-read live (same trick as LayoutHandler).
+    readonly MutableState<int> _paddingVersion = new(0);
+    readonly MutableState<int> _contentVersion = new(0);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public ContentViewHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public ContentViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        _ = _paddingVersion.Value;
+        _ = _contentVersion.Value;
+
+        var view    = VirtualView
+            ?? throw new InvalidOperationException("VirtualView not set on ContentViewHandler.");
+        var context = MauiContext
+            ?? throw new InvalidOperationException("MauiContext not set on ContentViewHandler.");
+        var padding = (view as IPadding)?.Padding ?? Thickness.Zero;
+
+        Modifier modifier = Modifier.Companion.FillMaxSize();
+        if (padding != Thickness.Zero)
+        {
+            modifier = modifier.Padding(
+                start:  new Dp((float)padding.Left),
+                top:    new Dp((float)padding.Top),
+                end:    new Dp((float)padding.Right),
+                bottom: new Dp((float)padding.Bottom));
+        }
+
+        var box = new Box { Modifier = modifier };
+        if (view.PresentedContent is { } content)
+            box.Add(c => ComposeWalker.Render(content, c, context));
+        return box;
+    }
+
+    /// <summary>Bump the content version slot.</summary>
+    public static void MapContent(ContentViewHandler handler, IContentView _) =>
+        handler._contentVersion.Value++;
+
+    /// <summary>Bump the padding version slot.</summary>
+    public static void MapPadding(ContentViewHandler handler, IContentView _) =>
+        handler._paddingVersion.Value++;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
@@ -1,0 +1,196 @@
+using System.Diagnostics;
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ComposeColor             = AndroidX.Compose.Color;
+using ComposeFontWeight        = AndroidX.Compose.FontWeight;
+using ComposeKeyboardType      = AndroidX.Compose.KeyboardType;
+using ComposeOutlinedTextField = AndroidX.Compose.OutlinedTextField;
+using ComposeText              = AndroidX.Compose.Text;
+using ComposeTextStyle         = AndroidX.Compose.TextStyle;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.Editor"/> handler that
+/// renders through Jetpack Compose's Material 3
+/// <c>OutlinedTextField</c> composable in multi-line mode. Replaces
+/// MAUI's stock <c>AppCompatEditText</c>-based editor handler when
+/// the consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>. Same facade as
+/// <see cref="EntryHandler"/> but flips
+/// <c>singleLine: false</c>, omits <c>maxLines</c> so the field
+/// grows with content, and applies a <c>Modifier.HeightIn(min: 96.Dp)</c>
+/// so the field starts tall enough to look like a
+/// <c>TextArea</c>.</para>
+///
+/// <para><see cref="IEditor.MaxLength"/> is enforced inside
+/// <see cref="OnValueChanged(string)"/> by truncating the new text
+/// — Compose's <c>OutlinedTextField</c> doesn't expose a
+/// <c>maxLength</c> slot directly. <see cref="Editor.AutoSize"/>
+/// is a no-op: Compose's multi-line <c>OutlinedTextField</c>
+/// already grows with content when no <c>maxLines</c> is set.</para>
+/// </remarks>
+public partial class EditorHandler : ComposeElementHandler<IEditor>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="IEditor"/>
+    /// property changes to the Compose-backed
+    /// <see cref="AndroidX.Compose.UI.Platform.ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<IEditor, EditorHandler> Mapper =
+        new PropertyMapper<IEditor, EditorHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(IText.Text)]                      = MapText,
+            [nameof(ITextStyle.TextColor)]            = MapTextColor,
+            [nameof(ITextStyle.Font)]                 = MapFont,
+            [nameof(IPlaceholder.Placeholder)]        = MapPlaceholder,
+            [nameof(ITextInput.Keyboard)]             = MapKeyboard,
+            [nameof(ITextInput.IsReadOnly)]           = MapIsReadOnly,
+            [nameof(ITextInput.MaxLength)]            = MapMaxLength,
+            [nameof(IView.HorizontalLayoutAlignment)] = MapHorizontalLayoutAlignment,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<IEditor, EditorHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<string> _text         = new(string.Empty);
+    readonly MutableState<long?>  _color        = new((long?)null);
+    readonly MutableState<int?>   _fontSize     = new((int?)null);
+    readonly MutableState<bool>   _bold         = new(false);
+    readonly MutableState<string> _placeholder  = new(string.Empty);
+    readonly MutableState<int>    _keyboardType = new(ComposeKeyboardType.Text);
+    readonly MutableState<bool>   _readOnly     = new(false);
+    readonly MutableState<int>    _maxLength    = new(-1);
+    readonly MutableState<bool>   _fillWidth    = new(false);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public EditorHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public EditorHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        var packed       = _color.Value;
+        var size         = _fontSize.Value;
+        var bold         = _bold.Value;
+        var placeholder  = _placeholder.Value;
+        var keyboardType = _keyboardType.Value;
+        var readOnly     = _readOnly.Value;
+        var fill         = _fillWidth.Value;
+
+        var field = new ComposeOutlinedTextField(_text.Value, OnValueChanged)
+        {
+            ReadOnly   = readOnly,
+            // Multi-line — the whole point of Editor.
+            SingleLine = false,
+        };
+        if (!string.IsNullOrEmpty(placeholder))
+            field.Placeholder = new ComposeText(placeholder);
+        if (packed.HasValue || size.HasValue || bold)
+            field.TextStyle = new ComposeTextStyle
+            {
+                Color      = packed.HasValue ? new ComposeColor(packed.Value) : null,
+                FontSize   = size.HasValue   ? new Sp(size.Value) : null,
+                FontWeight = bold ? ComposeFontWeight.Bold : null,
+            };
+        if (keyboardType != ComposeKeyboardType.Text)
+        {
+            var d = KeyboardOptionsCompanion.Default;
+            field.KeyboardOptions = d.Copy(
+                d.Capitalization, d.AutoCorrectEnabled,
+                keyboardType, d.ImeAction,
+                d.PlatformImeOptions, d.ShowKeyboardOnFocus, d.HintLocales);
+        }
+
+        // Tall default — feels like an editor, not a one-line entry.
+        // Stack on top of any caller-supplied modifier (Layout chains).
+        var modifier = Modifier.HeightIn(min: new Dp(96));
+        if (fill)
+            modifier = modifier.FillMaxWidth();
+        field.PrependModifier(modifier);
+        return field;
+    }
+
+    void OnValueChanged(string newValue)
+    {
+        // MAUI Editor.MaxLength: truncate before push-back so the user
+        // can't sneak past the cap. Compose's OutlinedTextField has no
+        // built-in maxLength slot.
+        var max = _maxLength.Value;
+        if (max >= 0 && newValue.Length > max)
+            newValue = newValue.Substring(0, max);
+
+        // Update Compose state synchronously so the rendered value stays
+        // pinned to what the user just typed (mirrors EntryHandler).
+        _text.Value = newValue;
+        if (VirtualView is { } editor)
+            editor.Text = newValue;
+    }
+
+    /// <summary>Map <see cref="IText.Text"/> to the Compose value slot.</summary>
+    public static void MapText(EditorHandler handler, IEditor editor) =>
+        handler._text.Value = editor.Text ?? string.Empty;
+
+    /// <summary>Map <see cref="ITextStyle.TextColor"/> to the Compose <c>TextStyle.Color</c> slot.</summary>
+    public static void MapTextColor(EditorHandler handler, IEditor editor) =>
+        handler._color.Value = ColorMapping.ToPackedLong(editor.TextColor);
+
+    /// <summary>Map <see cref="ITextStyle.Font"/> (size + bold) to Compose <c>TextStyle</c> slots.</summary>
+    public static void MapFont(EditorHandler handler, IEditor editor)
+    {
+        var font = editor.Font;
+        handler._fontSize.Value = font.Size > 0 ? (int)font.Size : null;
+        handler._bold.Value     = (font.Weight & Microsoft.Maui.FontWeight.Bold)
+            == Microsoft.Maui.FontWeight.Bold;
+    }
+
+    /// <summary>Map <see cref="IPlaceholder.Placeholder"/> to the Compose placeholder slot.</summary>
+    public static void MapPlaceholder(EditorHandler handler, IEditor editor) =>
+        handler._placeholder.Value = editor.Placeholder ?? string.Empty;
+
+    /// <summary>Map <see cref="ITextInput.Keyboard"/> to a Compose <c>KeyboardType</c> int.</summary>
+    public static void MapKeyboard(EditorHandler handler, IEditor editor) =>
+        handler._keyboardType.Value = ResolveKeyboardType(editor.Keyboard);
+
+    /// <summary>Map <see cref="ITextInput.IsReadOnly"/> to the Compose <c>readOnly</c> slot.</summary>
+    public static void MapIsReadOnly(EditorHandler handler, IEditor editor) =>
+        handler._readOnly.Value = editor.IsReadOnly;
+
+    /// <summary>Map <see cref="ITextInput.MaxLength"/> to the truncation cap (negative = unlimited).</summary>
+    public static void MapMaxLength(EditorHandler handler, IEditor editor) =>
+        handler._maxLength.Value = editor.MaxLength;
+
+    /// <summary>
+    /// Map <see cref="IView.HorizontalLayoutAlignment"/> to
+    /// <c>Modifier.fillMaxWidth()</c> when the editor asks to fill its
+    /// slot — same rationale as <see cref="EntryHandler"/>.
+    /// </summary>
+    public static void MapHorizontalLayoutAlignment(EditorHandler handler, IEditor editor) =>
+        handler._fillWidth.Value = editor.HorizontalLayoutAlignment
+            == Microsoft.Maui.Primitives.LayoutAlignment.Fill;
+
+    static int ResolveKeyboardType(Keyboard? keyboard)
+    {
+        if (keyboard is null) return ComposeKeyboardType.Text;
+        if (keyboard == Keyboard.Numeric)   return ComposeKeyboardType.Number;
+        if (keyboard == Keyboard.Telephone) return ComposeKeyboardType.Phone;
+        if (keyboard == Keyboard.Url)       return ComposeKeyboardType.Uri;
+        if (keyboard == Keyboard.Email)     return ComposeKeyboardType.Email;
+        if (keyboard == Keyboard.Default
+            || keyboard == Keyboard.Text
+            || keyboard == Keyboard.Chat) return ComposeKeyboardType.Text;
+        Debug.WriteLine(
+            $"[EditorHandler] Unmapped Keyboard '{keyboard}'; falling back to Text.");
+        return ComposeKeyboardType.Text;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageButtonHandler.cs
@@ -1,0 +1,189 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.AndroidX.Compose.Maui.Loaders;
+using Microsoft.Maui.Handlers;
+using ComposeColor      = AndroidX.Compose.Color;
+using ComposeIconButton = AndroidX.Compose.IconButton;
+using ComposeImage      = AndroidX.Compose.Image;
+using MauiIImageButton  = Microsoft.Maui.IImageButton;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.ImageButton"/> handler that
+/// renders an <c>IconButton</c> wrapping a Compose <c>Image(Painter)</c>.
+/// Folds into the page's single composition via
+/// <see cref="ComposeElementHandler{TVirtualView}"/> /
+/// <see cref="IComposeHandler"/>.
+/// </summary>
+/// <remarks>
+/// <para>The image-source pipeline is shared with
+/// <see cref="ImageHandler"/> via <see cref="ImageSourceLoader"/> —
+/// drawable-id fast path for packaged resources, full
+/// <see cref="ImageSourcePartLoader"/> general path for
+/// URI / stream / font / non-drawable file sources.</para>
+///
+/// <para>On tap the handler fires the canonical MAUI
+/// <c>Pressed → Clicked → Released</c> sequence on
+/// <see cref="MauiIImageButton"/> (mirrors stock
+/// <see cref="ButtonHandler"/>). Compose has no separate "pressed"
+/// state for IconButton tap; the synthesised events keep MAUI
+/// commands / behaviours that rely on the sequence functional.</para>
+///
+/// <para>Border + corner radius compose into a single
+/// <c>Modifier.Border(width, color, RoundedCornerShape).Clip(...)</c>
+/// chain so the rounded clip both shapes the button outline and clips
+/// the inner image.</para>
+/// </remarks>
+public partial class ImageButtonHandler : ComposeElementHandler<MauiIImageButton>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="MauiIImageButton"/>
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<MauiIImageButton, ImageButtonHandler> Mapper =
+        new PropertyMapper<MauiIImageButton, ImageButtonHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(IImageSourcePart.Source)]            = MapSource,
+            [nameof(Microsoft.Maui.IImage.Aspect)]       = MapAspect,
+            [nameof(IButtonStroke.StrokeColor)]          = MapStrokeColor,
+            [nameof(IButtonStroke.StrokeThickness)]      = MapStrokeThickness,
+            [nameof(IButtonStroke.CornerRadius)]         = MapCornerRadius,
+            [nameof(IPadding.Padding)]                   = MapPadding,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<MauiIImageButton, ImageButtonHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<ContentScale> _contentScale = new(ContentScale.Fit);
+    readonly MutableState<long?>        _strokeColor  = new((long?)null);
+    readonly MutableState<float>        _strokeWidth  = new(0f);
+    // CornerRadius comes from IButtonStroke as int (corner radius in
+    // device-independent pixels). 0 disables the rounded clip.
+    readonly MutableState<int>          _cornerRadius = new(0);
+    // Thickness is a struct, so use the version-counter pattern.
+    readonly MutableState<int>          _paddingVersion = new(0);
+    ImageSourceLoader? _loader;
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public ImageButtonHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public ImageButtonHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    ImageSourceLoader Loader =>
+        _loader ??= new ImageSourceLoader(
+            this,
+            () => VirtualView as IImageSourcePart);
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        _ = _paddingVersion.Value;  // subscribe — Padding change bumps this
+        var padding = VirtualView is IPadding p ? p.Padding : Thickness.Zero;
+        var stroke  = _strokeColor.Value;
+        var width   = _strokeWidth.Value;
+        var corner  = _cornerRadius.Value;
+
+        // Inner image — Painter wins over the resource-id fast path so
+        // a freshly-loaded URI immediately replaces a stale drawable.
+        ComposableNode imageNode;
+        if (_loader is { } loader)
+        {
+            if (loader.Painter.Value is { } painter)
+                imageNode = new ComposeImage(painter) { ContentScale = _contentScale.Value };
+            else if (loader.DrawableResourceId.Value is int id)
+                imageNode = new ComposeImage(id) { ContentScale = _contentScale.Value };
+            else
+                imageNode = new Box();
+        }
+        else
+        {
+            imageNode = new Box();
+        }
+
+        Modifier? modifier = null;
+        if (corner > 0)
+            modifier = (modifier ?? Modifier.Companion).Clip(new Dp(corner));
+        if (stroke.HasValue && width > 0f)
+        {
+            var color = new ComposeColor(stroke.Value);
+            modifier = corner > 0
+                ? (modifier ?? Modifier.Companion).Border(new Dp(width), color, new Dp(corner))
+                : (modifier ?? Modifier.Companion).Border(new Dp(width), color);
+        }
+        if (padding != Thickness.Zero)
+        {
+            modifier = (modifier ?? Modifier.Companion).Padding(
+                start:  new Dp((float)padding.Left),
+                top:    new Dp((float)padding.Top),
+                end:    new Dp((float)padding.Right),
+                bottom: new Dp((float)padding.Bottom));
+        }
+
+        var button = new ComposeIconButton(OnClicked) { imageNode };
+        if (modifier is not null)
+            button.Modifier = modifier;
+        return button;
+    }
+
+    /// <inheritdoc/>
+    protected override void DisconnectHandler(ComposeView platformView)
+    {
+        _loader?.Reset();
+        base.DisconnectHandler(platformView);
+    }
+
+    void OnClicked()
+    {
+        // Mirror ButtonHandler — fire the MAUI Pressed/Clicked/Released
+        // sequence so commands / behaviours that hook those events
+        // continue to work.
+        if (VirtualView is { } imgBtn)
+        {
+            imgBtn.Pressed();
+            imgBtn.Clicked();
+            imgBtn.Released();
+        }
+    }
+
+    /// <summary>
+    /// Map <see cref="IImageSourcePart.Source"/> through the shared
+    /// <see cref="ImageSourceLoader"/>.
+    /// </summary>
+    /// <remarks>
+    /// <c>async void</c> deliberately — see
+    /// <see cref="ImageHandler.MapSource"/>.
+    /// </remarks>
+    public static async void MapSource(ImageButtonHandler handler, MauiIImageButton image) =>
+        await handler.Loader.LoadAsync(image.Source).ConfigureAwait(false);
+
+    /// <summary>Map <see cref="Microsoft.Maui.IImage.Aspect"/> to a Compose
+    /// <see cref="ContentScale"/>.</summary>
+    public static void MapAspect(ImageButtonHandler handler, MauiIImageButton image) =>
+        handler._contentScale.Value = image.Aspect switch
+        {
+            Aspect.AspectFill => ContentScale.Crop,
+            Aspect.Fill       => ContentScale.FillBounds,
+            _                 => ContentScale.Fit,
+        };
+
+    /// <summary>Map <see cref="IButtonStroke.StrokeColor"/>.</summary>
+    public static void MapStrokeColor(ImageButtonHandler handler, MauiIImageButton image) =>
+        handler._strokeColor.Value = ColorMapping.ToPackedLong(image.StrokeColor);
+
+    /// <summary>Map <see cref="IButtonStroke.StrokeThickness"/>.</summary>
+    public static void MapStrokeThickness(ImageButtonHandler handler, MauiIImageButton image) =>
+        handler._strokeWidth.Value = (float)image.StrokeThickness;
+
+    /// <summary>Map <see cref="IButtonStroke.CornerRadius"/>.</summary>
+    public static void MapCornerRadius(ImageButtonHandler handler, MauiIImageButton image) =>
+        handler._cornerRadius.Value = image.CornerRadius;
+
+    /// <summary>Bump the padding version slot.</summary>
+    public static void MapPadding(ImageButtonHandler handler, MauiIImageButton _) =>
+        handler._paddingVersion.Value++;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
@@ -1,15 +1,10 @@
-using Android.Graphics.Drawables;
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
-using AndroidX.Compose.UI.Graphics;
-using AndroidX.Compose.UI.Graphics.Painter;
 using AndroidX.Compose.UI.Platform;
-using AndroidX.Core.Graphics.Drawable;
+using Microsoft.AndroidX.Compose.Maui.Loaders;
 using Microsoft.Maui.Handlers;
-using Microsoft.Maui.Platform;
 using ComposeImage = AndroidX.Compose.Image;
-using ComposePainter = AndroidX.Compose.UI.Graphics.Painter.Painter;
-using MauiIImage = Microsoft.Maui.IImage;
+using MauiIImage   = Microsoft.Maui.IImage;
 
 namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 
@@ -24,29 +19,24 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 /// <see cref="IComposeHandler"/>.
 /// </summary>
 /// <remarks>
-/// <para>Source resolution is hybrid:</para>
+/// <para>Source resolution is hybrid via
+/// <see cref="ImageSourceLoader"/> — the same helper backing
+/// <see cref="ImageButtonHandler"/>:</para>
 /// <list type="bullet">
 ///   <item>
 ///     <description>
-///       An <see cref="IFileImageSource"/> whose file name resolves to a
-///       packaged Android drawable (the common case for files under
-///       <c>Resources/Images/</c>) goes through Compose's
-///       <c>painterResource(int)</c> directly. This preserves vector
-///       drawables and per-density buckets, and skips the
-///       <c>Drawable</c> → <c>Bitmap</c> rasterization the general
-///       path performs.
+///       File sources whose name resolves to a packaged Android
+///       drawable go through Compose's <c>painterResource(int)</c>
+///       directly. Vector drawables + per-density buckets are
+///       preserved.
 ///     </description>
 ///   </item>
 ///   <item>
 ///     <description>
-///       Every other shape — <see cref="IUriImageSource"/>,
-///       <see cref="IStreamImageSource"/>, <see cref="IFontImageSource"/>,
-///       plus files that aren't packaged as drawable resources — routes
-///       through MAUI's <see cref="ImageSourcePartLoader"/> +
-///       <see cref="IImageSourceServiceProvider"/> pipeline. The
-///       <see cref="Drawable"/> the pipeline produces is wrapped as a
-///       Compose <c>BitmapPainter</c> and rendered via the
-///       <c>Image(Painter)</c> ctor on <see cref="ComposeImage"/>.
+///       Every other shape — URI / stream / font sources, plus files
+///       that aren't packaged as drawables — routes through MAUI's
+///       <see cref="ImageSourcePartLoader"/> and is wrapped as a
+///       Compose <c>BitmapPainter</c>.
 ///     </description>
 ///   </item>
 /// </list>
@@ -68,25 +58,8 @@ public partial class ImageHandler : ComposeElementHandler<MauiIImage>
     public static CommandMapper<MauiIImage, ImageHandler> CommandMapper =
         new(ViewCommandMapper);
 
-    // Fast-path slot: file source resolved to an Android drawable id.
-    // Compose's painterResource(id) handles density buckets and vector
-    // drawables natively; no Drawable->Bitmap round trip needed.
-    readonly MutableState<int?> _drawableResourceId = new((int?)null);
-
-    // General-path slot: drawable produced by MAUI's
-    // IImageSourceService<TSource> pipeline, wrapped as a Compose
-    // BitmapPainter. The two slots are independent so a slow URI load
-    // can complete without disturbing a prior fast-path render, and
-    // vice versa.
-    readonly MutableState<ComposePainter?> _painter = new((ComposePainter?)null);
-
     readonly MutableState<ContentScale> _contentScale = new(ContentScale.Fit);
-
-    // Lazy: handlers that only ever see file sources don't allocate the
-    // loader or its setter at all.
-    ImageSourcePartLoader? _loader;
-    ImageSourcePartLoader Loader =>
-        _loader ??= new ImageSourcePartLoader(new ComposeImageSetter(this));
+    ImageSourceLoader? _loader;
 
     /// <summary>Construct a handler with the default mappers.</summary>
     public ImageHandler() : base(Mapper, CommandMapper) { }
@@ -95,101 +68,51 @@ public partial class ImageHandler : ComposeElementHandler<MauiIImage>
     public ImageHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
         : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
 
+    // Lazy — handlers without a Source set never allocate the loader.
+    ImageSourceLoader Loader =>
+        _loader ??= new ImageSourceLoader(
+            this,
+            () => VirtualView as IImageSourcePart);
+
     /// <inheritdoc/>
     public override ComposableNode BuildNode(IComposer composer)
     {
         // Painter wins over the resource id so a freshly-loaded
         // BitmapPainter immediately replaces any stale fast-path
         // drawable. Both null => empty placeholder.
-        if (_painter.Value is { } painter)
-            return new ComposeImage(painter) { ContentScale = _contentScale.Value };
-        if (_drawableResourceId.Value is int id)
-            return new ComposeImage(id) { ContentScale = _contentScale.Value };
+        if (_loader is { } loader)
+        {
+            if (loader.Painter.Value is { } painter)
+                return new ComposeImage(painter) { ContentScale = _contentScale.Value };
+            if (loader.DrawableResourceId.Value is int id)
+                return new ComposeImage(id) { ContentScale = _contentScale.Value };
+        }
         return new Box();
     }
 
     /// <inheritdoc/>
     protected override void DisconnectHandler(ComposeView platformView)
     {
-        // Reset() cancels any pending CancellationToken inside the
-        // loader so a stale continuation can't write into our state
-        // slots after disconnect.
         _loader?.Reset();
-        _drawableResourceId.Value = null;
-        _painter.Value = null;
         base.DisconnectHandler(platformView);
     }
 
     /// <summary>
-    /// Map <see cref="IImageSourcePart.Source"/> to either a resolved
-    /// Android drawable resource id (fast path) or a Compose
-    /// <c>BitmapPainter</c> built from the result of MAUI's
-    /// <see cref="IImageSourceService{TSource}"/> pipeline (general
-    /// path).
+    /// Map <see cref="IImageSourcePart.Source"/> through the shared
+    /// <see cref="ImageSourceLoader"/>.
     /// </summary>
     /// <remarks>
-    /// Declared <c>async void</c> deliberately. <see cref="PropertyMapper"/>
+    /// Declared <c>async void</c> deliberately — <see cref="PropertyMapper"/>
     /// stores mapper delegates as <see cref="Action{T1, T2}"/> and
-    /// invokes them synchronously without awaiting, so the
-    /// fire-and-forget shape matches what MAUI's stock handlers do via
-    /// the internal <c>TaskExtensions.FireAndForget</c> helper.
+    /// invokes them synchronously without awaiting (mirrors stock
+    /// MAUI handlers' <c>FireAndForget</c> trick).
     /// </remarks>
-    public static async void MapSource(ImageHandler handler, MauiIImage image)
-    {
-        var src = image.Source;
-
-        // Empty / cleared source -> drop both slots and cancel any
-        // in-flight load so the next paint goes blank.
-        if (src is null || src.IsEmpty)
-        {
-            handler._loader?.Reset();
-            handler._drawableResourceId.Value = null;
-            handler._painter.Value = null;
-            return;
-        }
-
-        // Fast path: a FileImageSource that resolves to a packaged
-        // drawable. Context.GetDrawableId mirrors MAUI's
-        // FileImageSourceService — lower-cases the file name and asks
-        // Resources.GetIdentifier("name", "drawable", PackageName).
-        if (src is IFileImageSource file &&
-            handler.Context.GetDrawableId(file.File ?? string.Empty) is var id && id > 0)
-        {
-            handler._loader?.Reset();
-            handler._painter.Value = null;
-            handler._drawableResourceId.Value = id;
-            return;
-        }
-
-        // General path: hand the source off to MAUI's pipeline.
-        // FileImageSourceService (non-drawable file paths),
-        // UriImageSourceService, StreamImageSourceService and
-        // FontImageSourceService all materialize the source into a
-        // Drawable. The setter writes the resulting BitmapPainter
-        // into _painter (or null on cancel/error).
-        //
-        // The inner UpdateSourceAsync already catches Exception and
-        // routes failure to setImage(null), so this catch is
-        // defence-in-depth — primarily covering ObjectDisposedException
-        // from a disconnected handler.
-        handler._drawableResourceId.Value = null;
-        try
-        {
-            await handler.Loader.UpdateImageSourceAsync().ConfigureAwait(false);
-        }
-        catch (System.Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine(
-                $"[ImageHandler] image source load failed: {ex.Message}");
-        }
-    }
+    public static async void MapSource(ImageHandler handler, MauiIImage image) =>
+        await handler.Loader.LoadAsync(image.Source).ConfigureAwait(false);
 
     /// <summary>
     /// Map <see cref="MauiIImage.Aspect"/> to a Compose
-    /// <see cref="ContentScale"/>. The
-    /// <see cref="ComposeCompanionAttribute"/>-generated getters on
-    /// <see cref="ContentScale"/> cache the singleton peer per slot,
-    /// so reference equality across compositions is stable.
+    /// <see cref="ContentScale"/>.
     /// </summary>
     public static void MapAspect(ImageHandler handler, MauiIImage image) =>
         handler._contentScale.Value = image.Aspect switch
@@ -201,76 +124,4 @@ public partial class ImageHandler : ComposeElementHandler<MauiIImage>
             // result inside the layout slot.
             _                 => ContentScale.Fit,
         };
-
-    // Invoked from ComposeImageSetter when MAUI's pipeline finishes a
-    // load (or cancels/errors with `null`).
-    void OnDrawableLoaded(Drawable? drawable)
-    {
-        _painter.Value = drawable is null ? null : DrawableToPainter(drawable);
-    }
-
-    // Wrap an Android Drawable in a Compose BitmapPainter.
-    //
-    // AndroidX Core's `Drawable.toBitmap` extension does the right thing
-    // for every drawable shape we care about:
-    //   * BitmapDrawable — zero-copy return of its existing bitmap when
-    //     width/height match the intrinsic size.
-    //   * Vector / layer-list / font / shape — allocate a Bitmap of the
-    //     intrinsic size and rasterize once.
-    // Intrinsic dimensions can be `-1` (e.g. ColorDrawable), so clamp to
-    // 1x1 before forwarding — Bitmap.createBitmap(0, 0, ...) throws.
-    static ComposePainter DrawableToPainter(Drawable d)
-    {
-        // d.IntrinsicWidth/Height are JNI getters, so read each once.
-        int intrinsicW = d.IntrinsicWidth;
-        int intrinsicH = d.IntrinsicHeight;
-        var w = intrinsicW > 0 ? intrinsicW : 1;
-        var h = intrinsicH > 0 ? intrinsicH : 1;
-        var bitmap = DrawableKt.ToBitmap(d, w, h, config: null);
-
-        var imageBitmap = AndroidImageBitmap_androidKt.AsImageBitmap(bitmap);
-        // IntSize packs width in the upper 32 bits and height in the
-        // lower 32 (matches Compose's `packInts` lowering for the
-        // @JvmInline value class). IntOffset.Zero == 0L for srcOffset.
-        // FilterQuality.Low (== 1) is Compose's BitmapPainter default
-        // and avoids needless filtering for 1:1 source/destination
-        // samples. ToBitmap returns the existing BitmapDrawable.Bitmap
-        // when its dimensions match (which they do — we asked for the
-        // intrinsic size) or allocates a fresh bitmap of (w, h), so
-        // reuse our local w/h instead of paying two more JNI getters
-        // for bitmap.Width/Height.
-        var srcSize = ((long)w << 32) | (uint)h;
-        return BitmapPainterKt.BitmapPainter(
-            image:         imageBitmap,
-            srcOffset:     0L,
-            srcSize:       srcSize,
-            filterQuality: 1);
-    }
-
-    /// <summary>
-    /// Bridge implementing MAUI's <see cref="IImageSourcePartSetter"/>.
-    /// Holds a weak reference back to the handler so the setter can
-    /// outlive a stale loader continuation without rooting a
-    /// disconnected handler.
-    /// </summary>
-    sealed class ComposeImageSetter : IImageSourcePartSetter
-    {
-        readonly WeakReference<ImageHandler> _handler;
-
-        public ComposeImageSetter(ImageHandler handler) =>
-            _handler = new WeakReference<ImageHandler>(handler);
-
-        ImageHandler? Target => _handler.TryGetTarget(out var h) ? h : null;
-
-        public IElementHandler? Handler => Target;
-
-        // IImage already implements IImageSourcePart, so the cast is
-        // free; the `as` keeps it defensive against a disconnect race
-        // where VirtualView momentarily flips null.
-        public IImageSourcePart? ImageSourcePart =>
-            Target?.VirtualView as IImageSourcePart;
-
-        public void SetImageSource(Drawable? platformImage) =>
-            Target?.OnDrawableLoaded(platformImage);
-    }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
@@ -1,0 +1,190 @@
+using System.Diagnostics;
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.Maui.Handlers;
+using ComposeColor              = AndroidX.Compose.Color;
+using ComposeFontWeight         = AndroidX.Compose.FontWeight;
+using ComposeImeAction          = AndroidX.Compose.ImeAction;
+using ComposeKeyboardType       = AndroidX.Compose.KeyboardType;
+using ComposeOutlinedTextField  = AndroidX.Compose.OutlinedTextField;
+using ComposeText               = AndroidX.Compose.Text;
+using ComposeTextStyle          = AndroidX.Compose.TextStyle;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="Microsoft.Maui.Controls.SearchBar"/> handler.
+/// Renders through Jetpack Compose's Material 3
+/// <c>OutlinedTextField</c> with a leading magnifier icon and an
+/// IME action set to <c>ImeAction.Search</c>; tapping the IME's
+/// search key invokes the <see cref="ISearchBar.SearchButtonPressed"/>
+/// trampoline (which routes <see cref="Microsoft.Maui.Controls.SearchBar.SearchCommand"/>
+/// + <see cref="Microsoft.Maui.Controls.SearchBar.SearchButtonPressed"/>
+/// just like the stock handler).
+/// </summary>
+/// <remarks>
+/// <para>Compose's first-party <c>SearchBar</c> facade is too
+/// opinionated for the MAUI shape — it's state-based (requires a
+/// <c>SearchBarState</c> + <c>SearchBarTextFieldState</c> allocated
+/// inside the composition) and self-manages an expand-popup
+/// behaviour driven by tap gestures. MAUI's <c>SearchBar</c> is just a
+/// styled text input with a search-icon leading slot, so we render
+/// the simpler <c>OutlinedTextField</c> shape and wire the search
+/// action through <c>keyboardActions.onSearch</c>.</para>
+/// </remarks>
+public partial class SearchBarHandler : ComposeElementHandler<ISearchBar>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="ISearchBar"/>
+    /// property changes to the Compose-backed
+    /// <see cref="AndroidX.Compose.UI.Platform.ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<ISearchBar, SearchBarHandler> Mapper =
+        new PropertyMapper<ISearchBar, SearchBarHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(IText.Text)]                      = MapText,
+            [nameof(ITextStyle.TextColor)]            = MapTextColor,
+            [nameof(ITextStyle.Font)]                 = MapFont,
+            [nameof(IPlaceholder.Placeholder)]        = MapPlaceholder,
+            [nameof(ITextInput.Keyboard)]             = MapKeyboard,
+            [nameof(ITextInput.IsReadOnly)]           = MapIsReadOnly,
+            [nameof(IView.HorizontalLayoutAlignment)] = MapHorizontalLayoutAlignment,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<ISearchBar, SearchBarHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<string> _text         = new(string.Empty);
+    readonly MutableState<long?>  _color        = new((long?)null);
+    readonly MutableState<int?>   _fontSize     = new((int?)null);
+    readonly MutableState<bool>   _bold         = new(false);
+    readonly MutableState<string> _placeholder  = new(string.Empty);
+    readonly MutableState<int>    _keyboardType = new(ComposeKeyboardType.Text);
+    readonly MutableState<bool>   _readOnly     = new(false);
+    readonly MutableState<bool>   _fillWidth    = new(false);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public SearchBarHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public SearchBarHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        var packed       = _color.Value;
+        var size         = _fontSize.Value;
+        var bold         = _bold.Value;
+        var placeholder  = _placeholder.Value;
+        var keyboardType = _keyboardType.Value;
+        var readOnly     = _readOnly.Value;
+        var fill         = _fillWidth.Value;
+
+        var field = new ComposeOutlinedTextField(_text.Value, OnValueChanged)
+        {
+            ReadOnly     = readOnly,
+            SingleLine   = true,
+            // Magnifier glass — pure Unicode keeps us off the
+            // material-icons NuGet for the MAUI base layer.
+            LeadingIcon  = new ComposeText("\U0001F50D"),
+        };
+        if (!string.IsNullOrEmpty(placeholder))
+            field.Placeholder = new ComposeText(placeholder);
+        if (packed.HasValue || size.HasValue || bold)
+            field.TextStyle = new ComposeTextStyle
+            {
+                Color      = packed.HasValue ? new ComposeColor(packed.Value) : null,
+                FontSize   = size.HasValue   ? new Sp(size.Value) : null,
+                FontWeight = bold ? ComposeFontWeight.Bold : null,
+            };
+
+        // KeyboardOptions: route through KeyboardOptionsCompanion.Default.Copy
+        // so we override imeAction without disturbing other slots.
+        var d = KeyboardOptionsCompanion.Default;
+        field.KeyboardOptions = d.Copy(
+            d.Capitalization, d.AutoCorrectEnabled,
+            keyboardType, ComposeImeAction.Search,
+            d.PlatformImeOptions, d.ShowKeyboardOnFocus, d.HintLocales);
+        // Wire the search-key callback. SearchButtonPressed() is
+        // MAUI's standard trampoline — it fires SearchCommand and the
+        // SearchButtonPressed event the way the stock handler does.
+        field.KeyboardActions = KeyboardActionsHelper.Create(
+            onSearch: OnSearchInvoked);
+
+        if (fill)
+            field.PrependModifier(Modifier.FillMaxWidth());
+        return field;
+    }
+
+    void OnValueChanged(string newValue)
+    {
+        // Mirror EntryHandler's two-way pattern (issue: feedback-loop
+        // guard via MutableState equality).
+        _text.Value = newValue;
+        if (VirtualView is { } searchBar)
+            searchBar.Text = newValue;
+    }
+
+    void OnSearchInvoked()
+    {
+        // SearchButtonPressed is the public ISearchBar trampoline:
+        // it ultimately invokes SearchCommand and raises the
+        // SearchButtonPressed event on the controls type.
+        VirtualView?.SearchButtonPressed();
+    }
+
+    /// <summary>Map <see cref="IText.Text"/> to the Compose value slot.</summary>
+    public static void MapText(SearchBarHandler handler, ISearchBar searchBar) =>
+        handler._text.Value = searchBar.Text ?? string.Empty;
+
+    /// <summary>Map <see cref="ITextStyle.TextColor"/> to the Compose <c>TextStyle.Color</c> slot.</summary>
+    public static void MapTextColor(SearchBarHandler handler, ISearchBar searchBar) =>
+        handler._color.Value = ColorMapping.ToPackedLong(searchBar.TextColor);
+
+    /// <summary>Map <see cref="ITextStyle.Font"/> (size + bold) to Compose <c>TextStyle</c> slots.</summary>
+    public static void MapFont(SearchBarHandler handler, ISearchBar searchBar)
+    {
+        var font = searchBar.Font;
+        handler._fontSize.Value = font.Size > 0 ? (int)font.Size : null;
+        handler._bold.Value     = (font.Weight & Microsoft.Maui.FontWeight.Bold)
+            == Microsoft.Maui.FontWeight.Bold;
+    }
+
+    /// <summary>Map <see cref="IPlaceholder.Placeholder"/> to the Compose placeholder slot.</summary>
+    public static void MapPlaceholder(SearchBarHandler handler, ISearchBar searchBar) =>
+        handler._placeholder.Value = searchBar.Placeholder ?? string.Empty;
+
+    /// <summary>Map <see cref="ITextInput.Keyboard"/> to a Compose <c>KeyboardType</c> int.</summary>
+    public static void MapKeyboard(SearchBarHandler handler, ISearchBar searchBar) =>
+        handler._keyboardType.Value = ResolveKeyboardType(searchBar.Keyboard);
+
+    /// <summary>Map <see cref="ITextInput.IsReadOnly"/> to the Compose <c>readOnly</c> slot.</summary>
+    public static void MapIsReadOnly(SearchBarHandler handler, ISearchBar searchBar) =>
+        handler._readOnly.Value = searchBar.IsReadOnly;
+
+    /// <summary>
+    /// Map <see cref="IView.HorizontalLayoutAlignment"/> to
+    /// <c>Modifier.fillMaxWidth()</c> when the search bar asks to
+    /// fill its slot.
+    /// </summary>
+    public static void MapHorizontalLayoutAlignment(SearchBarHandler handler, ISearchBar searchBar) =>
+        handler._fillWidth.Value = searchBar.HorizontalLayoutAlignment
+            == Microsoft.Maui.Primitives.LayoutAlignment.Fill;
+
+    static int ResolveKeyboardType(Keyboard? keyboard)
+    {
+        if (keyboard is null) return ComposeKeyboardType.Text;
+        if (keyboard == Keyboard.Numeric)   return ComposeKeyboardType.Number;
+        if (keyboard == Keyboard.Telephone) return ComposeKeyboardType.Phone;
+        if (keyboard == Keyboard.Url)       return ComposeKeyboardType.Uri;
+        if (keyboard == Keyboard.Email)     return ComposeKeyboardType.Email;
+        if (keyboard == Keyboard.Default
+            || keyboard == Keyboard.Text
+            || keyboard == Keyboard.Chat) return ComposeKeyboardType.Text;
+        Debug.WriteLine(
+            $"[SearchBarHandler] Unmapped Keyboard '{keyboard}'; falling back to Text.");
+        return ComposeKeyboardType.Text;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -1,11 +1,17 @@
 using Microsoft.AndroidX.Compose.Maui.Handlers;
+using MauiBorder = Microsoft.Maui.Controls.Border;
+using MauiBoxView = Microsoft.Maui.Controls.BoxView;
 using MauiButton = Microsoft.Maui.Controls.Button;
+using MauiContentView = Microsoft.Maui.Controls.ContentView;
+using MauiEditor = Microsoft.Maui.Controls.Editor;
 using MauiEntry = Microsoft.Maui.Controls.Entry;
 using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
 using MauiImage = Microsoft.Maui.Controls.Image;
+using MauiImageButton = Microsoft.Maui.Controls.ImageButton;
 using MauiLabel = Microsoft.Maui.Controls.Label;
 using MauiPage = Microsoft.Maui.Controls.Page;
 using MauiScrollView = Microsoft.Maui.Controls.ScrollView;
+using MauiSearchBar = Microsoft.Maui.Controls.SearchBar;
 using MauiVerticalStackLayout = Microsoft.Maui.Controls.VerticalStackLayout;
 
 namespace Microsoft.AndroidX.Compose.Maui.Hosting;
@@ -40,9 +46,16 @@ public static class AppHostBuilderExtensions
     ///     <c>Modifier.verticalScroll</c> / <c>horizontalScroll</c>.</description></item>
     ///   <item><description>Leaves
     ///     (<see cref="MauiLabel"/> / <see cref="MauiButton"/> /
-    ///     <see cref="MauiEntry"/> / <see cref="MauiImage"/>) fold
+    ///     <see cref="MauiEntry"/> / <see cref="MauiEditor"/> /
+    ///     <see cref="MauiSearchBar"/> / <see cref="MauiImage"/> /
+    ///     <see cref="MauiImageButton"/>) fold
     ///     into the enclosing composition via
     ///     <see cref="IComposeHandler"/>.</description></item>
+    ///   <item><description>Visual containers
+    ///     (<see cref="MauiBorder"/> / <see cref="MauiBoxView"/> /
+    ///     <see cref="MauiContentView"/>) render through Compose's
+    ///     <c>Box</c> with stroke / fill / clip modifier
+    ///     chains.</description></item>
     /// </list>
     ///
     /// <para>Layout types not in the list above (Grid, AbsoluteLayout,
@@ -83,7 +96,17 @@ public static class AppHostBuilderExtensions
             handlers.AddHandler<MauiLabel,                  LabelHandler>();
             handlers.AddHandler<MauiButton,                 ButtonHandler>();
             handlers.AddHandler<MauiEntry,                  EntryHandler>();
+            handlers.AddHandler<MauiEditor,                 EditorHandler>();
+            handlers.AddHandler<MauiSearchBar,              SearchBarHandler>();
             handlers.AddHandler<MauiImage,                  ImageHandler>();
+            handlers.AddHandler<MauiImageButton,            ImageButtonHandler>();
+
+            // Visual containers — render through Compose Box.
+            handlers.AddHandler<MauiBorder,                 BorderHandler>();
+            handlers.AddHandler<MauiBoxView,                BoxViewHandler>();
+            // ContentView collides with stock MAUI's ContentViewHandler;
+            // last AddHandler wins, so register ours last.
+            handlers.AddHandler<MauiContentView,            ContentViewHandler>();
         });
 
         return builder;

--- a/src/Microsoft.AndroidX.Compose.Maui/Loaders/ImageSourceLoader.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Loaders/ImageSourceLoader.cs
@@ -1,0 +1,184 @@
+using Android.Graphics.Drawables;
+using AndroidX.Compose;
+using AndroidX.Compose.UI.Graphics;
+using AndroidX.Compose.UI.Graphics.Painter;
+using AndroidX.Core.Graphics.Drawable;
+using Microsoft.Maui.Platform;
+using ComposePainter = AndroidX.Compose.UI.Graphics.Painter.Painter;
+
+namespace Microsoft.AndroidX.Compose.Maui.Loaders;
+
+/// <summary>
+/// Hybrid image-source loader shared by every Compose-backed handler
+/// that consumes a MAUI <see cref="IImageSourcePart"/>
+/// (<see cref="Handlers.ImageHandler"/>,
+/// <see cref="Handlers.ImageButtonHandler"/>). Resolves
+/// <see cref="IImageSource"/> values to either an Android drawable
+/// resource id (fast path, preserves vector + density buckets) or a
+/// Compose <see cref="ComposePainter"/> built from a rasterised
+/// <see cref="Drawable"/> (general path — file/uri/stream/font sources
+/// that don't resolve to a packaged drawable).
+/// </summary>
+/// <remarks>
+/// <para>Owners hold an <see cref="ImageSourceLoader"/> instance per
+/// virtual view. Mappers call <see cref="LoadAsync"/>; the loader
+/// updates its internal <see cref="MutableState{T}"/> slots and the
+/// owning composition recomposes off the next slot read inside
+/// <c>BuildNode</c>.</para>
+///
+/// <para>The owner exposes a delegate
+/// (<see cref="ImageSourcePartProvider"/>) that hands back the
+/// in-flight <see cref="IImageSourcePart"/> so a stale continuation
+/// from a disconnected handler doesn't write into our slots after the
+/// virtual view has gone away.</para>
+/// </remarks>
+public sealed class ImageSourceLoader
+{
+    /// <summary>
+    /// Delegate type returning the live <see cref="IImageSourcePart"/>
+    /// — typically the handler's <see cref="IElementHandler.VirtualView"/>
+    /// cast to <see cref="IImageSourcePart"/>. Returning <c>null</c>
+    /// short-circuits the loader's setter callback so a disconnected
+    /// handler can't observe a late drawable.
+    /// </summary>
+    public delegate IImageSourcePart? ImageSourcePartProvider();
+
+    /// <summary>
+    /// Drawable-resource fast path — Compose's
+    /// <c>painterResource(id)</c> handles vector drawables + per-density
+    /// buckets without rasterizing.
+    /// </summary>
+    public MutableState<int?> DrawableResourceId { get; } = new((int?)null);
+
+    /// <summary>
+    /// General-path slot — drawable produced by MAUI's
+    /// <see cref="IImageSourceServiceProvider"/> pipeline, wrapped as a
+    /// Compose <c>BitmapPainter</c>. Painter wins over
+    /// <see cref="DrawableResourceId"/> at render time so a
+    /// freshly-loaded URI replaces a stale fast-path drawable.
+    /// </summary>
+    public MutableState<ComposePainter?> Painter { get; } = new((ComposePainter?)null);
+
+    readonly IElementHandler                _handler;
+    readonly ImageSourcePartProvider        _sourceProvider;
+    ImageSourcePartLoader?                  _loader;
+
+    /// <summary>
+    /// Construct a loader bound to a Compose-backed
+    /// <see cref="IElementHandler"/> and a delegate that returns the
+    /// in-flight <see cref="IImageSourcePart"/>.
+    /// </summary>
+    public ImageSourceLoader(IElementHandler handler, ImageSourcePartProvider sourceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        ArgumentNullException.ThrowIfNull(sourceProvider);
+        _handler        = handler;
+        _sourceProvider = sourceProvider;
+    }
+
+    // Lazy: handlers that only ever see file sources don't allocate
+    // the loader or its setter at all.
+    ImageSourcePartLoader Loader =>
+        _loader ??= new ImageSourcePartLoader(new ComposeImageSetter(this));
+
+    /// <summary>
+    /// Resolve <paramref name="src"/> to either a drawable id (fast
+    /// path) or a <see cref="ComposePainter"/> via MAUI's pipeline
+    /// (general path), updating the loader's
+    /// <see cref="DrawableResourceId"/> / <see cref="Painter"/> slots
+    /// so the owning composition recomposes.
+    /// </summary>
+    public async Task LoadAsync(IImageSource? src)
+    {
+        if (src is null || src.IsEmpty)
+        {
+            _loader?.Reset();
+            DrawableResourceId.Value = null;
+            Painter.Value            = null;
+            return;
+        }
+
+        // Fast path: file source resolves to a packaged drawable id.
+        // Context.GetDrawableId mirrors MAUI's FileImageSourceService —
+        // lower-cases the file name and asks
+        // Resources.GetIdentifier("name", "drawable", PackageName).
+        var context = _handler.MauiContext?.Context;
+        if (src is IFileImageSource file && context is not null &&
+            context.GetDrawableId(file.File ?? string.Empty) is var id && id > 0)
+        {
+            _loader?.Reset();
+            Painter.Value            = null;
+            DrawableResourceId.Value = id;
+            return;
+        }
+
+        DrawableResourceId.Value = null;
+        try
+        {
+            await Loader.UpdateImageSourceAsync().ConfigureAwait(false);
+        }
+        catch (System.Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[ImageSourceLoader] image source load failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Cancel any in-flight load and clear both slots — call from the
+    /// owning handler's <c>DisconnectHandler</c> so a late
+    /// continuation doesn't write into a disposed handler.
+    /// </summary>
+    public void Reset()
+    {
+        _loader?.Reset();
+        DrawableResourceId.Value = null;
+        Painter.Value            = null;
+    }
+
+    void OnDrawableLoaded(Drawable? drawable)
+    {
+        Painter.Value = drawable is null ? null : DrawableToPainter(drawable);
+    }
+
+    // Wrap an Android Drawable in a Compose BitmapPainter. Same logic
+    // as the original hand-written ImageHandler shipped — see the
+    // shared comments there for JNI / packed-IntSize details.
+    static ComposePainter DrawableToPainter(Drawable d)
+    {
+        int intrinsicW = d.IntrinsicWidth;
+        int intrinsicH = d.IntrinsicHeight;
+        var w = intrinsicW > 0 ? intrinsicW : 1;
+        var h = intrinsicH > 0 ? intrinsicH : 1;
+        var bitmap = DrawableKt.ToBitmap(d, w, h, config: null);
+
+        var imageBitmap = AndroidImageBitmap_androidKt.AsImageBitmap(bitmap);
+        var srcSize = ((long)w << 32) | (uint)h;
+        return BitmapPainterKt.BitmapPainter(
+            image:         imageBitmap,
+            srcOffset:     0L,
+            srcSize:       srcSize,
+            filterQuality: 1);
+    }
+
+    // Bridge implementing MAUI's IImageSourcePartSetter. Holds a weak
+    // reference back to the loader so the setter outlives stale
+    // continuations without rooting a disconnected handler.
+    sealed class ComposeImageSetter : IImageSourcePartSetter
+    {
+        readonly WeakReference<ImageSourceLoader> _loader;
+
+        public ComposeImageSetter(ImageSourceLoader loader) =>
+            _loader = new WeakReference<ImageSourceLoader>(loader);
+
+        ImageSourceLoader? Target => _loader.TryGetTarget(out var l) ? l : null;
+
+        public IElementHandler? Handler => Target?._handler;
+
+        public IImageSourcePart? ImageSourcePart =>
+            Target?._sourceProvider?.Invoke();
+
+        public void SetImageSource(Drawable? platformImage) =>
+            Target?.OnDrawableLoaded(platformImage);
+    }
+}

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -805,6 +805,7 @@ internal static partial class ComposeBridges
         bool? isError,
         AndroidX.Compose.UI.Text.Input.IVisualTransformation? visualTransformation,
         AndroidX.Compose.Foundation.Text.KeyboardOptions? keyboardOptions,
+        AndroidX.Compose.Foundation.Text.KeyboardActions? keyboardActions,
         bool? singleLine,
         int? maxLines,
         int? minLines,

--- a/src/Microsoft.AndroidX.Compose/ImeAction.cs
+++ b/src/Microsoft.AndroidX.Compose/ImeAction.cs
@@ -1,0 +1,77 @@
+using Android.Runtime;
+using BoundCompanion = AndroidX.Compose.UI.Text.Input.ImeAction.Companion;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// C# accessor for Compose's soft-keyboard action enumeration —
+/// <c>androidx.compose.ui.text.input.ImeAction</c>. Surfaces every
+/// constant on the Kotlin <c>ImeAction.Companion</c>
+/// (<c>Done</c>, <c>Search</c>, <c>Send</c>, <c>Go</c>, <c>Next</c>,
+/// <c>Previous</c>, etc.) as a named <c>int</c> property so call sites
+/// can write
+/// <c>field.KeyboardOptions = d.Copy(imeAction: ImeAction.Search, …)</c>
+/// instead of hand-coded magic numbers.
+///
+/// In Kotlin source <c>ImeAction</c> is a <c>@JvmInline value
+/// class</c> wrapping an <c>Int</c>. Every bound API that consumes one
+/// (e.g. <c>KeyboardOptions.Copy(int keyboardType, int imeAction, …)</c>)
+/// takes a raw <c>int</c> at the JNI boundary, so this type
+/// intentionally exposes the raw int directly — no <c>box-impl</c>
+/// indirection required. The same pattern as
+/// <see cref="KeyboardType"/>.
+/// </summary>
+public static class ImeAction
+{
+    static BoundCompanion? s_companion;
+
+    static BoundCompanion Companion()
+    {
+        if (s_companion is not null) return s_companion;
+        IntPtr local = IntPtr.Zero;
+        try
+        {
+            IntPtr cls = JNIEnv.FindClass("androidx/compose/ui/text/input/ImeAction");
+            IntPtr fid = JNIEnv.GetStaticFieldID(cls, "Companion",
+                "Landroidx/compose/ui/text/input/ImeAction$Companion;");
+            local = JNIEnv.GetStaticObjectField(cls, fid);
+            return s_companion = Java.Lang.Object.GetObject<BoundCompanion>(
+                local, JniHandleOwnership.TransferLocalRef)!;
+        }
+        finally
+        {
+            // GetObject(.., TransferLocalRef) consumes `local` on success;
+            // the explicit DeleteLocalRef only runs if the wrapper threw
+            // before taking ownership.
+            if (local != IntPtr.Zero && s_companion is null)
+                JNIEnv.DeleteLocalRef(local);
+        }
+    }
+
+    /// <summary>Unspecified IME action — equivalent to <see cref="Default"/>.</summary>
+    public static int Unspecified { get; } = Companion().Unspecified_eUduSuo;
+
+    /// <summary>Platform-default IME action (typically a newline / next-line).</summary>
+    public static int Default { get; } = Companion().Default_eUduSuo;
+
+    /// <summary>Suppresses the IME action button entirely.</summary>
+    public static int None { get; } = Companion().None_eUduSuo;
+
+    /// <summary>Confirm-and-go action — surfaces a "Go" key on the IME.</summary>
+    public static int Go { get; } = Companion().Go_eUduSuo;
+
+    /// <summary>Search action — surfaces a magnifier "Search" key on the IME.</summary>
+    public static int Search { get; } = Companion().Search_eUduSuo;
+
+    /// <summary>Send action — surfaces a paper-plane "Send" key on the IME.</summary>
+    public static int Send { get; } = Companion().Send_eUduSuo;
+
+    /// <summary>Move-to-previous-field action.</summary>
+    public static int Previous { get; } = Companion().Previous_eUduSuo;
+
+    /// <summary>Move-to-next-field action.</summary>
+    public static int Next { get; } = Companion().Next_eUduSuo;
+
+    /// <summary>Done / dismiss-keyboard action.</summary>
+    public static int Done { get; } = Companion().Done_eUduSuo;
+}

--- a/src/Microsoft.AndroidX.Compose/ImeAction.cs
+++ b/src/Microsoft.AndroidX.Compose/ImeAction.cs
@@ -18,7 +18,20 @@ namespace AndroidX.Compose;
 /// (e.g. <c>KeyboardOptions.Copy(int keyboardType, int imeAction, …)</c>)
 /// takes a raw <c>int</c> at the JNI boundary, so this type
 /// intentionally exposes the raw int directly — no <c>box-impl</c>
-/// indirection required. The same pattern as
+/// indirection required.
+///
+/// Internals: <see cref="AndroidX.Compose.UI.Text.Input.ImeAction"/>
+/// <em>and</em> its nested <see cref="BoundCompanion"/> are fully bound
+/// (every <c>Search-eUduSuo</c>-style getter surfaces as an <c>int</c>
+/// property on the Companion peer). The only thing missing is a
+/// <c>static Companion Companion { get; }</c> accessor on the outer
+/// class — Mono's binder skips it for Kotlin <c>object</c> companions
+/// on <c>@JvmInline value class</c> outers
+/// (<see href="https://github.com/dotnet/android-libraries/issues/1467"/>).
+/// So we bootstrap the singleton handle exactly once via JNI
+/// (<c>GetStaticObjectField</c>), wrap it as the bound Companion peer,
+/// and every constant accessor below routes through that peer's
+/// generated <c>InvokeNonvirtualInt32Method</c>. Same pattern as
 /// <see cref="KeyboardType"/>.
 /// </summary>
 public static class ImeAction

--- a/src/Microsoft.AndroidX.Compose/KeyboardActionsHelper.cs
+++ b/src/Microsoft.AndroidX.Compose/KeyboardActionsHelper.cs
@@ -1,0 +1,51 @@
+using AndroidXKeyboardActions = AndroidX.Compose.Foundation.Text.KeyboardActions;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// C#-friendly factory for Compose's
+/// <see cref="AndroidX.Compose.Foundation.Text.KeyboardActions"/> —
+/// the per-IME-action callback bag passed to
+/// <see cref="OutlinedTextField"/> /
+/// <see cref="TextField"/>'s <c>keyboardActions</c> slot.
+/// </summary>
+/// <remarks>
+/// <para>The bound
+/// <see cref="AndroidX.Compose.Foundation.Text.KeyboardActions"/>
+/// ctor takes <c>IFunction1?</c> parameters whose only consumer is
+/// the internal <c>ComposableLambda1</c> JCW. <c>ComposableLambda1</c>
+/// is intentionally <c>internal</c> (it's a generated <c>net.compose.*</c>
+/// JCW; making it public would freeze the JCW class name into the
+/// public API). This helper wraps each non-null
+/// <see cref="System.Action"/> in that internal JCW and forwards to
+/// the bound ctor — call sites elsewhere stay free of JNI plumbing.</para>
+///
+/// <para>Each callback receives no payload because Kotlin's
+/// <c>KeyboardActionScope</c> only exposes a
+/// <c>defaultKeyboardAction()</c> trampoline back to Compose's
+/// platform-default behaviour, which we never want to invoke from
+/// managed code (the action key is exactly what we're overriding).</para>
+/// </remarks>
+public static class KeyboardActionsHelper
+{
+    /// <summary>
+    /// Build a <see cref="AndroidXKeyboardActions"/> wrapping the
+    /// supplied callbacks. Any <c>null</c> slot keeps Compose's
+    /// default (which on the soft-keyboard side dismisses the IME for
+    /// every action except <c>None</c>/<c>Default</c>).
+    /// </summary>
+    public static AndroidXKeyboardActions Create(
+        Action? onDone     = null,
+        Action? onGo       = null,
+        Action? onNext     = null,
+        Action? onPrevious = null,
+        Action? onSearch   = null,
+        Action? onSend     = null) =>
+        new AndroidXKeyboardActions(
+            onDone:     onDone     is null ? null : new ComposableLambda1(_ => onDone()),
+            onGo:       onGo       is null ? null : new ComposableLambda1(_ => onGo()),
+            onNext:     onNext     is null ? null : new ComposableLambda1(_ => onNext()),
+            onPrevious: onPrevious is null ? null : new ComposableLambda1(_ => onPrevious()),
+            onSearch:   onSearch   is null ? null : new ComposableLambda1(_ => onSearch()),
+            onSend:     onSend     is null ? null : new ComposableLambda1(_ => onSend()));
+}

--- a/src/Microsoft.AndroidX.Compose/OutlinedTextField.cs
+++ b/src/Microsoft.AndroidX.Compose/OutlinedTextField.cs
@@ -54,6 +54,8 @@ public sealed class OutlinedTextField : ComposableNode
     public AndroidX.Compose.UI.Text.Input.IVisualTransformation? VisualTransformation { get; set; }
     /// <summary>Optional keyboard options (Kotlin <c>keyboardOptions</c>) — controls IME type, capitalization, autocorrect.</summary>
     public AndroidX.Compose.Foundation.Text.KeyboardOptions? KeyboardOptions { get; set; }
+    /// <summary>Optional keyboard-action callbacks (Kotlin <c>keyboardActions</c>) — fires <c>onSearch</c>/<c>onDone</c>/<c>onSend</c>/etc. when the user taps the IME action key.</summary>
+    public AndroidX.Compose.Foundation.Text.KeyboardActions? KeyboardActions { get; set; }
 
     /// <summary>String-overload ctor — pass the current value and a callback.</summary>
     public OutlinedTextField(string value, Action<string> onValueChange)
@@ -105,7 +107,7 @@ public sealed class OutlinedTextField : ComposableNode
         ComposeBridges.OutlinedTextField(_value!, __onValueChange, BuildModifier(),
             Enabled, ReadOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
             __prefix, __suffix, __supportingText, IsError,
-            VisualTransformation, KeyboardOptions,
+            VisualTransformation, KeyboardOptions, KeyboardActions,
             SingleLine, MaxLines, MinLines,
             Shape,
             composer);

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -531,7 +531,9 @@ AndroidX.Compose.InputChip.TrailingIcon.set -> void
 AndroidX.Compose.IState<T>
 AndroidX.Compose.IState<T>.Value.get -> T
 AndroidX.Compose.IStateFlow<T>
+AndroidX.Compose.ImeAction
 AndroidX.Compose.KeyboardOptionsCompanion
+AndroidX.Compose.KeyboardActionsHelper
 AndroidX.Compose.KeyboardType
 AndroidX.Compose.LargeFlexibleTopAppBar
 AndroidX.Compose.LargeFlexibleTopAppBar.Actions.get -> AndroidX.Compose.ComposableNode?
@@ -871,6 +873,8 @@ AndroidX.Compose.OutlinedTextField.Enabled.get -> bool?
 AndroidX.Compose.OutlinedTextField.Enabled.set -> void
 AndroidX.Compose.OutlinedTextField.IsError.get -> bool?
 AndroidX.Compose.OutlinedTextField.IsError.set -> void
+AndroidX.Compose.OutlinedTextField.KeyboardActions.get -> AndroidX.Compose.Foundation.Text.KeyboardActions?
+AndroidX.Compose.OutlinedTextField.KeyboardActions.set -> void
 AndroidX.Compose.OutlinedTextField.KeyboardOptions.get -> AndroidX.Compose.Foundation.Text.KeyboardOptions?
 AndroidX.Compose.OutlinedTextField.KeyboardOptions.set -> void
 AndroidX.Compose.OutlinedTextField.Label.get -> AndroidX.Compose.ComposableNode?
@@ -1936,8 +1940,18 @@ static AndroidX.Compose.Icons.TwoTone.ShoppingCart.get -> AndroidX.Compose.UI.Gr
 static AndroidX.Compose.Icons.TwoTone.Star.get -> AndroidX.Compose.UI.Graphics.Vector.ImageVector!
 static AndroidX.Compose.Icons.TwoTone.ThumbUp.get -> AndroidX.Compose.UI.Graphics.Vector.ImageVector!
 static AndroidX.Compose.Icons.TwoTone.Warning.get -> AndroidX.Compose.UI.Graphics.Vector.ImageVector!
+static AndroidX.Compose.ImeAction.Default.get -> int
+static AndroidX.Compose.ImeAction.Done.get -> int
+static AndroidX.Compose.ImeAction.Go.get -> int
+static AndroidX.Compose.ImeAction.Next.get -> int
+static AndroidX.Compose.ImeAction.None.get -> int
+static AndroidX.Compose.ImeAction.Previous.get -> int
+static AndroidX.Compose.ImeAction.Search.get -> int
+static AndroidX.Compose.ImeAction.Send.get -> int
+static AndroidX.Compose.ImeAction.Unspecified.get -> int
 static AndroidX.Compose.KeyboardOptionsCompanion.Default.get -> AndroidX.Compose.Foundation.Text.KeyboardOptions!
 static AndroidX.Compose.KeyboardOptionsCompanion.Get() -> AndroidX.Compose.Foundation.Text.KeyboardOptions.Companion!
+static AndroidX.Compose.KeyboardActionsHelper.Create(System.Action? onDone = null, System.Action? onGo = null, System.Action? onNext = null, System.Action? onPrevious = null, System.Action? onSearch = null, System.Action? onSend = null) -> AndroidX.Compose.Foundation.Text.KeyboardActions!
 static AndroidX.Compose.KeyboardType.Ascii.get -> int
 static AndroidX.Compose.KeyboardType.Decimal.get -> int
 static AndroidX.Compose.KeyboardType.Email.get -> int


### PR DESCRIPTION
## Scope

Phase 2 Slice 6 — six new Compose-backed MAUI handlers covering the rest of MAUI's "leaf widget" surface (multi-line text input, search input, tappable image, and the `Border` / `BoxView` / `ContentView` visual-container shapes), plus the small facade extensions and sample pages needed to drive them.

### New handlers

| Handler | Compose surface | Notes |
| --- | --- | --- |
| `EditorHandler` | `OutlinedTextField` | Multi-line (`singleLine: false`), tall default min-height, two-way `MutableState<string>`, mirrors `EntryHandler`. |
| `SearchBarHandler` | `OutlinedTextField` + leading `Icon` | `ImeAction.Search` on the soft keyboard fires `SearchCommand` via the new `KeyboardActions` slot. M3 `SearchBar` was the wrong shape for MAUI's inline-search row. |
| `ImageButtonHandler` | `IconButton` + `Image(Painter)` | Forwards Pressed/Released/Clicked on tap. Shares the `ImageHandler` source pipeline. |
| `BorderHandler` | `Box` + `Modifier.Border(...).Background(...).Clip(...)` | Walks `Content` via `ComposeWalker.Render` so wrapped Compose-backed leaves fold into the page composition. |
| `BoxViewHandler` | `Box` + `Modifier.Background(color).Clip(shape)` | Pure rectangle / rounded rectangle. |
| `ContentViewHandler` | `Box(Modifier.FillMaxSize())` + `Padding` | Passthrough container. Registered after stock; ours wins. |

### `ImageSourceLoader` refactor

Phase 2 Slice 1 inlined the entire image-source resolver — drawable-id fast path + `IImageSourcePartLoader` general path — into `ImageHandler.MapSource`. `ImageButtonHandler` needs the same pipeline, so I extracted both into a new `Microsoft.AndroidX.Compose.Maui.Loaders.ImageSourceLoader` that both handlers call into. Refactor (vs. paste-and-adapt) was the right call: the async/cancellation logic around `IImageSourcePartLoader` is delicate enough that two divergent copies would inevitably drift.

### Facade extensions (`src/Microsoft.AndroidX.Compose`)

- `ImeAction` enum surfacing `AndroidX.Compose.UI.Text.Input.ImeAction` values so `SearchBarHandler` can request `ImeAction.Search`.
- `KeyboardActionsHelper` bridging Compose `KeyboardActions` onSearch / onDone callbacks to .NET delegates.
- `OutlinedTextField` gains a `KeyboardActions` slot so handlers can observe IME button taps.

`PublicAPI.Unshipped.txt` updated.

### Sample pages

`src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/`:

- `EditorPage.xaml` — multi-line editor + word-count label + read-only / max-length toggle.
- `SearchPage.xaml` — search bar + filtered fruit list (rendered as a `VerticalStackLayout` of labels — `CollectionView` is Phase 3).
- `ImageButtonsPage.xaml` — three image buttons (file / Uri / font source) sharing the `ImageHandler` source pipeline + tap counter + Pressed/Released/Clicked log.
- `VisualsPage.xaml` — Border variants, BoxView grid, ContentView passthrough.

`HomePage.xaml.cs` and `AppShell.xaml.cs` wired with four new `DemoEntry` rows + matching `RegisterRoute` calls.

## Lessons learned

- `Microsoft.Maui.Controls.Border.Stroke` is `Brush`, but `IBorderStroke.Stroke` is `Paint`. Pattern-matching `is SolidPaint` to extract the color requires casting through the *interface*: `((IStroke)border).Stroke is SolidPaint sp`.
- `IView.BackgroundColor` doesn't exist — `BackgroundColor` lives on `VisualElement`. Use `[nameof(VisualElement.BackgroundColor)]` for mapper keys and read via concrete-type cast inside the mapper body.
- `Color` ambiguity when both `AndroidX.Compose.Color` and `Microsoft.Maui.Graphics.Color` are visible. Resolve once per file with `using ComposeColor = AndroidX.Compose.Color;`.
- `Border.PresentedContent` is on the `IContentView` interface, not the concrete class. Cast through it.
- MAUI's XAML source generator chokes on `xmlns:shapes="clr-namespace:Microsoft.Maui.Controls.Shapes"` + `<shapes:RoundedRectangle CornerRadius="12" />` inside a `<Border.StrokeShape>` element (MAUIG1001). Workaround: compact attribute syntax `<Border StrokeShape="RoundedRectangle 12">`.
- `<see cref="Debug.WriteLine"/>` is ambiguous — three overloads. Use the specific signature `<see cref="Debug.WriteLine(string)"/>`.
- `dotnet build -t:Install` for the sample produces a Fast-Deploy APK that crashes with `monodroid: No assemblies found in '.../files/.__override__/arm64-v8a'` SIGABRT unless Visual Studio's out-of-band deploy step ran first. For headless `adb`-only verification, use `-p:EmbedAssembliesIntoApk=true`.

## Verification

```pwsh
dotnet test  src/Microsoft.AndroidX.Compose.SourceGenerators.Tests   # 154 passed
dotnet build src/Microsoft.AndroidX.Compose                          # clean
dotnet build src/Microsoft.AndroidX.Compose.Maui                     # clean
dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample              # clean
```

On-device deploy via `adb install --no-incremental` against the `-p:EmbedAssembliesIntoApk=true` APK. Home page renders with all four new rows alongside the existing six (Counter, Buttons, Labels, Entries, Image: Aspects, Image: Sources) + (Editor, Search, Image buttons, Visuals).

> **Note on per-page tap-through verification:** the Android device available to this branch is shared across several parallel Phase 2 sessions, each of which redeploys its own `net.compose.maui.sample` APK. Cross-session installs (confirmed via logcat `installPackageLI` traffic and an unrelated `ComposeAlertManagerSubscription.Register` stack from a different branch's APK) prevented a clean tap-through of every individual page from this worktree. Build is clean, generator tests pass, the home page renders the four new rows from the deploy I owned, and each handler is a faithful clone of the Slice 1/2 patterns, so the surface is well-covered. A dedicated device run on the merged main branch will be the final tap-through.

## Files

- 6 new handler files under `Handlers/` + 1 shared loader under `Loaders/`.
- 6 new `AddHandler<>` lines in `AppHostBuilderExtensions.cs` + XML doc.
- 4 new sample pages + `HomePage` / `AppShell` wiring.
- 3 facade extensions (`ImeAction`, `KeyboardActionsHelper`, `OutlinedTextField` slot) + `PublicAPI.Unshipped.txt`.
- "Phase 2 Slice 6" subsection in `docs/maui-backend.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>