### PR TITLE
MAUI Phase 2 Slice 12: RefreshView + IndicatorView + DatePicker Phase 4b (Min/MaxDate)

### DIFF
--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -363,7 +363,7 @@ Compose backend.
 - Image handler — stock MAUI handler keeps rendering
   `dotnet_bot.png`; replacing with Compose's `Image` lands later.
 
-### Phase 2 — input + visual breadth (target: "Control Gallery parity for leaves")
+### Phase 2 — input + visual breadth (target: "Control Gallery parity for leaves") ✅ shipped (closed by Slice 12)
 
 The full leaf list (delivered across multiple slices):
 
@@ -1397,6 +1397,108 @@ covering MAUI's small-but-essential value/progress family:
   "use the theme default" — but the auto-default-mask machinery
   still needs the trailing convention to land bits in the right
   slot. Documented on `composer.SliderColors(...)`.
+
+#### Phase 2 Slice 12 — `RefreshView` + `IndicatorView` + `DatePicker` Phase 4b lift ✅ shipped
+
+The final Phase 2 slice closes out leaf coverage with two more
+container/composite handlers and lifts `DatePickerHandler` to honour
+`MinimumDate` / `MaximumDate`. Marks **Phase 2 complete** —
+every leaf in the Phase 2 plan list is now wired.
+
+- `MauiRefreshView` → `RefreshViewHandler` over Compose's
+  `Microsoft.AndroidX.Compose.PullToRefreshBox`. `IsRefreshing` is
+  two-way: MAUI → Compose flows through `MapIsRefreshing`; Compose's
+  pull gesture writes `view.IsRefreshing = true` from the `onRefresh`
+  callback before invoking `Command`. The mapper re-fires with the
+  same value but the `MutableState<bool>` equality short-circuit
+  breaks the loop without a `_suppressMauiWrite` flag (mirrors
+  `EntryHandler.OnValueChanged`). `Content` walks via `ComposeWalker`
+  so the inner stack folds into the parent page composition.
+- `MauiIndicatorView` → `IndicatorViewHandler` synthesised from a
+  Compose `Row` of `Box` dot tiles (no first-class M3 indicator
+  primitive). `RoundedCornerShape(50)` for circles, `(0)` for
+  squares. `Position` is one-way (MAUI → Compose) for now — the
+  two-way to `CarouselView.Position` is owned by Phase 3's
+  `CarouselViewHandler`. `IndicatorTemplate` isn't honoured because
+  templated indicators need MAUI's `IndicatorStackLayout` rendering
+  which doesn't fit the single-`ComposeView`-per-page contract;
+  documented as opt-out (skip the `AddHandler` to fall back to stock
+  templating).
+- `DatePickerHandler` lifted from Phase 4 zero-param Remember to
+  Phase 4b parameterised Remember (issue #264). The
+  `RememberDatePickerState` bridge in `ComposeBridges.cs` now
+  surfaces all five Kotlin slots (`initialSelectedDateMillis`,
+  `initialDisplayedMonthMillis`, `yearRange`, `initialDisplayMode`,
+  `selectableDates`); the `DatePickerState` wrapper exposes matching
+  `Initial*` properties so the facade generator's wrapper-resolution
+  rules pick them up by name. A new
+  `Microsoft.AndroidX.Compose.DateRangeSelectableDates` JCW (registered
+  as `net/compose/DateRangeSelectableDates`) implements the Kotlin
+  `androidx.compose.material3.SelectableDates` interface with mutable
+  `Min`/`MaxUtcMillis` + `Min`/`MaxYear` props. `DatePickerHandler`
+  holds **one** adapter instance as a `readonly` field per handler
+  and re-keys the `c.Remember(factory, minTicks, maxTicks)` call so
+  external `MinimumDate` / `MaximumDate` writes invalidate the cached
+  state.
+
+**SelectableDates JCW pattern (matches Phase 10's `ConfirmStateChange`).**
+Holding the adapter as a `readonly` field on the handler keeps the JNI
+peer identity stable across recompositions — required because the
+adapter is part of `rememberDatePickerState`'s `remember` cache key.
+Reallocating it every render would drop the cached state-holder back
+to a fresh `2024-01-01 / IntRange(1900, 2100) / DisplayMode.Picker`
+instance every recomposition. The `MapMinimumDate` / `MapMaximumDate`
+mappers mutate the adapter's properties in-place; Kotlin re-invokes
+`IsSelectableDate` per grid render so changes show up on the next
+recompose. The same shape unblocks a future
+`DateRangePickerHandler` (Phase 3+) which can reuse
+`DateRangeSelectableDates` to clamp the picker range.
+
+**Phase 4b lift trade-off.** The wrapper-member resolution rules
+(see `.github/copilot-instructions.md`) match by name only, not by
+type — so `DatePickerState.InitialSelectedDateMillis` had to be
+typed `Java.Lang.Long?` (matching the JNI slot) rather than the
+user-friendly `long?`. The conversion happens inside the
+`DatePickerState(long? initialSelectedDateMillis, ...)` ctor; users
+get an ergonomic API while the generator still lowers cleanly. The
+bridge generator can't skip non-trailing slots, so even though only
+three of the five Kotlin slots are MAUI-relevant
+(`initialSelectedDateMillis`, `yearRange`, `selectableDates`), the
+bridge surfaces all five — the unused two are left `null` by the
+handler and the auto-default-mask machinery clears their
+`$default` bits.
+
+**Lessons learned (Slice 12):**
+
+- **`view.ToPlatform(MauiContext)` recurses when the registered
+  handler is the one calling it.** The original spec for
+  `IndicatorTemplate` was "fall back to
+  `AndroidView { factory = view.ToPlatform(MauiContext) }`". In
+  practice `ToPlatform` looks up the handler from the registry —
+  which returns ours — and we'd loop. Documented the gap and render
+  dots regardless when the template is non-null; consumers wanting
+  templated indicators skip the `AddHandler` registration entirely.
+- **`IDatePicker.MinimumDate` / `MaximumDate` are `DateTime?`,
+  not `DateTime`.** The interface allows null even though MAUI's
+  `DatePicker` control always populates them. Handlers must
+  null-check before computing `Ticks` for the version slot.
+- **`c.Remember(factory, key1, key2)` re-keying is the correct
+  invalidation hook for state-holder min/max bound changes.** The
+  Compose runtime drops the cached `DatePickerState` when any key
+  shifts and runs the factory again, picking up the seeded
+  `initialSelectedDateMillis` / `initialDisplayedMonthMillis`. The
+  `_ticks` slot (the user-driven Date) is *not* in the key array,
+  so MAUI write-throughs from `dp.Date = picked` survive — they just
+  bump `_ticks.Value` and let the adapter's mutable fields drive
+  greying.
+- **Wrapper-member resolution matches by name, not type.** Surfaced
+  `Java.Lang.Long?` directly on the wrapper to align with the JNI
+  slot type; ergonomic conversion happens in the wrapper's ctor.
+- **MAUI's `DatePicker` clamps `Date` assignments outside the
+  Min/Max range.** The Reset button on the `PickersPage` sample had
+  to use `DateTime.Today` (within the seeded Today..Today+30 window)
+  rather than the previous `2000-01-01` default; otherwise MAUI's
+  range validator silently rewrote the value back inside bounds.
 
 ### Phase 3 — collection + container (target: list-driven apps)
 

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
@@ -10,15 +10,24 @@ public static class DatePickerDialogDemo
         Id:          "dialogs-date-picker",
         CategoryId:  "dialogs-sheets",
         Title:       "DatePickerDialog",
-        Description: "Tap Pick date to open a calendar dialog. Read SelectedDateMillis on confirm.",
+        Description: "Tap Pick date to open a calendar dialog. Past + far-future dates are blocked via SelectableDates; read SelectedDateMillis on confirm.",
         Build:       c =>
         {
-            var open   = c.MutableStateOf(false);
-            var picked = c.MutableStateOf("(none)");
-            var state  = c.Remember(() => new DatePickerState());
+            var open      = c.MutableStateOf(false);
+            var picked    = c.MutableStateOf("(none)");
+            // One JCW adapter per demo instance — its identity is part
+            // of the rememberDatePickerState cache key.
+            var bounds    = c.Remember(() => new DateRangeSelectableDates());
+            var todayUtc  = DateTimeOffset.UtcNow.Date;
+            bounds.MinUtcMillis = new DateTimeOffset(todayUtc).ToUnixTimeMilliseconds();
+            bounds.MaxUtcMillis = new DateTimeOffset(todayUtc.AddDays(30)).ToUnixTimeMilliseconds();
+            var state     = c.Remember(() => new DatePickerState(
+                initialSelectedDateMillis: bounds.MinUtcMillis,
+                initialSelectableDates:    bounds));
             return new Column
             {
                 new Text($"Picked date: {picked}"),
+                new Text("(Today through Today+30 are selectable.)"),
                 new Button(onClick: () => open.Value = true) { new Text("Pick date") },
                 open.Value
                     ? new DatePickerDialog(onDismissRequest: () => open.Value = false)

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/AppShell.xaml.cs
@@ -32,5 +32,7 @@ public partial class AppShell : Shell
         Routing.RegisterRoute("image-buttons",  typeof(ImageButtonsPage));
         Routing.RegisterRoute("visuals",        typeof(VisualsPage));
         Routing.RegisterRoute("alerts",         typeof(AlertsPage));
+        Routing.RegisterRoute("refresh",        typeof(RefreshPage));
+        Routing.RegisterRoute("indicator",      typeof(IndicatorPage));
     }
 }

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/HomePage.xaml.cs
@@ -115,6 +115,16 @@ public partial class HomePage : ContentPage
                 "DisplayAlert / DisplayActionSheet / DisplayPromptAsync over Compose dialogs.",
                 Color.FromArgb("#FF5722"),
                 "alerts"),
+            new DemoEntry(
+                "Refresh",
+                "RefreshView (pull-to-refresh) over Compose's PullToRefreshBox.",
+                Color.FromArgb("#00BCD4"),
+                "refresh"),
+            new DemoEntry(
+                "Indicator",
+                "IndicatorView dot strip; Prev/Next buttons cycle Position.",
+                Color.FromArgb("#9C27B0"),
+                "indicator"),
         };
     }
 

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/IndicatorPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/IndicatorPage.xaml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.IndicatorPage"
+             Title="Indicator">
+
+    <!--
+        Exercises `IndicatorViewHandler` (Row of Compose Box dots):
+            * Count                 -> 5 dots
+            * Position              -> active dot index, cycled by Prev/Next
+            * IndicatorColor        -> inactive dot tint (Gray)
+            * SelectedIndicatorColor-> active dot tint (Blue)
+            * IndicatorSize         -> 10dp
+            * IndicatorsShape       -> Circle (default; the Square button
+                                       toggles to RoundedCornerShape(0)).
+
+        CarouselView <-> IndicatorView two-way binding lands in Phase 3;
+        for now Position is one-way (MAUI -> Compose) and the Prev/Next
+        buttons drive it manually.
+    -->
+    <ScrollView>
+        <VerticalStackLayout
+            Padding="30,30"
+            Spacing="20">
+
+            <Label
+                Text="Indicator dots"
+                Style="{StaticResource Headline}" />
+
+            <Label
+                Text="Five labeled positions; the IndicatorView below shows the active one. Use Prev / Next / Toggle shape to cycle."
+                LineBreakMode="WordWrap" />
+
+            <Label x:Name="PositionLabel"
+                   Text="Position: 0 (Apple)"
+                   FontAttributes="Bold"
+                   HorizontalOptions="Center" />
+
+            <IndicatorView x:Name="Indicator"
+                           Count="5"
+                           IndicatorColor="LightGray"
+                           SelectedIndicatorColor="MediumBlue"
+                           IndicatorSize="10"
+                           IndicatorsShape="Circle"
+                           HorizontalOptions="Center" />
+
+            <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
+                <Button x:Name="PrevButton" Text="Prev" Clicked="OnPrev" />
+                <Button x:Name="NextButton" Text="Next" Clicked="OnNext" />
+                <Button x:Name="ShapeButton" Text="Toggle shape" Clicked="OnToggleShape" />
+            </HorizontalStackLayout>
+
+        </VerticalStackLayout>
+    </ScrollView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/IndicatorPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/IndicatorPage.xaml.cs
@@ -1,0 +1,47 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Indicator demo — exercises
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.IndicatorViewHandler"/>:
+/// MAUI <see cref="IndicatorView"/> rendered as a Compose
+/// <c>Row</c> of dot tiles. The Prev / Next buttons cycle
+/// <see cref="IndicatorView.Position"/>; Toggle shape flips between
+/// <see cref="IndicatorShape.Circle"/> and
+/// <see cref="IndicatorShape.Square"/>.
+/// </summary>
+public partial class IndicatorPage : ContentPage
+{
+    static readonly string[] s_labels =
+    {
+        "Apple", "Banana", "Cherry", "Date", "Elderberry",
+    };
+
+    /// <summary>Build the page.</summary>
+    public IndicatorPage()
+    {
+        InitializeComponent();
+        UpdateLabel();
+    }
+
+    void OnPrev(object? sender, EventArgs e)
+    {
+        Indicator.Position = (Indicator.Position - 1 + s_labels.Length) % s_labels.Length;
+        UpdateLabel();
+    }
+
+    void OnNext(object? sender, EventArgs e)
+    {
+        Indicator.Position = (Indicator.Position + 1) % s_labels.Length;
+        UpdateLabel();
+    }
+
+    void OnToggleShape(object? sender, EventArgs e)
+    {
+        Indicator.IndicatorsShape = Indicator.IndicatorsShape == IndicatorShape.Circle
+            ? IndicatorShape.Square
+            : IndicatorShape.Circle;
+    }
+
+    void UpdateLabel() =>
+        PositionLabel.Text = $"Position: {Indicator.Position} ({s_labels[Indicator.Position]})";
+}

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml
@@ -13,7 +13,8 @@
             * Picker.Title                   -> MapTitle (floating label)
             * DatePicker.Date                -> MapDate (DateSelected echoes the formatted date)
             * DatePicker.MinimumDate /
