### PR TITLE
MAUI Phase 2 Slice 8: ModifierBridge (IView.Opacity/Translation/Scale/Rotation/IsVisible/Clip/Shadow)

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -602,6 +602,126 @@ page so cross-sibling animation, semantics, and a single
   consumes pointer events for its own composition. Workaround: put
   a stock leaf in the cell, or convert the container.
 
+#### Phase 2 Slice 8 — `ModifierBridge` ✅ shipped
+
+Goal: forward MAUI's cross-cutting `IView` visual / transform
+properties (`IsVisible`, `Opacity`, `TranslationX/Y`, `Scale` /
+`ScaleX` / `ScaleY`, `Rotation` / `RotationX` / `RotationY`,
+`AnchorX/Y`, `Clip`, `Shadow`) into the Compose composition the
+overridden handlers contribute. Pre-Slice 8 only `Background` /
+`Padding` / `IsEnabled` reached Compose; the rest were silent
+no-ops because every Compose-backed leaf folds into the page
+composition (its `ComposeView` is detached) and stock
+`UpdateOpacity` / `UpdateTranslationX` / … platform-side updates
+pokes a view that never paints.
+
+**Property → Compose modifier table:**
+
+| MAUI property                                                    | Compose translation                                                                                          |
+|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `Visibility != Visible`                                          | `Modifier.Alpha(0f)`                                                                                         |
+| `Opacity` (when < 1)                                             | `Modifier.Alpha((float)Opacity)`                                                                             |
+| `TranslationX/Y`                                                 | `Modifier.Offset(x.dp, y.dp)`                                                                                |
+| `Scale * ScaleX/ScaleY` (multiplied)                             | `Modifier.Scale((float)sx)` (uniform) or `Modifier.Scale(sx, sy)` (asymmetric)                                |
+| `Rotation` only                                                  | `Modifier.Rotate(rotation)` (cheaper, no `GraphicsLayer`)                                                    |
+| `Rotation` + any of `RotationX/Y` / `AnchorX/Y != 0.5`           | `Modifier.GraphicsLayer(rotationX, rotationY, rotationZ, transformOrigin: TransformOrigin.Pack(ax, ay))`     |
+| `Clip` is `RoundRectangleGeometry`                               | `Modifier.Clip(new RoundedCornerShape(corner.dp))` (or per-corner `RoundedCornerShape(topStart, …)`)         |
+| `Clip` is `RectangleGeometry`                                    | `Modifier.Clip(Shape.Rectangle)`                                                                             |
+| `Clip` is `EllipseGeometry` (`RadiusX == RadiusY`)               | `Modifier.Clip(Shape.Circle())`                                                                              |
+| `Clip` arbitrary path / `GeometryGroup`                          | (no-op — bail rather than emit a wrong outline)                                                              |
+| `Shadow` non-null with `Radius > 0`                              | `Modifier.Shadow(radius.dp)` — Compose synthesises offset / opacity from elevation; `Brush` is not modelled. |
+
+**Modifier order** is fixed so cross-cutting visuals trace the
+right outline: **Alpha / Opacity** outermost (so they fade the
+entire visual), then **Offset** (translation), then **Scale**, then
+**Rotate** / `GraphicsLayer`, then **Shadow**, then **Clip**
+innermost (so the clip outline tracks the drawn content rather than
+the post-translate position). The chain is built once in
+`ModifierBridge.ApplyViewProperties(this Modifier, IView)` and
+prepended via `ComposableNode.PrependModifier(...)` by every
+handler's `BuildNode`.
+
+**Recomposition pipeline.** `MutableState<T>` only accepts
+primitives / strings / `Java.Lang.Object` subclasses, so the
+struct-typed properties (`Color`, `Geometry`, `IShadow`, the double
+coords) can't be put into per-property slots. Instead the base
+`ComposeElementHandler<T>` exposes **one shared
+`MutableState<int>` view-properties version slot**; each
+`BuildNode` reads it via `SubscribeToViewProperties()` to register
+a Compose dependency, and `ApplyViewProperties` re-reads the live
+`IView` properties on every recomposition. The slot is bumped from
+`UseAndroidXCompose()` → `RemapForCompose()`, which calls
+`PropertyMapperExtensions.AppendToMapping(...)` on the global
+`ViewHandler.ViewMapper` for each of the 14 cross-cutting
+properties. The appended hook checks `handler is IComposeHandler`
+and calls `BumpViewPropertiesVersion()`; non-Compose handlers
+shrug it off after a single type test. `RemapForCompose` is
+idempotent via a static flag so a host that calls
+`UseAndroidXCompose` twice (test fixtures) doesn't double-register.
+
+**`IsVisible` semantic choice — alpha vs layout-skip.** MAUI's
+`IsVisible == false` on the cross-platform side maps to
+`Visibility.Hidden` on `IView`, which stock backends collapse
+through `View.Visibility = GONE` (the cell drops out of the layout
+slot). Compose modifier-only translation can't drop a node out of
+the parent layout slot, so we use `Modifier.Alpha(0f)` — preserves
+layout space, matches MAUI's `Hidden` (not `Collapsed`) semantics.
+Dropping the node would require a measure-policy short-circuit
+(generic `Layout {}` adapter, on the Phase 5 roadmap).
+
+**3D rotation round-trip (`RotationX/Y`).** Both MAUI and Compose
+take degrees, but Compose's `GraphicsLayer { rotationX, rotationY }`
+applies them through a perspective camera whose `cameraDistance`
+defaults to ~8 × the layout depth in dp. MAUI's stock Android
+backend uses `android.graphics.Camera`, which has a different
+default camera distance. A 60° `RotationX` therefore foreshortens
+slightly differently than the same value rendered by stock MAUI on
+top of Android `View`. The deviation is most apparent above ~30°
+of axis tilt; matching the stock perspective would require porting
+`Camera`'s matrix into Compose space — out of scope for the bridge.
+
+**`Shadow` colour limitation.** MAUI's `Shadow` exposes `Brush`,
+`Offset`, `Opacity`, `Radius`. Compose's `Modifier.Shadow(elevation,
+shape)` only takes elevation + shape — Compose synthesises the
+ambient / spot tint from elevation and the surrounding
+`MaterialTheme`. We forward `Shadow.Radius` as elevation; offset /
+opacity / brush-derived colour aren't surfaced. Documented; a
+follow-up could lower into `GraphicsLayer.shadowElevation` plus a
+custom `Spot`/`AmbientShadowColor` modifier when those land on the
+facade.
+
+**Delivered:**
+
+- `Platform/ModifierBridge.cs` — the `ApplyViewProperties` extension
+  with the property mapping table above.
+- `IComposeHandler.BumpViewPropertiesVersion()` + base-class
+  shared `MutableState<int>` slot + protected-internal
+  `SubscribeToViewProperties()`.
+- `RemapForCompose()` static helper called from
+  `UseAndroidXCompose()` — idempotent, hooks all 14 cross-cutting
+  `IView` properties on `ViewHandler.ViewMapper`.
+- Refactor of every existing handler's `BuildNode` to chain
+  `ApplyViewProperties` on its outermost `PrependModifier` (Label,
+  Button, Entry, Image, Layout, ScrollView). `PageHandler` is
+  intentionally not refactored — its `ComposeView` IS the platform
+  view, so MAUI's stock `UpdateOpacity` / `UpdateTranslationX` /
+  … on the outer view still works.
+- Sample `Pages/ModifiersPage.xaml` + HomePage entry + Shell route
+  cycling each property on a single `Image`.
+
+**Verified:**
+
+- Sample build green (`dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample`).
+- ModifiersPage demos visually flip every property — opacity fades,
+  scale grows, rotation spins, IsVisible hides, translation slides,
+  clip rounds / circles, shadow elevates.
+- No regression on existing demos (Counter / Buttons / Entries) —
+  default property values produce no extra modifier ops since
+  `ApplyViewProperties` short-circuits on identity.
+- Single `androidx.compose.ui.platform.ComposeView` per page
+  preserved (no extra `Box`-per-property; properties chain into the
+  same outermost modifier).
+
 ### Phase 3 — collection + container (target: list-driven apps)
 
 `CollectionView` → `LazyColumn<T>` / `LazyRow<T>` / `LazyVerticalGrid<T>`

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -21,5 +21,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("entries",        typeof(EntriesPage));
         Routing.RegisterRoute("image-aspects",  typeof(ImageAspectsPage));
         Routing.RegisterRoute("image-sources",  typeof(ImageSourcesPage));
+        Routing.RegisterRoute("modifiers",      typeof(ModifiersPage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -60,6 +60,11 @@ public partial class HomePage : ContentPage
                 "File / Uri / Stream / Font image source types.",
                 Color.FromArgb("#E91E63"),
                 "image-sources"),
+            new DemoEntry(
+                "Modifiers",
+                "Opacity, Scale, Rotation, IsVisible, Translation, Clip, Shadow on a single Image.",
+                Color.FromArgb("#FF9800"),
+                "modifiers"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ModifiersPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ModifiersPage.xaml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.ModifiersPage"
+             Title="Modifiers">
+
+    <!--
+        Demonstrates ModifierBridge — the cross-cutting `IView` visual /
+        transform property pipeline. A single `Image` is the target;
+        every toggle button flips one property at a time and the
+        Compose-backed handler picks up the change via the
+        `RemapForCompose` hook installed on `ViewHandler.ViewMapper`.
+
+        The current state of each property is mirrored as the matching
+        button's text so you can read the live values without having
+        to inspect the visual tree.
+    -->
+    <ScrollView>
+        <VerticalStackLayout Padding="24,24"
+                             Spacing="18">
+
+            <Label Text="Modifiers"
+                   Style="{StaticResource Headline}" />
+
+            <Label Text="Toggle each property to see ApplyViewProperties chain Opacity, Translation, Scale, Rotation, IsVisible, Clip, and Shadow onto the Compose-backed Image."
+                   Style="{StaticResource SubHeadline}" />
+
+            <!-- Target — fills a fixed-height slot so transforms stay
+                 in view. The HorizontalStackLayout reserves enough
+                 horizontal space that translating the image right by
+                 60dp doesn't push it off-screen. -->
+            <VerticalStackLayout BackgroundColor="#E0E0E0"
+                                 HeightRequest="240"
+                                 HorizontalOptions="Fill">
+                <Image x:Name="Target"
+                       Source="dotnet_bot.png"
+                       HeightRequest="200"
+                       WidthRequest="200"
+                       HorizontalOptions="Center"
+                       VerticalOptions="Center" />
+            </VerticalStackLayout>
+
+            <Label Text="Tap to toggle"
+                   FontAttributes="Bold"
+                   FontSize="16" />
+
+            <Button x:Name="OpacityBtn"
+                    Text="Opacity: 1.00"
+                    Clicked="OnToggleOpacity" />
+
+            <Button x:Name="ScaleBtn"
+                    Text="Scale: 1.00"
+                    Clicked="OnToggleScale" />
+
+            <Button x:Name="RotationBtn"
+                    Text="Rotation: 0°"
+                    Clicked="OnToggleRotation" />
+
+            <Button x:Name="VisibilityBtn"
+                    Text="IsVisible: True"
+                    Clicked="OnToggleVisibility" />
+
+            <Button x:Name="TranslationBtn"
+                    Text="TranslationX: 0"
+                    Clicked="OnToggleTranslation" />
+
+            <Button x:Name="ClipBtn"
+                    Text="Clip: none"
+                    Clicked="OnToggleClip" />
+
+            <Button x:Name="ShadowBtn"
+                    Text="Shadow: off"
+                    Clicked="OnToggleShadow" />
+
+            <Button Text="Reset all"
+                    BackgroundColor="#F44336"
+                    TextColor="White"
+                    Clicked="OnResetAll" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ModifiersPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/ModifiersPage.xaml.cs
@@ -1,0 +1,116 @@
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Modifiers demo — exercises every cross-cutting <see cref="IView"/>
+/// property the <c>ModifierBridge</c> translates into Compose
+/// (<c>IsVisible</c>, <c>Opacity</c>, <c>TranslationX</c>,
+/// <c>Scale</c>, <c>Rotation</c>, <c>Clip</c>, <c>Shadow</c>) by
+/// flipping each one on a single shared <see cref="Image"/>. Every
+/// property change reaches Compose via <c>RemapForCompose</c>'s
+/// version-counter bump on <c>ViewHandler.ViewMapper</c>.
+/// </summary>
+public partial class ModifiersPage : ContentPage
+{
+    /// <summary>Build the page.</summary>
+    public ModifiersPage() => InitializeComponent();
+
+    void OnToggleOpacity(object? sender, EventArgs e)
+    {
+        Target.Opacity = Math.Abs(Target.Opacity - 1.0) < 0.01 ? 0.4 : 1.0;
+        OpacityBtn.Text = $"Opacity: {Target.Opacity:F2}";
+    }
+
+    void OnToggleScale(object? sender, EventArgs e)
+    {
+        Target.Scale = Math.Abs(Target.Scale - 1.0) < 0.01 ? 1.5 : 1.0;
+        ScaleBtn.Text = $"Scale: {Target.Scale:F2}";
+    }
+
+    void OnToggleRotation(object? sender, EventArgs e)
+    {
+        Target.Rotation = Target.Rotation == 0 ? 45 : 0;
+        RotationBtn.Text = $"Rotation: {Target.Rotation:F0}°";
+    }
+
+    void OnToggleVisibility(object? sender, EventArgs e)
+    {
+        Target.IsVisible = !Target.IsVisible;
+        VisibilityBtn.Text = $"IsVisible: {Target.IsVisible}";
+    }
+
+    void OnToggleTranslation(object? sender, EventArgs e)
+    {
+        Target.TranslationX = Target.TranslationX == 0 ? 60 : 0;
+        TranslationBtn.Text = $"TranslationX: {Target.TranslationX:F0}";
+    }
+
+    void OnToggleClip(object? sender, EventArgs e)
+    {
+        // Cycle: none → rounded → ellipse → none.
+        if (Target.Clip is null)
+        {
+            Target.Clip = new RoundRectangleGeometry
+            {
+                CornerRadius = new CornerRadius(40),
+                Rect = new Rect(0, 0, 1, 1),
+            };
+            ClipBtn.Text = "Clip: rounded 40dp";
+        }
+        else if (Target.Clip is RoundRectangleGeometry)
+        {
+            Target.Clip = new EllipseGeometry
+            {
+                RadiusX = 0.5,
+                RadiusY = 0.5,
+                Center  = new Point(0.5, 0.5),
+            };
+            ClipBtn.Text = "Clip: circle";
+        }
+        else
+        {
+            Target.Clip = null;
+            ClipBtn.Text = "Clip: none";
+        }
+    }
+
+    void OnToggleShadow(object? sender, EventArgs e)
+    {
+        if (Target.Shadow is null)
+        {
+            Target.Shadow = new Shadow
+            {
+                Brush = new SolidColorBrush(Colors.Black),
+                Radius = 16,
+                Opacity = 0.7f,
+                Offset = new Point(0, 6),
+            };
+            ShadowBtn.Text = "Shadow: 16dp";
+        }
+        else
+        {
+            Target.Shadow = null!;
+            ShadowBtn.Text = "Shadow: off";
+        }
+    }
+
+    void OnResetAll(object? sender, EventArgs e)
+    {
+        Target.Opacity     = 1.0;
+        Target.Scale       = 1.0;
+        Target.Rotation    = 0;
+        Target.IsVisible   = true;
+        Target.TranslationX = 0;
+        Target.Clip        = null!;
+        Target.Shadow      = null!;
+
+        OpacityBtn.Text     = "Opacity: 1.00";
+        ScaleBtn.Text       = "Scale: 1.00";
+        RotationBtn.Text    = "Rotation: 0°";
+        VisibilityBtn.Text  = "IsVisible: True";
+        TranslationBtn.Text = "TranslationX: 0";
+        ClipBtn.Text        = "Clip: none";
+        ShadowBtn.Text      = "Shadow: off";
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/ComposeElementHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/ComposeElementHandler.cs
@@ -48,6 +48,8 @@ namespace Microsoft.AndroidX.Compose.Maui;
 public abstract class ComposeElementHandler<TVirtualView> : ViewHandler<TVirtualView, ComposeView>, IComposeHandler
     where TVirtualView : class, IView
 {
+    readonly MutableState<int> _viewPropertiesVersion = new(0);
+
     /// <inheritdoc/>
     protected ComposeElementHandler(IPropertyMapper mapper, CommandMapper? commandMapper = null)
         : base(mapper, commandMapper) { }
@@ -84,5 +86,25 @@ public abstract class ComposeElementHandler<TVirtualView> : ViewHandler<TVirtual
     /// invalidates this subtree).
     /// </remarks>
     public abstract ComposableNode BuildNode(IComposer composer);
+
+    /// <summary>
+    /// Subscribe the current composition scope to the shared
+    /// view-properties version slot. Called from
+    /// <c>BuildNode</c> (or inside a deferred <c>Render</c>) so the
+    /// scope re-runs when a property mapper installed by
+    /// <see cref="Hosting.AppHostBuilderExtensions.RemapForCompose"/>
+    /// bumps the counter. The discarded value is intentional — only
+    /// the read matters; Compose registers the dependency.
+    /// </summary>
+    /// <remarks>
+    /// Marked <c>protected internal</c> so nested helper types in
+    /// other handler files (e.g. <c>ScrollViewHandler.ScrollContainer</c>)
+    /// can subscribe directly inside their own deferred
+    /// <c>Render</c> method without exposing the slot.
+    /// </remarks>
+    protected internal void SubscribeToViewProperties() => _ = _viewPropertiesVersion.Value;
+
+    /// <inheritdoc/>
+    void IComposeHandler.BumpViewPropertiesVersion() => _viewPropertiesVersion.Value++;
 }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
@@ -1,6 +1,7 @@
 using AndroidX.Compose;
 using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using ComposeButton = AndroidX.Compose.Button;
 
@@ -69,6 +70,8 @@ public partial class ButtonHandler : ComposeElementHandler<IButton>
     /// <inheritdoc/>
     public override ComposableNode BuildNode(IComposer composer)
     {
+        SubscribeToViewProperties();
+
         var container = _containerColor.Value;
         var content   = _contentColor.Value;
         var button = new ComposeButton(onClick: OnClicked)
@@ -79,8 +82,12 @@ public partial class ButtonHandler : ComposeElementHandler<IButton>
             button.Colors = composer.ButtonColors(
                 containerColor: container,
                 contentColor:   content);
-        if (_fillWidth.Value)
-            button.PrependModifier(Modifier.FillMaxWidth());
+        // Single chained PrependModifier — combines the layout-fill
+        // (when set) with the cross-cutting view properties (Opacity,
+        // Translation, Scale, Rotation, IsVisible, Clip, Shadow).
+        var outer = (_fillWidth.Value ? Modifier.FillMaxWidth() : Modifier.Companion)
+            .ApplyViewProperties(VirtualView!);
+        button.PrependModifier(outer);
         return button;
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Text.Input;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using ComposeColor          = AndroidX.Compose.Color;
 using ComposeFontWeight     = AndroidX.Compose.FontWeight;
@@ -71,6 +72,8 @@ public partial class EntryHandler : ComposeElementHandler<IEntry>
     /// <inheritdoc/>
     public override ComposableNode BuildNode(IComposer composer)
     {
+        SubscribeToViewProperties();
+
         var packed       = _color.Value;
         var size         = _fontSize.Value;
         var bold         = _bold.Value;
@@ -110,8 +113,11 @@ public partial class EntryHandler : ComposeElementHandler<IEntry>
                 d.PlatformImeOptions, d.ShowKeyboardOnFocus, d.HintLocales);
         }
 
-        if (fill)
-            field.PrependModifier(Modifier.FillMaxWidth());
+        // Single chained PrependModifier — combines layout-fill with
+        // the cross-cutting view properties.
+        var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
+            .ApplyViewProperties(VirtualView!);
+        field.PrependModifier(outer);
         return field;
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
@@ -5,6 +5,7 @@ using AndroidX.Compose.UI.Graphics;
 using AndroidX.Compose.UI.Graphics.Painter;
 using AndroidX.Compose.UI.Platform;
 using AndroidX.Core.Graphics.Drawable;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 using ComposeImage = AndroidX.Compose.Image;
@@ -98,14 +99,25 @@ public partial class ImageHandler : ComposeElementHandler<MauiIImage>
     /// <inheritdoc/>
     public override ComposableNode BuildNode(IComposer composer)
     {
+        SubscribeToViewProperties();
+
         // Painter wins over the resource id so a freshly-loaded
         // BitmapPainter immediately replaces any stale fast-path
         // drawable. Both null => empty placeholder.
+        ComposableNode node;
         if (_painter.Value is { } painter)
-            return new ComposeImage(painter) { ContentScale = _contentScale.Value };
-        if (_drawableResourceId.Value is int id)
-            return new ComposeImage(id) { ContentScale = _contentScale.Value };
-        return new Box();
+            node = new ComposeImage(painter) { ContentScale = _contentScale.Value };
+        else if (_drawableResourceId.Value is int id)
+            node = new ComposeImage(id) { ContentScale = _contentScale.Value };
+        else
+            node = new Box();
+
+        // Apply cross-cutting view properties (Opacity / Translation /
+        // Scale / Rotation / IsVisible / Clip / Shadow). The placeholder
+        // Box gets the modifier too, so an Image with Opacity=0 stays
+        // invisible even before the source loads.
+        node.PrependModifier(Modifier.Companion.ApplyViewProperties(VirtualView!));
+        return node;
     }
 
     /// <inheritdoc/>

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
@@ -1,5 +1,6 @@
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using ComposeColor = AndroidX.Compose.Color;
 using ComposeText = AndroidX.Compose.Text;
@@ -70,6 +71,12 @@ public partial class LabelHandler : ComposeElementHandler<ILabel>
     /// <inheritdoc/>
     public override ComposableNode BuildNode(IComposer composer)
     {
+        // Subscribe to the shared view-properties version slot so any
+        // ApplyViewProperties-relevant property change (Opacity,
+        // Translation, Scale, Rotation, IsVisible, Clip, Shadow)
+        // forces a recomposition through the IComposeHandler bumper.
+        SubscribeToViewProperties();
+
         var packed = _color.Value;
         var size   = _fontSize.Value;
         var bold   = _bold.Value;
@@ -87,8 +94,13 @@ public partial class LabelHandler : ComposeElementHandler<ILabel>
                 _                    => null,
             },
         };
-        if (fill)
-            text.PrependModifier(Modifier.FillMaxWidth());
+        // Single PrependModifier call combining the layout-fill (if
+        // applicable) with the cross-cutting view properties — calling
+        // PrependModifier twice would replace, not merge, so this
+        // builds the chain once.
+        var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
+            .ApplyViewProperties(VirtualView!);
+        text.PrependModifier(outer);
         return text;
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
@@ -1,5 +1,6 @@
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 using ILayout = Microsoft.Maui.ILayout;
 using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
@@ -105,6 +106,7 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
     {
         // Read live state on the composition thread so changes
         // observed via the mapper slots trigger recomposition.
+        SubscribeToViewProperties();
         var spacing = _spacing.Value;
         _ = _paddingVersion.Value;  // subscribe — padding change bumps this
         _ = _childrenVersion.Value; // subscribe — a tree mutation bumps this
@@ -116,14 +118,23 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
             ? new Column(verticalArrangement: arrangement)
             : new Row(horizontalArrangement: arrangement);
 
+        // Build the prepended modifier in one chain:
+        // 1. ApplyViewProperties wraps the OUTER box (Opacity / Scale /
+        //    Rotation / Clip / Shadow / IsVisible affect the entire
+        //    padded layout including its own background-painting slot).
+        // 2. Padding goes innermost so the inner content gets the
+        //    inset, while alpha / clip / shadow trace the outer box.
+        // PrependModifier replaces, so emit a single chained call.
+        var outer = Modifier.Companion.ApplyViewProperties(layout);
         if (padding != Thickness.Zero)
         {
-            container.Modifier = Modifier.Padding(
+            outer = outer.Padding(
                 start:  new Dp((float)padding.Left),
                 top:    new Dp((float)padding.Top),
                 end:    new Dp((float)padding.Right),
                 bottom: new Dp((float)padding.Bottom));
         }
+        container.Modifier = outer;
 
         for (int i = 0; i < layout.Count; i++)
         {

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ScrollViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ScrollViewHandler.cs
@@ -1,5 +1,6 @@
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
 
 namespace Microsoft.AndroidX.Compose.Maui.Handlers;
@@ -55,7 +56,7 @@ public partial class ScrollViewHandler : ComposeElementHandler<IScrollView>
         var context = MauiContext
             ?? throw new InvalidOperationException("MauiContext not set on ScrollViewHandler.");
 
-        return new ScrollContainer(scroll, _orientation, context);
+        return new ScrollContainer(this, scroll, _orientation, context);
     }
 
     /// <summary>Map <see cref="IScrollView.Orientation"/> to the cached enum slot.</summary>
@@ -72,12 +73,18 @@ public partial class ScrollViewHandler : ComposeElementHandler<IScrollView>
     /// </summary>
     sealed class ScrollContainer : ComposableNode
     {
+        readonly ScrollViewHandler _owner;
         readonly IScrollView _scroll;
         readonly MutableState<int> _orientation;
         readonly IMauiContext _context;
 
-        public ScrollContainer(IScrollView scroll, MutableState<int> orientation, IMauiContext context)
+        public ScrollContainer(
+            ScrollViewHandler owner,
+            IScrollView scroll,
+            MutableState<int> orientation,
+            IMauiContext context)
         {
+            _owner = owner;
             _scroll = scroll;
             _orientation = orientation;
             _context = context;
@@ -85,6 +92,12 @@ public partial class ScrollViewHandler : ComposeElementHandler<IScrollView>
 
         public override void Render(IComposer composer)
         {
+            // Subscribe inside Render so the deferred composition
+            // scope (the actual scope that builds the modifier chain)
+            // observes view-property bumps, not the parent-only scope
+            // that called BuildNode.
+            _owner.SubscribeToViewProperties();
+
             var orientation = (ScrollOrientation)_orientation.Value;
             var state = composer.Remember(() => new ScrollState());
 
@@ -97,7 +110,13 @@ public partial class ScrollViewHandler : ComposeElementHandler<IScrollView>
             // BuildModifier() is internal to Microsoft.AndroidX.Compose;
             // from this assembly we read the public Modifier property
             // (consumers don't call PrependModifier on internal nodes).
-            var modifier = Modifier is null ? fillMain : Modifier.Then(fillMain);
+            // Cross-cutting view properties go OUTERMOST (before the
+            // scroll modifier) so opacity / clip / shadow trace the
+            // ScrollView's bounding box, not the inner scrolling
+            // surface — matches MAUI's stock semantics where Opacity
+            // fades the entire scroll region as one.
+            var outer = Modifier.Companion.ApplyViewProperties(_scroll).Then(fillMain);
+            var modifier = Modifier is null ? outer : Modifier.Then(outer);
 
             var box = new Box { Modifier = modifier };
             var content = _scroll.PresentedContent;

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -69,6 +69,13 @@ public static class AppHostBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
+        // Slice 8: install the cross-cutting view-property bumpers on
+        // ViewHandler.ViewMapper *before* per-handler registration so
+        // every Compose-backed handler picks up Opacity / Translation
+        // / Scale / Rotation / IsVisible / Clip / Shadow recomposition
+        // through the shared mapper. Idempotent.
+        RemapForCompose();
+
         builder.ConfigureMauiHandlers(handlers =>
         {
             // Root: the only handler that creates a ComposeView.
@@ -87,5 +94,73 @@ public static class AppHostBuilderExtensions
         });
 
         return builder;
+    }
+
+    static bool s_remapped;
+
+    /// <summary>
+    /// Layer Compose-side recomposition triggers onto
+    /// <see cref="ViewHandler.ViewMapper"/> for every cross-cutting
+    /// <see cref="IView"/> visual / transform property
+    /// (<c>Visibility</c>, <c>Opacity</c>, <c>Translation</c>,
+    /// <c>Scale</c>, <c>Rotation</c>, <c>Anchor</c>, <c>Clip</c>,
+    /// <c>Shadow</c>). The base mapper entries continue to dispatch
+    /// to the platform <c>UpdateXxx</c> extensions on <c>ComposeView</c>
+    /// — those are no-ops for our folded leaves, since the
+    /// <c>ComposeView</c> is detached when a Compose-aware parent
+    /// hosts the handler — and the appended hook bumps the handler's
+    /// shared view-properties version slot so the next composition
+    /// pass re-reads via <see cref="Platform.ModifierBridge.ApplyViewProperties"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Why <c>AppendToMapping</c> on the global mapper.</b>
+    /// <c>ViewHandler.ViewMapper</c> is the static base mapper that
+    /// every handler inherits via the <c>PropertyMapper</c> ctor's
+    /// chained-defaults call. Mutating it once here adds the bump
+    /// hook to every handler in the app domain at once — including
+    /// future handlers we add in later slices. Non-Compose handlers
+    /// see the appended hook too; the inner <c>handler is
+    /// IComposeHandler</c> guard keeps the cost to a single type
+    /// check on those.</para>
+    ///
+    /// <para><b>Idempotency.</b> The static <see cref="s_remapped"/>
+    /// flag prevents double-registration when a host calls
+    /// <see cref="UseAndroidXCompose"/> twice (e.g. from a unit-test
+    /// fixture that rebuilds the app). The hook always runs after
+    /// the original mapper, never replaces it — the platform-side
+    /// <c>UpdateOpacity</c> still executes against the (detached)
+    /// <c>ComposeView</c>.</para>
+    /// </remarks>
+    public static void RemapForCompose()
+    {
+        if (s_remapped) return;
+        s_remapped = true;
+
+        var mapper = Microsoft.Maui.Handlers.ViewHandler.ViewMapper;
+
+        // Each cross-cutting IView visual / transform property gets a
+        // dedicated AppendToMapping call so future per-property logic
+        // (e.g. swap Visibility to a measure-policy short-circuit when
+        // the layout adapter ships) has a clear single-point edit.
+        mapper.AppendToMapping(nameof(IView.Visibility),    BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.Opacity),       BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.TranslationX),  BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.TranslationY),  BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.Scale),         BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.ScaleX),        BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.ScaleY),        BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.Rotation),      BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.RotationX),     BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.RotationY),     BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.AnchorX),       BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.AnchorY),       BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.Clip),          BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.Shadow),        BumpViewProperties);
+    }
+
+    static void BumpViewProperties(IViewHandler handler, IView view)
+    {
+        if (handler is IComposeHandler compose)
+            compose.BumpViewPropertiesVersion();
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui/IComposeHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/IComposeHandler.cs
@@ -33,4 +33,26 @@ internal interface IComposeHandler
     /// <see cref="ComposeWalker.Render(Microsoft.Maui.IView, IComposer, IMauiContext)"/>.
     /// </summary>
     ComposableNode BuildNode(IComposer composer);
+
+    /// <summary>
+    /// Bump the per-handler view-properties version slot so the
+    /// next composition pass re-reads the live <see cref="IView"/>
+    /// transform / visibility / clip / shadow values via
+    /// <see cref="Platform.ModifierBridge.ApplyViewProperties"/>.
+    /// Called from <see cref="Hosting.AppHostBuilderExtensions.RemapForCompose"/>
+    /// hooks installed on <c>ViewHandler.ViewMapper</c>.
+    /// </summary>
+    /// <remarks>
+    /// MAUI's <see cref="IView"/> transform properties are all
+    /// struct- or geometry-typed (<c>double</c> coords, <c>Visibility</c>
+    /// enum, <c>IShape</c>, <c>IShadow</c>) — none of which fit
+    /// <c>MutableState&lt;T&gt;</c>'s primitive-or-Java-peer
+    /// constraint. The version-counter pattern (mirror of
+    /// <see cref="Handlers.LayoutHandler.MapPadding"/>'s
+    /// <c>_paddingVersion</c>) replaces a per-property slot with a
+    /// single <c>MutableState&lt;int&gt;</c> bumped on any change;
+    /// <see cref="ComposableNode"/>s subscribe by reading it inside
+    /// <c>BuildNode</c> and live-read the value at composition time.
+    /// </remarks>
+    void BumpViewPropertiesVersion();
 }

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/ModifierBridge.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/ModifierBridge.cs
@@ -1,0 +1,253 @@
+using AndroidX.Compose;
+using Microsoft.Maui.Controls.Shapes;
+using ComposeShape = AndroidX.Compose.Shape;
+using MauiVisibility = Microsoft.Maui.Visibility;
+
+namespace Microsoft.AndroidX.Compose.Maui.Platform;
+
+/// <summary>
+/// Translates the cross-platform <see cref="IView"/> visual / transform
+/// properties (<c>IsVisible</c>, <c>Opacity</c>, <c>Translation</c>,
+/// <c>Scale</c>, <c>Rotation</c>, <c>AnchorX/Y</c>, <c>Clip</c>,
+/// <c>Shadow</c>) into a Compose modifier chain. Every Compose-backed
+/// handler chains <see cref="ApplyViewProperties"/> on its outermost
+/// (prepended) modifier so MAUI's struct-typed view-level properties
+/// take effect uniformly without each handler re-deriving the
+/// translation.
+/// </summary>
+/// <remarks>
+/// <para>This is the Compose analog of MAUI's stock per-property
+/// extensions (<c>UpdateOpacity</c>, <c>UpdateTranslationX</c>, …) on
+/// <c>Microsoft.Maui.Platform.ViewExtensions</c>. The stock pipeline
+/// pokes the Android <c>View</c> directly; for our handlers the view
+/// is a detached <c>ComposeView</c> on the leaf path (folded into the
+/// parent composition via <see cref="IComposeHandler.BuildNode"/>) so
+/// modifying its <c>Alpha</c> / <c>TranslationX</c> / … is invisible.
+/// We model the same effects via Compose modifiers instead.</para>
+///
+/// <para><b>Recomposition:</b> mapper writes go into one shared
+/// <c>MutableState&lt;int&gt;</c> view-properties version slot on
+/// <see cref="ComposeElementHandler{TVirtualView}"/>; <c>BuildNode</c>
+/// implementations subscribe by reading that slot inside the
+/// composition, then call <see cref="ApplyViewProperties"/> which
+/// reads the live struct values off the virtual view. The
+/// version-counter pattern is the only option for struct-valued
+/// properties (Color / Geometry / Shadow) because
+/// <c>MutableState&lt;T&gt;</c> only accepts primitives, strings, and
+/// <c>Java.Lang.Object</c> subclasses.</para>
+///
+/// <para><b>IsVisible semantic choice — alpha vs layout-skip.</b> MAUI's
+/// <c>IsVisible == false</c> on the cross-platform side maps to
+/// <see cref="MauiVisibility.Hidden"/> on the IView surface (which
+/// stock backends collapse via the platform's visibility flag). We
+/// translate to <c>Modifier.Alpha(0f)</c>, which preserves the cell's
+/// layout space — a transparent placeholder rather than a removed
+/// node. This is the closest single-modifier match because Compose's
+/// modifier system can't drop a child out of the parent layout slot;
+/// dropping the node would require a measure-policy short-circuit
+/// (a generic <c>Layout {}</c> adapter, on the Phase 5 roadmap). For
+/// now <c>IsVisible == false</c> hides the pixels but leaves the
+/// space — matching MAUI's <c>Hidden</c>, not <c>Collapsed</c>,
+/// semantics.</para>
+///
+/// <para><b>3D rotation round-trip.</b> Compose's
+/// <c>Modifier.GraphicsLayer { rotationX, rotationY, rotationZ }</c>
+/// uses a perspective camera (<c>cameraDistance</c> defaults to ~8 ×
+/// the layout depth in dp). MAUI's <c>RotationX</c>/<c>RotationY</c>
+/// were originally modelled on a similar perspective transform but
+/// with a different camera distance, so a 60° <c>RotationX</c>
+/// rendered through Compose's graphics layer foreshortens differently
+/// than the same value on the stock Android renderer. The visual
+/// difference is most apparent above ~30° of axis tilt; we accept it
+/// because matching the stock perspective would require porting
+/// Android's <c>android.graphics.Camera</c> matrix into Compose
+/// space — out of scope for the bridge.</para>
+/// </remarks>
+public static class ModifierBridge
+{
+    /// <summary>
+    /// Chain Compose modifier ops onto <paramref name="modifier"/> for
+    /// every <see cref="IView"/> visual / transform property the view
+    /// has set to a non-identity value. Returns
+    /// <paramref name="modifier"/> unchanged when the view's transform
+    /// state is the all-identity default (no allocation, no JNI calls
+    /// — common case).
+    /// </summary>
+    /// <param name="modifier">Starting modifier; usually
+    /// <c>Modifier.Companion</c> for the prepended slot.</param>
+    /// <param name="view">The MAUI virtual view whose properties feed
+    /// the modifier chain.</param>
+    /// <returns>A modifier with one or more of <c>Alpha</c>,
+    /// <c>Offset</c>, <c>Scale</c>, <c>Rotate</c>,
+    /// <c>GraphicsLayer</c>, <c>Clip</c>, <c>Shadow</c> appended in
+    /// that order. Order matters: alpha and translation go outermost
+    /// (so they affect the entire visual including any clip / shadow
+    /// outline), shadow and clip go innermost (so they outline the
+    /// drawn content rather than the post-translate position).</returns>
+    public static Modifier ApplyViewProperties(this Modifier modifier, IView view)
+    {
+        ArgumentNullException.ThrowIfNull(modifier);
+        ArgumentNullException.ThrowIfNull(view);
+
+        // -- Visibility / Opacity (outermost so they apply to the
+        //    entire box including any clipped / shadowed children).
+        // IView.Visibility (Visible / Hidden / Collapsed) is what
+        // mappers see. Hidden + Collapsed both render invisibly; we
+        // model both as Alpha(0f) and document the trade-off (see
+        // class remarks). Opacity stacks: a Visible view with
+        // Opacity=0.5 still gets Alpha(0.5).
+        if (view.Visibility != MauiVisibility.Visible)
+        {
+            modifier = modifier.Alpha(0f);
+        }
+        else if (view.Opacity < 1d)
+        {
+            modifier = modifier.Alpha((float)Math.Max(0d, view.Opacity));
+        }
+
+        // -- Translation. Skip at zero to keep the modifier chain
+        //    minimal in the common case.
+        var tx = view.TranslationX;
+        var ty = view.TranslationY;
+        if (tx != 0d || ty != 0d)
+        {
+            modifier = modifier.Offset(
+                x: tx != 0d ? new Dp((float)tx) : default,
+                y: ty != 0d ? new Dp((float)ty) : default);
+        }
+
+        // -- Scale. MAUI multiplies the uniform Scale by the per-axis
+        //    ScaleX / ScaleY, so a Scale=2 ScaleY=0.5 view ends up at
+        //    (2, 1).
+        var scale  = view.Scale;
+        var scaleX = view.ScaleX * scale;
+        var scaleY = view.ScaleY * scale;
+        if (scaleX != 1d || scaleY != 1d)
+        {
+            if (Math.Abs(scaleX - scaleY) < 1e-6)
+                modifier = modifier.Scale((float)scaleX);
+            else
+                modifier = modifier.Scale((float)scaleX, (float)scaleY);
+        }
+
+        // -- Rotation. The 2D fast path uses Modifier.Rotate (cheaper,
+        //    no GraphicsLayer allocation). When the view exercises any
+        //    of the 3D-rotation knobs (RotationX / RotationY) or moves
+        //    the pivot away from center (AnchorX / AnchorY != 0.5), we
+        //    fall back to a single GraphicsLayer that bundles them all
+        //    together — Compose only honours one transformOrigin per
+        //    layer, so two separate Rotate + GraphicsLayer ops would
+        //    pivot inconsistently.
+        var rotation  = view.Rotation;
+        var rotationX = view.RotationX;
+        var rotationY = view.RotationY;
+        var anchorX   = view.AnchorX;
+        var anchorY   = view.AnchorY;
+        bool needsLayer = rotationX != 0d || rotationY != 0d
+            || Math.Abs(anchorX - 0.5d) > 1e-6 || Math.Abs(anchorY - 0.5d) > 1e-6;
+
+        if (needsLayer)
+        {
+            long? origin = (Math.Abs(anchorX - 0.5d) > 1e-6 || Math.Abs(anchorY - 0.5d) > 1e-6)
+                ? TransformOrigin.Pack((float)anchorX, (float)anchorY)
+                : null;
+            modifier = modifier.GraphicsLayer(
+                rotationX:       rotationX != 0d ? (float)rotationX : null,
+                rotationY:       rotationY != 0d ? (float)rotationY : null,
+                rotationZ:       rotation  != 0d ? (float)rotation  : null,
+                transformOrigin: origin);
+        }
+        else if (rotation != 0d)
+        {
+            modifier = modifier.Rotate((float)rotation);
+        }
+
+        // -- Shadow. Innermost so it outlines the drawn content.
+        //    Compose's Modifier.Shadow only exposes elevation + shape;
+        //    MAUI's Brush / Offset / Opacity beyond the elevation tint
+        //    aren't surfaced (Compose synthesises them from the
+        //    elevation + the surrounding theme).
+        if (view.Shadow is { } shadow && shadow.Radius > 0)
+        {
+            modifier = modifier.Shadow(new Dp(shadow.Radius));
+        }
+
+        // -- Clip. Apply last so the clip outline tracks the content
+        //    rather than the post-translate / post-rotate bounds.
+        if (view.Clip is IShape clip)
+        {
+            var shape = TranslateClipToShape(clip);
+            if (shape is not null)
+                modifier = modifier.Clip(shape);
+        }
+
+        return modifier;
+    }
+
+    /// <summary>
+    /// Map a MAUI <see cref="IShape"/> to a Compose
+    /// <see cref="ComposeShape"/>. Only the simple primitive
+    /// geometries are recognised; unknown shapes / arbitrary paths
+    /// return <see langword="null"/> so the caller skips the
+    /// <c>Modifier.Clip</c> chain rather than emitting a wrong outline.
+    /// </summary>
+    static ComposeShape? TranslateClipToShape(IShape clip) => clip switch
+    {
+        // RoundRectangleGeometry — uniform CornerRadius is the common
+        // XAML shape; MAUI's CornerRadius is a struct of four doubles.
+        // Compose RoundedCornerShape supports four-corner builds via
+        // RoundedCorners(topStart, topEnd, bottomEnd, bottomStart).
+        RoundRectangleGeometry r => BuildRoundedRectangle(r),
+
+        // RectangleGeometry — pure rectangle, no clipping outline
+        // change. Compose's singleton RectangleShape is the canonical
+        // "draw a rectangle, no rounding" answer.
+        RectangleGeometry => ComposeShape.Rectangle,
+
+        // EllipseGeometry — only the equal-radii (circle / pill) case
+        // maps cleanly; an axis-aligned ellipse would require a
+        // RoundedCornerShape with percent=50 and an aspect-aware
+        // clip, which Compose doesn't expose as a single shape.
+        EllipseGeometry e when Math.Abs(e.RadiusX - e.RadiusY) < 1e-6 => ComposeShape.Circle(),
+
+        // Anything else (PathGeometry / GeometryGroup / line /
+        // polyline / Shape subclasses with custom paths) falls
+        // through to no-op clipping. We surface the documented
+        // limitation in docs/maui-backend.md rather than emit a
+        // wrong outline.
+        _ => null,
+    };
+
+    /// <summary>
+    /// Build a Compose <see cref="RoundedCornerShape"/> from a MAUI
+    /// <see cref="RoundRectangleGeometry"/>. The rectangle bounds
+    /// themselves are ignored (Compose's clip outline is implicitly
+    /// the layout box), only the <c>CornerRadius</c> contributes.
+    /// </summary>
+    static ComposeShape BuildRoundedRectangle(RoundRectangleGeometry geo)
+    {
+        var corner = geo.CornerRadius;
+        // Common case: a uniform corner radius — emit the cheap
+        // single-Dp ctor so the JNI bridge doesn't have to build a
+        // four-corner CornerSize array.
+        if (Math.Abs(corner.TopLeft - corner.TopRight) < 1e-6
+            && Math.Abs(corner.TopLeft - corner.BottomRight) < 1e-6
+            && Math.Abs(corner.TopLeft - corner.BottomLeft) < 1e-6)
+        {
+            return new RoundedCornerShape(new Dp((float)corner.TopLeft));
+        }
+
+        // Per-corner radii: MAUI orders TopLeft / TopRight / BottomRight /
+        // BottomLeft (visually clockwise from top-leading); Compose
+        // uses topStart / topEnd / bottomEnd / bottomStart, which is
+        // the same order under LTR layout (Start == Left). RTL apps
+        // would mirror the start/end in Compose; MAUI's
+        // RoundRectangleGeometry doesn't model that distinction so we
+        // pass through verbatim and accept the LTR-only fidelity.
+        return new RoundedCornerShape(
+            topStart:    new Dp((float)corner.TopLeft),
+            topEnd:      new Dp((float)corner.TopRight),
+            bottomEnd:   new Dp((float)corner.BottomRight),
+            bottomStart: new Dp((float)corner.BottomLeft));
+    }
+}


### PR DESCRIPTION
## Scope

Adds a shared modifier pipeline so cross-cutting `IView` visual / transform properties reach every Compose-backed handler. Without this, properties like `Opacity="0.5"` on a Compose-backed Label were silently ignored.

### Files

- **`Platform/ModifierBridge.cs`** (new, ~270 LOC) — the entry point. Exposes `Modifier ApplyViewProperties(this Modifier, IView)` plus `BuildClipShape` / `BuildShadow` helpers.
- **`ComposeElementHandler<T>.cs`** — adds `_viewPropertiesVersion` (`MutableState<int>`) read live during composition, plus `protected internal SubscribeToViewProperties()` and `IComposeHandler.BumpViewPropertiesVersion()`.
- **`Hosting/AppHostBuilderExtensions.cs`** — `RemapForCompose()` hooks 14 `IView` struct properties onto the GLOBAL `ViewHandler.ViewMapper`. Idempotent via static `s_remapped` flag.
- **`Handlers/{Label,Button,Entry,Image,Layout,ScrollView}Handler.cs`** — refactored to chain `ApplyViewProperties(VirtualView)` on the root `Modifier`.
- **Sample** — `ModifiersPage.xaml(.cs)` with toggle buttons for Opacity / Scale / Rotation / IsVisible / TranslationX / Clip / Shadow on a single Image, plus Reset; HomePage entry + Shell route wired.
- **`docs/maui-backend.md`** — Phase 2 Slice 8 subsection with the property→modifier table, the IsVisible semantics trade-off, and Shadow caveats.

### Property → Compose mapping

| MAUI property | Compose translation | Notes |
|---|---|---|
| `IsVisible == false` | `Modifier.Alpha(0f)` | Preserves layout space (matches MAUI semantics; layout-skip is a future iteration). |
| `Opacity` (< 1) | `Modifier.Alpha((float)opacity)` | |
| `TranslationX/Y` | `Modifier.Offset(x.dp, y.dp)` | |
| `Scale * ScaleX/Y` | `Modifier.Scale(sx, sy)` | MAUI multiplies the per-axis values |
| `Rotation` only | `Modifier.Rotate(rotation)` | |
| `Rotation + RotationX/Y/Anchor` | `Modifier.GraphicsLayer` | 3D rotation + transformOrigin |
| `Clip` (RoundRectangle/Rectangle/Ellipse) | `Modifier.Clip(shape)` | Bails for arbitrary paths |
| `Shadow` (`Radius > 0`) | `Modifier.Shadow(radius.dp)` | Brush/Offset/Opacity not modelled (Compose Shadow doesn't expose them) |

## Verification

- `dotnet build src/Microsoft.AndroidX.Compose.Maui` — clean.
- `dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample -t:Install` — clean.
- On-device (Pixel 8):
  - **HomePage shows the new "Modifiers" entry**.
  - ModifiersPage hosts **exactly 1 `androidx.compose.ui.platform.ComposeView`** per the rule.
  - Toggling Opacity (1.00 → 0.40), Scale (1.00 → 1.50), Rotation (0° → 45°), TranslationX (0 → 60), Clip (none → rounded 40dp), and Shadow (off → 16dp) each visibly transforms the target Image.
  - IsVisible uses the same `Modifier.Alpha(0f)` path as Opacity.
  - Existing pages (Buttons / Entries / Image: Aspects) render unchanged.

## Lessons learned

- **MAUI struct properties (Color, Geometry, Shadow, Thickness) throw `NotSupportedException` from `MutableState<T>`'s ctor.** Solution: shared `MutableState<int>` version slot bumped by per-property mappers, read live by `ApplyViewProperties` at composition time.
- **`RemapForCompose()` mutates the GLOBAL `ViewHandler.ViewMapper` via `AppendToMapping`**, so non-Compose handlers also receive the callback. Inner `handler is IComposeHandler` guard handles that; `PageHandler` does not implement `IComposeHandler` and is correctly skipped (its ComposeView IS the platform view).
- **`ComposableNode.PrependModifier` replaces rather than accumulates** — handlers that previously called `PrependModifier(FillMaxWidth())` had to merge their existing modifier with `ApplyViewProperties` in a single chained call.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>