### PR TITLE
MAUI Phase 2 Slice 9: ComposeAlertManagerSubscription (DisplayAlert / ActionSheet / Prompt over Compose dialogs)

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -602,6 +602,125 @@ page so cross-sibling animation, semantics, and a single
   consumes pointer events for its own composition. Workaround: put
   a stock leaf in the cell, or convert the container.
 
+#### Phase 2 Slice 9 — `ComposeAlertManagerSubscription` ✅ shipped
+
+`Page.DisplayAlert(...)` / `Page.DisplayActionSheet(...)` /
+`Page.DisplayPromptAsync(...)` route through MAUI's internal
+`AlertManager` on Android. Stock `AlertManager` shows AppCompat
+`AlertDialog.Builder` / `ListView` bottom-sheets that look out of
+place against Compose-skinned pages. Slice 9 intercepts at the DI
+contract layer and renders through Compose `AlertDialog` /
+`ModalBottomSheet` / `OutlinedTextField` overlays.
+
+**Approach: `DispatchProxy` over MAUI's internal
+`AlertManager.IAlertManagerSubscription`.** MAUI's
+`AlertManager.Subscribe()` resolves
+`Services.GetService<IAlertManagerSubscription>()` and **only falls
+back to the stock subscription when DI returns null**. Registering
+our own implementation as that interface short-circuits the stock
+path entirely — no MessagingCenter races, no need to wholesale
+replace `AlertManager` via reflection.
+
+Catch: the interface is `internal`. We can't `: IAlertManagerSubscription`
+at compile time. Instead we mirror maui-labs's WPF
+`WPFAlertManagerSubscription` pattern:
+
+1. Reflectively look up
+   `Microsoft.Maui.Controls.Platform.AlertManager+IAlertManagerSubscription`
+   from the loaded `Microsoft.Maui.Controls` assembly.
+2. Use `System.Reflection.DispatchProxy.Create<TInterface, TProxy>()`
+   to synthesise an instance of that interface backed by our
+   `ComposeAlertManagerSubscription : DispatchProxy` class.
+3. The runtime-emitted subclass routes every interface call into our
+   `Invoke(MethodInfo, object?[])` override, which fans out by
+   method name to `OnAlertRequested` / `OnPromptRequested` /
+   `OnActionSheetRequested` / no-op for `OnPageBusy`.
+4. Register the proxy via
+   `services.AddSingleton(serviceType: <runtime IAlertManagerSubscription>, factory)`.
+
+This binds us to MAUI's internal interface shape — version pinning
+hazard. Pinned to `Microsoft.Maui.Controls` 10.0.20. If the interface
+gains/renames members in a future MAUI, the proxy will throw
+`MissingMethodException` at first call. The contract has been stable
+since net6.0; risk is low but real.
+
+**Render mappings:**
+
+- `AlertArguments(title, message, accept, cancel)` → Compose
+  `AlertDialog(title, text, confirmButton, dismissButton)`. For the
+  three-arg `DisplayAlert(title, message, cancel)` overload — single
+  button — MAUI passes `Accept = null`. Detect that, render `Cancel`
+  as the confirm button label only, omit the dismiss slot. (First
+  bug of the slice: not detecting → "OK / OK" twin buttons.)
+- `ActionSheetArguments(title, cancel, destruction, buttons[])` →
+  Compose `ModalBottomSheet` listing buttons as a
+  `LazyColumn` of `ListItem`s, with `destruction` styled red.
+- `PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue)`
+  → Compose `AlertDialog` with an `OutlinedTextField` between `text`
+  and `confirmButton`, pre-filled with `InitialValue`.
+
+**Overlay attach/detach lifecycle.** Each handler resolves the
+`Activity` from `sender.Window.Handler.PlatformView` (with a fallback
+to `Platform.CurrentActivity`), creates a fresh `ComposeView`, sets
+content via the existing `ComposeView.SetContent(node => …)`
+extension, and adds the view to the activity's `android.R.id.content`
+`FrameLayout`. The dismiss closure removes the view from its parent
+on the UI thread. `args.Result.TrySetResult(...)` is set **before**
+detach so the awaiting `Task` completes deterministically — even if
+`RemoveView` synchronously re-enters another dialog flow.
+
+`onUnattached` is invoked when `ResolveActivity` fails (rare —
+e.g. background page). It completes the awaiter with the cancel
+value so the caller's `await` doesn't hang.
+
+**Memory leak hazards.** The proxy itself is a process-wide singleton,
+so it's safe to capture services + activity-lookup state. Per-call
+overlay state lives only inside the dismiss closure (lambda-captured
+by the on-confirm/on-cancel handlers); once detached, the
+`ComposeView` and its captured page reference are dropped. No long-
+lived `WeakReference`-to-`Activity` is needed because no field on
+the singleton holds a strong activity reference — every call goes
+`sender.Window` → `Handler.PlatformView`.
+
+**Theme alignment — known mismatch (deferred to Slice 7).** The
+overlay wraps content in the default Compose `MaterialTheme()`
+because the page's theme is currently passed through ad-hoc in
+`PageHandler`. Once `ThemeManager` (Slice 7) ships, the overlay
+will pull from the same `Application` `UserAppTheme` /
+`RequestedTheme` source as the page composer. For now, dialog
+M3 colours match the page theme by visual coincidence (both default
+dynamic colour) but won't track explicit `App.Resources` overrides.
+
+**Action-sheet animation — known polish gap.** `ModalBottomSheet`
+currently dismisses by removing the overlay view — the bottom
+sheet does not animate out. Polishing this requires `sheetState`
+plumbing (suspend `Hide()` then detach inside a continuation). Out
+of scope for Slice 9; tracked separately.
+
+**Lessons learned (Slice 9):**
+
+- **`DispatchProxy.Create<T, TProxy>` requires `TProxy` non-sealed.**
+  Reflection.Emit synthesises a runtime subclass; sealed bases throw
+  `ArgumentException` at the first `Create` call. The error doesn't
+  surface through `JavaProxyThrowable`'s default crash log on
+  Android — only `AndroidRuntime: FATAL EXCEPTION: main` with the
+  proxy class name, no inner detail. Always wrap `DispatchProxy.Create`
+  in a try/catch that explicitly logs `ex.InnerException` via
+  `global::Android.Util.Log` to surface the real reason. (`Android`
+  alone resolves to `Microsoft.Android` once `using Android.App;`
+  is in scope — qualify as `global::Android` for `Android.Util.Log`.)
+- **Fast-Dev (`EmbedAssembliesIntoApk = false`) breaks after a clean
+  uninstall.** `dotnet build -t:Install` complains about a missing
+  `files/.__override__/<arch>/Mono.Android.Runtime.dll` (XA0127). Add
+  `-p:EmbedAssembliesIntoApk=true` to use a fully-bundled APK; the
+  flag is the safest for slice verification.
+- **Multiple `compose-net` apps confuse on-device verification.** The
+  Gallery app and the MAUI sample both use `Title="Compose Gallery"`
+  by default (the MAUI sample inherits MAUI's title from `MainPage`).
+  Always verify foreground via
+  `adb shell dumpsys activity activities | findstr topResumedActivity`
+  before screenshotting.
+
 ### Phase 3 — collection + container (target: list-driven apps)
 
 `CollectionView` → `LazyColumn<T>` / `LazyRow<T>` / `LazyVerticalGrid<T>`

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -846,20 +846,21 @@ since net6.0; risk is low but real.
   bug of the slice: not detecting → "OK / OK" twin buttons.)
 - `ActionSheetArguments(title, cancel, destruction, buttons[])` →
   Compose `ModalBottomSheet` listing buttons as a
