### PR TITLE
Move TextField primitive defaults to constructors

### DIFF
--- a/samples/JetNews/HomeScreen.cs
+++ b/samples/JetNews/HomeScreen.cs
@@ -65,10 +65,9 @@ public static class HomeScreen
                 new Icon(Resource.Drawable.ic_menu, "Open navigation drawer"),
             },
             Title = searchOpen.Value
-                ? new OutlinedTextField(searchQuery)
+                ? new OutlinedTextField(searchQuery, singleLine: true)
                 {
                     Modifier    = Modifier.FillMaxWidth().Padding(horizontal: 8),
-                    SingleLine  = true,
                     Placeholder = new Text("Search JetNews"),
                 }
                 : new Icon(Resource.Drawable.ic_jetnews_wordmark, "JetNews")

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/NumericKeyboardDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/NumericKeyboardDemo.cs
@@ -37,20 +37,18 @@ public static class NumericKeyboardDemo
             var d       = KeyboardOptionsCompanion.Default;
             return new Column
             {
-                new TextField(phone)
+                new TextField(phone, singleLine: true)
                 {
                     Label           = new Text("Phone (numeric IME)"),
-                    SingleLine      = true,
                     KeyboardOptions = d.Copy(
                         d.Capitalization, d.AutoCorrectEnabled,
                         KeyboardTypeNumber, d.ImeAction,
                         d.PlatformImeOptions, d.ShowKeyboardOnFocus,
                         d.HintLocales),
                 },
-                new TextField(generic)
+                new TextField(generic, singleLine: true)
                 {
-                    Label      = new Text("Generic (text IME)"),
-                    SingleLine = true,
+                    Label = new Text("Generic (text IME)"),
                 },
                 new Text($"Digits typed: {phone.Value.Length}"),
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/OutlinedTextFieldDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/OutlinedTextFieldDemo.cs
@@ -16,13 +16,12 @@ public static class OutlinedTextFieldDemo
             var handle = c.MutableStateOf("");
             return new Column
             {
-                new OutlinedTextField(handle)
+                new OutlinedTextField(handle, singleLine: true)
                 {
                     Label          = new Text("Handle"),
                     Prefix         = new Text("@"),
                     Suffix         = new Text(".dev"),
                     SupportingText = new Text($"len={handle.Value.Length}"),
-                    SingleLine     = true,
                 },
                 new Text($"You'll be @{(string.IsNullOrEmpty(handle.Value) ? "?" : handle.Value)}.dev"),
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/PasswordFieldDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/PasswordFieldDemo.cs
@@ -23,11 +23,10 @@ public static class PasswordFieldDemo
             var pwd = c.MutableStateOf("secret");
             return new Column
             {
-                new OutlinedTextField(pwd)
+                new OutlinedTextField(pwd, singleLine: true)
                 {
                     Label                = new Text("Password"),
                     VisualTransformation = new PasswordVisualTransformation('•'),
-                    SingleLine           = true,
                 },
                 new Text($"Buffer length: {pwd.Value.Length}"),
                 new Text($"Echo (proves real chars): \"{pwd.Value}\""),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldCursorPlacementDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldCursorPlacementDemo.cs
@@ -29,11 +29,10 @@ public static class TextFieldCursorPlacementDemo
                 {
                     FontWeight = FontWeight.Medium,
                 },
-                new TextField(input)
+                new TextField(input, singleLine: true)
                 {
                     Label       = new Text("Message"),
                     Placeholder = new Text("Type something…"),
-                    SingleLine  = true,
                 },
                 new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()))
                 {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldSlotsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/TextInputs/TextFieldSlotsDemo.cs
@@ -10,20 +10,36 @@ public static class TextFieldSlotsDemo
         Id:          "text-textfield-slots",
         CategoryId:  "text-inputs",
         Title:       "TextField slots",
-        Description: "Label, Placeholder, LeadingIcon, TrailingIcon, SupportingText, SingleLine.",
+        Description: "Slots plus constructor-backed Enabled, ReadOnly, and SingleLine defaults.",
         Build:       c =>
         {
-            var name = c.MutableStateOf("");
+            var name     = c.MutableStateOf("");
+            var enabled  = c.MutableStateOf(true);
+            var readOnly = c.MutableStateOf(false);
             return new Column
             {
-                new TextField(name)
+                new TextField(
+                    name,
+                    enabled: enabled.Value,
+                    readOnly: readOnly.Value,
+                    singleLine: true)
                 {
                     Label          = new Text("Your name"),
                     Placeholder    = new Text("Type something…"),
                     LeadingIcon    = new Text("👤"),
                     TrailingIcon   = new Text("✎"),
                     SupportingText = new Text("All five slots filled"),
-                    SingleLine     = true,
+                },
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()))
+                {
+                    new Button(onClick: () => enabled.Value = !enabled.Value)
+                    {
+                        new Text(enabled.Value ? "Disable" : "Enable"),
+                    },
+                    new Button(onClick: () => readOnly.Value = !readOnly.Value)
+                    {
+                        new Text(readOnly.Value ? "Make editable" : "Make read-only"),
+                    },
                 },
                 new Text($"Hi {(string.IsNullOrEmpty(name.Value) ? "stranger" : name.Value)}"),
             };

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
@@ -117,12 +117,7 @@ public partial class EditorHandler : ComposeElementHandler<IEditor>
         var hTextAlign      = (TextAlignment)_hTextAlign.Value;
         var fill            = _fillWidth.Value;
 
-        var field = new ComposeOutlinedTextField(_tfv)
-        {
-            ReadOnly   = readOnly,
-            // Multi-line — the whole point of Editor.
-            SingleLine = false,
-        };
+        var field = new ComposeOutlinedTextField(_tfv, readOnly: readOnly);
         if (!string.IsNullOrEmpty(placeholder))
             field.Placeholder = new ComposeText(placeholder)
             {

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
@@ -126,11 +126,10 @@ public partial class EntryHandler : ComposeElementHandler<IEntry>
         var clearButtonMode = (ClearButtonVisibility)_clearButtonMode.Value;
         var fill            = _fillWidth.Value;
 
-        var field = new ComposeOutlinedTextField(_tfv)
-        {
-            ReadOnly   = readOnly,
-            SingleLine = true,
-        };
+        var field = new ComposeOutlinedTextField(
+            _tfv,
+            readOnly: readOnly,
+            singleLine: true);
         if (!string.IsNullOrEmpty(placeholder))
             field.Placeholder = new ComposeText(placeholder)
             {

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
@@ -164,10 +164,12 @@ public partial class PickerHandler : ComposeElementHandler<IPicker>
             ? items[selectedIndex] ?? string.Empty
             : string.Empty;
 
-        var trigger = new ComposeOutlinedTextField(displayValue, _ => { /* read-only */ })
+        var trigger = new ComposeOutlinedTextField(
+            displayValue,
+            _ => { /* read-only */ },
+            readOnly: true,
+            singleLine: true)
         {
-            ReadOnly   = true,
-            SingleLine = true,
             TrailingIcon = new IconButton(onClick: () => SetOpen(virtualView, !_open.Value))
             {
                 new ComposeText(isOpen ? "▲" : "▼"),

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
@@ -130,10 +130,11 @@ public partial class SearchBarHandler : ComposeElementHandler<ISearchBar>
         var vTextAlign         = (TextAlignment)_vTextAlign.Value;
         var fill               = _fillWidth.Value;
 
-        var field = new ComposeOutlinedTextField(_tfv)
+        var field = new ComposeOutlinedTextField(
+            _tfv,
+            readOnly: readOnly,
+            singleLine: true)
         {
-            ReadOnly     = readOnly,
-            SingleLine   = true,
             // Magnifier glass — pure Unicode keeps us off the
             // material-icons NuGet for the MAUI base layer. Coloured
             // via SearchIconColor when set.

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/ComposeAlertManagerSubscription.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/ComposeAlertManagerSubscription.cs
@@ -308,9 +308,11 @@ public class ComposeAlertManagerSubscription : DispatchProxy
 
             // Use the (string, Action<string>) ctor so OnTextChanged
             // can intercept and truncate before writing to the state.
-            var field = new ComposeOutlinedTextField(text.Value, OnTextChanged)
+            var field = new ComposeOutlinedTextField(
+                text.Value,
+                OnTextChanged,
+                singleLine: true)
             {
-                SingleLine      = true,
                 KeyboardOptions = keyboardOptions,
             };
             if (!string.IsNullOrEmpty(args.Placeholder))

--- a/src/Microsoft.AndroidX.Compose/OutlinedTextField.cs
+++ b/src/Microsoft.AndroidX.Compose/OutlinedTextField.cs
@@ -19,6 +19,12 @@ public sealed class OutlinedTextField : ComposableNode
     readonly string?                       _value;
     readonly Action<string>?               _onValueChange;
     readonly MutableState<TextFieldValue>? _tfvState;
+    readonly bool                          _enabled;
+    readonly bool                          _readOnly;
+    readonly bool                          _isError;
+    readonly bool                          _singleLine;
+    readonly int                           _maxLines;
+    readonly int                           _minLines;
 
     /// <summary>Floating label (e.g. <c>new Text("Email")</c>).</summary>
     public ComposableNode? Label          { get; set; }
@@ -34,18 +40,6 @@ public sealed class OutlinedTextField : ComposableNode
     public ComposableNode? Suffix         { get; set; }
     /// <summary>Helper text rendered below the field.</summary>
     public ComposableNode? SupportingText { get; set; }
-    /// <summary>Whether the field accepts focus and input.</summary>
-    public bool?           Enabled        { get; set; }
-    /// <summary>Whether the field is read-only.</summary>
-    public bool?           ReadOnly       { get; set; }
-    /// <summary>Whether the field is in an error state.</summary>
-    public bool?           IsError        { get; set; }
-    /// <summary>Whether the field is constrained to one line.</summary>
-    public bool?           SingleLine     { get; set; }
-    /// <summary>Maximum number of visible lines.</summary>
-    public int?            MaxLines       { get; set; }
-    /// <summary>Minimum number of visible lines.</summary>
-    public int?            MinLines       { get; set; }
     /// <summary>Optional shape applied to the field's outlined container (Kotlin <c>shape</c>).</summary>
     public Shape?          Shape          { get; set; }
     /// <summary>Optional <c>TextStyle</c> override (Kotlin <c>textStyle</c>) — controls text color, size, weight, etc.</summary>
@@ -58,18 +52,49 @@ public sealed class OutlinedTextField : ComposableNode
     public AndroidX.Compose.Foundation.Text.KeyboardActions? KeyboardActions { get; set; }
 
     /// <summary>String-overload ctor — pass the current value and a callback.</summary>
-    public OutlinedTextField(string value, Action<string> onValueChange)
+    public OutlinedTextField(
+        string value,
+        Action<string> onValueChange,
+        bool enabled = true,
+        bool readOnly = false,
+        bool isError = false,
+        bool singleLine = false,
+        int maxLines = int.MaxValue,
+        int minLines = 1)
     {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(onValueChange);
         _value = value;
         _onValueChange = onValueChange;
+        _enabled = enabled;
+        _readOnly = readOnly;
+        _isError = isError;
+        _singleLine = singleLine;
+        _maxLines = maxLines;
+        _minLines = minLines;
     }
 
     /// <summary>
     /// Bind this <c>OutlinedTextField</c> to a <see cref="MutableState{T}"/>
     /// of <see cref="string"/> so user edits trigger recomposition automatically.
     /// </summary>
-    public OutlinedTextField(MutableState<string> state)
-        : this(state.Value ?? string.Empty, v => state.Value = v)
+    public OutlinedTextField(
+        MutableState<string> state,
+        bool enabled = true,
+        bool readOnly = false,
+        bool isError = false,
+        bool singleLine = false,
+        int maxLines = int.MaxValue,
+        int minLines = 1)
+        : this(
+            CurrentValue(state),
+            v => state.Value = v,
+            enabled,
+            readOnly,
+            isError,
+            singleLine,
+            maxLines,
+            minLines)
     {
     }
 
@@ -79,10 +104,29 @@ public sealed class OutlinedTextField : ComposableNode
     /// <c>OutlinedTextField(TextFieldValue, (TextFieldValue) -&gt; Unit, …)</c>
     /// overload so caller-supplied selection state is honoured.
     /// </summary>
-    public OutlinedTextField(MutableState<TextFieldValue> state)
+    public OutlinedTextField(
+        MutableState<TextFieldValue> state,
+        bool enabled = true,
+        bool readOnly = false,
+        bool isError = false,
+        bool singleLine = false,
+        int maxLines = int.MaxValue,
+        int minLines = 1)
     {
         ArgumentNullException.ThrowIfNull(state);
         _tfvState = state;
+        _enabled = enabled;
+        _readOnly = readOnly;
+        _isError = isError;
+        _singleLine = singleLine;
+        _maxLines = maxLines;
+        _minLines = minLines;
+    }
+
+    static string CurrentValue(MutableState<string> state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        return state.Value ?? string.Empty;
     }
 
     /// <inheritdoc/>
@@ -96,8 +140,12 @@ public sealed class OutlinedTextField : ComposableNode
 
     void RenderString(IComposer composer)
     {
+        var value = _value
+            ?? throw new InvalidOperationException($"{nameof(OutlinedTextField)} string value was not initialized.");
+        var onValueChange = _onValueChange
+            ?? throw new InvalidOperationException($"{nameof(OutlinedTextField)} value-change callback was not initialized.");
         var __onValueChange = composer.RememberAction((Java.Lang.Object? v) =>
-            _onValueChange!(v?.ToString() ?? string.Empty));
+            onValueChange(v?.ToString() ?? string.Empty));
         var __label          = Label          is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
         var __placeholder    = Placeholder    is null ? null : ComposableLambdas.Wrap2(composer, c => Placeholder.Render(c));
         var __leadingIcon    = LeadingIcon    is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
@@ -110,28 +158,29 @@ public sealed class OutlinedTextField : ComposableNode
         // Remaining 12 params overflow to a second $changed int we
         // don't model — left at 0 (Uncertain), same as the generator.
         int __changed = 0;
-        __changed |= composer.DiffSlot(_value, ComposeExtensions.DiffSlotShift(0));
+        __changed |= composer.DiffSlot(value, ComposeExtensions.DiffSlotShift(0));
         __changed |= (int)ChangedBits.Static << ComposeExtensions.DiffSlotShift(1);
         __changed |= composer.DiffSlot(__modifierKey, ComposeExtensions.DiffSlotShift(2));
-        __changed |= composer.DiffSlot(Enabled, ComposeExtensions.DiffSlotShift(3));
-        __changed |= composer.DiffSlot(ReadOnly, ComposeExtensions.DiffSlotShift(4));
+        __changed |= composer.DiffSlot(_enabled, ComposeExtensions.DiffSlotShift(3));
+        __changed |= composer.DiffSlot(_readOnly, ComposeExtensions.DiffSlotShift(4));
         __changed |= composer.DiffSlot<object?>(TextStyle, ComposeExtensions.DiffSlotShift(5));
         __changed |= composer.DiffSlot<object?>(__label, ComposeExtensions.DiffSlotShift(6));
         __changed |= composer.DiffSlot<object?>(__placeholder, ComposeExtensions.DiffSlotShift(7));
         __changed |= composer.DiffSlot<object?>(__leadingIcon, ComposeExtensions.DiffSlotShift(8));
         __changed |= composer.DiffSlot<object?>(__trailingIcon, ComposeExtensions.DiffSlotShift(9));
-        ComposeBridges.OutlinedTextField(_value!, __onValueChange, BuildModifier(),
-            Enabled, ReadOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
-            __prefix, __suffix, __supportingText, IsError,
+        ComposeBridges.OutlinedTextField(value, __onValueChange, BuildModifier(),
+            _enabled, _readOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
+            __prefix, __suffix, __supportingText, _isError,
             VisualTransformation, KeyboardOptions, KeyboardActions,
-            SingleLine, MaxLines, MinLines,
+            _singleLine, _maxLines, _minLines,
             Shape,
             composer, _changed: __changed);
     }
 
     void RenderWithSelection(IComposer composer)
     {
-        var state = _tfvState!;
+        var state = _tfvState
+            ?? throw new InvalidOperationException($"{nameof(OutlinedTextField)} text-field-value state was not initialized.");
         var current = state.Value
             ?? throw new InvalidOperationException(
                 $"{nameof(OutlinedTextField)}: MutableState<TextFieldValue>.Value is null. " +
@@ -139,8 +188,11 @@ public sealed class OutlinedTextField : ComposableNode
 
         var __onValueChange = composer.RememberAction((Java.Lang.Object? v) =>
         {
+            var peer = v
+                ?? throw new InvalidOperationException($"{nameof(OutlinedTextField)} received a null TextFieldValue peer.");
             state.Value = Java.Lang.Object.GetObject<TextFieldValue>(
-                v!.Handle, JniHandleOwnership.DoNotTransfer)!;
+                peer.Handle, JniHandleOwnership.DoNotTransfer)
+                ?? throw new InvalidOperationException($"{nameof(OutlinedTextField)} could not resolve the TextFieldValue peer.");
         });
         var __label          = Label          is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
         var __placeholder    = Placeholder    is null ? null : ComposableLambdas.Wrap2(composer, c => Placeholder.Render(c));
@@ -154,18 +206,18 @@ public sealed class OutlinedTextField : ComposableNode
         __changed |= composer.DiffSlot<object?>(current, ComposeExtensions.DiffSlotShift(0));
         __changed |= (int)ChangedBits.Static << ComposeExtensions.DiffSlotShift(1);
         __changed |= composer.DiffSlot(__modifierKey, ComposeExtensions.DiffSlotShift(2));
-        __changed |= composer.DiffSlot(Enabled, ComposeExtensions.DiffSlotShift(3));
-        __changed |= composer.DiffSlot(ReadOnly, ComposeExtensions.DiffSlotShift(4));
+        __changed |= composer.DiffSlot(_enabled, ComposeExtensions.DiffSlotShift(3));
+        __changed |= composer.DiffSlot(_readOnly, ComposeExtensions.DiffSlotShift(4));
         __changed |= composer.DiffSlot<object?>(TextStyle, ComposeExtensions.DiffSlotShift(5));
         __changed |= composer.DiffSlot<object?>(__label, ComposeExtensions.DiffSlotShift(6));
         __changed |= composer.DiffSlot<object?>(__placeholder, ComposeExtensions.DiffSlotShift(7));
         __changed |= composer.DiffSlot<object?>(__leadingIcon, ComposeExtensions.DiffSlotShift(8));
         __changed |= composer.DiffSlot<object?>(__trailingIcon, ComposeExtensions.DiffSlotShift(9));
         ComposeBridges.OutlinedTextFieldWithValue(current, __onValueChange, BuildModifier(),
-            Enabled, ReadOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
-            __prefix, __suffix, __supportingText, IsError,
+            _enabled, _readOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
+            __prefix, __suffix, __supportingText, _isError,
             VisualTransformation, KeyboardOptions, KeyboardActions,
-            SingleLine, MaxLines, MinLines,
+            _singleLine, _maxLines, _minLines,
             Shape,
             composer, _changed: __changed);
     }

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -931,10 +931,6 @@ AndroidX.Compose.OutlinedSecureTextField.SupportingText.set -> void
 AndroidX.Compose.OutlinedSecureTextField.TrailingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.OutlinedSecureTextField.TrailingIcon.set -> void
 AndroidX.Compose.OutlinedTextField
-AndroidX.Compose.OutlinedTextField.Enabled.get -> bool?
-AndroidX.Compose.OutlinedTextField.Enabled.set -> void
-AndroidX.Compose.OutlinedTextField.IsError.get -> bool?
-AndroidX.Compose.OutlinedTextField.IsError.set -> void
 AndroidX.Compose.OutlinedTextField.KeyboardActions.get -> AndroidX.Compose.Foundation.Text.KeyboardActions?
 AndroidX.Compose.OutlinedTextField.KeyboardActions.set -> void
 AndroidX.Compose.OutlinedTextField.KeyboardOptions.get -> AndroidX.Compose.Foundation.Text.KeyboardOptions?
@@ -943,23 +939,15 @@ AndroidX.Compose.OutlinedTextField.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.OutlinedTextField.Label.set -> void
 AndroidX.Compose.OutlinedTextField.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.OutlinedTextField.LeadingIcon.set -> void
-AndroidX.Compose.OutlinedTextField.MaxLines.get -> int?
-AndroidX.Compose.OutlinedTextField.MaxLines.set -> void
-AndroidX.Compose.OutlinedTextField.MinLines.get -> int?
-AndroidX.Compose.OutlinedTextField.MinLines.set -> void
-AndroidX.Compose.OutlinedTextField.OutlinedTextField(AndroidX.Compose.MutableState<AndroidX.Compose.UI.Text.Input.TextFieldValue!>! state) -> void
-AndroidX.Compose.OutlinedTextField.OutlinedTextField(AndroidX.Compose.MutableState<string!>! state) -> void
-AndroidX.Compose.OutlinedTextField.OutlinedTextField(string! value, System.Action<string!>! onValueChange) -> void
+AndroidX.Compose.OutlinedTextField.OutlinedTextField(AndroidX.Compose.MutableState<AndroidX.Compose.UI.Text.Input.TextFieldValue!>! state, bool enabled = true, bool readOnly = false, bool isError = false, bool singleLine = false, int maxLines = 2147483647, int minLines = 1) -> void
+AndroidX.Compose.OutlinedTextField.OutlinedTextField(AndroidX.Compose.MutableState<string!>! state, bool enabled = true, bool readOnly = false, bool isError = false, bool singleLine = false, int maxLines = 2147483647, int minLines = 1) -> void
+AndroidX.Compose.OutlinedTextField.OutlinedTextField(string! value, System.Action<string!>! onValueChange, bool enabled = true, bool readOnly = false, bool isError = false, bool singleLine = false, int maxLines = 2147483647, int minLines = 1) -> void
 AndroidX.Compose.OutlinedTextField.Placeholder.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.OutlinedTextField.Placeholder.set -> void
 AndroidX.Compose.OutlinedTextField.Prefix.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.OutlinedTextField.Prefix.set -> void
-AndroidX.Compose.OutlinedTextField.ReadOnly.get -> bool?
-AndroidX.Compose.OutlinedTextField.ReadOnly.set -> void
 AndroidX.Compose.OutlinedTextField.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.OutlinedTextField.Shape.set -> void
-AndroidX.Compose.OutlinedTextField.SingleLine.get -> bool?
-AndroidX.Compose.OutlinedTextField.SingleLine.set -> void
 AndroidX.Compose.OutlinedTextField.Suffix.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.OutlinedTextField.Suffix.set -> void
 AndroidX.Compose.OutlinedTextField.SupportingText.get -> AndroidX.Compose.ComposableNode?
@@ -1271,37 +1259,25 @@ AndroidX.Compose.TextButton.Shape.set -> void
 AndroidX.Compose.TextButton.TextButton(System.Action! onClick) -> void
 AndroidX.Compose.TextDecoration
 AndroidX.Compose.TextField
-AndroidX.Compose.TextField.Enabled.get -> bool?
-AndroidX.Compose.TextField.Enabled.set -> void
-AndroidX.Compose.TextField.IsError.get -> bool?
-AndroidX.Compose.TextField.IsError.set -> void
 AndroidX.Compose.TextField.KeyboardOptions.get -> AndroidX.Compose.Foundation.Text.KeyboardOptions?
 AndroidX.Compose.TextField.KeyboardOptions.set -> void
 AndroidX.Compose.TextField.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.TextField.Label.set -> void
 AndroidX.Compose.TextField.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.TextField.LeadingIcon.set -> void
-AndroidX.Compose.TextField.MaxLines.get -> int?
-AndroidX.Compose.TextField.MaxLines.set -> void
-AndroidX.Compose.TextField.MinLines.get -> int?
-AndroidX.Compose.TextField.MinLines.set -> void
 AndroidX.Compose.TextField.Placeholder.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.TextField.Placeholder.set -> void
 AndroidX.Compose.TextField.Prefix.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.TextField.Prefix.set -> void
-AndroidX.Compose.TextField.ReadOnly.get -> bool?
-AndroidX.Compose.TextField.ReadOnly.set -> void
 AndroidX.Compose.TextField.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.TextField.Shape.set -> void
-AndroidX.Compose.TextField.SingleLine.get -> bool?
-AndroidX.Compose.TextField.SingleLine.set -> void
 AndroidX.Compose.TextField.Suffix.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.TextField.Suffix.set -> void
 AndroidX.Compose.TextField.SupportingText.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.TextField.SupportingText.set -> void
-AndroidX.Compose.TextField.TextField(AndroidX.Compose.MutableState<AndroidX.Compose.UI.Text.Input.TextFieldValue!>! state) -> void
-AndroidX.Compose.TextField.TextField(AndroidX.Compose.MutableState<string!>! state) -> void
-AndroidX.Compose.TextField.TextField(string! value, System.Action<string!>! onValueChange) -> void
+AndroidX.Compose.TextField.TextField(AndroidX.Compose.MutableState<AndroidX.Compose.UI.Text.Input.TextFieldValue!>! state, bool enabled = true, bool readOnly = false, bool isError = false, bool singleLine = false, int maxLines = 2147483647, int minLines = 1) -> void
+AndroidX.Compose.TextField.TextField(AndroidX.Compose.MutableState<string!>! state, bool enabled = true, bool readOnly = false, bool isError = false, bool singleLine = false, int maxLines = 2147483647, int minLines = 1) -> void
+AndroidX.Compose.TextField.TextField(string! value, System.Action<string!>! onValueChange, bool enabled = true, bool readOnly = false, bool isError = false, bool singleLine = false, int maxLines = 2147483647, int minLines = 1) -> void
 AndroidX.Compose.TextField.TextStyle.get -> AndroidX.Compose.TextStyle?
 AndroidX.Compose.TextField.TextStyle.set -> void
 AndroidX.Compose.TextField.TrailingIcon.get -> AndroidX.Compose.ComposableNode?

--- a/src/Microsoft.AndroidX.Compose/TextField.cs
+++ b/src/Microsoft.AndroidX.Compose/TextField.cs
@@ -35,6 +35,12 @@ public sealed class TextField : ComposableNode
     readonly string?                       _value;
     readonly Action<string>?               _onValueChange;
     readonly MutableState<TextFieldValue>? _tfvState;
+    readonly bool                          _enabled;
+    readonly bool                          _readOnly;
+    readonly bool                          _isError;
+    readonly bool                          _singleLine;
+    readonly int                           _maxLines;
+    readonly int                           _minLines;
 
     /// <summary>Floating label (e.g. <c>new Text("Email")</c>).</summary>
     public ComposableNode? Label          { get; set; }
@@ -50,18 +56,6 @@ public sealed class TextField : ComposableNode
     public ComposableNode? Suffix         { get; set; }
     /// <summary>Helper text rendered below the field.</summary>
     public ComposableNode? SupportingText { get; set; }
-    /// <summary>Whether the field accepts focus and input.</summary>
-    public bool?           Enabled        { get; set; }
-    /// <summary>Whether the field is read-only.</summary>
-    public bool?           ReadOnly       { get; set; }
-    /// <summary>Whether the field is in an error state.</summary>
-    public bool?           IsError        { get; set; }
-    /// <summary>Whether the field is constrained to one line.</summary>
-    public bool?           SingleLine     { get; set; }
-    /// <summary>Maximum number of visible lines.</summary>
-    public int?            MaxLines       { get; set; }
-    /// <summary>Minimum number of visible lines.</summary>
-    public int?            MinLines       { get; set; }
     /// <summary>Optional shape applied to the field's container (Kotlin <c>shape</c>).</summary>
     public Shape?          Shape          { get; set; }
     /// <summary>Optional <c>TextStyle</c> override (Kotlin <c>textStyle</c>) — controls text color, size, weight, etc.</summary>
@@ -72,18 +66,49 @@ public sealed class TextField : ComposableNode
     public AndroidX.Compose.Foundation.Text.KeyboardOptions? KeyboardOptions { get; set; }
 
     /// <summary>String-overload ctor — pass the current value and a callback.</summary>
-    public TextField(string value, Action<string> onValueChange)
+    public TextField(
+        string value,
+        Action<string> onValueChange,
+        bool enabled = true,
+        bool readOnly = false,
+        bool isError = false,
+        bool singleLine = false,
+        int maxLines = int.MaxValue,
+        int minLines = 1)
     {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(onValueChange);
         _value = value;
         _onValueChange = onValueChange;
+        _enabled = enabled;
+        _readOnly = readOnly;
+        _isError = isError;
+        _singleLine = singleLine;
+        _maxLines = maxLines;
+        _minLines = minLines;
     }
 
     /// <summary>
     /// Bind this <c>TextField</c> to a <see cref="MutableState{T}"/> of
     /// <see cref="string"/> so user edits trigger recomposition automatically.
     /// </summary>
-    public TextField(MutableState<string> state)
-        : this(state.Value ?? string.Empty, v => state.Value = v)
+    public TextField(
+        MutableState<string> state,
+        bool enabled = true,
+        bool readOnly = false,
+        bool isError = false,
+        bool singleLine = false,
+        int maxLines = int.MaxValue,
+        int minLines = 1)
+        : this(
+            CurrentValue(state),
+            v => state.Value = v,
+            enabled,
+            readOnly,
+            isError,
+            singleLine,
+            maxLines,
+            minLines)
     {
     }
 
@@ -94,10 +119,29 @@ public sealed class TextField : ComposableNode
     /// overload so caller-supplied selection state is honoured (e.g. for
     /// "place caret at end after inserting" behaviour).
     /// </summary>
-    public TextField(MutableState<TextFieldValue> state)
+    public TextField(
+        MutableState<TextFieldValue> state,
+        bool enabled = true,
+        bool readOnly = false,
+        bool isError = false,
+        bool singleLine = false,
+        int maxLines = int.MaxValue,
+        int minLines = 1)
     {
         ArgumentNullException.ThrowIfNull(state);
         _tfvState = state;
+        _enabled = enabled;
+        _readOnly = readOnly;
+        _isError = isError;
+        _singleLine = singleLine;
+        _maxLines = maxLines;
+        _minLines = minLines;
+    }
+
+    static string CurrentValue(MutableState<string> state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        return state.Value ?? string.Empty;
     }
 
     /// <inheritdoc/>
@@ -111,8 +155,12 @@ public sealed class TextField : ComposableNode
 
     void RenderString(IComposer composer)
     {
+        var value = _value
+            ?? throw new InvalidOperationException($"{nameof(TextField)} string value was not initialized.");
+        var onValueChange = _onValueChange
+            ?? throw new InvalidOperationException($"{nameof(TextField)} value-change callback was not initialized.");
         var __onValueChange = composer.RememberAction((Java.Lang.Object? v) =>
-            _onValueChange!(v?.ToString() ?? string.Empty));
+            onValueChange(v?.ToString() ?? string.Empty));
         var __label          = Label          is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
         var __placeholder    = Placeholder    is null ? null : ComposableLambdas.Wrap2(composer, c => Placeholder.Render(c));
         var __leadingIcon    = LeadingIcon    is null ? null : ComposableLambdas.Wrap2(composer, c => LeadingIcon.Render(c));
@@ -127,28 +175,29 @@ public sealed class TextField : ComposableNode
         // Params beyond bit 28 land in the next $changed int which we
         // leave at 0 (Uncertain) — same as ComposeFacadeGenerator.
         int __changed = 0;
-        __changed |= composer.DiffSlot(_value, ComposeExtensions.DiffSlotShift(0));
+        __changed |= composer.DiffSlot(value, ComposeExtensions.DiffSlotShift(0));
         __changed |= (int)ChangedBits.Static << ComposeExtensions.DiffSlotShift(1);
         __changed |= composer.DiffSlot(__modifierKey, ComposeExtensions.DiffSlotShift(2));
-        __changed |= composer.DiffSlot(Enabled, ComposeExtensions.DiffSlotShift(3));
-        __changed |= composer.DiffSlot(ReadOnly, ComposeExtensions.DiffSlotShift(4));
+        __changed |= composer.DiffSlot(_enabled, ComposeExtensions.DiffSlotShift(3));
+        __changed |= composer.DiffSlot(_readOnly, ComposeExtensions.DiffSlotShift(4));
         __changed |= composer.DiffSlot<object?>(TextStyle, ComposeExtensions.DiffSlotShift(5));
         __changed |= composer.DiffSlot<object?>(__label, ComposeExtensions.DiffSlotShift(6));
         __changed |= composer.DiffSlot<object?>(__placeholder, ComposeExtensions.DiffSlotShift(7));
         __changed |= composer.DiffSlot<object?>(__leadingIcon, ComposeExtensions.DiffSlotShift(8));
         __changed |= composer.DiffSlot<object?>(__trailingIcon, ComposeExtensions.DiffSlotShift(9));
-        ComposeBridges.TextField(_value!, __onValueChange, BuildModifier(),
-            Enabled, ReadOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
-            __prefix, __suffix, __supportingText, IsError,
+        ComposeBridges.TextField(value, __onValueChange, BuildModifier(),
+            _enabled, _readOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
+            __prefix, __suffix, __supportingText, _isError,
             VisualTransformation, KeyboardOptions,
-            SingleLine, MaxLines, MinLines,
+            _singleLine, _maxLines, _minLines,
             Shape,
             composer, _changed: __changed);
     }
 
     void RenderWithSelection(IComposer composer)
     {
-        var state = _tfvState!;
+        var state = _tfvState
+            ?? throw new InvalidOperationException($"{nameof(TextField)} text-field-value state was not initialized.");
         var current = state.Value
             ?? throw new InvalidOperationException(
                 $"{nameof(TextField)}: MutableState<TextFieldValue>.Value is null. " +
@@ -156,11 +205,11 @@ public sealed class TextField : ComposableNode
 
         var __onValueChange = composer.RememberAction((Java.Lang.Object? v) =>
         {
-            // Compose hands us the fresh Kotlin TextFieldValue peer; the
-            // peer registry maps it back to the bound binding type so we
-            // can store it directly.
+            var peer = v
+                ?? throw new InvalidOperationException($"{nameof(TextField)} received a null TextFieldValue peer.");
             state.Value = Java.Lang.Object.GetObject<TextFieldValue>(
-                v!.Handle, JniHandleOwnership.DoNotTransfer)!;
+                peer.Handle, JniHandleOwnership.DoNotTransfer)
+                ?? throw new InvalidOperationException($"{nameof(TextField)} could not resolve the TextFieldValue peer.");
         });
         var __label          = Label          is null ? null : ComposableLambdas.Wrap2(composer, c => Label.Render(c));
         var __placeholder    = Placeholder    is null ? null : ComposableLambdas.Wrap2(composer, c => Placeholder.Render(c));
@@ -178,18 +227,18 @@ public sealed class TextField : ComposableNode
         __changed |= composer.DiffSlot<object?>(current, ComposeExtensions.DiffSlotShift(0));
         __changed |= (int)ChangedBits.Static << ComposeExtensions.DiffSlotShift(1);
         __changed |= composer.DiffSlot(__modifierKey, ComposeExtensions.DiffSlotShift(2));
-        __changed |= composer.DiffSlot(Enabled, ComposeExtensions.DiffSlotShift(3));
-        __changed |= composer.DiffSlot(ReadOnly, ComposeExtensions.DiffSlotShift(4));
+        __changed |= composer.DiffSlot(_enabled, ComposeExtensions.DiffSlotShift(3));
+        __changed |= composer.DiffSlot(_readOnly, ComposeExtensions.DiffSlotShift(4));
         __changed |= composer.DiffSlot<object?>(TextStyle, ComposeExtensions.DiffSlotShift(5));
         __changed |= composer.DiffSlot<object?>(__label, ComposeExtensions.DiffSlotShift(6));
         __changed |= composer.DiffSlot<object?>(__placeholder, ComposeExtensions.DiffSlotShift(7));
         __changed |= composer.DiffSlot<object?>(__leadingIcon, ComposeExtensions.DiffSlotShift(8));
         __changed |= composer.DiffSlot<object?>(__trailingIcon, ComposeExtensions.DiffSlotShift(9));
         ComposeBridges.TextFieldWithValue(current, __onValueChange, BuildModifier(),
-            Enabled, ReadOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
-            __prefix, __suffix, __supportingText, IsError,
+            _enabled, _readOnly, TextStyle?.Build(), __label, __placeholder, __leadingIcon, __trailingIcon,
+            __prefix, __suffix, __supportingText, _isError,
             VisualTransformation, KeyboardOptions,
-            SingleLine, MaxLines, MinLines,
+            _singleLine, _maxLines, _minLines,
             Shape,
             composer, _changed: __changed);
     }


### PR DESCRIPTION
`TextField` and `OutlinedTextField` still exposed primitive Kotlin defaults through nullable object-initializer properties, even though these values have concrete defaults. This made common configuration more awkward and preserved unnecessary `null` sentinel semantics.

This change moves `enabled`, `readOnly`, `isError`, `singleLine`, `maxLines`, and `minLines` into all three constructor overloads with their Material 3 defaults. It also migrates Gallery, MAUI, and sample call sites, updates public API tracking, and expands the TextField Gallery demo with enabled/read-only toggles.

Validation includes the 164 source-generator tests, clean facade and Gallery builds, and successful Compile targets for MAUI, Gallery, JetNews, and Jetchat. The full solution packaging target remains affected by an existing local AAPT2 failure opening generated MAUI `.flat` resource files; no C# compile errors remain.

Fixes: #242