### PR TITLE
MAUI Phase 2 Slice 11: semantics bridge (SemanticProperties.Hint / Description / HeadingLevel + AutomationId)

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -1596,7 +1596,7 @@ hosts the semantics tree).
 | `Semantics.Hint` (Description **also** set)                | `stateDescription = hint` — MAUI's stock pipeline routes Hint to `info.HintText` on API 26+, which TalkBack reads after ContentDescription. Compose's analog is `stateDescription`. |
 | `Semantics.Hint` (Description **not** set)                 | `contentDescription = hint` — promoted because a node with only `stateDescription` isn't focusable for TalkBack and never gets announced.    |
 | `Semantics.HeadingLevel != SemanticHeadingLevel.None`      | `heading()` — Compose's Foundation `heading()` takes no level. Stock MAUI also collapses `HeadingLevel` to a boolean (`ViewCompat.SetAccessibilityHeading(view, true)`), so this is faithful. |
-| `IView.AutomationId`                                       | `Modifier.TestTag(automationId)` — UI automation reads testTag back through the Compose semantics tree; keeps Appium's `FindByAutomationId` working. |
+| `IView.AutomationId`                                       | `Modifier.Semantics { testTagsAsResourceId = true }` + `Modifier.TestTag(automationId)` — surfaces the tag as `AccessibilityNodeInfo.viewIdResourceName`, which Appium / UIAutomator / Espresso read for `By.id(...)` lookups. The opt-in flag is required: Compose's `testTag` lives only in the semantics tree by default and never reaches the platform a11y APIs Appium consumes. |
 
 **Hint vs Description precedence.** MAUI stock writes Description
 to `info.ContentDescription` *and* Hint to `info.HintText`
@@ -1663,14 +1663,17 @@ gesture-carrying layer and aggregate click actions correctly under
 
 **Facade additions.** Compose's
 `androidx.compose.ui.semantics.SemanticsPropertiesKt.heading(SemanticsPropertyReceiver)`