-  `LazyColumn` of `ListItem`s, with `destruction` styled red.
+  `Column` of `ListItem`s, with `destruction` styled red.
 - `PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue)`
   → Compose `AlertDialog` with an `OutlinedTextField` between `text`
   and `confirmButton`, pre-filled with `InitialValue`.
 
 **Overlay attach/detach lifecycle.** Each handler resolves the
-`Activity` from `sender.Window.Handler.PlatformView` (with a fallback
-to `Platform.CurrentActivity`), creates a fresh `ComposeView`, sets
-content via the existing `ComposeView.SetContent(node => …)`
-extension, and adds the view to the activity's `android.R.id.content`
-`FrameLayout`. The dismiss closure removes the view from its parent
-on the UI thread. `args.Result.TrySetResult(...)` is set **before**
-detach so the awaiting `Task` completes deterministically — even if
-`RemoveView` synchronously re-enters another dialog flow.
+`Activity` from `sender.Handler?.MauiContext?.Context.GetActivity()`
+(returning `null` if the page isn't attached to a handler yet),
+creates a fresh `ComposeView`, sets content via the existing
+`ComposeView.SetContent(node => …)` extension, and adds the view to
+the activity's `android.R.id.content` `FrameLayout`. The dismiss
+closure removes the view from its parent on the UI thread.
+`args.Result.TrySetResult(...)` is set **before** detach so the
+awaiting `Task` completes deterministically — even if `RemoveView`
+synchronously re-enters another dialog flow.
 
 `onUnattached` is invoked when `ResolveActivity` fails (rare —
 e.g. background page). It completes the awaiter with the cancel
@@ -872,7 +873,7 @@ by the on-confirm/on-cancel handlers); once detached, the
 `ComposeView` and its captured page reference are dropped. No long-
 lived `WeakReference`-to-`Activity` is needed because no field on
 the singleton holds a strong activity reference — every call goes
-`sender.Window` → `Handler.PlatformView`.
+through the live `sender.Handler?.MauiContext?.Context` chain.
 
 **Theme alignment — known mismatch (deferred to Slice 7).** The
 overlay wraps content in the default Compose `MaterialTheme()`

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -21,5 +21,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("entries",        typeof(EntriesPage));
         Routing.RegisterRoute("image-aspects",  typeof(ImageAspectsPage));
         Routing.RegisterRoute("image-sources",  typeof(ImageSourcesPage));