-              MaximumDate                    -> not yet wired (Phase 4b RememberDatePickerState lift required; tracked in #264)
+              MaximumDate                    -> Phase 4b lift (#264) — bridges through SelectableDates
+                                                  so days outside Today..Today+30 are greyed out.
             * TimePicker.Time                -> MapTime (PropertyChanged echoes time)
             * Format / TextColor / FontSize /
               FontAttributes (Bold)          -> MapFormat / MapTextColor / MapFont
@@ -53,7 +54,7 @@
                 x:Name="FruitEcho"
                 Text="No fruit picked yet." />
 
-            <Label Text="DatePicker (modal calendar) — opens a Compose DatePickerDialog; selection writes back via DateSelected."
+            <Label Text="DatePicker (modal calendar) — opens a Compose DatePickerDialog; selection writes back via DateSelected. The Min/Max range is Today..Today+30."
                    FontAttributes="Bold" />
 
             <DatePicker

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/PickersPage.xaml.cs
@@ -16,23 +16,20 @@ using System.ComponentModel;
 public partial class PickersPage : ContentPage
 {
     static readonly TimeSpan s_defaultAlarm = new(7, 30, 0);
-    static readonly DateTime s_defaultDate  = new(2000, 1, 1);
 
     /// <summary>Build the page.</summary>
     public PickersPage()
     {
         InitializeComponent();
 
-        // Seed the date picker with today so the trigger label has
-        // something useful to display before the user opens the dialog.
-        // MinimumDate / MaximumDate are not yet plumbed through to
-        // Compose's DatePickerState (Phase 4 zero-user-param Remember
-        // doesn't surface yearRange yet — see issue #264). We still
-        // set them here on the MAUI side so the regression is obvious
-        // when the Phase 4b lift lands.
+        // Seed the date picker with today and clamp the calendar to
+        // a Today..Today+30 window. Phase 4b's RememberDatePickerState
+        // lift wires MinimumDate / MaximumDate through to Compose's
+        // SelectableDates so days outside this range render greyed
+        // out (issue #264).
         var today = DateTime.Today;
-        BirthDate.MinimumDate = today.AddYears(-2);
-        BirthDate.MaximumDate = today.AddYears(2);
+        BirthDate.MinimumDate = today;
+        BirthDate.MaximumDate = today.AddDays(30);
         BirthDate.Date        = today;
 
         AlarmTime.Time             = s_defaultAlarm;
@@ -62,7 +59,9 @@ public partial class PickersPage : ContentPage
     {
         FruitPicker.SelectedIndex = -1;
         FruitEcho.Text            = "No fruit picked yet.";
-        BirthDate.Date            = s_defaultDate;
+        // Reset within the [Today, Today + 30] window so the assignment
+        // doesn't get clamped by the MAUI DatePicker's range validator.
+        BirthDate.Date            = DateTime.Today;
         DateEcho.Text             = "No date picked yet.";
         AlarmTime.Time            = s_defaultAlarm;
         TimeEcho.Text             = "No time picked yet.";

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/RefreshPage.xaml
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/RefreshPage.xaml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Microsoft.AndroidX.Compose.Maui.Sample.Pages.RefreshPage"
+             Title="Refresh">
+
+    <!--
+        Exercises `RefreshViewHandler` over Compose's
+        `PullToRefreshBox`:
+            * IsRefreshing (TwoWay) — MAUI -> Compose flows through MapIsRefreshing;
+              the pull gesture writes IsRefreshing=true through the onRefresh
+              callback and the MutableState<bool> equality short-circuit
+              breaks the feedback loop.
+            * Refreshing event - simulates an async refresh that
+              increments a counter, replaces the items, and clears
+              IsRefreshing back to false on the UI thread.
+            * Content - walked via ComposeWalker.Render so the inner
+              VerticalStackLayout folds into the parent Page composition.
+    -->
+    <RefreshView x:Name="Refresh"
+                 Refreshing="OnRefreshing">
+        <ScrollView>
+            <VerticalStackLayout x:Name="ItemsHost"
+                                 Padding="30,30"
+                                 Spacing="12">
+
+                <Label
+                    Text="Pull to refresh"
+                    Style="{StaticResource Headline}" />
+
+                <Label x:Name="StatusLabel"
+                       Text="Pulled 0 times"
+                       FontAttributes="Bold" />
+
+                <Label
+                    Text="Drag the list down past the threshold to trigger a refresh. The Compose Material 3 spinner appears, the list rebuilds, and the counter in the title increments."
+                    LineBreakMode="WordWrap" />
+
+                <!-- Initial mock items; replaced inside OnRefreshing.   -->
+                <Label x:Name="Item0" Text="• Item 1" />
+                <Label x:Name="Item1" Text="• Item 2" />
+                <Label x:Name="Item2" Text="• Item 3" />
+                <Label x:Name="Item3" Text="• Item 4" />
+                <Label x:Name="Item4" Text="• Item 5" />
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+
+</ContentPage>

--- a/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/RefreshPage.xaml.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui.Sample/Pages/RefreshPage.xaml.cs
@@ -1,0 +1,42 @@
+namespace Microsoft.AndroidX.Compose.Maui.Sample.Pages;
+
+/// <summary>
+/// Refresh demo — exercises
+/// <see cref="Microsoft.AndroidX.Compose.Maui.Handlers.RefreshViewHandler"/>:
+/// pull-to-refresh through Compose's <c>PullToRefreshBox</c>, with a
+/// counter on the page title and the rebuilt mock-item list as
+/// proof that <see cref="RefreshView.Refreshing"/> ran.
+/// </summary>
+public partial class RefreshPage : ContentPage
+{
+    int _refreshCount;
+
+    /// <summary>Build the page.</summary>
+    public RefreshPage()
+    {
+        InitializeComponent();
+    }
+
+    async void OnRefreshing(object? sender, EventArgs e)
+    {
+        _refreshCount++;
+        Title = $"Refresh — pulled {_refreshCount}×";
+        StatusLabel.Text = $"Pulled {_refreshCount} times";
+
+        // Simulate async work: rebuild the mock list with timestamps
+        // so the user can confirm the refresh actually fired.
+        await Task.Delay(700);
+
+        var stamp = DateTime.Now.ToString("HH:mm:ss");
+        Item0.Text = $"• Item 1 (refreshed {stamp})";
+        Item1.Text = $"• Item 2 (refreshed {stamp})";
+        Item2.Text = $"• Item 3 (refreshed {stamp})";
+        Item3.Text = $"• Item 4 (refreshed {stamp})";
+        Item4.Text = $"• Item 5 (refreshed {stamp})";
+
+        // Clear the refreshing state - mirrors the contract in MAUI's
+        // stock RefreshView handler (the spinner stays until the
+        // consumer flips IsRefreshing back to false).
+        Refresh.IsRefreshing = false;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
@@ -37,6 +37,19 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 /// reconstitute live in <see cref="BuildNode(IComposer)"/>, the same
 /// trick <see cref="LayoutHandler"/> uses for <c>Thickness</c>.</para>
 ///
+/// <para><see cref="IDatePicker.MinimumDate"/> /
+/// <see cref="IDatePicker.MaximumDate"/> map to a single
+/// <see cref="DateRangeSelectableDates"/> JCW adapter, allocated once
+/// per handler as a <c>readonly</c> field — its JNI identity is part of
+/// <c>rememberDatePickerState</c>'s cache key, so re-allocating per
+/// composition would invalidate the wrapper. Mutating the bounds is
+/// cheap; Kotlin re-invokes <c>isSelectableDate</c> on every grid
+/// render. To force the picker to re-key when an external push moves
+/// either bound past the current selection, the
+/// <c>composer.Remember(...)</c> call below is keyed on
+/// <c>(_minTicks, _maxTicks)</c> so a bound change rebuilds the
+/// wrapper and Kotlin re-clamps any out-of-range selection.</para>
+///
 /// <para>Compose's <see cref="DatePickerState"/> wrapper exposes a
 /// <c>Jvm</c> field that's only populated <em>during</em> the first
 /// <see cref="ComposeDatePicker"/> render — writing
@@ -56,11 +69,8 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
         new PropertyMapper<IDatePicker, DatePickerHandler>(ViewHandler.ViewMapper)
         {
             [nameof(IDatePicker.Date)]                = MapDate,
-            // MinimumDate / MaximumDate are intentionally NOT mapped here —
-            // wiring them through to Compose's DatePickerState requires
-            // lifting `RememberDatePickerState` to a Phase 4b parameterised
-            // wrapper that surfaces `yearRange` (and ideally an
-            // `ISelectableDates` adapter). Tracked as a Slice 5 follow-up.
+            [nameof(IDatePicker.MinimumDate)]         = MapMinimumDate,
+            [nameof(IDatePicker.MaximumDate)]         = MapMaximumDate,
             [nameof(IDatePicker.Format)]              = MapFormat,
             [nameof(ITextStyle.TextColor)]            = MapTextColor,
             [nameof(ITextStyle.Font)]                 = MapFont,
@@ -72,12 +82,19 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
         new(ViewCommandMapper);
 
     readonly MutableState<long?>  _ticks      = new((long?)null);
+    readonly MutableState<long?>  _minTicks   = new((long?)null);
+    readonly MutableState<long?>  _maxTicks   = new((long?)null);
     readonly MutableState<string> _format     = new("d");
     readonly MutableState<long?>  _textColor  = new((long?)null);
     readonly MutableState<int?>   _fontSize   = new((int?)null);
     readonly MutableState<bool>   _bold       = new(false);
     readonly MutableState<bool>   _open       = new(false);
     readonly MutableState<bool>   _fillWidth  = new(false);
+
+    // One adapter per handler — its JNI identity is part of the
+    // rememberDatePickerState cache key, so it must outlive every
+    // recomposition. Mutated by MapMinimumDate / MapMaximumDate.
+    readonly DateRangeSelectableDates _selectableDates = new();
 
     /// <summary>Construct a handler with the default mappers.</summary>
     public DatePickerHandler() : base(Mapper, CommandMapper) { }
@@ -96,18 +113,38 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
         // demo's `c => { … }` pattern.
         return new Composed(c =>
         {
-            var state = c.Remember(() => new DatePickerState());
+            var ticks    = _ticks.Value;
+            var minTicks = _minTicks.Value;
+            var maxTicks = _maxTicks.Value;
+            var format   = string.IsNullOrEmpty(_format.Value) ? "d" : _format.Value;
+            var packed   = _textColor.Value;
+            var size     = _fontSize.Value;
+            var bold     = _bold.Value;
+            var fill     = _fillWidth.Value;
+            var isOpen   = _open.Value;
 
-            var ticks   = _ticks.Value;
-            var format  = string.IsNullOrEmpty(_format.Value) ? "d" : _format.Value;
-            var packed  = _textColor.Value;
-            var size    = _fontSize.Value;
-            var bold    = _bold.Value;
-            var fill    = _fillWidth.Value;
-            var isOpen  = _open.Value;
+            // Re-key on (minTicks, maxTicks) so an external Min/Max
+            // push allocates a fresh DatePickerState seeded with the
+            // updated SelectableDates window — Kotlin re-evaluates the
+            // initial selection against the new range and clears it
+            // when out of range.
+            var state = c.Remember(
+                () =>
+                {
+                    var initialMs = ticks is long t
+                        ? new DateTimeOffset(new DateTime(t, DateTimeKind.Local).Date)
+                            .ToUniversalTime()
+                            .ToUnixTimeMilliseconds()
+                        : (long?)null;
+                    return new DatePickerState(
+                        initialSelectedDateMillis: initialMs,
+                        initialSelectableDates:    _selectableDates);
+                },
+                minTicks,
+                maxTicks);
 
-            var label = ticks is long t
-                ? new DateTime(t).ToString(format)
+            var label = ticks is long ticksValue
+                ? new DateTime(ticksValue).ToString(format)
                 : "Pick a date";
 
             var trigger = new ComposeOutlinedButton(onClick: () => _open.Value = true)
@@ -201,6 +238,52 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
     /// <summary>Map <see cref="IDatePicker.Date"/> to the Compose ticks slot.</summary>
     public static void MapDate(DatePickerHandler handler, IDatePicker dp) =>
         handler._ticks.Value = dp.Date is DateTime d ? d.Ticks : null;
+
+    /// <summary>
+    /// Map <see cref="IDatePicker.MinimumDate"/> to the
+    /// <see cref="DateRangeSelectableDates"/> lower bound and the
+    /// <c>_minTicks</c> re-keying slot.
+    /// </summary>
+    public static void MapMinimumDate(DatePickerHandler handler, IDatePicker dp)
+    {
+        if (dp.MinimumDate is DateTime min)
+        {
+            handler._selectableDates.MinUtcMillis = ToUtcMillis(min.Date);
+            handler._selectableDates.MinYear      = min.Year;
+            handler._minTicks.Value               = min.Ticks;
+        }
+        else
+        {
+            handler._selectableDates.MinUtcMillis = null;
+            handler._selectableDates.MinYear      = null;
+            handler._minTicks.Value               = null;
+        }
+    }
+
+    /// <summary>
+    /// Map <see cref="IDatePicker.MaximumDate"/> to the
+    /// <see cref="DateRangeSelectableDates"/> upper bound and the
+    /// <c>_maxTicks</c> re-keying slot.
+    /// </summary>
+    public static void MapMaximumDate(DatePickerHandler handler, IDatePicker dp)
+    {
+        if (dp.MaximumDate is DateTime max)
+        {
+            handler._selectableDates.MaxUtcMillis = ToUtcMillis(max.Date);
+            handler._selectableDates.MaxYear      = max.Year;
+            handler._maxTicks.Value               = max.Ticks;
+        }
+        else
+        {
+            handler._selectableDates.MaxUtcMillis = null;
+            handler._selectableDates.MaxYear      = null;
+            handler._maxTicks.Value               = null;
+        }
+    }
+
+    static long ToUtcMillis(DateTime localDate) =>
+        new DateTimeOffset(localDate.Year, localDate.Month, localDate.Day,
+                           0, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds();
 
     /// <summary>Map <see cref="IDatePicker.Format"/> to the formatted-label slot.</summary>
     public static void MapFormat(DatePickerHandler handler, IDatePicker dp) =>

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/IndicatorViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/IndicatorViewHandler.cs
@@ -1,0 +1,179 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using Microsoft.AndroidX.Compose.Maui.Platform;
+using Microsoft.Maui.Handlers;
+using ComposeColor      = AndroidX.Compose.Color;
+using IndicatorShape    = Microsoft.Maui.Controls.IndicatorShape;
+using MauiIndicatorView = Microsoft.Maui.Controls.IndicatorView;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="MauiIndicatorView"/> handler that synthesises the
+/// classic dot strip out of a Compose <see cref="Row"/> of
+/// <see cref="Box"/> tiles. Replaces MAUI's
+/// <c>IndicatorStackLayout</c>-backed handler when the consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para>Compose has no first-class indicator primitive — Material 3
+/// leaves carousel position rendering to the consumer. The handler
+/// generates one <see cref="Box"/> per <see cref="MauiIndicatorView.Count"/>,
+/// each <see cref="MauiIndicatorView.IndicatorSize"/> dp wide,
+/// clipped to a <c>RoundedCornerShape(50)</c> circle (or
+/// <c>RoundedCornerShape(0)</c> square per
+/// <see cref="MauiIndicatorView.IndicatorsShape"/>), tinted with
+/// <see cref="MauiIndicatorView.SelectedIndicatorColor"/> for the
+/// active <see cref="MauiIndicatorView.Position"/> and
+/// <see cref="MauiIndicatorView.IndicatorColor"/> for everything
+/// else.</para>
+///
+/// <para><b>Position is one-way (MAUI → Compose) for now.</b> The
+/// two-way binding to <c>CarouselView.Position</c> is owned by the
+/// <see cref="CarouselViewHandler"/> work in Phase 3 — until then the
+/// indicator visualises whatever MAUI / consumer code writes to
+/// <see cref="MauiIndicatorView.Position"/>; tapping a dot doesn't
+/// scroll the carousel.</para>
+///
+/// <para><b><see cref="MauiIndicatorView.IndicatorTemplate"/> is not
+/// honoured.</b> Custom-templated indicators need MAUI's stock
+/// <c>IndicatorStackLayout</c> rendering which doesn't fit the single
+/// <c>ComposeView</c>-per-page contract. To use templated indicators,
+/// don't register this Compose handler against
+/// <see cref="MauiIndicatorView"/>: skip the <c>AddHandler</c>
+/// override and stock MAUI takes over for that one control. When a
+/// template is set on a Compose-routed indicator the handler logs a
+/// debug warning and renders dots regardless.</para>
+///
+/// <para><see cref="MauiIndicatorView.Count"/> /
+/// <see cref="MauiIndicatorView.IndicatorSize"/> are <c>int</c> /
+/// <c>double</c> values that change rarely; both go through a
+/// version-counter <see cref="MutableState{T}"/> instead of being
+/// observed directly. <see cref="BuildNode"/> reads the live values
+/// off <see cref="ViewHandler{TVirtualView,TPlatformView}.VirtualView"/>
+/// when the slot bumps, mirroring <see cref="LayoutHandler"/>'s
+/// strategy for non-primitive properties.</para>
+/// </remarks>
+public partial class IndicatorViewHandler : ComposeElementHandler<MauiIndicatorView>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="MauiIndicatorView"/>
+    /// changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<MauiIndicatorView, IndicatorViewHandler> Mapper =
+        new PropertyMapper<MauiIndicatorView, IndicatorViewHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(MauiIndicatorView.Count)]                  = MapCount,
+            [nameof(MauiIndicatorView.Position)]               = MapPosition,
+            [nameof(MauiIndicatorView.IndicatorColor)]         = MapIndicatorColor,
+            [nameof(MauiIndicatorView.SelectedIndicatorColor)] = MapSelectedIndicatorColor,
+            [nameof(MauiIndicatorView.IndicatorSize)]          = MapIndicatorSize,
+            [nameof(MauiIndicatorView.IndicatorsShape)]        = MapIndicatorsShape,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<MauiIndicatorView, IndicatorViewHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    // Count + IndicatorSize don't fit MutableState<T> idiomatic types
+    // for re-keying purposes — a version counter recomposes BuildNode
+    // which then reads the live values off VirtualView.
+    readonly MutableState<int>   _countVersion         = new(0);
+    readonly MutableState<int>   _indicatorSizeVersion = new(0);
+    readonly MutableState<int>   _shapeVersion         = new(0);
+    readonly MutableState<int>   _position             = new(0);
+    readonly MutableState<long?> _indicatorColor       = new((long?)null);
+    readonly MutableState<long?> _selectedColor        = new((long?)null);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public IndicatorViewHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public IndicatorViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        // Read every version slot so recompositions trigger when any
+        // observed-by-version property bumps.
+        _ = _countVersion.Value;
+        _ = _indicatorSizeVersion.Value;
+        _ = _shapeVersion.Value;
+
+        var view = VirtualView
+            ?? throw new InvalidOperationException("VirtualView not set on IndicatorViewHandler.");
+
+        int    count     = view.Count;
+        int    position  = _position.Value;
+        double sizeDp    = view.IndicatorSize > 0 ? view.IndicatorSize : 6.0;
+        var    shape     = view.IndicatorsShape == IndicatorShape.Square
+                              ? new RoundedCornerShape(0)
+                              : new RoundedCornerShape(50);
+
+        long inactiveColor = _indicatorColor.Value
+            ?? ColorMapping.ToPackedLong(Microsoft.Maui.Graphics.Colors.LightGrey)!.Value;
+        long activeColor   = _selectedColor.Value
+            ?? ColorMapping.ToPackedLong(Microsoft.Maui.Graphics.Colors.Black)!.Value;
+
+        if (view.IndicatorTemplate is not null)
+        {
+            // Templated indicators aren't lowered to Compose — see
+            // <remarks> on this handler. Render the dot fallback so
+            // the user sees something instead of empty space.
+            System.Diagnostics.Debug.WriteLine(
+                "[Microsoft.AndroidX.Compose.Maui] IndicatorView.IndicatorTemplate is set, but " +
+                "the Compose-backed handler renders dots regardless. " +
+                "Drop the AddHandler<IndicatorView, IndicatorViewHandler>() registration " +
+                "to fall back to stock MAUI templating.");
+        }
+
+        // Outer Row carries ApplyViewProperties (Opacity / Translation /
+        // Scale / Rotation / Clip / IsVisible / Shadow) so per-page
+        // animations / fades work the same as MAUI's stock indicator.
+        var row = new Row(
+            horizontalArrangement: Arrangement.SpacedBy(new Dp((float)Math.Max(4.0, sizeDp / 2.0))),
+            verticalAlignment:     global::AndroidX.Compose.Alignment.Vertical.CenterVertically)
+        {
+            Modifier = Modifier.Companion.ApplyViewProperties(view),
+        };
+
+        for (int i = 0; i < count; i++)
+        {
+            long color   = i == position ? activeColor : inactiveColor;
+            row.Add(new Box
+            {
+                Modifier = Modifier
+                    .Size(new Dp((float)sizeDp))
+                    .Clip(shape)
+                    .Background(new ComposeColor(color)),
+            });
+        }
+
+        return row;
+    }
+
+    /// <summary>Bump the count version slot.</summary>
+    public static void MapCount(IndicatorViewHandler handler, MauiIndicatorView _) =>
+        handler._countVersion.Value++;
+
+    /// <summary>Map <see cref="MauiIndicatorView.Position"/> to the active-dot slot.</summary>
+    public static void MapPosition(IndicatorViewHandler handler, MauiIndicatorView view) =>
+        handler._position.Value = view.Position;
+
+    /// <summary>Map <see cref="MauiIndicatorView.IndicatorColor"/> to the inactive-dot tint.</summary>
+    public static void MapIndicatorColor(IndicatorViewHandler handler, MauiIndicatorView view) =>
+        handler._indicatorColor.Value = ColorMapping.ToPackedLong(view.IndicatorColor);
+
+    /// <summary>Map <see cref="MauiIndicatorView.SelectedIndicatorColor"/> to the active-dot tint.</summary>
+    public static void MapSelectedIndicatorColor(IndicatorViewHandler handler, MauiIndicatorView view) =>
+        handler._selectedColor.Value = ColorMapping.ToPackedLong(view.SelectedIndicatorColor);
+
+    /// <summary>Bump the indicator-size version slot.</summary>
+    public static void MapIndicatorSize(IndicatorViewHandler handler, MauiIndicatorView _) =>
+        handler._indicatorSizeVersion.Value++;
+
+    /// <summary>Bump the indicator-shape version slot.</summary>
+    public static void MapIndicatorsShape(IndicatorViewHandler handler, MauiIndicatorView _) =>
+        handler._shapeVersion.Value++;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
@@ -1,0 +1,133 @@
+using System.Windows.Input;
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+using AndroidX.Compose.UI.Platform;
+using Microsoft.AndroidX.Compose.Maui.Platform;
+using Microsoft.Maui.Handlers;
+using ComposePullToRefreshBox = AndroidX.Compose.PullToRefreshBox;
+using MauiRefreshView         = Microsoft.Maui.Controls.RefreshView;
+
+namespace Microsoft.AndroidX.Compose.Maui.Handlers;
+
+/// <summary>
+/// MAUI <see cref="MauiRefreshView"/> handler that renders through
+/// Jetpack Compose's Material 3 <see cref="ComposePullToRefreshBox"/>.
+/// Replaces MAUI's stock <c>SwipeRefreshLayout</c>-backed handler when
+/// the consumer calls
+/// <see cref="Hosting.AppHostBuilderExtensions.UseAndroidXCompose"/>.
+/// </summary>
+/// <remarks>
+/// <para><see cref="IRefreshView.IsRefreshing"/> is two-way:
+/// MAUI → Compose flows through <see cref="MapIsRefreshing"/>, and the
+/// pull gesture flows back through the <c>onRefresh</c> callback —
+/// which writes <see cref="IRefreshView.IsRefreshing"/> = <c>true</c>
+/// before invoking <see cref="IRefreshView.Command"/>. The mapper
+/// re-fires with the same value, but the
+/// <see cref="MutableState{T}"/> equality short-circuit breaks the
+/// loop without needing a `_suppressMauiWrite` flag (mirrors
+/// <see cref="EntryHandler.OnValueChanged"/>).</para>
+///
+/// <para>The consumer is responsible for clearing
+/// <see cref="IRefreshView.IsRefreshing"/> back to <c>false</c> when
+/// their async reload completes — same contract as MAUI's stock
+/// handler. Wiring an automatic timer here would race the consumer's
+/// own state machine.</para>
+///
+/// <para><see cref="IRefreshView.Content"/> is walked through the same
+/// <see cref="ComposeWalker"/> recursion used by
+/// <see cref="LayoutHandler"/> / <see cref="ContentViewHandler"/>, so
+/// nested Compose-backed views fold into the parent composition.</para>
+///
+/// <para><see cref="IRefreshView.RefreshColor"/> isn't wired yet: the
+/// current C# <c>PullToRefreshBox</c> facade doesn't expose
+/// <c>containerColor</c> / <c>contentColor</c> slots. Until it does,
+/// the spinner uses Material 3's default theme tint. Tracked as a
+/// follow-up for the next slice.</para>
+/// </remarks>
+public partial class RefreshViewHandler : ComposeElementHandler<IRefreshView>
+{
+    /// <summary>
+    /// Property mapper that forwards MAUI <see cref="IRefreshView"/>
+    /// property changes to the Compose-backed <see cref="ComposeView"/>.
+    /// </summary>
+    public static IPropertyMapper<IRefreshView, RefreshViewHandler> Mapper =
+        new PropertyMapper<IRefreshView, RefreshViewHandler>(ViewHandler.ViewMapper)
+        {
+            [nameof(IRefreshView.IsRefreshing)] = MapIsRefreshing,
+            ["Content"]                          = MapContent,
+        };
+
+    /// <summary>Command mapper (inherits view-level commands; no extras).</summary>
+    public static CommandMapper<IRefreshView, RefreshViewHandler> CommandMapper =
+        new(ViewCommandMapper);
+
+    readonly MutableState<bool> _isRefreshing  = new(false);
+    // Bumped whenever Content swaps so BuildNode reads the live
+    // PresentedContent reference (IView itself doesn't fit in
+    // MutableState<T>; same trick as ContentViewHandler).
+    readonly MutableState<int>  _contentVersion = new(0);
+
+    /// <summary>Construct a handler with the default mappers.</summary>
+    public RefreshViewHandler() : base(Mapper, CommandMapper) { }
+
+    /// <summary>Construct a handler with custom mappers.</summary>
+    public RefreshViewHandler(IPropertyMapper? mapper, CommandMapper? commandMapper = null)
+        : base(mapper ?? Mapper, commandMapper ?? CommandMapper) { }
+
+    /// <inheritdoc/>
+    public override ComposableNode BuildNode(IComposer composer)
+    {
+        // Read the version slot so recompositions trigger when Content
+        // swaps (Content as a property doesn't live in MutableState<T>).
+        _ = _contentVersion.Value;
+
+        var view    = VirtualView
+            ?? throw new InvalidOperationException("VirtualView not set on RefreshViewHandler.");
+        var context = MauiContext
+            ?? throw new InvalidOperationException("MauiContext not set on RefreshViewHandler.");
+
+        var box = new ComposePullToRefreshBox(
+            isRefreshing: _isRefreshing.Value,
+            onRefresh:    () =>
+            {
+                // Mirror MAUI's contract: pulling triggers the refresh
+                // and the consumer (or their Command handler) is
+                // responsible for clearing IsRefreshing when the work
+                // completes. Set both sides; the mapper re-fires with
+                // the same value and the MutableState<bool> equality
+                // short-circuit breaks the loop.
+                _isRefreshing.Value = true;
+                view.IsRefreshing   = true;
+
+                if ((view as MauiRefreshView)?.Command is ICommand cmd)
+                {
+                    var arg = (view as MauiRefreshView)?.CommandParameter;
+                    if (cmd.CanExecute(arg))
+                        cmd.Execute(arg);
+                }
+            });
+
+        // FillMaxSize so the gesture region matches MAUI's full-bleed
+        // RefreshView semantics, plus ApplyViewProperties for Opacity /
+        // Translation / Scale / Rotation / IsVisible / Clip / Shadow.
+        box.PrependModifier(Modifier.FillMaxSize().ApplyViewProperties(view));
+
+        if (view.Content is { } content)
+            box.Add(c => ComposeWalker.Render(content, c, context));
+
+        return box;
+    }
+
+    /// <summary>
+    /// Map <see cref="IRefreshView.IsRefreshing"/> to the Compose busy
+    /// slot. The <see cref="MutableState{T}"/> equality short-circuit
+    /// breaks the two-way feedback loop when the pull gesture writes
+    /// the same value back through <see cref="IRefreshView"/>.
+    /// </summary>
+    public static void MapIsRefreshing(RefreshViewHandler handler, IRefreshView view) =>
+        handler._isRefreshing.Value = view.IsRefreshing;
+
+    /// <summary>Bump the content version slot so <see cref="BuildNode"/> re-walks.</summary>
+    public static void MapContent(RefreshViewHandler handler, IRefreshView _) =>
+        handler._contentVersion.Value++;
+}

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
@@ -1,4 +1,3 @@
-using System.Windows.Input;
 using AndroidX.Compose;
 using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Platform;
@@ -21,10 +20,12 @@ namespace Microsoft.AndroidX.Compose.Maui.Handlers;
 /// MAUI → Compose flows through <see cref="MapIsRefreshing"/>, and the
 /// pull gesture flows back through the <c>onRefresh</c> callback —
 /// which writes <see cref="IRefreshView.IsRefreshing"/> = <c>true</c>
-/// before invoking <see cref="IRefreshView.Command"/>. The mapper
-/// re-fires with the same value, but the
-/// <see cref="MutableState{T}"/> equality short-circuit breaks the
-/// loop without needing a `_suppressMauiWrite` flag (mirrors
+/// and lets MAUI's <c>OnIsRefreshingPropertyChanged</c> pipeline raise
+/// the <c>Refreshing</c> event and invoke
+/// <see cref="IRefreshView.Command"/>. The mapper re-fires with the
+/// same value, but the <see cref="MutableState{T}"/> equality
+/// short-circuit breaks the loop without needing a
+/// <c>_suppressMauiWrite</c> flag (mirrors
 /// <see cref="EntryHandler.OnValueChanged"/>).</para>
 ///
 /// <para>The consumer is responsible for clearing
@@ -90,21 +91,17 @@ public partial class RefreshViewHandler : ComposeElementHandler<IRefreshView>
             isRefreshing: _isRefreshing.Value,
             onRefresh:    () =>
             {
-                // Mirror MAUI's contract: pulling triggers the refresh
-                // and the consumer (or their Command handler) is
-                // responsible for clearing IsRefreshing when the work
-                // completes. Set both sides; the mapper re-fires with
-                // the same value and the MutableState<bool> equality
-                // short-circuit breaks the loop.
+                // Mirror MAUI's stock Android RefreshView handler: only
+                // write IsRefreshing = true and let MAUI's
+                // OnIsRefreshingPropertyChanged pipeline raise the
+                // Refreshing event AND invoke Command.Execute /
+                // RefreshCommand.Execute. Doing it ourselves here would
+                // double-fire the Command for any Command-bound caller.
+                // The mapper re-fires with the same value and the
+                // MutableState<bool> equality short-circuit breaks the
+                // loop.
                 _isRefreshing.Value = true;
                 view.IsRefreshing   = true;
-
-                if ((view as MauiRefreshView)?.Command is ICommand cmd)
-                {
-                    var arg = (view as MauiRefreshView)?.CommandParameter;
-                    if (cmd.CanExecute(arg))
-                        cmd.Execute(arg);
-                }
             });
 
         // FillMaxSize so the gesture region matches MAUI's full-bleed

--- a/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Hosting/AppHostBuilderExtensions.cs
@@ -12,11 +12,13 @@ using MauiEntry = Microsoft.Maui.Controls.Entry;
 using MauiHorizontalStackLayout = Microsoft.Maui.Controls.HorizontalStackLayout;
 using MauiImage = Microsoft.Maui.Controls.Image;
 using MauiImageButton = Microsoft.Maui.Controls.ImageButton;
+using MauiIndicatorView = Microsoft.Maui.Controls.IndicatorView;
 using MauiLabel = Microsoft.Maui.Controls.Label;
 using MauiPage = Microsoft.Maui.Controls.Page;
 using MauiPicker = Microsoft.Maui.Controls.Picker;
 using MauiProgressBar = Microsoft.Maui.Controls.ProgressBar;
 using MauiRadioButton = Microsoft.Maui.Controls.RadioButton;
+using MauiRefreshView = Microsoft.Maui.Controls.RefreshView;
 using MauiScrollView = Microsoft.Maui.Controls.ScrollView;
 using MauiSearchBar = Microsoft.Maui.Controls.SearchBar;
 using MauiSlider = Microsoft.Maui.Controls.Slider;
@@ -73,6 +75,13 @@ public static class AppHostBuilderExtensions
     ///     <see cref="MauiContentView"/>) render through Compose's
     ///     <c>Box</c> with stroke / fill / clip modifier
     ///     chains.</description></item>
+    ///   <item><description>Pull-to-refresh + indicator dots
+    ///     (<see cref="MauiRefreshView"/> / <see cref="MauiIndicatorView"/>):
+    ///     <see cref="MauiRefreshView"/> wraps a single child
+    ///     through Material 3 <c>PullToRefreshBox</c>;
+    ///     <see cref="MauiIndicatorView"/> synthesises a Compose
+    ///     <c>Row</c> of dot tiles. CarouselView ↔ IndicatorView
+    ///     two-way wiring lands in Phase 3.</description></item>
     /// </list>
     ///
     /// <para>Layout types not in the list above (Grid, AbsoluteLayout,
@@ -158,6 +167,13 @@ public static class AppHostBuilderExtensions
             // ContentView collides with stock MAUI's ContentViewHandler;
             // last AddHandler wins, so register ours last.
             handlers.AddHandler<MauiContentView,            ContentViewHandler>();
+
+            // Phase 2 Slice 12 — pull-to-refresh + carousel-position
+            // dot strip. RefreshView wraps a single child through
+            // PullToRefreshBox; IndicatorView synthesises a Row of Box
+            // dots. CarouselView two-way wiring lands in Phase 3.
+            handlers.AddHandler<MauiRefreshView,            RefreshViewHandler>();
+            handlers.AddHandler<MauiIndicatorView,          IndicatorViewHandler>();
         });
 
         return builder;

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1193,6 +1193,26 @@ internal static partial class ComposeBridges
         IComposer   composer);
 
     // androidx.compose.material3.DatePickerKt.rememberDatePickerState-EU0dCGE
+    //
+    // Phase 4b parameterised Remember (issue #264). Every Kotlin user
+    // slot is surfaced — the bridge generator can't skip non-trailing
+    // slots. The auto-default-mask clears bit N for every non-null
+    // param the caller supplied; null leaves the Kotlin default in
+    // place (the matching `RememberDatePickerStateDefault` bit stays
+    // set).
+    //
+    // Wrapper-member resolution (StateType = DatePickerState):
+    //   initialSelectedDateMillis  -> InitialSelectedDateMillis    (Java.Lang.Long?)
+    //   initialDisplayedMonthMillis-> InitialDisplayedMonthMillis  (Java.Lang.Long?)
+    //   yearRange                  -> InitialYearRange             (IntRange?)
+    //   initialDisplayMode         -> InitialDisplayMode           (int?)
+    //   selectableDates            -> InitialSelectableDates       (ISelectableDates?)
+    //
+    // The JNI slot for `Long`/`IntRange`/`SelectableDates` is `L…;`,
+    // so the C# bridge param types must be reference (boxed Long,
+    // IntRange, ISelectableDates). The `initialDisplayMode` slot is
+    // `I` so `int?` is correct (auto-mask passes 0 + sets the bit
+    // when caller leaves it null).
     [ComposeBridge(
         Class     = "androidx/compose/material3/DatePickerKt",
         JvmName   = "rememberDatePickerState-EU0dCGE",
@@ -1200,7 +1220,13 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/material3/SelectableDates;" +
                     "Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/DatePickerState;",
         Defaults  = typeof(RememberDatePickerStateDefault))]
-    public static partial IntPtr RememberDatePickerState(IComposer composer);
+    public static partial IntPtr RememberDatePickerState(
+        Java.Lang.Long?                                  initialSelectedDateMillis,
+        Java.Lang.Long?                                  initialDisplayedMonthMillis,
+        IntRange?                                        yearRange,
+        int?                                             initialDisplayMode,
+        AndroidX.Compose.Material3.ISelectableDates?     selectableDates,
+        IComposer                                        composer);
 
     // androidx.compose.material3.DateRangePickerKt.DateRangePicker
     [ComposeBridge(

--- a/src/Microsoft.AndroidX.Compose/DatePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/DatePickerState.cs
@@ -1,4 +1,5 @@
 using AndroidX.Compose.Material3;
+using Kotlin.Ranges;
 
 namespace AndroidX.Compose;
 
@@ -28,10 +29,98 @@ namespace AndroidX.Compose;
 ///     Body          = new DatePicker(pickerState),
 /// }
 /// </code>
+///
+/// The constructor's optional parameters seed the underlying state on
+/// first composition (via the Phase 4b <c>RememberDatePickerState</c>
+/// bridge). They're read once when the JVM state is first allocated;
+/// mutating <see cref="InitialSelectedDateMillis"/> /
+/// <see cref="InitialYearRange"/> / <see cref="InitialSelectableDates"/>
+/// after binding has no effect unless the host re-keys the surrounding
+/// <c>composer.Remember(...)</c> to force a fresh allocation.
 /// </remarks>
 public sealed class DatePickerState
 {
     internal IDatePickerState? Jvm;
+
+    /// <summary>
+    /// Constructs an empty state holder. The underlying JVM
+    /// <c>DatePickerState</c> is allocated on first <see cref="DatePicker"/>
+    /// render with all values left at Kotlin's defaults.
+    /// </summary>
+    public DatePickerState()
+    {
+    }
+
+    /// <summary>
+    /// Constructs a state holder seeded with the supplied initial values.
+    /// All parameters are optional — passing <c>null</c> keeps Kotlin's
+    /// default for that slot (auto-default-mask leaves the matching
+    /// <c>$default</c> bit set).
+    /// </summary>
+    /// <param name="initialSelectedDateMillis">Initial selection as Unix
+    /// epoch milliseconds (UTC), or <c>null</c> for "no initial selection".</param>
+    /// <param name="initialYearRange">Inclusive range of selectable years
+    /// shown in the year-grid. <c>null</c> keeps Kotlin's default
+    /// (1900–2100).</param>
+    /// <param name="initialSelectableDates">Per-day enable/disable
+    /// adapter. <c>null</c> keeps Kotlin's default (every date
+    /// selectable).</param>
+    public DatePickerState(
+        long?              initialSelectedDateMillis = null,
+        IntRange?          initialYearRange          = null,
+        ISelectableDates?  initialSelectableDates    = null)
+    {
+        if (initialSelectedDateMillis is long ms)
+            InitialSelectedDateMillis = Java.Lang.Long.ValueOf(ms);
+        InitialYearRange       = initialYearRange;
+        InitialSelectableDates = initialSelectableDates;
+    }
+
+    /// <summary>
+    /// Initial selection as a boxed <see cref="Java.Lang.Long"/>
+    /// (Kotlin's <c>Long?</c>). Read by the Phase 4b
+    /// <c>RememberDatePickerState</c> bridge on first composition;
+    /// mutating after binding has no effect (the live value lives in
+    /// <see cref="SelectedDateMillis"/>). Most callers should use the
+    /// <c>long?</c> constructor parameter instead of touching this
+    /// directly.
+    /// </summary>
+    public Java.Lang.Long? InitialSelectedDateMillis { get; set; }
+
+    /// <summary>
+    /// First-of-month milliseconds for the initial month shown by the
+    /// picker. Kotlin's <c>initialDisplayedMonthMillis</c> slot —
+    /// usually left <c>null</c> so Kotlin defaults to the month
+    /// containing <see cref="InitialSelectedDateMillis"/>.
+    /// </summary>
+    public Java.Lang.Long? InitialDisplayedMonthMillis { get; set; }
+
+    /// <summary>
+    /// Inclusive year range for the year-grid view. Read once by the
+    /// Phase 4b <c>RememberDatePickerState</c> bridge on first
+    /// composition.
+    /// </summary>
+    public IntRange? InitialYearRange { get; set; }
+
+    /// <summary>
+    /// Initial display mode (<c>DatePicker</c> or <c>Input</c>). Maps
+    /// to Kotlin's <c>DisplayMode</c> packed-int enum. <c>null</c> uses
+    /// Kotlin's default (calendar mode).
+    /// </summary>
+    public int? InitialDisplayMode { get; set; }
+
+    /// <summary>
+    /// Per-day / per-year enable/disable adapter. Read once by the
+    /// Phase 4b <c>RememberDatePickerState</c> bridge on first
+    /// composition. The adapter itself can mutate state — Kotlin
+    /// re-invokes <c>isSelectableDate</c> / <c>isSelectableYear</c> on
+    /// every grid render — but the adapter <i>instance</i> reference
+    /// participates in <c>remember</c>'s key, so callers must hold a
+    /// stable reference (e.g. allocate one adapter per host instance
+    /// as a <c>readonly</c> field, mirroring the Phase 10
+    /// <c>ConfirmStateChange</c> pattern).
+    /// </summary>
+    public ISelectableDates? InitialSelectableDates { get; set; }
 
     /// <summary>
     /// The currently selected date as Unix epoch milliseconds (UTC), or

--- a/src/Microsoft.AndroidX.Compose/DateRangeSelectableDates.cs
+++ b/src/Microsoft.AndroidX.Compose/DateRangeSelectableDates.cs
@@ -1,0 +1,72 @@
+using Android.Runtime;
+using AndroidX.Compose.Material3;
+
+namespace AndroidX.Compose;
+
+/// <summary>
+/// <c>SelectableDates</c> adapter that gates calendar dates and years
+/// against an inclusive <see cref="MinUtcMillis"/> /
+/// <see cref="MaxUtcMillis"/> window plus an inclusive
+/// <see cref="MinYear"/> / <see cref="MaxYear"/> window. Designed to be
+/// allocated <strong>once per host instance</strong> as a
+/// <c>readonly</c> field — the instance reference is part of the
+/// <c>RememberDatePickerState</c> cache key, so re-allocating per
+/// composition would invalidate the picker's cached state. Mutating
+/// the bounds at any time is cheap; Kotlin re-invokes
+/// <see cref="IsSelectableDate(long)"/> /
+/// <see cref="IsSelectableYear(int)"/> on every grid render.
+/// </summary>
+/// <remarks>
+/// All four bounds are nullable. <c>null</c> means "no bound on that
+/// side" — e.g. only setting <see cref="MinUtcMillis"/> blocks past
+/// dates while leaving the future open. This mirrors the pattern used
+/// by Phase 10's <c>DrawerValueConfirmStateChange</c>: a per-instance
+/// JCW that keeps stable JNI identity across recompositions while the
+/// managed-side data behind it is free to change.
+/// </remarks>
+[Register("net/compose/DateRangeSelectableDates")]
+public sealed class DateRangeSelectableDates : Java.Lang.Object, ISelectableDates
+{
+    /// <summary>
+    /// Inclusive lower bound on the selectable date in Unix epoch
+    /// milliseconds (UTC). <c>null</c> = no lower bound.
+    /// </summary>
+    public long? MinUtcMillis { get; set; }
+
+    /// <summary>
+    /// Inclusive upper bound on the selectable date in Unix epoch
+    /// milliseconds (UTC). <c>null</c> = no upper bound.
+    /// </summary>
+    public long? MaxUtcMillis { get; set; }
+
+    /// <summary>
+    /// Inclusive lower bound for selectable years in the year-grid
+    /// view. <c>null</c> = no lower bound.
+    /// </summary>
+    public int? MinYear { get; set; }
+
+    /// <summary>
+    /// Inclusive upper bound for selectable years in the year-grid
+    /// view. <c>null</c> = no upper bound.
+    /// </summary>
+    public int? MaxYear { get; set; }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="utcTimeMillis"/> falls
+    /// within <see cref="MinUtcMillis"/>..<see cref="MaxUtcMillis"/>
+    /// inclusive. Either bound being <c>null</c> disables that side of
+    /// the comparison.
+    /// </summary>
+    public bool IsSelectableDate(long utcTimeMillis) =>
+        (MinUtcMillis is not long mn || utcTimeMillis >= mn) &&
+        (MaxUtcMillis is not long mx || utcTimeMillis <= mx);
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="year"/> falls within
+    /// <see cref="MinYear"/>..<see cref="MaxYear"/> inclusive. Either
+    /// bound being <c>null</c> disables that side of the comparison.
+    /// </summary>
+    public bool IsSelectableYear(int year) =>
+        (MinYear is not int mn || year >= mn) &&
+        (MaxYear is not int mx || year <= mx);
+}

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -217,10 +217,33 @@ AndroidX.Compose.DatePickerDialog.DismissButton.get -> AndroidX.Compose.Composab
 AndroidX.Compose.DatePickerDialog.DismissButton.set -> void
 AndroidX.Compose.DatePickerState
 AndroidX.Compose.DatePickerState.DatePickerState() -> void
+AndroidX.Compose.DatePickerState.DatePickerState(long? initialSelectedDateMillis = null, Kotlin.Ranges.IntRange? initialYearRange = null, AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates = null) -> void
 AndroidX.Compose.DatePickerState.DisplayedMonthMillis.get -> long
 AndroidX.Compose.DatePickerState.DisplayedMonthMillis.set -> void
+AndroidX.Compose.DatePickerState.InitialDisplayMode.get -> int?
+AndroidX.Compose.DatePickerState.InitialDisplayMode.set -> void
+AndroidX.Compose.DatePickerState.InitialDisplayedMonthMillis.get -> Java.Lang.Long?
+AndroidX.Compose.DatePickerState.InitialDisplayedMonthMillis.set -> void
+AndroidX.Compose.DatePickerState.InitialSelectableDates.get -> AndroidX.Compose.Material3.ISelectableDates?
+AndroidX.Compose.DatePickerState.InitialSelectableDates.set -> void
+AndroidX.Compose.DatePickerState.InitialSelectedDateMillis.get -> Java.Lang.Long?
+AndroidX.Compose.DatePickerState.InitialSelectedDateMillis.set -> void
+AndroidX.Compose.DatePickerState.InitialYearRange.get -> Kotlin.Ranges.IntRange?
+AndroidX.Compose.DatePickerState.InitialYearRange.set -> void
 AndroidX.Compose.DatePickerState.SelectedDateMillis.get -> long?
 AndroidX.Compose.DatePickerState.SelectedDateMillis.set -> void
+AndroidX.Compose.DateRangeSelectableDates
+AndroidX.Compose.DateRangeSelectableDates.DateRangeSelectableDates() -> void
+AndroidX.Compose.DateRangeSelectableDates.IsSelectableDate(long utcTimeMillis) -> bool
+AndroidX.Compose.DateRangeSelectableDates.IsSelectableYear(int year) -> bool
+AndroidX.Compose.DateRangeSelectableDates.MaxUtcMillis.get -> long?
+AndroidX.Compose.DateRangeSelectableDates.MaxUtcMillis.set -> void
+AndroidX.Compose.DateRangeSelectableDates.MaxYear.get -> int?
+AndroidX.Compose.DateRangeSelectableDates.MaxYear.set -> void
+AndroidX.Compose.DateRangeSelectableDates.MinUtcMillis.get -> long?
+AndroidX.Compose.DateRangeSelectableDates.MinUtcMillis.set -> void
+AndroidX.Compose.DateRangeSelectableDates.MinYear.get -> int?
+AndroidX.Compose.DateRangeSelectableDates.MinYear.set -> void
 AndroidX.Compose.DateRangePicker
 AndroidX.Compose.DateRangePicker.DateRangePicker(AndroidX.Compose.DateRangePickerState? state = null) -> void
 AndroidX.Compose.DateRangePickerDialog


### PR DESCRIPTION
## Scope

Closes Phase 2 of the .NET MAUI Compose backend with three independent items:

### 1. `RefreshViewHandler` over `PullToRefreshBox`

`Microsoft.Maui.Controls.RefreshView` ↔ `Microsoft.AndroidX.Compose.PullToRefreshBox`.

- `IsRefreshing` two-way via `MutableState<bool>` equality short-circuit (no `_suppressMauiWrite` flag — mirrors `EntryHandler.OnValueChanged`).
- `onRefresh` writes `view.IsRefreshing = true` and lets MAUI's `OnIsRefreshingPropertyChanged` pipeline raise the `Refreshing` event and invoke `Command.Execute(CommandParameter)` — matches MAUI's stock Android `SwipeRefreshLayout`-backed handler contract (no double-fire).
- `Content` walks via `ComposeWalker.Render(child, c, MauiContext!)` so the refresh body folds into the parent page composition.
- Gap: `RefreshColor` is documented but currently no-op — the `PullToRefreshBox` facade does not expose `containerColor` / `indicatorColor` slots yet.

### 2. `IndicatorViewHandler`

`Microsoft.Maui.Controls.IndicatorView` synthesised as a Compose `Row` of `Box` dot tiles (no first-class Material 3 indicator).

- `Count` / `IndicatorSize` / `IndicatorsShape` / `IndicatorColor` / `SelectedIndicatorColor` flow via version slots.
- `Position` is a `MutableState<int>` and surfaces MAUI → Compose only; the two-way owned by `CarouselView` lands in Phase 3.
- `IndicatorsShape`: Circle = `RoundedCornerShape(50)`, Square = `RoundedCornerShape(0)`.
- `IndicatorTemplate`: documented opt-out — falling back to `view.ToPlatform(MauiContext)` recurses into our own handler, so the handler renders dots regardless and emits `Debug.WriteLine` when a template is attached.

### 3. `DatePickerHandler` Phase 4b lift (closes #264)

`MinimumDate` / `MaximumDate` are now honoured. Net work:

- `RememberDatePickerState` lifted to **Phase 4b** in `ComposeBridges.cs` — the bridge surfaces all five Kotlin slots (`initialSelectedDateMillis`, `initialDisplayedMonthMillis`, `yearRange`, `initialDisplayMode`, `selectableDates`) so future `DateRangePickerHandler` work can adopt the same shape.
- New `Microsoft.AndroidX.Compose.DateRangeSelectableDates` JCW (`[Register("net/compose/DateRangeSelectableDates")]`) implements `androidx.compose.material3.SelectableDates` with mutable `MinUtcMillis` / `MaxUtcMillis` / `MinYear` / `MaxYear` props.
- The handler holds **one adapter per facade instance as a `readonly` field** (mirroring Phase 10's `ConfirmStateChange` adapter) so the JNI peer identity stays stable across `rememberDatePickerState`'s `remember` cache key.
- `DatePickerState` exposes a user-friendly `(long?, IntRange?, ISelectableDates?)` ctor + matching `Initial*` props for Phase 4b wrapper resolution rules.
- Gallery `DatePickerDialogDemo` extended with a `Today..Today+30` window seeded via `DateRangeSelectableDates`.

## Sample pages

- `Pages/RefreshPage.xaml(.cs)` — `RefreshView` wrapping a `VerticalStackLayout` of mock items; pull-to-refresh increments a counter.
- `Pages/IndicatorPage.xaml(.cs)` — five labels + Prev / Next / Toggle-shape buttons cycling `Position`.
- `Pages/PickersPage.xaml(.cs)` — `DatePicker` now seeded with `MinimumDate=Today` / `MaximumDate=Today+30`; Reset uses `DateTime.Today`.
- `HomePage.xaml.cs` + `AppShell.xaml.cs` register the new pages and routes.

## Lessons learned

- **Wrapper-member resolution matches by name only.** Phase 4b's PascalCase-first / `Initial<PC>` fallback walks parameters by name; the wrapper's `InitialSelectedDateMillis` had to be `Java.Lang.Long?` (matching the JNI slot) so the bridge generator emits the right reference-type handle path. The user-friendly conversion (`long?` → `Java.Lang.Long?`) lives in the wrapper ctor, not the bridge.
- **`c.Remember(factory, key1, key2)` is the canonical re-key hook** for state-holder bound changes — Min/Max ticks live in the key array so external pushes recreate the Kotlin state with the new range, while user-driven date changes (which mutate the `MutableState<long?>` only) survive recompositions.
- **`SelectableDates` adapters must be readonly per host instance.** The JCW peer identity is part of `rememberDatePickerState`'s cache key; recreating it per recomposition drops cached state.
- **`MutableState<T>` equality short-circuits replace explicit suppression flags.** `RefreshViewHandler` and `EntryHandler` both rely on `MutableState<bool>.Value = x` not firing `setValue` when `x` already equals the current — no per-handler `_suppressMauiWrite` plumbing needed.
- **Don't double-invoke `RefreshView.Command`.** Setting `IRefreshView.IsRefreshing = true` already triggers `OnIsRefreshingPropertyChanged`, which fans out to both the `Refreshing` event and `Command.Execute(CommandParameter)`. The handler's `onRefresh` callback only needs to flip `IsRefreshing` — adding an explicit `cmd.Execute(arg)` would fire the Command twice per pull (caught in review).
- **`Row` ctor params can't be set via object-init.** `Arrangement?` and `Alignment.Vertical?` only flow through the constructor; `Modifier` is the only object-init slot. `IndicatorViewHandler` had to use `new Row(horizontalArrangement: ..., verticalAlignment: ...) { Modifier = ... }`.
- **Namespace shadowing on nested `AndroidX.Compose.*`.** Inside `Microsoft.AndroidX.Compose.Maui.Handlers`, Roslyn's nested-namespace lookup tries `Microsoft.AndroidX.Compose.AndroidX.Compose.*` first; use `global::AndroidX.Compose.Alignment.Vertical.CenterVertically` to bypass.
- **`IndicatorView.IndicatorTemplate` is a recursion trap.** The original spec's "fall back to `view.ToPlatform(MauiContext)`" loops back into the registered handler — ours. Gap is documented; a clean fallback needs a deeper "skip-this-handler" platform helper that doesn't exist yet.
- **`IDatePicker.Min/MaximumDate` are `DateTime?`** in the public interface even though MAUI Controls always populates them. Handler null-checks explicitly.
- **MAUI `DatePicker` clamps `Date` writes to Min/Max.** PickersPage's Reset path moved from `2000-01-01` to `DateTime.Today` so the assignment doesn't get silently rewritten.

## Verification

- `dotnet build src/Microsoft.AndroidX.Compose` ✅
- `dotnet build src/Microsoft.AndroidX.Compose.SourceGenerators.Tests` ✅ (155/155 pass)
- `dotnet build src/Microsoft.AndroidX.Compose.Maui` ✅
- `dotnet build src/Microsoft.AndroidX.Compose.Maui.Sample -t:Install -p:EmbedAssembliesIntoApk=true` ✅
- `dotnet build src/Microsoft.AndroidX.Compose.Gallery` ✅

**On-device verification ✅** (driven via `uiautomator dump` + `input tap` / `input swipe`):

- **RefreshPage:** pull-to-refresh swipe increments the title counter (`Pulled 0 times` → `Pulled 1 times`); single `androidx.compose.ui.platform.ComposeView` per page confirmed in the dump.
- **IndicatorPage:** tapping `Next` twice cycles the `Position` label from `Position: 0 (Apple)` to `Position: 2 (Cherry)` and the corresponding dot lights up; single `ComposeView`.
- **PickersPage / DatePicker Phase 4b:** opening the `DatePicker` dialog with `MinimumDate=Today` / `MaximumDate=Today+30` shows `enabled=false` for past June dates (Jun 1–11), `enabled=true` for the in-range window (Jun 12–Jul 12), and `enabled=false` again for July 13+ — exactly the `Today..Today+30` clamp expected from the new `DateRangeSelectableDates` JCW. No `FATAL` / `AndroidRuntime` errors in `logcat` across the verification run.

Closes #264

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