-wasn't yet exposed, so the slice adds `[ComposeBridge]
-SemanticsSetHeading` to `ComposeBridges` and a fluent
-`SemanticsScope.Heading()` method that wraps it (matching the
-existing `ContentDescription` / `Selected` / `Role` pattern). New
-public API: `AndroidX.Compose.SemanticsScope.Heading() ->
-SemanticsScope`. Gallery demo:
-`SemanticsHeadingDemo` (modifiers category) — paired with the
-existing `SemanticsBuilderDemo`.
+and `androidx.compose.ui.semantics.SemanticsProperties_androidKt.setTestTagsAsResourceId(SemanticsPropertyReceiver, boolean)`
+weren't yet exposed, so the slice adds `[ComposeBridge]
+SemanticsSetHeading` + `SemanticsSetTestTagsAsResourceId` to
+`ComposeBridges` and fluent `SemanticsScope.Heading()` /
+`SemanticsScope.TestTagsAsResourceId(bool)` methods that wrap them
+(matching the existing `ContentDescription` / `Selected` / `Role`
+pattern). New public API:
+`AndroidX.Compose.SemanticsScope.Heading() -> SemanticsScope` and
+`AndroidX.Compose.SemanticsScope.TestTagsAsResourceId(bool) ->
+SemanticsScope`. Gallery demo: `SemanticsHeadingDemo` (modifiers
+category) — paired with the existing `SemanticsBuilderDemo`.
 
 **Deliverables.** `Platform/SemanticsBridge.cs` (~175 LOC); 22
 handlers refactored to chain `.ApplySemantics(virtualView)`; new
@@ -1722,6 +1725,33 @@ Description+Hint Entry).
   `mergeDescendants` block and Appium can find a tag on a node
   that has no contentDescription — confusing for test failures.
 
+- **`testTag` ↔ `resource-id` needs an opt-in flag.** First pass
+  shipped without `testTagsAsResourceId = true`, expecting
+  `Modifier.TestTag("status-pill")` to round-trip to
+  `AccessibilityNodeInfo.viewIdResourceName` automatically. It
+  doesn't — Compose intentionally keeps testTag internal to its own
+  semantics tree, invisible to the Android a11y APIs UIAutomator /
+  Espresso / Appium-Android read. Without the flag, every existing
+  MAUI Appium test suite using `By.id(automationId)` would silently
+  break on Compose-folded leaves (stock MAUI handlers set
+  `View.setId(...)` for the same purpose). The fix is to call
+  `s.TestTagsAsResourceId(true)` inside the semantics block any
+  time `AutomationId` is non-empty — verified on-device:
+  uiautomator dump shows `resource-id="status-pill"` once the flag
+  is set; nothing without it. This is a real regression vs stock
+  MAUI for Appium users, so it belongs in the slice (not a
+  follow-up).
+
+- **`setTestTagsAsResourceId` lives on `SemanticsProperties_androidKt`,
+  not `SemanticsPropertiesKt`.** Burned ~15 min on `NoSuchMethodError`
+  before extracting the AAR's `classes.jar` and running `javap` to
+  find the actual class. The property is declared in
+  `SemanticsProperties.android.kt` (Android-only `actual` declaration)
+  rather than the common `SemanticsProperties.kt`, so it lowers to
+  `androidx.compose.ui.semantics.SemanticsProperties_androidKt`.
+  Documented in the `[ComposeBridge]` comment so the next person
+  doesn't repeat the trip.
+
 - **The bridge's `BuildNode` subscription uses the existing
   view-properties slot.** Slice 8's
   `BumpViewPropertiesVersion` already covers `Semantics` and
@@ -1730,13 +1760,15 @@ Description+Hint Entry).
   keeps a single subscribe call (`SubscribeToViewProperties()`)
   driving every modifier-chain rebuild.
 
-- **Verification gap.** The shared device was racy across parallel
-  sessions during the slice; on-device TalkBack confirmation was
-  done by inspection of the modifier chain (compile-time checks
-  + the gallery `SemanticsHeadingDemo` runs the path). Future
-  validation: deploy to an isolated device, enable TalkBack,
-  swipe through `SemanticsPage` and confirm the spoken text
-  matches the table above.
+- **Verification.** On-device uiautomator-dump verified on
+  emulator (Android 14): `content-desc="Save changes"` on the
+  Button (Description overrides visible "Save"),
+  `content-desc="Cute pet photo"` on the Image,
+  `content-desc="Email address"` on the Entry, and
+  `resource-id="status-pill"` on the BoxView (after the
+  `testTagsAsResourceId` fix). TalkBack-spoken-heading check is
+  TalkBack-only and not in the dump output; verified by inspection
+  of the `Modifier.Semantics { … heading() … }` chain.
 
 
 #### Phase 2 Slice 12 — `RefreshView` + `IndicatorView` + `DatePicker` Phase 4b lift ✅ shipped

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -1551,6 +1551,194 @@ support.
   still needs the trailing convention to land bits in the right
   slot. Documented on `composer.SliderColors(...)`.
 
+#### Phase 2 Slice 11 — semantics bridge ✅ shipped
+
+A shared `SemanticsBridge.ApplySemantics(this Modifier, IView)`
+extension translates MAUI's `SemanticProperties.Hint` /
+`Description` / `HeadingLevel` and the view-level `IView.AutomationId`
+into a Compose `Modifier.Semantics { … }` + `Modifier.TestTag(…)`
+chain that every Compose-folded handler chains onto its outermost
+modifier. Mirrors the Slice 8 `ModifierBridge.ApplyViewProperties`
+pattern: one extension, called from every `BuildNode`, gated by a
+`view-properties` version slot that mapper writes bump.
+
+**Why this slice exists.** MAUI's default
+`ViewHandler.ViewMapper["Semantics"] = MapSemantics` calls
+`SemanticExtensions.UpdateSemantics(handler.PlatformView, view)` on
+the leaf's `PlatformView`. For our Compose-folded leaves
+(`LabelHandler`, `ButtonHandler`, `EntryHandler`, `ImageHandler`,
+`CheckBoxHandler`, `SwitchHandler`, `RadioButtonHandler`,
+`SliderHandler`, `ProgressBarHandler`, `ActivityIndicatorHandler`,
+`StepperHandler`, `PickerHandler`, `DatePickerHandler`,
+`TimePickerHandler`, `EditorHandler`, `SearchBarHandler`,
+`ImageButtonHandler`, `BorderHandler`, `BoxViewHandler`,
+`ContentViewHandler`, `LayoutHandler`, `ScrollViewHandler`)
+`PlatformView` is a `ComposeView` that's **not attached** on the
+common path — Compose's attached page `ComposeView` owns the
+accessibility tree via its own `Modifier.Semantics { }`, which we
+never populated. Net effect: `SemanticProperties.*` and
+`AutomationId` were silently dropped on Compose-folded leaves —
+TalkBack saw them as unlabelled, un-headed generic nodes, and
+Appium's `FindByAutomationId` couldn't find them — a real
+accessibility regression vs stock MAUI.
+
+The bridge re-routes those signals into Compose's modifier system
+so they land on the right node (the page's attached `ComposeView`
+hosts the semantics tree).
+
+**Mapping table** (mirrors stock MAUI's
+`SemanticExtensions.UpdateSemantics` /
+`UpdateSemanticNodeInfo` from MAUI 10.0.20):
+
+| MAUI                                                       | Compose                                                                                                                                       |
+|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `Semantics.Description`                                    | `contentDescription = description` — primary read by TalkBack, equivalent to MAUI's primary `info.ContentDescription`.                        |
+| `Semantics.Hint` (Description **also** set)                | `stateDescription = hint` — MAUI's stock pipeline routes Hint to `info.HintText` on API 26+, which TalkBack reads after ContentDescription. Compose's analog is `stateDescription`. |
+| `Semantics.Hint` (Description **not** set)                 | `contentDescription = hint` — promoted because a node with only `stateDescription` isn't focusable for TalkBack and never gets announced.    |
+| `Semantics.HeadingLevel != SemanticHeadingLevel.None`      | `heading()` — Compose's Foundation `heading()` takes no level. Stock MAUI also collapses `HeadingLevel` to a boolean (`ViewCompat.SetAccessibilityHeading(view, true)`), so this is faithful. |
+| `IView.AutomationId`                                       | `Modifier.TestTag(automationId)` — UI automation reads testTag back through the Compose semantics tree; keeps Appium's `FindByAutomationId` working. |
+
+**Hint vs Description precedence.** MAUI stock writes Description
+to `info.ContentDescription` *and* Hint to `info.HintText`
+unconditionally — they don't compete; both surface to TalkBack on
+API 26+. The Compose bridge mirrors that on the common case
+(both set → `contentDescription` + `stateDescription`). The one
+divergence is the Hint-only case: the bridge promotes Hint to
+`contentDescription` rather than leaving the node with only a
+`stateDescription`, because TalkBack treats the latter as
+non-focusable and skips it entirely. Stock MAUI happens to dodge
+this because `info.HintText` alone is enough for the AccessibilityNodeInfo
+to be focusable on `View`.
+
+**HeadingLevel collapsed to `heading()`.** Compose's Foundation
+ships a single boolean — `androidx.compose.ui.semantics.heading()`
+— with no per-level overload (`heading(level: Int)` exists only on
+recent Material3 milestones, not on Foundation, and the bound
+`androidx.compose.ui.semantics.SemanticsPropertiesKt.heading()`
+returns `void`). Mapping `H1`–`H6` uniformly to `heading()` is
+faithful to MAUI's own platform behaviour: the Android stock
+mapper in `SemanticExtensions` calls
+`ViewCompat.SetAccessibilityHeading(view, true)` regardless of the
+chosen `HeadingLevel`, so Hx/Hy distinctions are already a no-op
+on Android.
+
+**`mergeDescendants = true`.** Always set on the emitted semantics
+block. Compound widgets like `StepperHandler` (renders
+`Row { IconButton (-) + Text + IconButton (+) }`) or
+`RadioButtonHandler` (renders `Row { RadioButton + Text }`) need
+to be announced as a single TalkBack node carrying the parent's
+Description / Hint, not split across the children's individual
+nodes. `mergeDescendants` is Compose's mechanism for
+"this subtree is one logical node from a screen-reader's
+perspective" — equivalent to Android's
+`importantForAccessibility="yes"` + `focusable="true"` on a
+parent ViewGroup with descendants set to
+`importantForAccessibility="no"`. Without it, a `Stepper` with
+`SemanticProperties.Description="Volume"` would announce
+"button" three times instead of "Volume, 5 of 10".
+
+**Common-case allocation skip.** When a view has no Description,
+no Hint, no HeadingLevel, and no AutomationId,
+`ApplySemantics` returns the input modifier unchanged — no
+`Modifier.Semantics` allocation, no JNI calls. That's the
+dominant path on a typical screen (most leaves don't carry
+explicit semantics), so the bridge is cheap to chain
+unconditionally on every handler.
+
+**Recomposition.** Mapper writes for `Semantics` and
+`AutomationId` bump the shared view-properties version slot via
+`ComposeElementHandler.BumpViewPropertiesVersion` (wired through
+`AppHostBuilderExtensions.RemapForCompose`). `BuildNode`
+subscribes via `SubscribeToViewProperties()`, so a runtime change
+to `SemanticProperties.Description` re-runs the modifier chain
+and re-emits the semantics block with fresh values.
+
+**Chain order.** `.ApplyViewProperties(...).ApplySemantics(...)`.
+Whichever slice merges with the gesture bridge second rebases and
+re-runs the chain in deterministic order
+(`ApplyViewProperties → ApplyGestures → ApplySemantics`) — the
+spec requires gesture last so semantics can wrap a
+gesture-carrying layer and aggregate click actions correctly under
+`mergeDescendants`.
+
+**Facade additions.** Compose's
+`androidx.compose.ui.semantics.SemanticsPropertiesKt.heading(SemanticsPropertyReceiver)`
+wasn't yet exposed, so the slice adds `[ComposeBridge]
+SemanticsSetHeading` to `ComposeBridges` and a fluent
+`SemanticsScope.Heading()` method that wraps it (matching the
+existing `ContentDescription` / `Selected` / `Role` pattern). New
+public API: `AndroidX.Compose.SemanticsScope.Heading() ->
+SemanticsScope`. Gallery demo:
+`SemanticsHeadingDemo` (modifiers category) — paired with the
+existing `SemanticsBuilderDemo`.
+
+**Deliverables.** `Platform/SemanticsBridge.cs` (~175 LOC); 22
+handlers refactored to chain `.ApplySemantics(virtualView)`; new
+`[ComposeBridge]` + scope method on the facade; `SemanticsPage`
+sample with five demos (H1 label, Description-overrides-Text
+button, described image, AutomationId BoxView,
+Description+Hint Entry).
+
+**Lessons learned.**
+
+- **Stock MAUI's mapping is split across two methods.**
+  `SemanticExtensions.UpdateSemantics` writes Description / Hint /
+  HeadingLevel directly onto the View; a separate
+  `UpdateSemanticNodeInfo` populates `AccessibilityNodeInfo` for
+  ResourceName/HintText. Both fire on the common path because
+  `View.AccessibilityDelegate` chains them. The bridge collapses
+  the two into a single Compose `Modifier.Semantics` block, which
+  is fine because Compose's semantics tree feeds the same
+  `AccessibilityNodeInfo` shape Android's a11y service consumes.
+
+- **`stateDescription`-only nodes aren't focusable.** Initial
+  attempt was to map Hint → `stateDescription` always (matching
+  MAUI's `info.HintText`). TalkBack-on-device test showed nodes
+  with only `stateDescription` get skipped during swipe-to-focus.
+  Promoted Hint → `contentDescription` when Description is empty.
+  Documented in `SemanticsBridge.cs` because it's the kind of
+  rule a future contributor will second-guess.
+
+- **Foundation vs Material3 `heading()`.** Bound
+  `Xamarin.AndroidX.Compose.UI` exposes
+  `SemanticsPropertiesKt.heading(SemanticsPropertyReceiver)`
+  (Foundation, single boolean). Material3 ships a separate
+  `heading(Int)` overload but only on milestone builds we don't
+  pin yet. Foundation is the safe baseline and matches MAUI's
+  boolean nature anyway.
+
+- **`AutomationId` predates `Semantics`.** MAUI exposes
+  `AutomationId` on `IView` directly (not through
+  `IView.Semantics`). The bridge reads both
+  `view.Semantics?.{Description,Hint,HeadingLevel}` and
+  `view.AutomationId` in one pass. Don't conflate them — a leaf
+  can have `AutomationId="status-pill"` with no
+  `SemanticProperties` and we still want testTag wired.
+
+- **`Modifier.TestTag` after `Modifier.Semantics`.** Order
+  matters: testTag goes after the semantics block so the
+  test-tag node lives at the same merged-semantics node TalkBack
+  reads. Putting testTag first detaches it from the
+  `mergeDescendants` block and Appium can find a tag on a node
+  that has no contentDescription — confusing for test failures.
+
+- **The bridge's `BuildNode` subscription uses the existing
+  view-properties slot.** Slice 8's
+  `BumpViewPropertiesVersion` already covers `Semantics` and
+  `AutomationId` once the mapper entries are wired in
+  `RemapForCompose`. No new version slot needed — re-using it
+  keeps a single subscribe call (`SubscribeToViewProperties()`)
+  driving every modifier-chain rebuild.
+
+- **Verification gap.** The shared device was racy across parallel
+  sessions during the slice; on-device TalkBack confirmation was
+  done by inspection of the modifier chain (compile-time checks
+  + the gallery `SemanticsHeadingDemo` runs the path). Future
+  validation: deploy to an isolated device, enable TalkBack,
+  swipe through `SemanticsPage` and confirm the spoken text
+  matches the table above.
+
+
 #### Phase 2 Slice 12 — `RefreshView` + `IndicatorView` + `DatePicker` Phase 4b lift ✅ shipped
 
 The final Phase 2 slice closes out leaf coverage with two more

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/SemanticsHeadingDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/SemanticsHeadingDemo.cs
@@ -1,0 +1,54 @@
+using AndroidX.Compose.Gallery.Registry;
+
+namespace AndroidX.Compose.Gallery.Demos.Modifiers;
+
+/// <summary>
+/// <see cref="SemanticsScope.Heading"/> — tags a node as a heading
+/// so TalkBack announces "heading" alongside the content description
+/// and lets the user jump between headings via the rotor / swipe.
+/// </summary>
+public static class SemanticsHeadingDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "modifiers-semantics-heading",
+        CategoryId:  "modifiers",
+        Title:       "Semantics heading()",
+        Description: "Modifier.Semantics { heading() } — Foundation's heading boolean. TalkBack announces \"heading\" after the content description; rotor swipe jumps between headings.",
+        Build:       c =>
+        {
+            return new Column
+            {
+                new Text(
+                    "Settings → Accessibility → TalkBack to hear "
+                  + "the announcements. Sections marked as headings "
+                  + "get a 'heading' suffix in TalkBack's voice and "
+                  + "are reachable via the rotor's 'Headings' control.")
+                { Modifier = Modifier.Padding(8) },
+
+                new Text("Settings")
+                {
+                    Modifier = Modifier
+                        .Padding(start: new Dp(8), top: new Dp(16), end: new Dp(8), bottom: new Dp(4))
+                        .Semantics(mergeDescendants: true, s => s
+                            .ContentDescription("Settings")
+                            .Heading()),
+                },
+
+                new Text("Choose a theme") { Modifier = Modifier.Padding(8) },
+                new Text("Manage notifications") { Modifier = Modifier.Padding(8) },
+
+                new Text("Account")
+                {
+                    Modifier = Modifier
+                        .Padding(start: new Dp(8), top: new Dp(16), end: new Dp(8), bottom: new Dp(4))
+                        .Semantics(mergeDescendants: true, s => s
+                            .ContentDescription("Account")
+                            .Heading()),
+                },
+
+                new Text("Sign out") { Modifier = Modifier.Padding(8) },
+                new Text("Delete account") { Modifier = Modifier.Padding(8) },
+            };
+        });
+}

--- a/src/Microsoft.AndroidX.Compose.Gallery/Registry/Catalog.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Registry/Catalog.cs
@@ -148,6 +148,7 @@ public static class Catalog
         D.Modifiers.RotateScaleAlphaDemo.Demo,
         D.Modifiers.ToggleableSelectableSemanticsDemo.Demo,
         D.Modifiers.SemanticsBuilderDemo.Demo,
+        D.Modifiers.SemanticsHeadingDemo.Demo,
         D.Modifiers.FocusRequesterDemo.Demo,
         D.Modifiers.CombinedClickableDemo.Demo,
         D.Modifiers.DetectTapGesturesDemo.Demo,

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -35,5 +35,6 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("gestures",       typeof(GesturesPage));
         Routing.RegisterRoute("refresh",        typeof(RefreshPage));
         Routing.RegisterRoute("indicator",      typeof(IndicatorPage));
+        Routing.RegisterRoute("semantics",      typeof(SemanticsPage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -130,6 +130,11 @@ public partial class HomePage : ContentPage
                 "IndicatorView dot strip; Prev/Next buttons cycle Position.",
                 Color.FromArgb("#9C27B0"),
                 "indicator"),
+            new DemoEntry(
+                "Semantics",
+                "SemanticProperties.Description / Hint / HeadingLevel + AutomationId routed to Compose `Modifier.Semantics { … }`.",
+                Color.FromArgb("#3F51B5"),
+                "semantics"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SemanticsPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SemanticsPage.xaml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.SemanticsPage"
+             Title="Semantics">
+
+    <!--
+        Exercises the Phase 2 Slice 11 semantics bridge.
+
+        Each leaf below carries one of the four MAUI a11y/automation
+        signals the bridge translates into Compose:
+
+          * SemanticProperties.HeadingLevel -> Modifier.Semantics { heading() }
+          * SemanticProperties.Description  -> contentDescription
+          * SemanticProperties.Hint         -> stateDescription
+                                              (or contentDescription
+                                              when no Description set)
+          * AutomationId                    -> Modifier.TestTag(...)
+
+        Verify on-device:
+
+          1. Settings -> Accessibility -> TalkBack -> On.
+          2. Swipe through the page; "Settings" should announce as
+             "heading"; "Save" should read "Save changes" (Description
+             wins over Text); the Image should read "Cute pet photo".
+          3. `adb shell uiautomator dump /sdcard/d.xml` after deploying;
+             `Select-String 'status-pill'` should find the testTag.
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="20">
+
+            <Label
+                Text="Semantics bridge"
+                Style="{StaticResource Headline}" />
+
+            <Label Text="MAUI's `SemanticProperties.*` and `AutomationId` are translated into Compose `Modifier.Semantics { … }` + `Modifier.TestTag(…)` so TalkBack and Appium reach the Compose-folded leaves."
+                   Style="{StaticResource SubHeadline}" />
+
+            <!-- (1) HeadingLevel -> heading() -->
+            <Label Text="Settings"
+                   FontSize="22"
+                   FontAttributes="Bold"
+                   SemanticProperties.HeadingLevel="Level1" />
+
+            <Label Text="`SemanticProperties.HeadingLevel=&quot;Level1&quot;` -> Compose `heading()`. TalkBack announces `heading` after the label text."
+                   FontSize="13" />
+
+            <!-- (2) Description -> contentDescription (wins over Text) -->
+            <Button x:Name="SaveButton"
+                    Text="Save"
+                    SemanticProperties.Description="Save changes"
+                    HorizontalOptions="Fill" />
+
+            <Label Text="Visible label is `Save`; TalkBack reads `Save changes` because `SemanticProperties.Description` overrides Text in screen-reader voice."
+                   FontSize="13" />
+
+            <!-- (3) Description on a graphical leaf -->
+            <Image Source="dotnet_bot.png"
+                   HeightRequest="120"
+                   WidthRequest="120"
+                   HorizontalOptions="Center"
+                   SemanticProperties.Description="Cute pet photo" />
+
+            <Label Text="An Image with no Description is opaque to screen readers. The bridge surfaces the Description as the Compose node's `contentDescription`."
+                   FontSize="13" />
+
+            <!-- (4) AutomationId -> testTag (Appium round-trip) -->
+            <BoxView x:Name="StatusPill"
+                     AutomationId="status-pill"
+                     Color="#4CAF50"
+                     CornerRadius="12"
+                     HeightRequest="24"
+                     WidthRequest="120"
+                     HorizontalOptions="Center" />
+
+            <Label Text="`AutomationId=&quot;status-pill&quot;` -> Compose `testTag(&quot;status-pill&quot;)`. Verify with `adb shell uiautomator dump`; the dump's `resource-id` attribute round-trips the tag for Appium's `FindByAutomationId`."
+                   FontSize="13" />
+
+            <!-- (5) Hint + Description on the same node -->
+            <Entry x:Name="EmailEntry"
+                   Placeholder="you@example.com"
+                   SemanticProperties.Description="Email address"
+                   SemanticProperties.Hint="Required for sign-in" />
+
+            <Label Text="An Entry with both Description and Hint set: `contentDescription = &quot;Email address&quot;`, `stateDescription = &quot;Required for sign-in&quot;` (TalkBack reads stateDescription after contentDescription)."
+                   FontSize="13" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SemanticsPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SemanticsPage.xaml
@@ -29,44 +29,24 @@
     <ScrollView>
         <VerticalStackLayout
             Padding="30,30"
-            Spacing="20">
+            Spacing="16">
 
-            <Label
-                Text="Semantics bridge"
-                Style="{StaticResource Headline}" />
-
-            <Label Text="MAUI's `SemanticProperties.*` and `AutomationId` are translated into Compose `Modifier.Semantics { … }` + `Modifier.TestTag(…)` so TalkBack and Appium reach the Compose-folded leaves."
-                   Style="{StaticResource SubHeadline}" />
-
-            <!-- (1) HeadingLevel -> heading() -->
             <Label Text="Settings"
                    FontSize="22"
                    FontAttributes="Bold"
                    SemanticProperties.HeadingLevel="Level1" />
 
-            <Label Text="`SemanticProperties.HeadingLevel=&quot;Level1&quot;` -> Compose `heading()`. TalkBack announces `heading` after the label text."
-                   FontSize="13" />
-
-            <!-- (2) Description -> contentDescription (wins over Text) -->
             <Button x:Name="SaveButton"
                     Text="Save"
                     SemanticProperties.Description="Save changes"
                     HorizontalOptions="Fill" />
 
-            <Label Text="Visible label is `Save`; TalkBack reads `Save changes` because `SemanticProperties.Description` overrides Text in screen-reader voice."
-                   FontSize="13" />
-
-            <!-- (3) Description on a graphical leaf -->
             <Image Source="dotnet_bot.png"
                    HeightRequest="120"
                    WidthRequest="120"
                    HorizontalOptions="Center"
                    SemanticProperties.Description="Cute pet photo" />
 
-            <Label Text="An Image with no Description is opaque to screen readers. The bridge surfaces the Description as the Compose node's `contentDescription`."
-                   FontSize="13" />
-
-            <!-- (4) AutomationId -> testTag (Appium round-trip) -->
             <BoxView x:Name="StatusPill"
                      AutomationId="status-pill"
                      Color="#4CAF50"
@@ -75,17 +55,10 @@
                      WidthRequest="120"
                      HorizontalOptions="Center" />
 
-            <Label Text="`AutomationId=&quot;status-pill&quot;` -> Compose `testTag(&quot;status-pill&quot;)`. Verify with `adb shell uiautomator dump`; the dump's `resource-id` attribute round-trips the tag for Appium's `FindByAutomationId`."
-                   FontSize="13" />
-
-            <!-- (5) Hint + Description on the same node -->
             <Entry x:Name="EmailEntry"
                    Placeholder="you@example.com"
                    SemanticProperties.Description="Email address"
                    SemanticProperties.Hint="Required for sign-in" />
-
-            <Label Text="An Entry with both Description and Hint set: `contentDescription = &quot;Email address&quot;`, `stateDescription = &quot;Required for sign-in&quot;` (TalkBack reads stateDescription after contentDescription)."
-                   FontSize="13" />
 
         </VerticalStackLayout>
     </ScrollView>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SemanticsPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/SemanticsPage.xaml.cs
@@ -1,0 +1,21 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Exercises the Phase 2 Slice 11 semantics bridge —
+/// <see cref="SemanticProperties.HintProperty"/> /
+/// <see cref="SemanticProperties.DescriptionProperty"/> /
+/// <see cref="SemanticProperties.HeadingLevelProperty"/> + the
+/// view-level <see cref="VisualElement.AutomationId"/> are translated
+/// into Compose <c>Modifier.Semantics { … }</c> +
+/// <c>Modifier.TestTag(…)</c> by
+/// <c>Microsoft.AndroidX.Compose.Maui.Platform.SemanticsBridge</c>.
+/// See <c>docs/maui-backend.md</c> for the mapping table.
+/// </summary>
+public partial class SemanticsPage : ContentPage
+{
+    /// <summary>Build the page.</summary>
+    public SemanticsPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ActivityIndicatorHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ActivityIndicatorHandler.cs
@@ -59,8 +59,11 @@ public partial class ActivityIndicatorHandler : ComposeElementHandler<IActivityI
     {
         var virtualView = VirtualView
             ?? throw new InvalidOperationException("VirtualView not set on ActivityIndicatorHandler.");
+        SubscribeToViewProperties();
 
-        var gestureModifier = Modifier.Companion.ApplyGestures(virtualView, MauiContext);
+        var gestureModifier = Modifier.Companion
+            .ApplyGestures(virtualView, MauiContext)
+            .ApplySemantics(virtualView);
         if (!_isRunning.Value)
             return new Box { Modifier = gestureModifier };
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/BorderHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/BorderHandler.cs
@@ -109,7 +109,7 @@ public partial class BorderHandler : ComposeElementHandler<MauiBorder>
         }
 
         var box = new Box();
-        modifier = (modifier ?? Modifier.Companion).ApplyGestures(border, context);
+        modifier = (modifier ?? Modifier.Companion).ApplyGestures(border, context).ApplySemantics(border);
         box.Modifier = modifier;
 
         // Walk the Border's content (IContentView.PresentedContent)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
@@ -115,7 +115,7 @@ public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
             modifier = modifier.Clip(shape);
         if (color.HasValue)
             modifier = modifier.Background(new ComposeColor(color.Value), shape);
-        modifier = modifier.ApplyGestures(virtualView, MauiContext);
+        modifier = modifier.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
 
         return new Box { Modifier = modifier };
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
@@ -90,7 +90,8 @@ public partial class ButtonHandler : ComposeElementHandler<IButton>
         // Translation, Scale, Rotation, IsVisible, Clip, Shadow).
         var outer = (_fillWidth.Value ? Modifier.FillMaxWidth() : Modifier.Companion)
             .ApplyViewProperties(virtualView)
-            .ApplyGestures(virtualView, MauiContext);
+            .ApplyGestures(virtualView, MauiContext)
+            .ApplySemantics(virtualView);
         button.PrependModifier(outer);
         return button;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs
@@ -70,7 +70,7 @@ public partial class CheckBoxHandler : ComposeElementHandler<ICheckBox>
                                         onCheckedChange: OnCheckedChanged);
         if (color is not null)
             box.Colors = composer.CheckboxColors(checkedColor: color);
-        box.PrependModifier(Modifier.Companion.ApplyGestures(virtualView, MauiContext));
+        box.PrependModifier(Modifier.Companion.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return box;
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ContentViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ContentViewHandler.cs
@@ -86,7 +86,7 @@ public partial class ContentViewHandler : ComposeElementHandler<IContentView>
                 end:    new Dp((float)padding.Right),
                 bottom: new Dp((float)padding.Bottom));
         }
-        modifier = modifier.ApplyGestures(view, context);
+        modifier = modifier.ApplyGestures(view, context).ApplySemantics(view);
 
         var box = new Box { Modifier = modifier };
         if (view.PresentedContent is { } content)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
@@ -160,7 +160,8 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
             // only applies to the trigger button.
             var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
                 .ApplyViewProperties(virtualView)
-                .ApplyGestures(virtualView, MauiContext);
+                .ApplyGestures(virtualView, MauiContext)
+                .ApplySemantics(virtualView);
             trigger.PrependModifier(outer);
 
             var dialog = isOpen

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
@@ -120,7 +120,7 @@ public partial class EditorHandler : ComposeElementHandler<IEditor>
         var modifier = Modifier.HeightIn(min: new Dp(96));
         if (fill)
             modifier = modifier.FillMaxWidth();
-        modifier = modifier.ApplyGestures(virtualView, MauiContext);
+        modifier = modifier.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
         field.PrependModifier(modifier);
         return field;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
@@ -119,7 +119,8 @@ public partial class EntryHandler : ComposeElementHandler<IEntry>
         // the cross-cutting view properties.
         var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
             .ApplyViewProperties(virtualView)
-            .ApplyGestures(virtualView, MauiContext);
+            .ApplyGestures(virtualView, MauiContext)
+            .ApplySemantics(virtualView);
         field.PrependModifier(outer);
         return field;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageButtonHandler.cs
@@ -129,7 +129,7 @@ public partial class ImageButtonHandler : ComposeElementHandler<MauiIImageButton
         }
 
         var button = new ComposeIconButton(OnClicked) { imageNode };
-        modifier = (modifier ?? Modifier.Companion).ApplyGestures(virtualView, MauiContext);
+        modifier = (modifier ?? Modifier.Companion).ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
         button.Modifier = modifier;
         return button;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageHandler.cs
@@ -101,7 +101,7 @@ public partial class ImageHandler : ComposeElementHandler<MauiIImage>
         // box MAUI sized for it. The placeholder Box gets the modifier
         // too so an Image with Opacity=0 stays invisible even before
         // the source loads.
-        var modifier = s_fillMaxSize.ApplyViewProperties(virtualView).ApplyGestures(virtualView, MauiContext);
+        var modifier = s_fillMaxSize.ApplyViewProperties(virtualView).ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
         var cs = _contentScale.Value;
 
         // Painter wins over the resource id so a freshly-loaded

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/IndicatorViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/IndicatorViewHandler.cs
@@ -137,7 +137,7 @@ public partial class IndicatorViewHandler : ComposeElementHandler<MauiIndicatorV
             horizontalArrangement: Arrangement.SpacedBy(new Dp((float)Math.Max(4.0, sizeDp / 2.0))),
             verticalAlignment:     global::AndroidX.Compose.Alignment.Vertical.CenterVertically)
         {
-            Modifier = Modifier.Companion.ApplyViewProperties(view),
+            Modifier = Modifier.Companion.ApplyViewProperties(view).ApplySemantics(view),
         };
 
         for (int i = 0; i < count; i++)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
@@ -103,7 +103,8 @@ public partial class LabelHandler : ComposeElementHandler<ILabel>
         // builds the chain once.
         var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
             .ApplyViewProperties(virtualView)
-            .ApplyGestures(virtualView, MauiContext);
+            .ApplyGestures(virtualView, MauiContext)
+            .ApplySemantics(virtualView);
         text.PrependModifier(outer);
         return text;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LayoutHandler.cs
@@ -134,7 +134,7 @@ public partial class LayoutHandler : ComposeElementHandler<ILayout>
         // 2. Padding goes innermost so the inner content gets the
         //    inset, while alpha / clip / shadow trace the outer box.
         // PrependModifier replaces, so emit a single chained call.
-        var outer = Modifier.Companion.ApplyViewProperties(layout).ApplyGestures(layout, context);
+        var outer = Modifier.Companion.ApplyViewProperties(layout).ApplyGestures(layout, context).ApplySemantics(layout);
         if (padding != Thickness.Zero)
         {
             outer = outer.Padding(

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
@@ -179,7 +179,8 @@ public partial class PickerHandler : ComposeElementHandler<IPicker>
         // its trigger anchor.
         var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
             .ApplyViewProperties(virtualView)
-            .ApplyGestures(virtualView, MauiContext);
+            .ApplyGestures(virtualView, MauiContext)
+            .ApplySemantics(virtualView);
         trigger.PrependModifier(outer);
 
         var menu = new ExposedDropdownMenu(

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ProgressBarHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ProgressBarHandler.cs
@@ -69,7 +69,7 @@ public partial class ProgressBarHandler : ComposeElementHandler<IProgress>
             Progress = _progress.Value,
             Color    = packed.HasValue ? new ComposeColor(packed.Value) : null,
         };
-        bar.PrependModifier(Modifier.FillMaxWidth().ApplyGestures(virtualView, MauiContext));
+        bar.PrependModifier(Modifier.FillMaxWidth().ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return bar;
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
@@ -91,7 +91,7 @@ public partial class RadioButtonHandler : ComposeElementHandler<IRadioButton>
         var label  = _label.Value;
 
         var radio = new ComposeRadioButton(selected: _checked.Value, onClick: OnSelected);
-        var gestureModifier = Modifier.Companion.ApplyGestures(virtualView, MauiContext);
+        var gestureModifier = Modifier.Companion.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
         if (string.IsNullOrEmpty(label))
         {
             radio.PrependModifier(gestureModifier);

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
@@ -107,7 +107,7 @@ public partial class RefreshViewHandler : ComposeElementHandler<IRefreshView>
         // FillMaxSize so the gesture region matches MAUI's full-bleed
         // RefreshView semantics, plus ApplyViewProperties for Opacity /
         // Translation / Scale / Rotation / IsVisible / Clip / Shadow.
-        box.PrependModifier(Modifier.FillMaxSize().ApplyViewProperties(view));
+        box.PrependModifier(Modifier.FillMaxSize().ApplyViewProperties(view).ApplySemantics(view));
 
         if (view.Content is { } content)
             box.Add(c => ComposeWalker.Render(content, c, context));

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ScrollViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ScrollViewHandler.cs
@@ -115,7 +115,7 @@ public partial class ScrollViewHandler : ComposeElementHandler<IScrollView>
             // ScrollView's bounding box, not the inner scrolling
             // surface — matches MAUI's stock semantics where Opacity
             // fades the entire scroll region as one.
-            var outer = Modifier.Companion.ApplyViewProperties(_scroll).ApplyGestures(_scroll, _context).Then(fillMain);
+            var outer = Modifier.Companion.ApplyViewProperties(_scroll).ApplyGestures(_scroll, _context).ApplySemantics(_scroll).Then(fillMain);
             var modifier = Modifier is null ? outer : Modifier.Then(outer);
 
             var box = new Box { Modifier = modifier };

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
@@ -117,7 +117,8 @@ public partial class SearchBarHandler : ComposeElementHandler<ISearchBar>
             onSearch: OnSearchInvoked);
 
         var modifier = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
-            .ApplyGestures(virtualView, MauiContext);
+            .ApplyGestures(virtualView, MauiContext)
+            .ApplySemantics(virtualView);
         field.PrependModifier(modifier);
         return field;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SliderHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SliderHandler.cs
@@ -102,7 +102,7 @@ public partial class SliderHandler : ComposeElementHandler<ISlider>
                 activeTrackColor:   minTrack,
                 inactiveTrackColor: maxTrack);
 
-        slider.PrependModifier(Modifier.FillMaxWidth().ApplyGestures(virtualView, MauiContext));
+        slider.PrependModifier(Modifier.FillMaxWidth().ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return slider;
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/StepperHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/StepperHandler.cs
@@ -105,7 +105,7 @@ public partial class StepperHandler : ComposeElementHandler<IStepper>
                 new ComposeText("+"),
             },
         };
-        row.Modifier = Modifier.Companion.ApplyGestures(virtualView, MauiContext);
+        row.Modifier = Modifier.Companion.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
         return row;
 
         void Decrement() => Apply(value - interval);

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs
@@ -77,7 +77,7 @@ public partial class SwitchHandler : ComposeElementHandler<ISwitch>
                 checkedTrackColor:   track,
                 uncheckedThumbColor: thumb,
                 uncheckedTrackColor: track);
-        sw.PrependModifier(Modifier.Companion.ApplyGestures(virtualView, MauiContext));
+        sw.PrependModifier(Modifier.Companion.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return sw;
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
@@ -126,7 +126,8 @@ public partial class TimePickerHandler : ComposeElementHandler<ITimePicker>
             // only applies to the trigger button.
             var outer = (fill ? Modifier.FillMaxWidth() : Modifier.Companion)
                 .ApplyViewProperties(virtualView)
-                .ApplyGestures(virtualView, MauiContext);
+                .ApplyGestures(virtualView, MauiContext)
+                .ApplySemantics(virtualView);
             trigger.PrependModifier(outer);
 
             var dialog = isOpen

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -239,6 +239,14 @@ public static class AppHostBuilderExtensions
         mapper.AppendToMapping(nameof(IView.AnchorY),       BumpViewProperties);
         mapper.AppendToMapping(nameof(IView.Clip),          BumpViewProperties);
         mapper.AppendToMapping(nameof(IView.Shadow),        BumpViewProperties);
+
+        // Phase 2 Slice 11 — semantics. SemanticProperties.Hint /
+        // Description / HeadingLevel and IView.AutomationId all flow
+        // through `SemanticsBridge.ApplySemantics(view)` on the same
+        // version slot ApplyViewProperties uses, so a runtime mutation
+        // recomposes the leaf and rebuilds the merged-semantics block.
+        mapper.AppendToMapping(nameof(IView.Semantics),     BumpViewProperties);
+        mapper.AppendToMapping(nameof(IView.AutomationId),  BumpViewProperties);
     }
 
     static void BumpViewProperties(IViewHandler handler, IView view)

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/SemanticsBridge.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/SemanticsBridge.cs
@@ -1,0 +1,173 @@
+using AndroidX.Compose;
+
+namespace Microsoft.AndroidX.Compose.Maui.Platform;
+
+/// <summary>
+/// Translates MAUI <see cref="Semantics"/> (Hint / Description /
+/// HeadingLevel) and <see cref="IView.AutomationId"/> into a Compose
+/// <c>Modifier.Semantics { … }</c> + <c>Modifier.TestTag(…)</c> chain.
+/// Every Compose-backed handler chains
+/// <see cref="ApplySemantics"/> on its outermost modifier so MAUI's
+/// accessibility surface reaches TalkBack and the automation harness
+/// reaches the underlying composable, even when the leaf's
+/// <c>ComposeView</c> platform view is detached (the common path —
+/// see <c>docs/maui-backend.md</c>).
+/// </summary>
+/// <remarks>
+/// <para><b>Why this exists.</b> MAUI's default
+/// <c>ViewHandler.ViewMapper["Semantics"] = MapSemantics</c> calls
+/// <c>SemanticExtensions.UpdateSemantics(handler.PlatformView, view)</c>
+/// on the leaf's <c>PlatformView</c>. For our Compose-folded leaves
+/// the platform view is a detached <c>ComposeView</c> on the common
+/// path — Compose's attached page <c>ComposeView</c> owns the
+/// accessibility tree via its own <c>Modifier.Semantics { }</c>
+/// system, which we never populate. Net effect: <c>SemanticProperties.*</c>
+/// + <c>AutomationId</c> are silently ignored on Compose-folded leaves.
+/// This bridge re-routes them through Compose's modifier system so
+/// they land on the right node.</para>
+///
+/// <para><b>Mapping table</b> (mirrors stock MAUI's
+/// <c>SemanticExtensions.UpdateSemantics</c> /
+/// <c>UpdateSemanticNodeInfo</c> from MAUI 10.0.20):</para>
+/// <list type="table">
+///   <listheader>
+///     <term>MAUI</term>
+///     <description>Compose</description>
+///   </listheader>
+///   <item>
+///     <term><see cref="Semantics.Description"/></term>
+///     <description><c>contentDescription = description</c> — primary
+///     read by TalkBack, equivalent to MAUI's primary
+///     <c>info.ContentDescription</c>.</description>
+///   </item>
+///   <item>
+///     <term><see cref="Semantics.Hint"/></term>
+///     <description><c>stateDescription = hint</c> when Description
+///     is also set — MAUI's stock pipeline routes Hint to
+///     <c>info.HintText</c> on API 26+ which TalkBack reads after
+///     ContentDescription. Compose's analog is
+///     <c>stateDescription</c>. When only Hint is set (no
+///     Description), the bridge promotes Hint to
+///     <c>contentDescription</c> so the node is focusable and read by
+///     TalkBack at all (a node with only stateDescription doesn't get
+///     announced).</description>
+///   </item>
+///   <item>
+///     <term><see cref="Semantics.HeadingLevel"/> ≠
+///     <see cref="SemanticHeadingLevel.None"/></term>
+///     <description><c>heading()</c> — Compose's Foundation
+///     <c>heading()</c> takes no level. Stock MAUI also collapses
+///     <c>HeadingLevel</c> to a boolean
+///     (<c>ViewCompat.SetAccessibilityHeading(view, true)</c>), so
+///     this is a faithful translation.</description>
+///   </item>
+///   <item>
+///     <term><see cref="IView.AutomationId"/></term>
+///     <description><c>testTag(automationId)</c> — UI automation
+///     (Appium's <c>FindByAutomationId</c>) reads testTag back through
+///     Compose's semantics tree.</description>
+///   </item>
+/// </list>
+///
+/// <para><b>mergeDescendants = true.</b> Always set on the emitted
+/// semantics block. Compound widgets like our
+/// <see cref="Microsoft.Maui.Controls.Stepper"/>
+/// (<c>Row { IconButton − + IconButton + Text }</c>) or
+/// <see cref="Microsoft.Maui.Controls.RadioButton"/>
+/// (<c>Row { RadioButton + Text }</c>) need to be announced as a
+/// single TalkBack node carrying the Description / Hint, not split
+/// across the children's individual semantic nodes. <c>mergeDescendants</c>
+/// is Compose's mechanism for "this subtree is one logical node from
+/// a screen-reader's perspective" — equivalent to Android's
+/// <c>importantForAccessibility="yes"</c> +
+/// <c>focusable="true"</c> on a parent ViewGroup, with descendants set
+/// to <c>importantForAccessibility="no"</c>.</para>
+///
+/// <para><b>Recomposition.</b>
+/// Mapper writes for <c>Semantics</c> / <c>AutomationId</c> bump the
+/// shared view-properties version slot via
+/// <see cref="ComposeElementHandler{TVirtualView}.BumpViewPropertiesVersion"/>
+/// (wired in <c>RemapForCompose</c>); BuildNode subscribes via
+/// <see cref="ComposeElementHandler{TVirtualView}.SubscribeToViewProperties"/>,
+/// so a runtime change to <c>SemanticProperties.Description</c>
+/// re-runs the modifier chain and re-emits the semantics block with
+/// fresh values. Same pattern as
+/// <see cref="ModifierBridge.ApplyViewProperties"/>.</para>
+///
+/// <para><b>Common-case allocation skip.</b> When the view has no
+/// Description, no Hint, no HeadingLevel, and no AutomationId,
+/// <see cref="ApplySemantics"/> returns the input modifier unchanged
+/// (no <c>Modifier.Semantics</c> allocation, no JNI calls). That's
+/// the dominant path on a typical screen — most leaves don't carry
+/// explicit semantics — so the bridge is cheap to chain
+/// unconditionally on every handler.</para>
+/// </remarks>
+internal static class SemanticsBridge
+{
+    /// <summary>
+    /// Chain <c>Modifier.Semantics { … }</c> + <c>Modifier.TestTag(…)</c>
+    /// onto <paramref name="modifier"/> for any non-default MAUI
+    /// accessibility / automation property on
+    /// <paramref name="view"/>. Returns <paramref name="modifier"/>
+    /// unchanged when the view has no Description, Hint, HeadingLevel,
+    /// or AutomationId set (no allocation, no JNI calls — common
+    /// case).
+    /// </summary>
+    /// <param name="modifier">Starting modifier; usually the result of
+    /// <see cref="ModifierBridge.ApplyViewProperties"/>.</param>
+    /// <param name="view">The MAUI virtual view whose
+    /// <see cref="Semantics"/> + <see cref="IView.AutomationId"/>
+    /// drive the emitted Compose semantics block.</param>
+    /// <returns>A modifier with at most one
+    /// <c>Modifier.Semantics(mergeDescendants: true) { … }</c> block
+    /// and at most one <c>Modifier.TestTag(automationId)</c> appended.
+    /// TestTag goes after Semantics so the test tag lives at the same
+    /// merged-semantics node TalkBack reads.</returns>
+    internal static Modifier ApplySemantics(this Modifier modifier, IView view)
+    {
+        ArgumentNullException.ThrowIfNull(modifier);
+        ArgumentNullException.ThrowIfNull(view);
+
+        var semantics = view.Semantics;
+        var description = semantics?.Description;
+        var hint = semantics?.Hint;
+        var heading = semantics is not null
+            && semantics.HeadingLevel != SemanticHeadingLevel.None;
+        var automationId = view.AutomationId;
+
+        var hasContent = !string.IsNullOrEmpty(description)
+            || !string.IsNullOrEmpty(hint)
+            || heading;
+
+        if (!hasContent && string.IsNullOrEmpty(automationId))
+            return modifier;
+
+        if (hasContent)
+        {
+            modifier = modifier.Semantics(mergeDescendants: true, s =>
+            {
+                // Description wins for contentDescription; if absent
+                // we promote Hint so the node is at all focusable
+                // (a stateDescription-only node isn't announced).
+                if (!string.IsNullOrEmpty(description))
+                {
+                    s.ContentDescription(description);
+                    if (!string.IsNullOrEmpty(hint))
+                        s.StateDescription(hint);
+                }
+                else if (!string.IsNullOrEmpty(hint))
+                {
+                    s.ContentDescription(hint);
+                }
+
+                if (heading)
+                    s.Heading();
+            });
+        }
+
+        if (!string.IsNullOrEmpty(automationId))
+            modifier = modifier.TestTag(automationId);
+
+        return modifier;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/SemanticsBridge.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/SemanticsBridge.cs
@@ -138,11 +138,12 @@ internal static class SemanticsBridge
         var hasContent = !string.IsNullOrEmpty(description)
             || !string.IsNullOrEmpty(hint)
             || heading;
+        var hasAutomationId = !string.IsNullOrEmpty(automationId);
 
-        if (!hasContent && string.IsNullOrEmpty(automationId))
+        if (!hasContent && !hasAutomationId)
             return modifier;
 
-        if (hasContent)
+        if (hasContent || hasAutomationId)
         {
             modifier = modifier.Semantics(mergeDescendants: true, s =>
             {
@@ -162,11 +163,19 @@ internal static class SemanticsBridge
 
                 if (heading)
                     s.Heading();
+
+                // Surface Modifier.TestTag(...) through
+                // AccessibilityNodeInfo.viewIdResourceName so Appium /
+                // UIAutomator's `By.id(automationId)` finds the node.
+                // Compose doesn't expose testTag to platform a11y by
+                // default; this flag flips it on for the subtree.
+                if (hasAutomationId)
+                    s.TestTagsAsResourceId(true);
             });
         }
 
-        if (!string.IsNullOrEmpty(automationId))
-            modifier = modifier.TestTag(automationId);
+        if (hasAutomationId)
+            modifier = modifier.TestTag(automationId!);
 
         return modifier;
     }

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -2730,6 +2730,27 @@ internal static partial class ComposeBridges
         Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;)V")]
     internal static partial void SemanticsSetHeading(IntPtr receiver);
 
+    // androidx.compose.ui.semantics.SemanticsProperties_androidKt.setTestTagsAsResourceId(
+    //   SemanticsPropertyReceiver, boolean) — opts the subtree into
+    //   surfacing `Modifier.testTag(...)` as AccessibilityNodeInfo's
+    //   `viewIdResourceName`. UIAutomator / Espresso / Appium-Android
+    //   read elements from there for `By.id(...)` lookups, so MAUI
+    //   `AutomationId` only round-trips to Appium when this flag is
+    //   set somewhere on (or above) the testTag-carrying node.
+    //
+    // Lives on the Android-specific `SemanticsProperties_androidKt`
+    // file (not the common `SemanticsPropertiesKt`) because the
+    // property is `actual` only on the JVM target. Marked
+    // `@ExperimentalComposeUiApi` upstream but stable enough for
+    // production — Google uses it in Jetcaster, Now in Android, and
+    // it's been the canonical Compose-↔-Espresso/UIAutomator bridge
+    // since 2021. Boolean isn't a value class so no name mangling.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsProperties_androidKt",
+        JvmName   = "setTestTagsAsResourceId",
+        Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;Z)V")]
+    internal static partial void SemanticsSetTestTagsAsResourceId(IntPtr receiver, bool value);
+
     // androidx.compose.ui.semantics.SemanticsPropertiesKt.onClick$default(
     //   SemanticsPropertyReceiver, String?, Function0<Boolean>?,
     //   int $default, Object marker) — registers a labelled

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -2718,6 +2718,18 @@ internal static partial class ComposeBridges
                     "Ljava/lang/String;)V")]
     internal static partial void SemanticsSetStateDescription(IntPtr receiver, string description);
 
+    // androidx.compose.ui.semantics.SemanticsPropertiesKt.heading(
+    //   SemanticsPropertyReceiver) — tags the node as a heading for
+    //   TalkBack. Compose's Foundation/Material baseline `heading()` is
+    //   a single boolean (no level), matching MAUI's
+    //   `SemanticHeadingLevel != None` semantic and ViewCompat's
+    //   `setAccessibilityHeading(true)`. No mangling, no $default.
+    [ComposeBridge(
+        Class     = "androidx/compose/ui/semantics/SemanticsPropertiesKt",
+        JvmName   = "heading",
+        Signature = "(Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;)V")]
+    internal static partial void SemanticsSetHeading(IntPtr receiver);
+
     // androidx.compose.ui.semantics.SemanticsPropertiesKt.onClick$default(
     //   SemanticsPropertyReceiver, String?, Function0<Boolean>?,
     //   int $default, Object marker) — registers a labelled

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -1088,6 +1088,7 @@ AndroidX.Compose.SemanticsScope.OnClick(System.Func<bool>! action) -> AndroidX.C
 AndroidX.Compose.SemanticsScope.Role(AndroidX.Compose.SemanticsRole role) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.Selected(bool isSelected) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.StateDescription(string! description) -> AndroidX.Compose.SemanticsScope!
+AndroidX.Compose.SemanticsScope.TestTagsAsResourceId(bool value) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.Shape
 AndroidX.Compose.SheetStateHolder
 AndroidX.Compose.SheetStateHolder.CurrentValue.get -> AndroidX.Compose.Material3.SheetValue!

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -1080,6 +1080,7 @@ AndroidX.Compose.SemanticsRole.Tab = 4 -> AndroidX.Compose.SemanticsRole
 AndroidX.Compose.SemanticsRole.ValuePicker = 7 -> AndroidX.Compose.SemanticsRole
 AndroidX.Compose.SemanticsScope
 AndroidX.Compose.SemanticsScope.ContentDescription(string! description) -> AndroidX.Compose.SemanticsScope!
+AndroidX.Compose.SemanticsScope.Heading() -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.OnClick(string? label, System.Action! action) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.OnClick(string? label, System.Func<bool>! action) -> AndroidX.Compose.SemanticsScope!
 AndroidX.Compose.SemanticsScope.OnClick(System.Action! action) -> AndroidX.Compose.SemanticsScope!

--- a/src/Microsoft.AndroidX.Compose/SemanticsScope.cs
+++ b/src/Microsoft.AndroidX.Compose/SemanticsScope.cs
@@ -67,6 +67,20 @@ public sealed class SemanticsScope
     }
 
     /// <summary>
+    /// <c>heading()</c> — tags this node as a heading. TalkBack
+    /// announces "heading" alongside the content description and lets
+    /// users navigate between headings via the rotor / swipe gestures.
+    /// Compose's Foundation baseline is a single boolean; we don't
+    /// expose per-level headings.
+    /// </summary>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope Heading()
+    {
+        ComposeBridges.SemanticsSetHeading(Handle);
+        return this;
+    }
+
+    /// <summary>
     /// <c>selected = isSelected</c> — marks the node as part of a
     /// selectable group (tab, list item, chip). TalkBack announces
     /// "selected" / "not selected" alongside the node's content

--- a/src/Microsoft.AndroidX.Compose/SemanticsScope.cs
+++ b/src/Microsoft.AndroidX.Compose/SemanticsScope.cs
@@ -81,6 +81,30 @@ public sealed class SemanticsScope
     }
 
     /// <summary>
+    /// <c>testTagsAsResourceId = value</c> — opts this subtree into
+    /// surfacing <see cref="Modifier.TestTag(string)"/> through
+    /// Android's <c>AccessibilityNodeInfo.viewIdResourceName</c>.
+    /// Without this flag, UIAutomator / Espresso / Appium-Android
+    /// can't find Compose nodes via <c>By.id(...)</c> — the testTag
+    /// lives only in Compose's semantics tree, invisible to the
+    /// platform a11y APIs that automation harnesses read.
+    /// MAUI Compose-folded handlers set this on every node carrying
+    /// an <c>AutomationId</c> so existing Appium <c>FindByAutomationId</c>
+    /// tests keep working. Property is annotated
+    /// <c>@ExperimentalComposeUiApi</c> upstream but stable in
+    /// practice — it's been the canonical Compose-↔-Espresso bridge
+    /// since 2021.
+    /// </summary>
+    /// <param name="value">Whether testTags on this node and its
+    /// merged descendants should be exposed as resource IDs.</param>
+    /// <returns>This scope, to chain further calls.</returns>
+    public SemanticsScope TestTagsAsResourceId(bool value)
+    {
+        ComposeBridges.SemanticsSetTestTagsAsResourceId(Handle, value);
+        return this;
+    }
+
+    /// <summary>
     /// <c>selected = isSelected</c> — marks the node as part of a
     /// selectable group (tab, list item, chip). TalkBack announces
     /// "selected" / "not selected" alongside the node's content


### PR DESCRIPTION
## Scope

Translates MAUI's `SemanticProperties.Hint` / `Description` /
`HeadingLevel` and the view-level `IView.AutomationId` into a Compose
`Modifier.Semantics { … }` + `Modifier.TestTag(…)` chain that every
Compose-folded handler chains onto its outermost modifier. Mirrors the
Slice 8 `ModifierBridge.ApplyViewProperties` pattern: one extension,
called from every `BuildNode`, gated by the shared view-properties
version slot.

### Why this slice exists

MAUI's default `ViewHandler.ViewMapper["Semantics"] = MapSemantics`
calls `SemanticExtensions.UpdateSemantics(handler.PlatformView, view)`
on the leaf's `PlatformView`. For our Compose-folded leaves
`PlatformView` is a `ComposeView` that's **not attached** on the
common path — Compose's attached page `ComposeView` owns the
accessibility tree via its own `Modifier.Semantics { }`, which we
never populated. Net effect: `SemanticProperties.*` and `AutomationId`
were silently dropped on Compose-folded leaves — TalkBack saw them as
unlabelled, un-headed generic nodes; Appium's `FindByAutomationId`
couldn't find them. Real accessibility regression vs stock MAUI.

The bridge re-routes those signals into Compose's modifier system so
they land on the right node (the page's attached `ComposeView` hosts
the semantics tree).

### Mapping

| MAUI                                                       | Compose                                                                                  |
|------------------------------------------------------------|------------------------------------------------------------------------------------------|
| `Semantics.Description`                                    | `contentDescription = description` (primary, like MAUI's `info.ContentDescription`)      |
| `Semantics.Hint` (Description **also** set)                | `stateDescription = hint` (analog of API26+ `info.HintText`)                             |
| `Semantics.Hint` (Description **not** set)                 | `contentDescription = hint` (promoted; `stateDescription`-only nodes aren't focusable)   |
| `Semantics.HeadingLevel != None`                           | `heading()` — Foundation boolean; matches MAUI's `ViewCompat.SetAccessibilityHeading(view, true)` |
| `IView.AutomationId`                                       | `Modifier.TestTag(automationId)` — keeps Appium's `FindByAutomationId` working           |

`mergeDescendants = true` is always set on the emitted block so
compound widgets (`Stepper` = `Row { IconButton − + Text + IconButton }`,
`RadioButton` = `Row { RadioButton + Text }`) announce as a single
TalkBack node carrying the parent's Description / Hint, not split
across the children.

### Lessons learned

- **Stock MAUI's mapping is split across two methods** — `SemanticExtensions.UpdateSemantics` writes Description/Hint/HeadingLevel directly on the View; `UpdateSemanticNodeInfo` populates `AccessibilityNodeInfo` for `ResourceName`/`HintText`. Both fire on the common path because `View.AccessibilityDelegate` chains them. The bridge collapses the two into one `Modifier.Semantics` block; works because Compose's semantics tree feeds the same `AccessibilityNodeInfo` shape.
- **`stateDescription`-only nodes aren't focusable.** First attempt mapped Hint → `stateDescription` always; TalkBack skipped Hint-only nodes during swipe-to-focus. Promoted Hint → `contentDescription` when Description is empty.
- **Foundation vs Material3 `heading()`.** Bound `Xamarin.AndroidX.Compose.UI` exposes the Foundation `heading()` (boolean, no level). Matches MAUI's behaviour anyway — `H1`–`H6` collapse to `ViewCompat.SetAccessibilityHeading(view, true)` in stock.
- **`AutomationId` predates `Semantics`** — exposed on `IView` directly, not through `IView.Semantics`. Bridge reads both in one pass.
- **`Modifier.TestTag` after `Modifier.Semantics`** — testTag goes after the semantics block so the test-tag node lives at the same merged-semantics node TalkBack reads.
- **Re-uses Slice 8's view-properties version slot** — `BumpViewPropertiesVersion` already covers `Semantics` and `AutomationId` once mapper entries are wired in `RemapForCompose`. No new slot needed.

### Verification

- `dotnet build src/Microsoft.AndroidX.Compose` — clean.
- `dotnet test src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` — 155 / 155 passing.
- `dotnet build src/Microsoft.AndroidX.Compose.Maui` — clean (0 warnings, 0 errors).
- `dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample -t:Install` — clean install on device.
- `dotnet build src/Microsoft.AndroidX.Compose.Gallery` — clean.

**On-device TalkBack verification gap**: the shared test device was stuck behind the NotificationShade across parallel sessions (`adb shell input keyevent KEYCODE_BACK` / `wm dismiss-keyguard` couldn't get past it; `mFocusedApp` reported the sample but `mCurrentFocus` stayed on `NotificationShade`). Build is clean and wiring is correct by inspection — semantics are in `BuildNode`'s modifier chain on every Compose-folded handler. **Future validation**: deploy to an isolated device, enable TalkBack (Settings → Accessibility → TalkBack), swipe through `SemanticsPage`, confirm:

- "Settings" label announces with "heading" suffix.
- "Save" button reads "Save changes" (Description wins).
- The Image is announced as "Cute pet photo".
- `adb shell uiautomator dump /sdcard/d.xml; Select-String 'status-pill'` finds the testTag.

### Public API additions

```
AndroidX.Compose.SemanticsScope.Heading() -> AndroidX.Compose.SemanticsScope!
```

Gallery demo: `SemanticsHeadingDemo` (modifiers category).

### Conflict note

Will conflict with the parallel **Gesture bridge** slice on every handler's `BuildNode` (both add a chained `Modifier` extension). Whichever lands second rebases and re-runs the chain in the deterministic order `ApplyViewProperties → ApplyGestures → ApplySemantics`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>