+        Routing.RegisterRoute("alerts",         typeof(AlertsPage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -60,6 +60,11 @@ public partial class HomePage : ContentPage
                 "File / Uri / Stream / Font image source types.",
                 Color.FromArgb("#E91E63"),
                 "image-sources"),
+            new DemoEntry(
+                "Alerts",
+                "DisplayAlert / DisplayActionSheet / DisplayPromptAsync over Compose dialogs.",
+                Color.FromArgb("#FF5722"),
+                "alerts"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.AlertsPage"
+             Title="Alerts">
+
+    <!--
+        Exercises the four `Page.Display*` channels routed through
+        `ComposeAlertManagerSubscription`:
+            * DisplayAlert          -> Compose AlertDialog (confirm + cancel)
+            * DisplayActionSheet    -> Compose ModalBottomSheet
+            * DisplayPromptAsync    -> Compose AlertDialog + OutlinedTextField
+            * DisplayAlert (1-btn)  -> Compose AlertDialog (no DismissButton)
+        Each handler echoes the result into the status label below so
+        the awaiting Task's completion value is observable on-device.
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="20">
+
+            <Label
+                Text="Alerts"
+                Style="{StaticResource Headline}" />
+
+            <Label Text="Each button calls `Page.Display*` — the dialogs render through Compose `AlertDialog` / `ModalBottomSheet`, not the stock AppCompat dialogs."
+                   Style="{StaticResource SubHeadline}" />
+
+            <Button x:Name="ShowAlertBtn"
+                    Text="Show Alert (OK / Cancel)"
+                    Clicked="OnShowAlertClicked"
+                    HorizontalOptions="Fill" />
+
+            <Button x:Name="ShowActionSheetBtn"
+                    Text="Action Sheet"
+                    Clicked="OnShowActionSheetClicked"
+                    HorizontalOptions="Fill" />
+
+            <Button x:Name="ShowPromptBtn"
+                    Text="Prompt"
+                    Clicked="OnShowPromptClicked"
+                    HorizontalOptions="Fill" />
+
+            <Button x:Name="ShowSingleButtonBtn"
+                    Text="OK-only Alert"
+                    Clicked="OnShowSingleButtonClicked"
+                    HorizontalOptions="Fill" />
+
+            <Label Text="Last result"
+                   FontAttributes="Bold"
+                   Margin="0,12,0,0" />
+
+            <Label x:Name="ResultLabel"
+                   Text="(no dialog dismissed yet)"
+                   FontSize="14" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml
@@ -41,6 +41,11 @@
                     Clicked="OnShowPromptClicked"
                     HorizontalOptions="Fill" />
 
+            <Button x:Name="ShowNumericPromptBtn"
+                    Text="Prompt — Numeric IME, MaxLength 4"
+                    Clicked="OnShowNumericPromptClicked"
+                    HorizontalOptions="Fill" />
+
             <Button x:Name="ShowSingleButtonBtn"
                     Text="OK-only Alert"
                     Clicked="OnShowSingleButtonClicked"

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml.cs
@@ -1,0 +1,72 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Exercises <see cref="Page.DisplayAlert(string, string, string)"/> /
+/// <see cref="Page.DisplayActionSheet(string, string, string, string[])"/>
+/// / <see cref="Page.DisplayPromptAsync(string, string, string, string, string, int, Keyboard, string)"/>.
+/// All three are intercepted by
+/// <c>ComposeAlertManagerSubscription</c> so the visible dialog is a
+/// Compose <c>AlertDialog</c> / <c>ModalBottomSheet</c>, not the
+/// stock AppCompat dialog.
+/// </summary>
+public partial class AlertsPage : ContentPage
+{
+    /// <summary>Build the page.</summary>
+    public AlertsPage()
+    {
+        InitializeComponent();
+    }
+
+    async void OnShowAlertClicked(object? sender, EventArgs e)
+    {
+        // bool DisplayAlertAsync(string title, string message,
+        //                        string accept, string cancel)
+        var ok = await DisplayAlertAsync(
+            "Confirm reset",
+            "This clears every demo's local state. Continue?",
+            "OK",
+            "Cancel");
+        ResultLabel.Text = $"DisplayAlertAsync → {(ok ? "OK" : "Cancel")}";
+    }
+
+    async void OnShowActionSheetClicked(object? sender, EventArgs e)
+    {
+        // string DisplayActionSheetAsync(string title, string cancel,
+        //                                string destruction,
+        //                                params string[] buttons)
+        var pick = await DisplayActionSheetAsync(
+            "Pick one",
+            "Cancel",
+            "Delete",
+            "Edit", "Archive", "Share");
+        ResultLabel.Text = $"DisplayActionSheetAsync → {pick ?? "(null)"}";
+    }
+
+    async void OnShowPromptClicked(object? sender, EventArgs e)
+    {
+        // string DisplayPromptAsync(string title, string message,
+        //                           string accept, string cancel,
+        //                           string placeholder, int maxLength,
+        //                           Keyboard keyboard, string initialValue)
+        var name = await DisplayPromptAsync(
+            "Your name",
+            "Enter the name to greet:",
+            "OK",
+            "Cancel",
+            "name",
+            -1,
+            Keyboard.Default,
+            "World");
+        ResultLabel.Text = $"DisplayPromptAsync → {name ?? "(null — cancel)"}";
+    }
+
+    async void OnShowSingleButtonClicked(object? sender, EventArgs e)
+    {
+        // void DisplayAlertAsync(string title, string message, string cancel)
+        await DisplayAlertAsync(
+            "All done",
+            "This alert has only an OK button — no DismissButton slot.",
+            "OK");
+        ResultLabel.Text = "DisplayAlertAsync (single button) → dismissed";
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.xaml.cs
@@ -60,6 +60,21 @@ public partial class AlertsPage : ContentPage
         ResultLabel.Text = $"DisplayPromptAsync → {name ?? "(null — cancel)"}";
     }
 
+    async void OnShowNumericPromptClicked(object? sender, EventArgs e)
+    {
+        // Exercise MaxLength + Keyboard forwarding — the IME should
+        // surface the digit pad and the field caps at 4 chars.
+        var pin = await DisplayPromptAsync(
+            "PIN",
+            "Enter a 4-digit PIN (numeric keyboard, max 4 chars):",
+            "OK",
+            "Cancel",
+            "0000",
+            4,
+            Keyboard.Numeric);
+        ResultLabel.Text = $"DisplayPromptAsync (numeric, len ≤ 4) → {pin ?? "(null — cancel)"}";
+    }
+
     async void OnShowSingleButtonClicked(object? sender, EventArgs e)
     {
         // void DisplayAlertAsync(string title, string message, string cancel)

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AndroidX.Compose.Maui.Handlers;
+using Microsoft.AndroidX.Compose.Maui.Platform;
 using MauiButton = Microsoft.Maui.Controls.Button;
 using MauiEntry = Microsoft.Maui.Controls.Entry;
 using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
@@ -68,6 +69,15 @@ public static class AppHostBuilderExtensions
     public static MauiAppBuilder UseAndroidXCompose(this MauiAppBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
+
+        // Register a DispatchProxy-backed IAlertManagerSubscription so
+        // MAUI's per-window AlertManager.Subscribe() picks us up
+        // before falling back to AlertRequestHelper. Renders
+        // DisplayAlert / DisplayActionSheet / DisplayPromptAsync via
+        // Compose AlertDialog / ModalBottomSheet instead of stock
+        // AppCompat dialogs. See ComposeAlertManagerSubscription's
+        // remarks for the version-pinning hazard.
+        ComposeAlertManagerSubscription.Register(builder.Services);
 
         builder.ConfigureMauiHandlers(handlers =>
         {

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/ComposeAlertManagerSubscription.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/ComposeAlertManagerSubscription.cs
@@ -9,6 +9,8 @@ using Microsoft.Maui.Platform;
 using ComposeAlertDialog       = AndroidX.Compose.AlertDialog;
 using ComposeColor             = AndroidX.Compose.Color;
 using ComposeColumn            = AndroidX.Compose.Column;
+using ComposeKeyboardOptions   = AndroidX.Compose.Foundation.Text.KeyboardOptions;
+using ComposeKeyboardType      = AndroidX.Compose.KeyboardType;
 using ComposeListItem          = AndroidX.Compose.ListItem;
 using ComposeMaterialTheme     = AndroidX.Compose.MaterialTheme;
 using ComposeModalBottomSheet  = AndroidX.Compose.ModalBottomSheet;
@@ -274,6 +276,24 @@ public class ComposeAlertManagerSubscription : DispatchProxy
         // ensures recomposition fires on each keystroke.
         var text = new MutableState<string>(args.InitialValue ?? string.Empty);
 
+        // Enforce MaxLength here (Compose's OutlinedTextField has no
+        // native max-length property) and write through to the
+        // MutableState. MAUI's contract: -1 = unlimited; <= 0 also
+        // treated as unlimited so the field stays usable.
+        var maxLength = args.MaxLength;
+        void OnTextChanged(string newValue)
+        {
+            if (maxLength > 0 && newValue.Length > maxLength)
+                newValue = newValue.Substring(0, maxLength);
+            text.Value = newValue;
+        }
+
+        // Map MAUI's Keyboard enum to a Compose KeyboardOptions so
+        // the IME surfaces digits / email layout / etc. Mirrors
+        // EntryHandler.ResolveKeyboardType — kept inline because
+        // the ResolveKeyboardType helper isn't exposed publicly.
+        var keyboardOptions = ResolveKeyboardOptions(args.Keyboard);
+
         ShowOnUiThread(activity, (overlay, dismiss) =>
         {
             void Confirm() { args.Result.TrySetResult(text.Value); dismiss(); }
@@ -286,9 +306,12 @@ public class ComposeAlertManagerSubscription : DispatchProxy
             if (!string.IsNullOrEmpty(args.Message))
                 body.Add(new ComposeText(args.Message));
 
-            var field = new ComposeOutlinedTextField(text)
+            // Use the (string, Action<string>) ctor so OnTextChanged
+            // can intercept and truncate before writing to the state.
+            var field = new ComposeOutlinedTextField(text.Value, OnTextChanged)
             {
-                SingleLine = true,
+                SingleLine      = true,
+                KeyboardOptions = keyboardOptions,
             };
             if (!string.IsNullOrEmpty(args.Placeholder))
                 field.Placeholder = new ComposeText(args.Placeholder);
@@ -381,6 +404,42 @@ public class ComposeAlertManagerSubscription : DispatchProxy
             sheet.Add(column);
             return sheet;
         }, onUnattached: () => args.Result.TrySetResult(args.Cancel ?? string.Empty));
+    }
+
+    /// <summary>
+    /// Map MAUI's <see cref="Keyboard"/> to a Compose
+    /// <see cref="ComposeKeyboardOptions"/> so the IME surfaces the
+    /// right layout. <see langword="null"/> result means "use Kotlin
+    /// default" (plain text).
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <c>EntryHandler.ResolveKeyboardType</c>. Kept local
+    /// because that helper is private.
+    /// </remarks>
+    static ComposeKeyboardOptions? ResolveKeyboardOptions(Keyboard? keyboard)
+    {
+        int type;
+        if (keyboard is null
+            || keyboard == Keyboard.Default
+            || keyboard == Keyboard.Text
+            || keyboard == Keyboard.Chat)
+        {
+            return null;
+        }
+        else if (keyboard == Keyboard.Numeric)   type = ComposeKeyboardType.Number;
+        else if (keyboard == Keyboard.Telephone) type = ComposeKeyboardType.Phone;
+        else if (keyboard == Keyboard.Url)       type = ComposeKeyboardType.Uri;
+        else if (keyboard == Keyboard.Email)     type = ComposeKeyboardType.Email;
+        else
+        {
+            return null;
+        }
+
+        var d = KeyboardOptionsCompanion.Default;
+        return d.Copy(
+            d.Capitalization, d.AutoCorrectEnabled,
+            type, d.ImeAction,
+            d.PlatformImeOptions, d.ShowKeyboardOnFocus, d.HintLocales);
     }
 
     /// <summary>

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/ComposeAlertManagerSubscription.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/ComposeAlertManagerSubscription.cs
@@ -1,0 +1,476 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Android.App;
+using Android.Views;
+using AndroidX.Compose;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.Maui.Controls.Internals;
+using Microsoft.Maui.Platform;
+using ComposeAlertDialog       = AndroidX.Compose.AlertDialog;
+using ComposeColor             = AndroidX.Compose.Color;
+using ComposeColumn            = AndroidX.Compose.Column;
+using ComposeListItem          = AndroidX.Compose.ListItem;
+using ComposeMaterialTheme     = AndroidX.Compose.MaterialTheme;
+using ComposeModalBottomSheet  = AndroidX.Compose.ModalBottomSheet;
+using ComposeOutlinedTextField = AndroidX.Compose.OutlinedTextField;
+using ComposeText              = AndroidX.Compose.Text;
+using ComposeTextButton        = AndroidX.Compose.TextButton;
+using MauiPage                 = Microsoft.Maui.Controls.Page;
+
+namespace Microsoft.AndroidX.Compose.Maui.Platform;
+
+/// <summary>
+/// MAUI <c>IAlertManagerSubscription</c> implementation that renders
+/// <c>Page.DisplayAlert</c> / <c>DisplayActionSheet</c> /
+/// <c>DisplayPromptAsync</c> through Material 3 Compose composables
+/// (<see cref="ComposeAlertDialog"/> / <see cref="ComposeModalBottomSheet"/>)
+/// instead of MAUI's stock AppCompat dialogs.
+/// </summary>
+/// <remarks>
+/// <para>
+/// MAUI's per-window <c>AlertManager.Subscribe()</c> calls
+/// <c>context.Services.GetService&lt;IAlertManagerSubscription&gt;()</c>
+/// <em>before</em> falling back to its built-in
+/// <c>AlertRequestHelper</c>. So registering this proxy in the host's
+/// service collection is enough for MAUI to route every Display* call
+/// here. We never replace <c>AlertManager</c> wholesale via reflection.
+/// </para>
+/// <para>
+/// <c>IAlertManagerSubscription</c> is <em>internal</em> to
+/// <c>Microsoft.Maui.Controls</c>, so we mirror the pattern used by
+/// <c>maui-labs</c>'s <c>WPFAlertManagerSubscription</c>: build a
+/// <see cref="DispatchProxy"/> that implements it via reflection, then
+/// register the proxy under the resolved <see cref="System.Type"/>.
+/// </para>
+/// <para>
+/// MAUI version pinning hazard: the interface lives at
+/// <c>Microsoft.Maui.Controls.Platform.AlertManager+IAlertManagerSubscription</c>
+/// in MAUI 10.0.20 (and is nested-private in 10.0.x). If a future MAUI
+/// version moves or renames it, <see cref="ResolveSubscriptionInterface"/>
+/// needs to grow another fallback. We log + no-op when resolution
+/// fails so the host app keeps booting.
+/// </para>
+/// <para>
+/// Theme alignment: each dialog is rendered into its own transient
+/// <see cref="ComposeView"/> attached to the activity's content frame,
+/// wrapped in a default <see cref="ComposeMaterialTheme"/>. Until the
+/// future <c>ThemeManager</c> ships, the overlay's M3 palette is
+/// independent of any per-page theme override the consumer may
+/// install — the visual identity matches a stock M3 dialog. Dynamic
+/// color (Material You) on API 31+ is enabled by default.
+/// </para>
+/// <para>
+/// Lifecycle: each call attaches a fresh <see cref="ComposeView"/> to
+/// <c>android.R.id.content</c>, sets its content, and detaches +
+/// disposes the composition once the user resolves the dialog. We
+/// hold no strong references to the activity or the originating
+/// <see cref="MauiPage"/> — both are reachable only through
+/// <c>sender.Handler.MauiContext</c>, so a navigation-away while a
+/// dialog is showing simply cancels the awaiting <see cref="Task"/>
+/// (the parent activity is destroyed and its content frame torn down,
+/// taking the overlay with it).
+/// </para>
+/// </remarks>
+public class ComposeAlertManagerSubscription : DispatchProxy
+{
+    /// <summary>
+    /// Register this subscription as the host's
+    /// <c>IAlertManagerSubscription</c>. Called from
+    /// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+    /// </summary>
+    /// <remarks>
+    /// Resolves MAUI's internal interface via reflection, builds a
+    /// <see cref="DispatchProxy"/> implementing it, and adds the proxy
+    /// as a singleton under the interface type. If interface
+    /// resolution fails (unsupported MAUI version), the registration
+    /// is silently skipped — MAUI then falls back to its stock
+    /// AppCompat dialog.
+    /// </remarks>
+    [UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+        Justification = "MAUI's IAlertManagerSubscription type is preserved by the host (it's the only consumer of this DI registration).")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070:UnrecognizedReflectionPattern",
+        Justification = "We resolve a single MAUI interface by name; trimming may rename it but we no-op on miss.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
+        Justification = "DispatchProxy.Create<T,TProxy>() emits IL at runtime; supported on Android (Mono) but not on full NativeAOT — sample uses Mono.")]
+    public static void Register(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var ifaceType = ResolveSubscriptionInterface();
+        if (ifaceType is null)
+        {
+            // Logging: cheap System.Diagnostics. Avoid pulling
+            // ILogger here — DI resolution happens before the host
+            // is built when called from UseAndroidXCompose.
+            System.Diagnostics.Debug.WriteLine(
+                "[ComposeAlertManagerSubscription] " +
+                "Could not resolve IAlertManagerSubscription on " +
+                "Microsoft.Maui.Controls; stock AppCompat dialogs " +
+                "will be used. (MAUI version drift?)");
+            return;
+        }
+
+        // DispatchProxy.Create<TInterface, TProxy>() requires both
+        // type args at compile time, but TInterface is internal to
+        // MAUI. Find the open-generic via reflection and close it.
+        // We register a *factory* so the proxy is built lazily — this
+        // keeps a DispatchProxy initialization failure (e.g. a stripped
+        // System.Reflection.Emit on a trimmed build) from blowing up
+        // application startup; instead the missing service falls back
+        // to MAUI's stock AppCompat dialog.
+        var createGeneric = typeof(DispatchProxy)
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .First(m => m.Name == nameof(DispatchProxy.Create)
+                && m.IsGenericMethodDefinition
+                && m.GetGenericArguments().Length == 2);
+        var create = createGeneric.MakeGenericMethod(
+            ifaceType, typeof(ComposeAlertManagerSubscription));
+
+        services.AddSingleton(ifaceType, _ =>
+        {
+            try
+            {
+                return create.Invoke(null, null)
+                    ?? throw new InvalidOperationException(
+                        $"DispatchProxy.Create returned null for " +
+                        $"{ifaceType.FullName}.");
+            }
+            catch (Exception ex)
+            {
+                var inner = ex is TargetInvocationException tie ? (tie.InnerException ?? tie) : ex;
+                global::Android.Util.Log.Error(
+                    "ComposeAlertManager",
+                    "DispatchProxy.Create failed for " + ifaceType.FullName +
+                    "; falling back to stock AppCompat dialogs. Inner: " +
+                    inner.GetType().FullName + ": " + inner.Message + "\n" +
+                    inner.StackTrace);
+                throw;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Locate MAUI's <c>IAlertManagerSubscription</c> interface
+    /// reflectively. Tries the modern shape first
+    /// (nested under <c>AlertManager</c>) then a hypothetical
+    /// top-level fallback for forward-compat with future MAUI
+    /// reorganizations.
+    /// </summary>
+    static Type? ResolveSubscriptionInterface()
+    {
+        var asm = typeof(MauiPage).Assembly;
+
+        // MAUI 10.0.x — interface is nested under AlertManager.
+        var alertManager = asm.GetType("Microsoft.Maui.Controls.Platform.AlertManager");
+        if (alertManager is not null)
+        {
+            var nested = alertManager.GetNestedType(
+                "IAlertManagerSubscription",
+                BindingFlags.Public | BindingFlags.NonPublic);
+            if (nested is not null)
+                return nested;
+        }
+
+        // Forward-compat: the type might surface as top-level if MAUI
+        // ever externalises it (mirrors WPFAlertManagerSubscription's
+        // dual lookup).
+        return asm.GetType("Microsoft.Maui.Controls.Platform.IAlertManagerSubscription");
+    }
+
+    /// <summary>
+    /// <see cref="DispatchProxy"/> entry point — fan out by method
+    /// name to the right handler. <c>OnPageBusy</c> is deprecated in
+    /// .NET 10 and intentionally a no-op (the stock alert manager
+    /// only used it for the legacy <c>IsBusy</c> flag).
+    /// </summary>
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if (targetMethod is null || args is null)
+            return null;
+
+        switch (targetMethod.Name)
+        {
+            case "OnAlertRequested":
+                if (args[0] is MauiPage alertPage && args[1] is AlertArguments alertArgs)
+                    OnAlertRequested(alertPage, alertArgs);
+                return null;
+
+            case "OnPromptRequested":
+                if (args[0] is MauiPage promptPage && args[1] is PromptArguments promptArgs)
+                    OnPromptRequested(promptPage, promptArgs);
+                return null;
+
+            case "OnActionSheetRequested":
+                if (args[0] is MauiPage sheetPage && args[1] is ActionSheetArguments sheetArgs)
+                    OnActionSheetRequested(sheetPage, sheetArgs);
+                return null;
+
+            case "OnPageBusy":
+                // Deprecated in .NET 10 — no-op intentionally.
+                return null;
+
+            default:
+                System.Diagnostics.Debug.WriteLine(
+                    $"[ComposeAlertManagerSubscription] " +
+                    $"Unhandled IAlertManagerSubscription method " +
+                    $"'{targetMethod.Name}'.");
+                return null;
+        }
+    }
+
+    static void OnAlertRequested(MauiPage sender, AlertArguments args)
+    {
+        var activity = ResolveActivity(sender);
+        if (activity is null)
+        {
+            // Couldn't surface the dialog — complete the awaiter
+            // with the cancel value so the caller doesn't hang.
+            args.Result.TrySetResult(false);
+            return;
+        }
+
+        ShowOnUiThread(activity, (overlay, dismiss) =>
+        {
+            void Confirm() { args.Result.TrySetResult(true);  dismiss(); }
+            void Cancel()  { args.Result.TrySetResult(false); dismiss(); }
+
+            // MAUI's `DisplayAlert(title, message, cancel)` overload (no
+            // accept text) marks the alert as single-button by passing
+            // Accept == null. Render the Cancel label as the only button
+            // and route it through the confirm path — the result is
+            // ignored by the awaiter (the public API returns Task, not
+            // Task<bool>), but `true` is the conventional "user
+            // acknowledged" value.
+            var singleButton = string.IsNullOrEmpty(args.Accept);
+
+            return new ComposeAlertDialog(onDismissRequest: Cancel)
+            {
+                Title         = string.IsNullOrEmpty(args.Title)   ? null : new ComposeText(args.Title),
+                Text          = string.IsNullOrEmpty(args.Message) ? null : new ComposeText(args.Message),
+                ConfirmButton = new ComposeTextButton(onClick: Confirm)
+                {
+                    new ComposeText(singleButton ? (args.Cancel ?? "OK") : args.Accept!),
+                },
+                DismissButton = singleButton || string.IsNullOrEmpty(args.Cancel) ? null
+                    : new ComposeTextButton(onClick: Cancel)
+                    {
+                        new ComposeText(args.Cancel),
+                    },
+            };
+        }, onUnattached: () => args.Result.TrySetResult(false));
+    }
+
+    static void OnPromptRequested(MauiPage sender, PromptArguments args)
+    {
+        var activity = ResolveActivity(sender);
+        if (activity is null)
+        {
+            args.Result.TrySetResult(null!);
+            return;
+        }
+
+        // Hold the user-edited text outside the composition so the
+        // confirm callback can read the latest value. MutableState
+        // ensures recomposition fires on each keystroke.
+        var text = new MutableState<string>(args.InitialValue ?? string.Empty);
+
+        ShowOnUiThread(activity, (overlay, dismiss) =>
+        {
+            void Confirm() { args.Result.TrySetResult(text.Value); dismiss(); }
+            void Cancel()  { args.Result.TrySetResult(null!);      dismiss(); }
+
+            // Compose AlertDialog's "text" slot is a single
+            // composable — pack the message + the field in a
+            // Column so both render between Title and ConfirmButton.
+            var body = new ComposeColumn();
+            if (!string.IsNullOrEmpty(args.Message))
+                body.Add(new ComposeText(args.Message));
+
+            var field = new ComposeOutlinedTextField(text)
+            {
+                SingleLine = true,
+            };
+            if (!string.IsNullOrEmpty(args.Placeholder))
+                field.Placeholder = new ComposeText(args.Placeholder);
+            body.Add(field);
+
+            return new ComposeAlertDialog(onDismissRequest: Cancel)
+            {
+                Title         = string.IsNullOrEmpty(args.Title) ? null : new ComposeText(args.Title),
+                Text          = body,
+                ConfirmButton = new ComposeTextButton(onClick: Confirm)
+                {
+                    new ComposeText(args.Accept ?? "OK"),
+                },
+                DismissButton = string.IsNullOrEmpty(args.Cancel) ? null
+                    : new ComposeTextButton(onClick: Cancel)
+                    {
+                        new ComposeText(args.Cancel),
+                    },
+            };
+        }, onUnattached: () => args.Result.TrySetResult(null!));
+    }
+
+    static void OnActionSheetRequested(MauiPage sender, ActionSheetArguments args)
+    {
+        var activity = ResolveActivity(sender);
+        if (activity is null)
+        {
+            args.Result.TrySetResult(args.Cancel ?? string.Empty);
+            return;
+        }
+
+        // Snapshot the buttons collection — it's `IEnumerable<string>`
+        // and we read it from the Compose composition (potentially
+        // multiple recompositions).
+        var buttons = (args.Buttons ?? Array.Empty<string>()).ToArray();
+
+        ShowOnUiThread(activity, (overlay, dismiss) =>
+        {
+            void Pick(string label) { args.Result.TrySetResult(label); dismiss(); }
+
+            var sheet = new ComposeModalBottomSheet(onDismissRequest: () =>
+            {
+                args.Result.TrySetResult(args.Cancel ?? string.Empty);
+                dismiss();
+            });
+
+            var column = new ComposeColumn();
+            if (!string.IsNullOrEmpty(args.Title))
+            {
+                column.Add(new ComposeListItem
+                {
+                    Headline = new ComposeText(args.Title),
+                });
+            }
+
+            foreach (var button in buttons)
+            {
+                if (string.IsNullOrEmpty(button))
+                    continue;
+                var labelLocal = button;
+                column.Add(new ComposeListItem
+                {
+                    Modifier = Modifier.Clickable(() => Pick(labelLocal)),
+                    Headline = new ComposeText(labelLocal),
+                });
+            }
+
+            // Destruction button styled red — convention from
+            // iOS UIActionSheet but a familiar M3 affordance.
+            if (!string.IsNullOrEmpty(args.Destruction))
+            {
+                var destructLocal = args.Destruction;
+                column.Add(new ComposeListItem
+                {
+                    Modifier = Modifier.Clickable(() => Pick(destructLocal)),
+                    Headline = new ComposeText(destructLocal) { Color = ComposeColor.Red },
+                });
+            }
+
+            if (!string.IsNullOrEmpty(args.Cancel))
+            {
+                var cancelLocal = args.Cancel;
+                column.Add(new ComposeListItem
+                {
+                    Modifier = Modifier.Clickable(() => Pick(cancelLocal)),
+                    Headline = new ComposeText(cancelLocal),
+                });
+            }
+
+            sheet.Add(column);
+            return sheet;
+        }, onUnattached: () => args.Result.TrySetResult(args.Cancel ?? string.Empty));
+    }
+
+    /// <summary>
+    /// Resolve the host <see cref="Activity"/> for a MAUI page.
+    /// Returns <see langword="null"/> if the page hasn't been
+    /// attached to a handler yet — caller short-circuits with the
+    /// cancel value rather than hanging the awaiting Task.
+    /// </summary>
+    static Activity? ResolveActivity(MauiPage sender)
+    {
+        var context = sender.Handler?.MauiContext?.Context;
+        return context?.GetActivity();
+    }
+
+    /// <summary>
+    /// Marshal to UI thread, attach a fresh <see cref="ComposeView"/>
+    /// to the activity's content frame, and install
+    /// <paramref name="contentFactory"/> as the composition.
+    /// <paramref name="contentFactory"/> receives the overlay view
+    /// and a <c>dismiss</c> action; calling <c>dismiss()</c> detaches
+    /// + disposes the composition.
+    /// </summary>
+    /// <param name="onUnattached">
+    /// Called if we couldn't find a content view to attach the
+    /// overlay to (e.g. activity in a teardown state). Caller uses
+    /// this to fault the awaiting Task with a sensible default.
+    /// </param>
+    static void ShowOnUiThread(
+        Activity activity,
+        Func<ComposeView, Action, ComposableNode> contentFactory,
+        Action onUnattached)
+    {
+        activity.RunOnUiThread(() =>
+        {
+            // android.R.id.content is the FrameLayout the activity's
+            // content is hosted under — adding our overlay there
+            // keeps it above MAUI's page content but below the
+            // status / nav bars (Compose Dialog/BottomSheet manage
+            // their own Window so visual stacking is correct
+            // regardless).
+            var content = activity.FindViewById<ViewGroup>(global::Android.Resource.Id.Content);
+            if (content is null)
+            {
+                onUnattached();
+                return;
+            }
+
+            var overlay = new ComposeView(activity)
+            {
+                LayoutParameters = new ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MatchParent,
+                    ViewGroup.LayoutParams.MatchParent),
+            };
+            content.AddView(overlay);
+
+            // Latch so dismiss is idempotent — Compose may invoke
+            // the dismiss callback on touch-outside *and* the user
+            // can still tap a button before recomposition removes
+            // the dialog.
+            bool detached = false;
+            void Dismiss()
+            {
+                if (detached) return;
+                detached = true;
+                // Post the detach so we don't tear down the view
+                // while Compose is still inside its event handler.
+                activity.RunOnUiThread(() =>
+                {
+                    try
+                    {
+                        overlay.DisposeComposition();
+                    }
+                    catch (Exception ex)
+                    {
+                        // Composition disposal can throw if the
+                        // host window was already destroyed (e.g.
+                        // user backed out of the activity). Log
+                        // and continue with the view detach.
+                        System.Diagnostics.Debug.WriteLine(
+                            $"[ComposeAlertManagerSubscription] " +
+                            $"DisposeComposition threw: {ex.Message}");
+                    }
+                    (overlay.Parent as ViewGroup)?.RemoveView(overlay);
+                });
+            }
+
+            overlay.SetContent(c => new ComposeMaterialTheme
+            {
+                contentFactory(overlay, Dismiss),
+            });
+        });
+    }
+}


### PR DESCRIPTION
## Scope

Intercepts MAUI's `Page.DisplayAlert(...)` / `Page.DisplayActionSheet(...)` /
`Page.DisplayPromptAsync(...)` on Android and renders them through Compose
`AlertDialog` / `ModalBottomSheet` / `OutlinedTextField` overlays instead of
the stock AppCompat dialogs.

## Approach

Register a `System.Reflection.DispatchProxy`-backed implementation of MAUI's
internal `Microsoft.Maui.Controls.Platform.AlertManager+IAlertManagerSubscription`
in DI. MAUI's `AlertManager.Subscribe()` resolves the interface from
`IServiceProvider` and **only falls back to its stock subscription when DI
returns null**, so this short-circuits the stock path entirely without
needing wholesale reflection over `AlertManager` itself.

The interface is `internal` — looked up reflectively from
`Microsoft.Maui.Controls` (pinned to 10.0.20). Pattern mirrors maui-labs's
WPF `WPFAlertManagerSubscription`.

## Render mappings

- `AlertArguments(title, message, accept, cancel)` →
  `AlertDialog(title, text, confirmButton, dismissButton)`. The single-button
  `DisplayAlert(title, message, cancel)` overload (`Accept == null`) renders
  `Cancel` as the only button — no twin "OK / OK".
- `ActionSheetArguments(title, cancel, destruction, buttons[])` →
  `ModalBottomSheet` with a `LazyColumn` of `ListItem`s; `destruction`
  styled red.
- `PromptArguments(...)` → `AlertDialog` with an `OutlinedTextField` between
  the message and the confirm button, pre-filled with `InitialValue`.

## Files

- **`src/Microsoft.AndroidX.Compose.Maui/Platform/ComposeAlertManagerSubscription.cs`** (~410 LOC)
- **`src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs`** —
  `ComposeAlertManagerSubscription.Register(builder.Services)` at the top of
  `UseAndroidXCompose()`.
- **`src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/AlertsPage.{xaml,cs}`** —
  four buttons exercising every flow.
- **`docs/maui-backend.md`** — Slice 9 subsection documenting:
  - chosen DI approach vs. MessagingCenter / wholesale-replace alternatives;
  - DispatchProxy + sealed-base footgun;
  - MAUI version-pinning hazard;
  - overlay window-attach lifecycle;
  - theme alignment mismatch deferred to Slice 7;
  - bottom-sheet animation deferred polish gap.

## Verification (Pixel 9-class device, Android 16)

- `Show Alert (OK / Cancel)` → tap OK → `DisplayAlertAsync → OK`
- `Action Sheet` → tap Edit → `DisplayActionSheetAsync → Edit` (Delete red)
- `Prompt` → typed input → `DisplayPromptAsync → Mayo` (autocorrect on
  "Maui" 🤝)
- `OK-only Alert` → tap OK → `DisplayAlertAsync (single button) → dismissed`

`adb shell uiautomator dump` after each dismissal: zero lingering
`AndroidComposeView` overlay nodes.

## Lessons learned

- **`DispatchProxy.Create<T, TProxy>` requires `TProxy` non-sealed.**
  Reflection.Emit synthesises a runtime subclass; sealed bases throw
  `ArgumentException`. Crash log on Android only shows
  `JavaProxyThrowable` — wrap `Create` in a try/catch + explicit
  `global::Android.Util.Log.Error(ex.InnerException.Message)` to surface.
- **`Android` alone resolves to `Microsoft.Android` once `using Android.App;`
  is in scope** — qualify as `global::Android.Util.Log` to reach the AOSP
  logging APIs.
- **Fast-Dev (`EmbedAssembliesIntoApk = false`) breaks after a clean
  uninstall** with XA0127 (missing `Mono.Android.Runtime.dll` override).
  Slice verification used `-p:EmbedAssembliesIntoApk=true`.
- **Single-button alert detection.** MAUI's `DisplayAlert(title, message,
  cancel)` calls `DisplayAlertAsync(title, message, null, cancel, ...)`.
  First implementation checked `args.Cancel` for null/empty (always set);
  fix is `string.IsNullOrEmpty(args.Accept)` to choose the single-button
  rendering.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>