### PR TITLE
Fix omitted primitive Compose facade defaults

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -308,6 +308,10 @@ helpers, operators.
   content lambda.
 - `[Callback(typeof(T))]` — surface `IFunction1` as typed `Action<T>` ctor
   slot. `T` ∈ {`bool`, `string`, `float`}.
+- `[FacadeDefault(value)]` — give a primitive generated-facade constructor
+  slot a C# default while keeping the bridge parameter and trailing
+  `IComposer` required. Use this instead of making bridge parameters optional;
+  it avoids `composer = null!` solely for C# optional-parameter ordering.
 - `[PainterResource]` — annotate `IntPtr` taking the resolved Painter handle.
   Facade exposes synthetic `int painterResourceId` ctor in its place; emits
   `PainterResource(id, composer)` + try/finally + `DeleteLocalRef` preamble.

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/PrimaryScrollableTabRowDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/AppBars/PrimaryScrollableTabRowDemo.cs
@@ -14,18 +14,25 @@ public static class PrimaryScrollableTabRowDemo
         Build:       c =>
         {
             var sub = c.MutableStateOf(0);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: value => enabled.Value = value),
+                    new Text("Tabs enabled"),
+                },
                 new PrimaryScrollableTabRow(selectedTabIndex: sub.Value)
                 {
-                    new Tab(selected: sub.Value == 0, onClick: () => sub.Value = 0) { Text = new Text("Greeting") },
-                    new Tab(selected: sub.Value == 1, onClick: () => sub.Value = 1) { Text = new Text("Counter") },
-                    new LeadingIconTab(selected: sub.Value == 2, onClick: () => sub.Value = 2)
+                    new Tab(selected: sub.Value == 0, onClick: () => sub.Value = 0, enabled: enabled.Value) { Text = new Text("Greeting") },
+                    new Tab(selected: sub.Value == 1, onClick: () => sub.Value = 1, enabled: enabled.Value) { Text = new Text("Counter") },
+                    new LeadingIconTab(selected: sub.Value == 2, onClick: () => sub.Value = 2, enabled: enabled.Value)
                     {
                         Text = new Text("List"),
                         Icon = new Text("📋"),
                     },
-                    new CustomTab(selected: sub.Value == 3, onClick: () => sub.Value = 3)
+                    new CustomTab(selected: sub.Value == 3, onClick: () => sub.Value = 3, enabled: enabled.Value)
                     {
                         new Column { new Text("Custom"), new Text("tab") },
                     },

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/ChipsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/ChipsDemo.cs
@@ -15,23 +15,32 @@ public static class ChipsDemo
         {
             var count = c.MutableStateOf(0);
             var liked = c.MutableStateOf(false);
+            var enabled = c.MutableStateOf(true);
             return new Column(verticalArrangement: Arrangement.SpacedBy(8.Dp()))
             {
                 new Text($"Count: {count}, liked: {liked.Value}"),
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: value => enabled.Value = value),
+                    new Text("Enabled"),
+                },
                 new FlowRow
                 {
                     Modifier.FillMaxWidth(),
-                    new AssistChip(onClick: () => count++)
+                    new AssistChip(onClick: () => count++, enabled: enabled.Value)
                         { Label = new Text("Assist (+1)") },
-                    new ElevatedAssistChip(onClick: () => count++)
+                    new ElevatedAssistChip(onClick: () => count++, enabled: enabled.Value)
                         { Label = new Text("Elevated assist (+1)") },
-                    new FilterChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value)
+                    new FilterChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value, enabled: enabled.Value)
                         { Label = new Text(liked.Value ? "Liked" : "Like") },
-                    new ElevatedFilterChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value)
+                    new ElevatedFilterChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value, enabled: enabled.Value)
                         { Label = new Text(liked.Value ? "Elevated liked" : "Elevated like") },
-                    new SuggestionChip(onClick: () => count.Value = 0)
+                    new InputChip(selected: liked.Value, onClick: () => liked.Value = !liked.Value, enabled: enabled.Value)
+                        { Label = new Text("Input") },
+                    new SuggestionChip(onClick: () => count.Value = 0, enabled: enabled.Value)
                         { Label = new Text("Reset") },
-                    new ElevatedSuggestionChip(onClick: () => count.Value = 0)
+                    new ElevatedSuggestionChip(onClick: () => count.Value = 0, enabled: enabled.Value)
                         { Label = new Text("Elevated reset") },
                 },
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/FillStylesDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/FillStylesDemo.cs
@@ -14,14 +14,21 @@ public static class FillStylesDemo
         Build:       c =>
         {
             var count = c.MutableStateOf(0);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
                 new Text($"Tapped: {count}"),
-                new Button(onClick: () => count++) { new Text("Filled") },
-                new ElevatedButton(onClick: () => count++) { new Text("Elevated") },
-                new FilledTonalButton(onClick: () => count++) { new Text("Filled tonal") },
-                new OutlinedButton(onClick: () => count++) { new Text("Outlined") },
-                new TextButton(onClick: () => count++) { new Text("Text") },
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: value => enabled.Value = value),
+                    new Text("Enabled"),
+                },
+                new Button(onClick: () => count++, enabled: enabled.Value) { new Text("Filled") },
+                new ElevatedButton(onClick: () => count++, enabled: enabled.Value) { new Text("Elevated") },
+                new FilledTonalButton(onClick: () => count++, enabled: enabled.Value) { new Text("Filled tonal") },
+                new OutlinedButton(onClick: () => count++, enabled: enabled.Value) { new Text("Outlined") },
+                new TextButton(onClick: () => count++, enabled: enabled.Value) { new Text("Text") },
             };
         });
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconButtonsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconButtonsDemo.cs
@@ -14,15 +14,22 @@ public static class IconButtonsDemo
         Build:       c =>
         {
             var count = c.MutableStateOf(0);
+            var enabled = c.MutableStateOf(true);
             return new Column
             {
                 new Text($"Tapped: {count}"),
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: value => enabled.Value = value),
+                    new Text("Enabled"),
+                },
                 new Row
                 {
-                    new IconButton(onClick: () => count++) { new Text("☆") },
-                    new FilledIconButton(onClick: () => count++) { new Text("★") },
-                    new FilledTonalIconButton(onClick: () => count++) { new Text("◆") },
-                    new OutlinedIconButton(onClick: () => count++) { new Text("◇") },
+                    new IconButton(onClick: () => count++, enabled: enabled.Value) { new Text("☆") },
+                    new FilledIconButton(onClick: () => count++, enabled: enabled.Value) { new Text("★") },
+                    new FilledTonalIconButton(onClick: () => count++, enabled: enabled.Value) { new Text("◆") },
+                    new OutlinedIconButton(onClick: () => count++, enabled: enabled.Value) { new Text("◇") },
                 },
             };
         });

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconToggleButtonsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Buttons/IconToggleButtonsDemo.cs
@@ -17,16 +17,26 @@ public static class IconToggleButtonsDemo
             var b = c.MutableStateOf(false);
             var ct = c.MutableStateOf(false);
             var d = c.MutableStateOf(false);
-            return new Row
+            var enabled = c.MutableStateOf(true);
+            return new Column
             {
-                new IconToggleButton(@checked: a.Value, onCheckedChange: v => a.Value = v)
-                    { new Text(a.Value ? "★" : "☆") },
-                new FilledIconToggleButton(@checked: b.Value, onCheckedChange: v => b.Value = v)
-                    { new Text(b.Value ? "★" : "☆") },
-                new FilledTonalIconToggleButton(@checked: ct.Value, onCheckedChange: v => ct.Value = v)
-                    { new Text(ct.Value ? "◆" : "◇") },
-                new OutlinedIconToggleButton(@checked: d.Value, onCheckedChange: v => d.Value = v)
-                    { new Text(d.Value ? "◆" : "◇") },
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: value => enabled.Value = value),
+                    new Text("Enabled"),
+                },
+                new Row
+                {
+                    new IconToggleButton(@checked: a.Value, onCheckedChange: v => a.Value = v, enabled: enabled.Value)
+                        { new Text(a.Value ? "★" : "☆") },
+                    new FilledIconToggleButton(@checked: b.Value, onCheckedChange: v => b.Value = v, enabled: enabled.Value)
+                        { new Text(b.Value ? "★" : "☆") },
+                    new FilledTonalIconToggleButton(@checked: ct.Value, onCheckedChange: v => ct.Value = v, enabled: enabled.Value)
+                        { new Text(ct.Value ? "◆" : "◇") },
+                    new OutlinedIconToggleButton(@checked: d.Value, onCheckedChange: v => d.Value = v, enabled: enabled.Value)
+                        { new Text(d.Value ? "◆" : "◇") },
+                },
             };
         });
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BoxAlignmentDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BoxAlignmentDemo.cs
@@ -10,29 +10,28 @@ public static class BoxAlignmentDemo
         Id:          "containers-box-alignment",
         CategoryId:  "containers",
         Title:       "Box alignment",
-        Description: "Children stack at the same anchor — later children draw above earlier ones.",
-        Build:       _ => new Box
+        Description: "Children stack at one anchor; propagateMinConstraints controls child minimums.",
+        Build:       _ => new Column
         {
-            Modifier
-                .Size(160)
-                .Background(Color.FromRgb(0xB3, 0xE5, 0xFC)),
+            new Text("Default constraints"),
             new Box
             {
                 Modifier
-                    .Size(120)
-                    .Padding(8)
+                    .Size(160)
+                    .Background(Color.FromRgb(0xB3, 0xE5, 0xFC)),
+                new Text("Front") { Modifier = Modifier.Padding(28) },
+            },
+            new Text("propagateMinConstraints: true"),
+            new Box(propagateMinConstraints: true)
+            {
+                Modifier
+                    .Size(160)
                     .Background(Color.FromRgb(0x81, 0xD4, 0xFA)),
-            },
-            new Box
-            {
-                Modifier
-                    .Size(80)
-                    .Padding(16)
-                    .Background(Color.FromRgb(0x4F, 0xC3, 0xF7)),
-            },
-            new Text("Front")
-            {
-                Modifier = Modifier.Padding(28),
+                new Box
+                {
+                    Modifier.Background(Color.FromRgb(0x4F, 0xC3, 0xF7)),
+                    new Text("Child receives minimums"),
+                },
             },
         });
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BoxAlignmentDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BoxAlignmentDemo.cs
@@ -19,7 +19,11 @@ public static class BoxAlignmentDemo
                 Modifier
                     .Size(160)
                     .Background(Color.FromRgb(0xB3, 0xE5, 0xFC)),
-                new Text("Front") { Modifier = Modifier.Padding(28) },
+                new Text("Front")
+                {
+                    Color = Color.Black,
+                    Modifier = Modifier.Padding(28),
+                },
             },
             new Text("propagateMinConstraints: true"),
             new Box(propagateMinConstraints: true)
@@ -30,7 +34,7 @@ public static class BoxAlignmentDemo
                 new Box
                 {
                     Modifier.Background(Color.FromRgb(0x4F, 0xC3, 0xF7)),
-                    new Text("Child receives minimums"),
+                    new Text("Child receives minimums") { Color = Color.Black },
                 },
             },
         });

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/FlowRowFlowColumnDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/FlowRowFlowColumnDemo.cs
@@ -10,11 +10,11 @@ public static class FlowRowFlowColumnDemo
         Id:          "containers-flow",
         CategoryId:  "containers",
         Title:       "FlowRow / FlowColumn",
-        Description: "Wrapping row of chip-styled Cards plus a wrapping column.",
+        Description: "Bounded FlowRow and FlowColumn item/line counts.",
         Build:       _ => new Column
         {
-            new Text("FlowRow (wraps when out of width)"),
-            new FlowRow
+            new Text("FlowRow: max 2 items per row, 2 lines"),
+            new FlowRow(maxItemsInEachRow: 2, maxLines: 2)
             {
                 Modifier.FillMaxWidth().Padding(4),
                 new Card { Modifier.Padding(4), new Text("Music") },
@@ -25,6 +25,16 @@ public static class FlowRowFlowColumnDemo
                 new Card { Modifier.Padding(4), new Text("Books") },
                 new Card { Modifier.Padding(4), new Text("Games") },
                 new Card { Modifier.Padding(4), new Text("Photography") },
+            },
+            new Text("FlowColumn: max 2 items per column, 2 lines"),
+            new FlowColumn(maxItemsInEachColumn: 2, maxLines: 2)
+            {
+                Modifier.Height(120).Padding(4),
+                new Card { Modifier.Padding(4), new Text("One") },
+                new Card { Modifier.Padding(4), new Text("Two") },
+                new Card { Modifier.Padding(4), new Text("Three") },
+                new Card { Modifier.Padding(4), new Text("Four") },
+                new Card { Modifier.Padding(4), new Text("Five") },
             },
         });
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/SnackbarLayoutDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/SnackbarLayoutDemo.cs
@@ -1,0 +1,32 @@
+using AndroidX.Compose.Gallery.Registry;
+
+namespace AndroidX.Compose.Gallery.Demos.Containers;
+
+/// <summary>Snackbar action placement controlled by actionOnNewLine.</summary>
+public static class SnackbarLayoutDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "containers-snackbar-layout",
+        CategoryId:  "containers",
+        Title:       "Snackbar action layout",
+        Description: "Toggle whether the action is placed on a new line.",
+        Build:       c =>
+        {
+            var newLine = c.MutableStateOf(false);
+            return new Column
+            {
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: newLine.Value, onCheckedChange: value => newLine.Value = value),
+                    new Text("Action on new line"),
+                },
+                new Snackbar(actionOnNewLine: newLine.Value)
+                {
+                    Body = new Text("A message with an action"),
+                    Action = new Text("UNDO"),
+                },
+            };
+        });
+}

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
@@ -15,6 +15,7 @@ public static class DatePickerDialogDemo
         {
             var open      = c.MutableStateOf(false);
             var picked    = c.MutableStateOf("(none)");
+            var showModes = c.MutableStateOf(true);
             // One JCW adapter per demo instance — its identity is part
             // of the rememberDatePickerState cache key.
             var bounds    = c.Remember(() => new DateRangeSelectableDates());
@@ -28,6 +29,12 @@ public static class DatePickerDialogDemo
             {
                 new Text($"Picked date: {picked}"),
                 new Text("(Today through Today+30 are selectable.)"),
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: showModes.Value, onCheckedChange: value => showModes.Value = value),
+                    new Text("Show mode toggle"),
+                },
                 new Button(onClick: () => open.Value = true) { new Text("Pick date") },
                 open.Value
                     ? new DatePickerDialog(onDismissRequest: () => open.Value = false)
@@ -40,7 +47,7 @@ public static class DatePickerDialogDemo
                             open.Value = false;
                         }) { new Text("OK") },
                         DismissButton = new Button(onClick: () => open.Value = false) { new Text("Cancel") },
-                        Body          = new DatePicker(state),
+                        Body          = new DatePicker(state, showModeToggle: showModes.Value),
                     }
                     : (ComposableNode?)null,
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DateRangePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DateRangePickerDialogDemo.cs
@@ -16,9 +16,16 @@ public static class DateRangePickerDialogDemo
             var open   = c.MutableStateOf(false);
             var picked = c.MutableStateOf("(none)");
             var state  = c.Remember(() => new DateRangePickerState());
+            var showModes = c.MutableStateOf(true);
             return new Column
             {
                 new Text($"Picked range: {picked}"),
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: showModes.Value, onCheckedChange: value => showModes.Value = value),
+                    new Text("Show mode toggle"),
+                },
                 new Button(onClick: () => open.Value = true) { new Text("Pick range") },
                 open.Value
                     ? new DateRangePickerDialog(onDismissRequest: () => open.Value = false)
@@ -33,7 +40,7 @@ public static class DateRangePickerDialogDemo
                             open.Value = false;
                         }) { new Text("OK") },
                         DismissButton = new Button(onClick: () => open.Value = false) { new Text("Cancel") },
-                        Body          = new DateRangePicker(state),
+                        Body          = new DateRangePicker(state, showModeToggle: showModes.Value),
                     }
                     : (ComposableNode?)null,
             };

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/NavigationRailOptionsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Navigation/NavigationRailOptionsDemo.cs
@@ -1,0 +1,56 @@
+using AndroidX.Compose.Gallery.Registry;
+
+namespace AndroidX.Compose.Gallery.Demos.Navigation;
+
+/// <summary>NavigationRailItem enabled and label-visibility defaults.</summary>
+public static class NavigationRailOptionsDemo
+{
+    /// <summary>Registry entry exposed via <see cref="Catalog.Demos"/>.</summary>
+    public static Demo Demo => new(
+        Id:          "navigation-rail-options",
+        CategoryId:  "navigation",
+        Title:       "Navigation rail options",
+        Description: "Toggle item enabled state and alwaysShowLabel.",
+        Build:       c =>
+        {
+            var selected = c.MutableStateOf(0);
+            var enabled = c.MutableStateOf(true);
+            var labels = c.MutableStateOf(true);
+            return new Column
+            {
+                new Row(horizontalArrangement: Arrangement.SpacedBy(8.Dp()),
+                        verticalAlignment: Alignment.Vertical.CenterVertically)
+                {
+                    new Switch(@checked: enabled.Value, onCheckedChange: value => enabled.Value = value),
+                    new Text("Enabled"),
+                    new Switch(@checked: labels.Value, onCheckedChange: value => labels.Value = value),
+                    new Text("Always show labels"),
+                },
+                new Box
+                {
+                    Modifier.Height(280),
+                    new NavigationRail
+                    {
+                        new NavigationRailItem(
+                            selected: selected.Value == 0,
+                            onClick: () => selected.Value = 0,
+                            enabled: enabled.Value,
+                            alwaysShowLabel: labels.Value)
+                        {
+                            Icon = new Text("H"),
+                            Label = new Text("Home"),
+                        },
+                        new NavigationRailItem(
+                            selected: selected.Value == 1,
+                            onClick: () => selected.Value = 1,
+                            enabled: enabled.Value,
+                            alwaysShowLabel: labels.Value)
+                        {
+                            Icon = new Text("S"),
+                            Label = new Text("Search"),
+                        },
+                    },
+                },
+            };
+        });
+}

--- a/src/Microsoft.AndroidX.Compose.Gallery/Registry/Catalog.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Registry/Catalog.cs
@@ -86,6 +86,7 @@ public static class Catalog
         D.Containers.SpacerDemo.Demo,
         D.Containers.DividerDemo.Demo,
         D.Containers.FlowRowFlowColumnDemo.Demo,
+        D.Containers.SnackbarLayoutDemo.Demo,
         D.Containers.BoxWithConstraintsDemo.Demo,
         D.Containers.CustomLayoutDemo.Demo,
 
@@ -126,6 +127,7 @@ public static class Catalog
         D.Navigation.DismissibleDrawerDemo.Demo,
         D.Navigation.PermanentDrawerDemo.Demo,
         D.Navigation.WideNavigationRailDemo.Demo,
+        D.Navigation.NavigationRailOptionsDemo.Demo,
         D.Navigation.ModalWideNavigationRailDemo.Demo,
 
         // ---- Dialogs & sheets ----

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -376,13 +376,10 @@ public class FacadeGeneratorTests
     [InlineData("double", "2.5",                      "2.5")]
     [InlineData("string", "\"hello\"",                "\"hello\"")]
     [InlineData("string?", "null",                    "null")]
-    public void PrimitiveCtorParam_HonoursExplicitDefaultValue(string type, string sourceDefault, string emittedDefault)
+    public void PrimitiveCtorParam_HonoursFacadeDefaultAttribute(string type, string sourceDefault, string emittedDefault)
     {
-        // The bridge `Render` itself never needs the trailing C# default
-        // — but the partial-method declaration must be valid C# (optional
-        // params must be trailing), so the test bridge defaults the
-        // trailing `IComposer composer` to `null!` and the (optional)
-        // user param goes between modifier and composer.
+        // The facade owns the public C# default. The bridge parameter and
+        // trailing Composer both remain required.
         var code = $$"""
             using global::AndroidX.Compose.Runtime;
             using global::AndroidX.Compose.UI;
@@ -400,7 +397,7 @@ public class FacadeGeneratorTests
                                    Signature="(Landroidx/compose/ui/Modifier;ILandroidx/compose/runtime/Composer;II)V",
                                    Defaults=typeof(WidgetDefault))]
                     [ComposeFacade]
-                    public static partial void Widget(IModifier? modifier, {{type}} value = {{sourceDefault}}, IComposer composer = null!);
+                    public static partial void Widget(IModifier? modifier, [FacadeDefault({{sourceDefault}})] {{type}} value, IComposer composer);
                 }
             }
             """;

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -3973,10 +3973,50 @@ public class FacadeGeneratorTests
         // modifier (param 1) contributes a real DiffSlot on the
         // captured key — bit 4.
         Assert.Contains("__changed |= composer.DiffSlot(__modifierKey, global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(1));", emitted);
-        // content (param 2) contributes Static at bit 7.
-        Assert.Contains("__changed |= (int)global::AndroidX.Compose.ChangedBits.Static << global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(2);", emitted);
+        // content is Kotlin param 9 even though omitted defaults leave it
+        // third in the C# bridge declaration.
+        Assert.Contains("__changed |= (int)global::AndroidX.Compose.ChangedBits.Static << global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(9);", emitted);
         // Bridge call uses named composer + _changed args.
         Assert.Contains("composer: composer, _changed: __changed", emitted);
+
+        var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Changed_ReorderedOptionalPrimitive_UsesKotlinDefaultSlotPosition()
+    {
+        var code = """
+            using global::AndroidX.Compose.Runtime;
+            using global::AndroidX.Compose.UI;
+            using AndroidX.Compose;
+            using Kotlin.Jvm.Functions;
+
+            [assembly: ComposeDefaults("WidgetDefault",
+                "!value", "modifier", "enabled", "!content")]
+
+            namespace AndroidX.Compose
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="my/pkg/WidgetKt", JvmName="Widget",
+                                   Signature="(ILandroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V",
+                                   Defaults=typeof(WidgetDefault))]
+                    [ComposeFacade]
+                    public static partial void Widget(
+                        int value, IModifier? modifier, IFunction2 content,
+                        bool enabled = true, IComposer composer = null!, int _changed = 0);
+                }
+            }
+            """;
+
+        var (output, diags, emitted) = Run(code, "Widget");
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("__changed |= composer.DiffSlot(_value, global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(0));", emitted);
+        Assert.Contains("__changed |= composer.DiffSlot(__modifierKey, global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(1));", emitted);
+        Assert.Contains("__changed |= composer.DiffSlot(_enabled, global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(2));", emitted);
+        Assert.Contains("__changed |= (int)global::AndroidX.Compose.ChangedBits.Static << global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(3);", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
@@ -4274,8 +4314,8 @@ public class FacadeGeneratorTests
         Assert.Contains("int __changed = 0;", emitted);
         // modifier (param 0) → __modifierKey at bit 1.
         Assert.Contains("__changed |= composer.DiffSlot(__modifierKey, global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(0));", emitted);
-        // content (param 1, RequiredFunction3 → Static via composableLambda) at bit 4.
-        Assert.Contains("__changed |= (int)global::AndroidX.Compose.ChangedBits.Static << global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(1);", emitted);
+        // content is Kotlin slot 3, even though C# moves it before optional primitives.
+        Assert.Contains("__changed |= (int)global::AndroidX.Compose.ChangedBits.Static << global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(3);", emitted);
         // Bridge call uses named composer + _changed args.
         Assert.Contains("composer: composer, _changed: __changed", emitted);
 

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -4002,7 +4002,7 @@ public class FacadeGeneratorTests
                     [ComposeFacade]
                     public static partial void Widget(
                         int value, IModifier? modifier, IFunction2 content,
-                        bool enabled = true, IComposer composer = null!, int _changed = 0);
+                        [FacadeDefault(true)] bool enabled, IComposer composer, int _changed = 0);
                 }
             }
             """;

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
@@ -343,6 +343,24 @@ internal static class Attributes
             }
 
             /// <summary>
+            /// Apply to a primitive bridge parameter when the generated
+            /// facade constructor should expose a C# default without making
+            /// the bridge parameter itself optional. This keeps the required
+            /// <c>IComposer</c> parameter non-null and trailing.
+            /// </summary>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class FacadeDefaultAttribute : global::System.Attribute
+            {
+                public FacadeDefaultAttribute(bool value) { }
+                public FacadeDefaultAttribute(int value) { }
+                public FacadeDefaultAttribute(long value) { }
+                public FacadeDefaultAttribute(float value) { }
+                public FacadeDefaultAttribute(double value) { }
+                public FacadeDefaultAttribute(string? value) { }
+            }
+
+            /// <summary>
             /// Phase 7 — apply to the <c>Painter</c> bridge parameter
             /// that takes the resolved Painter wrapper. The facade
             /// replaces this parameter with a synthetic ctor argument

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -47,6 +47,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     const string GenericDefaultsAttributeMetadataName = "AndroidX.Compose.ComposeDefaultsAttribute`1";
     const string SlotAttributeMetadataName = "AndroidX.Compose.SlotAttribute";
     const string CallbackAttributeMetadataName = "AndroidX.Compose.CallbackAttribute";
+    const string FacadeDefaultAttributeMetadataName = "AndroidX.Compose.FacadeDefaultAttribute";
     const string PainterResourceAttributeMetadataName = "AndroidX.Compose.PainterResourceAttribute";
     const string StateHolderAttributeMetadataName = "AndroidX.Compose.StateHolderAttribute";
     const string ConfirmStateChangeAttributeMetadataName = "AndroidX.Compose.ConfirmStateChangeAttribute";
@@ -1981,27 +1982,49 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     /// True when the slot surfaces as a defaulted ctor parameter on the
     /// generated facade — either a <see cref="FacadeSlotKind.StateHolder"/>
     /// (always <c>= null</c>) or a <see cref="FacadeSlotKind.Primitive"/>
-    /// whose bridge parameter carries an explicit default value. Used to
+    /// whose bridge parameter carries an explicit C# default or a
+    /// <c>[FacadeDefault]</c> marker. Used to
     /// push defaulted slots after required slots so the ctor compiles
     /// (C# requires optional params to trail required ones).
     /// </summary>
     static bool HasFacadeCtorDefault(FacadeSlot s) =>
         s.Kind == FacadeSlotKind.StateHolder ||
-        (s.Kind == FacadeSlotKind.Primitive && s.Param.HasExplicitDefaultValue);
+        (s.Kind == FacadeSlotKind.Primitive && TryGetFacadeCtorDefault(s.Param, out _));
+
+    static bool TryGetFacadeCtorDefault(IParameterSymbol p, out object? value)
+    {
+        if (p.HasExplicitDefaultValue)
+        {
+            value = p.ExplicitDefaultValue;
+            return true;
+        }
+
+        var attr = p.GetAttributes().FirstOrDefault(a =>
+            a.AttributeClass?.ToDisplayString() == FacadeDefaultAttributeMetadataName);
+        if (attr is not null && attr.ConstructorArguments.Length == 1)
+        {
+            value = attr.ConstructorArguments[0].Value;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
 
     /// <summary>
-    /// Format an <see cref="IParameterSymbol.ExplicitDefaultValue"/> as
-    /// a C# literal for emission in a generated ctor parameter list.
+    /// Format a bridge parameter's explicit C# default or
+    /// <c>[FacadeDefault]</c> value as a C# literal for emission in a
+    /// generated ctor parameter list.
     /// Handles the primitive types accepted by
     /// <see cref="IsPrimitiveCtorType"/> (<c>bool</c>, <c>int</c>,
     /// <c>long</c>, <c>float</c>, <c>double</c>, <c>string</c>) plus
     /// enum members. Falls back to <c>default</c> for shapes that
     /// shouldn't reach here (the caller already guards with
-    /// <see cref="IParameterSymbol.HasExplicitDefaultValue"/>).
+    /// <see cref="TryGetFacadeCtorDefault"/>).
     /// </summary>
     static string FormatPrimitiveDefaultLiteral(IParameterSymbol p)
     {
-        var value = p.ExplicitDefaultValue;
+        if (!TryGetFacadeCtorDefault(p, out var value)) return "default";
         if (value is null) return "null";
         return value switch
         {
@@ -2097,7 +2120,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             sb.Append(CtorParamType(s)).Append(' ').Append(EscapeIdent(CtorIdentifier(s)));
             if (s.Kind == FacadeSlotKind.StateHolder)
                 sb.Append(" = null");
-            else if (s.Kind == FacadeSlotKind.Primitive && s.Param.HasExplicitDefaultValue)
+            else if (s.Kind == FacadeSlotKind.Primitive && HasFacadeCtorDefault(s))
                 sb.Append(" = ").Append(FormatPrimitiveDefaultLiteral(s.Param));
         }
         sb.AppendLine(")");
@@ -2228,7 +2251,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 sb.Append(CtorParamType(s)).Append(' ').Append(EscapeIdent(CtorIdentifier(s)));
                 if (s.Kind == FacadeSlotKind.StateHolder)
                     sb.Append(" = null");
-                else if (s.Kind == FacadeSlotKind.Primitive && s.Param.HasExplicitDefaultValue)
+                else if (s.Kind == FacadeSlotKind.Primitive && HasFacadeCtorDefault(s))
                     sb.Append(" = ").Append(FormatPrimitiveDefaultLiteral(s.Param));
             }
         }

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -1570,7 +1570,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
             if (callerProvidesChanged)
             {
-                EmitChangedMask(sb, indent, slots, composerName);
+                EmitChangedMask(sb, indent, slots, composerName, defaults);
             }
 
             // Bridge call. Preserve original bridge param order. When the
@@ -1648,15 +1648,15 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             hasModifier: hoistModifier, hasPainter: false);
         if (callerProvidesChanged)
         {
-            // Build a slot list matching the alternate bridge's user-param
-            // order (not the facade's slot order) so bit positions line up
-            // with what Kotlin assigned.
+            // Build the slots used by the alternate bridge. Kotlin bit
+            // positions come from its Defaults map, so C# declaration
+            // order may differ to keep optional parameters trailing.
             var altSlots = new List<FacadeSlot>(branch.AlternateUserParams.Count);
             foreach (var p in branch.AlternateUserParams)
             {
                 if (slotByName.TryGetValue(p.Name, out var s)) altSlots.Add(s);
             }
-            EmitChangedMask(sb, inner, altSlots, composerName);
+            EmitChangedMask(sb, inner, altSlots, composerName, branch.AlternateDefaults);
         }
         EmitBridgeCallByParams(sb, inner, branch.AlternateMethodName, branch.AlternateUserParams,
             slotByName, composerName, hoistModifier, callerProvidesChanged);
@@ -1674,7 +1674,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             {
                 if (slotByName.TryGetValue(p.Name, out var s)) primSlots.Add(s);
             }
-            EmitChangedMask(sb, inner, primSlots, composerName);
+            EmitChangedMask(sb, inner, primSlots, composerName, primaryDefaults);
         }
         EmitBridgeCallByParams(sb, inner, primaryMethodName, primaryUserParams,
             slotByName, composerName, hoistModifier, callerProvidesChanged);
@@ -1831,21 +1831,26 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
     /// <summary>
     /// Emit the per-slot Kotlin <c>$changed</c> mask. One <c>__changed</c>
-    /// local that ORs together a contribution per slot in the bridge's
-    /// user-param order. Bit position is <c>1 + paramIndex * 3</c> per
-    /// the compose-compiler convention; <see cref="FacadeSlotKind.ScopeReceiver"/>
-    /// slots are skipped because the bridge generator strips the receiver
-    /// before assigning bits.
+    /// local that ORs together a contribution per surfaced slot. Kotlin
+    /// parameter positions come from <paramref name="defaults"/> when
+    /// available because C# optional parameters may be moved after required
+    /// content slots. Bit position is <c>1 + paramIndex * 3</c> per the
+    /// compose-compiler convention; <see cref="FacadeSlotKind.ScopeReceiver"/>
+    /// slots are skipped because receivers are outside the Kotlin parameter
+    /// list.
     /// </summary>
     static void EmitChangedMask(StringBuilder sb, string indent,
-        IReadOnlyList<FacadeSlot> slots, string composerName,
+        IReadOnlyList<FacadeSlot> slots, string composerName, DefaultsInfo? defaults,
         string changedVar = "__changed")
     {
         sb.Append(indent).Append("int ").Append(changedVar).AppendLine(" = 0;");
-        int bitParamIndex = 0;
+        int fallbackParamIndex = 0;
         foreach (var s in slots)
         {
             if (s.Kind == FacadeSlotKind.ScopeReceiver) continue;
+            int bitParamIndex = defaults?.FindByKotlinName(s.Param.Name)?.Bit
+                ?? fallbackParamIndex;
+            fallbackParamIndex++;
             int shift = 1 + bitParamIndex * 3;
             // Cap at 30 bits (10 user params per Kotlin $changed int).
             // Anything beyond that lands in the next $changed slot which
@@ -1853,7 +1858,6 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             // Uncertain rather than corrupting the first int.
             if (shift > 30 - 2)
             {
-                bitParamIndex++;
                 continue;
             }
             string bitOffset = "global::AndroidX.Compose.ComposeExtensions.DiffSlotShift(" +
@@ -1871,7 +1875,6 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                     // whole point.
                     sb.Append(indent).Append(changedVar).Append(" |= ").Append(composerName)
                       .Append(".DiffSlot(__modifierKey, ").Append(bitOffset).AppendLine(");");
-                    bitParamIndex++;
                     continue;
                 case FacadeSlotKind.OnClick:
                 case FacadeSlotKind.Callback:
@@ -1925,7 +1928,6 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                     // Unknown — leave as Uncertain (0) for this slot.
                     break;
             }
-            bitParamIndex++;
         }
     }
 

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -405,7 +405,8 @@ internal static partial class ComposeBridges
     public static partial void Button(IFunction0 onClick, IModifier? modifier,
                                       Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                       PaddingValues? contentPadding,
-                                      IFunction3 content, IComposer composer, int _changed = 0);
+                                      IFunction3 content, bool enabled = true,
+                                      IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.OutlinedButton — same Kotlin
     // signature as Button (10 user params with shape/colors/elevation/
@@ -424,7 +425,8 @@ internal static partial class ComposeBridges
     public static partial void OutlinedButton(IFunction0 onClick, IModifier? modifier,
                                               Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                               PaddingValues? contentPadding,
-                                              IFunction3 content, IComposer composer, int _changed = 0);
+                                              IFunction3 content, bool enabled = true,
+                                              IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.TextButton — same shape as Button.
     [ComposeBridge(
@@ -441,7 +443,8 @@ internal static partial class ComposeBridges
     public static partial void TextButton(IFunction0 onClick, IModifier? modifier,
                                           Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                           PaddingValues? contentPadding,
-                                          IFunction3 content, IComposer composer, int _changed = 0);
+                                          IFunction3 content, bool enabled = true,
+                                          IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.ElevatedButton — same shape as Button.
     [ComposeBridge(
@@ -458,7 +461,8 @@ internal static partial class ComposeBridges
     public static partial void ElevatedButton(IFunction0 onClick, IModifier? modifier,
                                               Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                               PaddingValues? contentPadding,
-                                              IFunction3 content, IComposer composer, int _changed = 0);
+                                              IFunction3 content, bool enabled = true,
+                                              IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.FilledTonalButton — same shape as Button.
     [ComposeBridge(
@@ -475,7 +479,8 @@ internal static partial class ComposeBridges
     public static partial void FilledTonalButton(IFunction0 onClick, IModifier? modifier,
                                                  Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                                  PaddingValues? contentPadding,
-                                                 IFunction3 content, IComposer composer, int _changed = 0);
+                                                 IFunction3 content, bool enabled = true,
+                                                 IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.IconButton
     [ComposeBridge(
@@ -488,7 +493,8 @@ internal static partial class ComposeBridges
         Defaults  = typeof(IconButtonDefault))]
     [ComposeFacade]
     public static partial void IconButton(IFunction0 onClick, IModifier? modifier,
-                                          IFunction2 content, IComposer composer, int _changed = 0);
+                                          IFunction2 content, bool enabled = true,
+                                          IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledIconButton — adds Shape
     // before colors compared to plain IconButton (7 user params).
@@ -504,7 +510,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledIconButton(IFunction0 onClick, IModifier? modifier,
                                                 Shape? shape,
-                                                IFunction2 content, IComposer composer, int _changed = 0);
+                                                IFunction2 content, bool enabled = true,
+                                                IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledTonalIconButton — same
     // signature as FilledIconButton.
@@ -520,7 +527,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledTonalIconButton(IFunction0 onClick, IModifier? modifier,
                                                      Shape? shape,
-                                                     IFunction2 content, IComposer composer, int _changed = 0);
+                                                     IFunction2 content, bool enabled = true,
+                                                     IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.OutlinedIconButton — adds
     // BorderStroke between colors and interactionSource (8 user params).
@@ -537,7 +545,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void OutlinedIconButton(IFunction0 onClick, IModifier? modifier,
                                                   Shape? shape,
-                                                  IFunction2 content, IComposer composer, int _changed = 0);
+                                                  IFunction2 content, bool enabled = true,
+                                                  IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.IconToggleButton — toggle
     // shape: leading boolean checked + Function1 onCheckedChange instead of
@@ -553,7 +562,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void IconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                 IModifier? modifier, IFunction2 content,
-                                                IComposer composer, int _changed = 0);
+                                                bool enabled = true,
+                                                IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledIconToggleButton — adds
     // Shape between enabled and colors compared to plain IconToggleButton
@@ -570,7 +580,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                       IModifier? modifier, Shape? shape, IFunction2 content,
-                                                      IComposer composer, int _changed = 0);
+                                                      bool enabled = true,
+                                                      IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledTonalIconToggleButton —
     // same signature as FilledIconToggleButton.
@@ -586,7 +597,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledTonalIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                            IModifier? modifier, Shape? shape, IFunction2 content,
-                                                           IComposer composer, int _changed = 0);
+                                                           bool enabled = true,
+                                                           IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.OutlinedIconToggleButton —
     // adds BorderStroke between colors and interactionSource (9 user params).
@@ -603,7 +615,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void OutlinedIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                         IModifier? modifier, Shape? shape, IFunction2 content,
-                                                        IComposer composer, int _changed = 0);
+                                                        bool enabled = true,
+                                                        IComposer composer = null!, int _changed = 0);
 
     // androidx.compose.material3.FloatingActionButtonKt.FloatingActionButton-X-z6DiA
     [ComposeBridge(
@@ -1212,8 +1225,9 @@ internal static partial class ComposeBridges
                      StateType = typeof(DatePickerState))]
         IntPtr      state,
         IModifier?  modifier,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        showModeToggle = true,
+        int         defaults       = 0,
+        IComposer   composer       = null!, int _changed = 0);
 
     // androidx.compose.material3.DatePickerKt.rememberDatePickerState-EU0dCGE
     //
@@ -1268,8 +1282,9 @@ internal static partial class ComposeBridges
                      StateType = typeof(DateRangePickerState))]
         IntPtr      state,
         IModifier?  modifier,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        showModeToggle = true,
+        int         defaults       = 0,
+        IComposer   composer       = null!, int _changed = 0);
 
     // androidx.compose.material3.DateRangePickerKt.rememberDateRangePickerState-IlFM19s
     [ComposeBridge(
@@ -1465,8 +1480,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     [ComposeBridge(
         Class     = "androidx/compose/material3/ChipKt",
@@ -1480,8 +1496,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     const string FilterChipSig =
         "(ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
@@ -1508,8 +1525,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     [ComposeBridge(
         Class     = "androidx/compose/material3/ChipKt",
@@ -1524,8 +1542,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     // androidx.compose.material3.ChipKt.InputChip
     [ComposeBridge(
@@ -1551,8 +1570,9 @@ internal static partial class ComposeBridges
         IFunction2? avatar,
         IFunction2? trailingIcon,
         Shape?      shape,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     const string SuggestionChipSig =
         "(Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
@@ -1575,8 +1595,9 @@ internal static partial class ComposeBridges
         IModifier?  modifier,
         IFunction2? icon,
         Shape?      shape,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     [ComposeBridge(
         Class     = "androidx/compose/material3/ChipKt",
@@ -1589,8 +1610,9 @@ internal static partial class ComposeBridges
         IFunction2  label,
         IFunction2? icon,
         Shape?      shape,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     // androidx.compose.material3.NavigationBarKt.NavigationBar-HsRjFd4
     [ComposeBridge(
@@ -1658,8 +1680,10 @@ internal static partial class ComposeBridges
         IFunction2  icon,
         IModifier?  modifier,
         IFunction2? label,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled         = true,
+        bool        alwaysShowLabel = true,
+        int         defaults        = 0,
+        IComposer   composer        = null!, int _changed = 0);
 
     // androidx.compose.material3.NavigationDrawerKt.NavigationDrawerItem
     // (no JVM mangling — no @JvmInline value-class params). label is the
@@ -3012,8 +3036,9 @@ internal static partial class ComposeBridges
         IModifier?  modifier,
         IFunction2? text,
         IFunction2? icon,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        enabled  = true,
+        int         defaults = 0,
+        IComposer   composer = null!, int _changed = 0);
 
     // androidx.compose.material3.TabKt.LeadingIconTab-wqdebIU.
     // 9 user params: selected, onClick, text, icon, modifier, enabled,
@@ -3035,7 +3060,8 @@ internal static partial class ComposeBridges
         IFunction2 text,
         IFunction2 icon,
         IModifier? modifier,
-        IComposer  composer, int _changed = 0);
+        bool       enabled  = true,
+        IComposer  composer = null!, int _changed = 0);
 
     // androidx.compose.material3.SnackbarKt.Snackbar-eQBnUkQ. 10 user
     // params: modifier, action, dismissAction, actionOnNewLine, shape,
@@ -3054,8 +3080,9 @@ internal static partial class ComposeBridges
         IFunction2? action,
         IFunction2? dismissAction,
         [Slot("Body")] IFunction2 content,
-        int         defaults,
-        IComposer   composer, int _changed = 0);
+        bool        actionOnNewLine = false,
+        int         defaults        = 0,
+        IComposer   composer        = null!, int _changed = 0);
 
     // androidx.compose.material3.SnackbarHostKt.SnackbarHost — UNMANGLED
     // (no inline-class params). 3 user params: hostState, modifier,
@@ -3633,7 +3660,8 @@ internal static partial class ComposeBridges
         IFunction0 onClick,
         IModifier? modifier,
         IFunction3 content,
-        IComposer  composer, int _changed = 0);
+        bool       enabled  = true,
+        IComposer  composer = null!, int _changed = 0);
 
     // androidx.compose.material3.SnackbarKt.Snackbar-sDKtq54 (SnackbarData
     // overload — fed by SnackbarHost's content lambda when state has
@@ -3664,13 +3692,16 @@ internal static partial class ComposeBridges
     // hand-picked.
 
     [ComposeFacade(Defaults = typeof(BoxDefault), Scope = "Box")]
-    public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer, int _changed = 0);
+    public static partial void Box(IModifier? modifier, IFunction3 content,
+        bool propagateMinConstraints = false, int defaults = 0,
+        IComposer composer = null!, int _changed = 0);
 
-    public static partial void Box(IModifier? modifier, IFunction3 content, int defaults, IComposer composer, int _changed)
+    public static partial void Box(IModifier? modifier, IFunction3 content,
+        bool propagateMinConstraints, int defaults, IComposer composer, int _changed)
         => BoxKt.Box(
             modifier:                modifier,
             contentAlignment:        null,
-            propagateMinConstraints: false,
+            propagateMinConstraints: propagateMinConstraints,
             content:                 content,
             _composer:               composer,
             p5:                      _changed,
@@ -3844,42 +3875,45 @@ internal static partial class ComposeBridges
 
     // FlowRow / FlowColumn — Phase 8 wrapper-passthrough facades. The
     // simpler 7-Kotlin-param overloads (no FlowRowOverflow / FlowColumnOverflow
-    // slot) are bound directly. The Int params `maxItemsInEachRow` /
-    // `maxLines` (resp. `maxItemsInEachColumn` / `maxLines`) can't be
-    // safely auto-masked from a nullable C# slot, so v1 leaves their
-    // $default bits set and passes 0 — Kotlin substitutes Int.MAX_VALUE.
+    // slot) are bound directly.
     // The binder rename pattern: the C# `p4` param is the actual Kotlin
     // `maxItemsInEachRow`/`maxItemsInEachColumn` Int, and the C# named
     // `maxItemsInEachRow`/`maxItemsInEachColumn` is the Kotlin `maxLines`
     // Int. The `maxLines` slot in C# is the JVM `$changed` int; `_changed`
     // is `$default`.
     [ComposeFacade(Defaults = typeof(FlowRowDefault), Scope = "Row")]
-    public static partial void FlowRow(IModifier? modifier, IFunction3 content, int defaults, IComposer composer, int _changed = 0);
+    public static partial void FlowRow(IModifier? modifier, IFunction3 content,
+        int maxItemsInEachRow = int.MaxValue, int maxLines = int.MaxValue,
+        int defaults = 0, IComposer composer = null!, int _changed = 0);
 
-    public static partial void FlowRow(IModifier? modifier, IFunction3 content, int defaults, IComposer composer, int _changed)
+    public static partial void FlowRow(IModifier? modifier, IFunction3 content,
+        int maxItemsInEachRow, int maxLines, int defaults, IComposer composer, int _changed)
         => FlowLayoutKt.FlowRow(
             modifier:              modifier,
             horizontalArrangement: null,
             verticalArrangement:   null,
             itemVerticalAlignment: null,
-            p4:                    0,
-            maxItemsInEachRow:     0,
+            p4:                    maxItemsInEachRow,
+            maxItemsInEachRow:     maxLines,
             content:               content,
             _composer:             composer,
             maxLines:              _changed,
             _changed:              defaults);
 
     [ComposeFacade(Defaults = typeof(FlowColumnDefault), Scope = "Column")]
-    public static partial void FlowColumn(IModifier? modifier, IFunction3 content, int defaults, IComposer composer, int _changed = 0);
+    public static partial void FlowColumn(IModifier? modifier, IFunction3 content,
+        int maxItemsInEachColumn = int.MaxValue, int maxLines = int.MaxValue,
+        int defaults = 0, IComposer composer = null!, int _changed = 0);
 
-    public static partial void FlowColumn(IModifier? modifier, IFunction3 content, int defaults, IComposer composer, int _changed)
+    public static partial void FlowColumn(IModifier? modifier, IFunction3 content,
+        int maxItemsInEachColumn, int maxLines, int defaults, IComposer composer, int _changed)
         => FlowLayoutKt.FlowColumn(
             modifier:                modifier,
             verticalArrangement:     null,
             horizontalArrangement:   null,
             itemHorizontalAlignment: null,
-            p4:                      0,
-            maxItemsInEachColumn:    0,
+            p4:                      maxItemsInEachColumn,
+            maxItemsInEachColumn:    maxLines,
             content:                 content,
             _composer:               composer,
             maxLines:                _changed,
@@ -4519,4 +4553,3 @@ internal static partial class ComposeBridges
         }
     }
 }
-

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -405,8 +405,8 @@ internal static partial class ComposeBridges
     public static partial void Button(IFunction0 onClick, IModifier? modifier,
                                       Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                       PaddingValues? contentPadding,
-                                      IFunction3 content, bool enabled = true,
-                                      IComposer composer = null!, int _changed = 0);
+                                      IFunction3 content, [FacadeDefault(true)] bool enabled,
+                                      IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.OutlinedButton — same Kotlin
     // signature as Button (10 user params with shape/colors/elevation/
@@ -425,8 +425,8 @@ internal static partial class ComposeBridges
     public static partial void OutlinedButton(IFunction0 onClick, IModifier? modifier,
                                               Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                               PaddingValues? contentPadding,
-                                              IFunction3 content, bool enabled = true,
-                                              IComposer composer = null!, int _changed = 0);
+                                              IFunction3 content, [FacadeDefault(true)] bool enabled,
+                                              IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.TextButton — same shape as Button.
     [ComposeBridge(
@@ -443,8 +443,8 @@ internal static partial class ComposeBridges
     public static partial void TextButton(IFunction0 onClick, IModifier? modifier,
                                           Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                           PaddingValues? contentPadding,
-                                          IFunction3 content, bool enabled = true,
-                                          IComposer composer = null!, int _changed = 0);
+                                          IFunction3 content, [FacadeDefault(true)] bool enabled,
+                                          IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.ElevatedButton — same shape as Button.
     [ComposeBridge(
@@ -461,8 +461,8 @@ internal static partial class ComposeBridges
     public static partial void ElevatedButton(IFunction0 onClick, IModifier? modifier,
                                               Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                               PaddingValues? contentPadding,
-                                              IFunction3 content, bool enabled = true,
-                                              IComposer composer = null!, int _changed = 0);
+                                              IFunction3 content, [FacadeDefault(true)] bool enabled,
+                                              IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.ButtonKt.FilledTonalButton — same shape as Button.
     [ComposeBridge(
@@ -479,8 +479,8 @@ internal static partial class ComposeBridges
     public static partial void FilledTonalButton(IFunction0 onClick, IModifier? modifier,
                                                  Shape? shape, AndroidX.Compose.Material3.ButtonColors? colors,
                                                  PaddingValues? contentPadding,
-                                                 IFunction3 content, bool enabled = true,
-                                                 IComposer composer = null!, int _changed = 0);
+                                                 IFunction3 content, [FacadeDefault(true)] bool enabled,
+                                                 IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.IconButton
     [ComposeBridge(
@@ -493,8 +493,8 @@ internal static partial class ComposeBridges
         Defaults  = typeof(IconButtonDefault))]
     [ComposeFacade]
     public static partial void IconButton(IFunction0 onClick, IModifier? modifier,
-                                          IFunction2 content, bool enabled = true,
-                                          IComposer composer = null!, int _changed = 0);
+                                          IFunction2 content, [FacadeDefault(true)] bool enabled,
+                                          IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledIconButton — adds Shape
     // before colors compared to plain IconButton (7 user params).
@@ -510,8 +510,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledIconButton(IFunction0 onClick, IModifier? modifier,
                                                 Shape? shape,
-                                                IFunction2 content, bool enabled = true,
-                                                IComposer composer = null!, int _changed = 0);
+                                                IFunction2 content, [FacadeDefault(true)] bool enabled,
+                                                IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledTonalIconButton — same
     // signature as FilledIconButton.
@@ -527,8 +527,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledTonalIconButton(IFunction0 onClick, IModifier? modifier,
                                                      Shape? shape,
-                                                     IFunction2 content, bool enabled = true,
-                                                     IComposer composer = null!, int _changed = 0);
+                                                     IFunction2 content, [FacadeDefault(true)] bool enabled,
+                                                     IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.OutlinedIconButton — adds
     // BorderStroke between colors and interactionSource (8 user params).
@@ -545,8 +545,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void OutlinedIconButton(IFunction0 onClick, IModifier? modifier,
                                                   Shape? shape,
-                                                  IFunction2 content, bool enabled = true,
-                                                  IComposer composer = null!, int _changed = 0);
+                                                  IFunction2 content, [FacadeDefault(true)] bool enabled,
+                                                  IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.IconToggleButton — toggle
     // shape: leading boolean checked + Function1 onCheckedChange instead of
@@ -562,8 +562,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void IconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                 IModifier? modifier, IFunction2 content,
-                                                bool enabled = true,
-                                                IComposer composer = null!, int _changed = 0);
+                                                [FacadeDefault(true)] bool enabled,
+                                                IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledIconToggleButton — adds
     // Shape between enabled and colors compared to plain IconToggleButton
@@ -580,8 +580,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                       IModifier? modifier, Shape? shape, IFunction2 content,
-                                                      bool enabled = true,
-                                                      IComposer composer = null!, int _changed = 0);
+                                                      [FacadeDefault(true)] bool enabled,
+                                                      IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.FilledTonalIconToggleButton —
     // same signature as FilledIconToggleButton.
@@ -597,8 +597,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void FilledTonalIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                            IModifier? modifier, Shape? shape, IFunction2 content,
-                                                           bool enabled = true,
-                                                           IComposer composer = null!, int _changed = 0);
+                                                           [FacadeDefault(true)] bool enabled,
+                                                           IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.IconButtonKt.OutlinedIconToggleButton —
     // adds BorderStroke between colors and interactionSource (9 user params).
@@ -615,8 +615,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void OutlinedIconToggleButton(bool @checked, [Callback(typeof(bool))] IFunction1 onCheckedChange,
                                                         IModifier? modifier, Shape? shape, IFunction2 content,
-                                                        bool enabled = true,
-                                                        IComposer composer = null!, int _changed = 0);
+                                                        [FacadeDefault(true)] bool enabled,
+                                                        IComposer composer, int _changed = 0);
 
     // androidx.compose.material3.FloatingActionButtonKt.FloatingActionButton-X-z6DiA
     [ComposeBridge(
@@ -1225,9 +1225,9 @@ internal static partial class ComposeBridges
                      StateType = typeof(DatePickerState))]
         IntPtr      state,
         IModifier?  modifier,
-        bool        showModeToggle = true,
-        int         defaults       = 0,
-        IComposer   composer       = null!, int _changed = 0);
+        [FacadeDefault(true)] bool showModeToggle,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.DatePickerKt.rememberDatePickerState-EU0dCGE
     //
@@ -1282,9 +1282,9 @@ internal static partial class ComposeBridges
                      StateType = typeof(DateRangePickerState))]
         IntPtr      state,
         IModifier?  modifier,
-        bool        showModeToggle = true,
-        int         defaults       = 0,
-        IComposer   composer       = null!, int _changed = 0);
+        [FacadeDefault(true)] bool showModeToggle,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.DateRangePickerKt.rememberDateRangePickerState-IlFM19s
     [ComposeBridge(
@@ -1480,9 +1480,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     [ComposeBridge(
         Class     = "androidx/compose/material3/ChipKt",
@@ -1496,9 +1496,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     const string FilterChipSig =
         "(ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
@@ -1525,9 +1525,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     [ComposeBridge(
         Class     = "androidx/compose/material3/ChipKt",
@@ -1542,9 +1542,9 @@ internal static partial class ComposeBridges
         IFunction2? leadingIcon,
         IFunction2? trailingIcon,
         Shape?      shape,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.ChipKt.InputChip
     [ComposeBridge(
@@ -1570,9 +1570,9 @@ internal static partial class ComposeBridges
         IFunction2? avatar,
         IFunction2? trailingIcon,
         Shape?      shape,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     const string SuggestionChipSig =
         "(Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;" +
@@ -1595,9 +1595,9 @@ internal static partial class ComposeBridges
         IModifier?  modifier,
         IFunction2? icon,
         Shape?      shape,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     [ComposeBridge(
         Class     = "androidx/compose/material3/ChipKt",
@@ -1610,9 +1610,9 @@ internal static partial class ComposeBridges
         IFunction2  label,
         IFunction2? icon,
         Shape?      shape,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.NavigationBarKt.NavigationBar-HsRjFd4
     [ComposeBridge(
@@ -1680,10 +1680,10 @@ internal static partial class ComposeBridges
         IFunction2  icon,
         IModifier?  modifier,
         IFunction2? label,
-        bool        enabled         = true,
-        bool        alwaysShowLabel = true,
-        int         defaults        = 0,
-        IComposer   composer        = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        [FacadeDefault(true)] bool alwaysShowLabel,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.NavigationDrawerKt.NavigationDrawerItem
     // (no JVM mangling — no @JvmInline value-class params). label is the
@@ -3036,9 +3036,9 @@ internal static partial class ComposeBridges
         IModifier?  modifier,
         IFunction2? text,
         IFunction2? icon,
-        bool        enabled  = true,
-        int         defaults = 0,
-        IComposer   composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.TabKt.LeadingIconTab-wqdebIU.
     // 9 user params: selected, onClick, text, icon, modifier, enabled,
@@ -3060,8 +3060,8 @@ internal static partial class ComposeBridges
         IFunction2 text,
         IFunction2 icon,
         IModifier? modifier,
-        bool       enabled  = true,
-        IComposer  composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        IComposer  composer, int _changed = 0);
 
     // androidx.compose.material3.SnackbarKt.Snackbar-eQBnUkQ. 10 user
     // params: modifier, action, dismissAction, actionOnNewLine, shape,
@@ -3080,9 +3080,9 @@ internal static partial class ComposeBridges
         IFunction2? action,
         IFunction2? dismissAction,
         [Slot("Body")] IFunction2 content,
-        bool        actionOnNewLine = false,
-        int         defaults        = 0,
-        IComposer   composer        = null!, int _changed = 0);
+        [FacadeDefault(false)] bool actionOnNewLine,
+        int         defaults,
+        IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.SnackbarHostKt.SnackbarHost — UNMANGLED
     // (no inline-class params). 3 user params: hostState, modifier,
@@ -3660,8 +3660,8 @@ internal static partial class ComposeBridges
         IFunction0 onClick,
         IModifier? modifier,
         IFunction3 content,
-        bool       enabled  = true,
-        IComposer  composer = null!, int _changed = 0);
+        [FacadeDefault(true)] bool enabled,
+        IComposer  composer, int _changed = 0);
 
     // androidx.compose.material3.SnackbarKt.Snackbar-sDKtq54 (SnackbarData
     // overload — fed by SnackbarHost's content lambda when state has
@@ -3693,8 +3693,8 @@ internal static partial class ComposeBridges
 
     [ComposeFacade(Defaults = typeof(BoxDefault), Scope = "Box")]
     public static partial void Box(IModifier? modifier, IFunction3 content,
-        bool propagateMinConstraints = false, int defaults = 0,
-        IComposer composer = null!, int _changed = 0);
+        [FacadeDefault(false)] bool propagateMinConstraints, int defaults,
+        IComposer composer, int _changed = 0);
 
     public static partial void Box(IModifier? modifier, IFunction3 content,
         bool propagateMinConstraints, int defaults, IComposer composer, int _changed)
@@ -3883,8 +3883,9 @@ internal static partial class ComposeBridges
     // is `$default`.
     [ComposeFacade(Defaults = typeof(FlowRowDefault), Scope = "Row")]
     public static partial void FlowRow(IModifier? modifier, IFunction3 content,
-        int maxItemsInEachRow = int.MaxValue, int maxLines = int.MaxValue,
-        int defaults = 0, IComposer composer = null!, int _changed = 0);
+        [FacadeDefault(int.MaxValue)] int maxItemsInEachRow,
+        [FacadeDefault(int.MaxValue)] int maxLines,
+        int defaults, IComposer composer, int _changed = 0);
 
     public static partial void FlowRow(IModifier? modifier, IFunction3 content,
         int maxItemsInEachRow, int maxLines, int defaults, IComposer composer, int _changed)
@@ -3902,8 +3903,9 @@ internal static partial class ComposeBridges
 
     [ComposeFacade(Defaults = typeof(FlowColumnDefault), Scope = "Column")]
     public static partial void FlowColumn(IModifier? modifier, IFunction3 content,
-        int maxItemsInEachColumn = int.MaxValue, int maxLines = int.MaxValue,
-        int defaults = 0, IComposer composer = null!, int _changed = 0);
+        [FacadeDefault(int.MaxValue)] int maxItemsInEachColumn,
+        [FacadeDefault(int.MaxValue)] int maxLines,
+        int defaults, IComposer composer, int _changed = 0);
 
     public static partial void FlowColumn(IModifier? modifier, IFunction3 content,
         int maxItemsInEachColumn, int maxLines, int defaults, IComposer composer, int _changed)

--- a/src/Microsoft.AndroidX.Compose/ComposeDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeDefaults.cs
@@ -60,10 +60,8 @@ using AndroidX.Compose;
 
 // androidx.compose.foundation.layout.FlowLayoutKt — the simpler
 // FlowRow / FlowColumn overloads (no FlowRowOverflow / FlowColumnOverflow
-// slot) lower to 7 user params + content. The trailing `maxItemsInEachRow`
-// / `maxLines` (resp. `maxItemsInEachColumn` / `maxLines`) Ints can't be
-// auto-masked from a nullable C# slot, so the v1 facade leaves both bits
-// set and lets Kotlin substitute Int.MAX_VALUE.
+// slot) lower to 7 user params + content. The facade surfaces the trailing
+// max-item and max-line Int slots with Kotlin's Int.MAX_VALUE defaults.
 [assembly: ComposeDefaults("FlowRowDefault",
     "modifier", "horizontalArrangement", "verticalArrangement",
     "itemVerticalAlignment", "maxItemsInEachRow", "maxLines", "!content")]

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -75,7 +75,7 @@ AndroidX.Compose.AnnotatedText.SoftWrap.get -> bool?
 AndroidX.Compose.AnnotatedText.SoftWrap.set -> void
 AndroidX.Compose.Arrangement
 AndroidX.Compose.AssistChip
-AndroidX.Compose.AssistChip.AssistChip(System.Action! onClick) -> void
+AndroidX.Compose.AssistChip.AssistChip(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.AssistChip.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.AssistChip.Label.set -> void
 AndroidX.Compose.AssistChip.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
@@ -110,7 +110,7 @@ AndroidX.Compose.BottomSheetScaffold.SheetDragHandle.set -> void
 AndroidX.Compose.BottomSheetScaffold.TopBar.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.BottomSheetScaffold.TopBar.set -> void
 AndroidX.Compose.Box
-AndroidX.Compose.Box.Box() -> void
+AndroidX.Compose.Box.Box(bool propagateMinConstraints = false) -> void
 AndroidX.Compose.BoxConstraints
 AndroidX.Compose.BoxConstraints.BoxConstraints() -> void
 AndroidX.Compose.BoxConstraints.MaxHeight.get -> float
@@ -121,7 +121,7 @@ AndroidX.Compose.BoxWithConstraints
 AndroidX.Compose.BoxWithConstraints.BoxWithConstraints(System.Func<AndroidX.Compose.BoxConstraints, AndroidX.Compose.ComposableNode!>! content) -> void
 AndroidX.Compose.Brush
 AndroidX.Compose.Button
-AndroidX.Compose.Button.Button(System.Action! onClick) -> void
+AndroidX.Compose.Button.Button(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.Button.Colors.get -> AndroidX.Compose.Material3.ButtonColors?
 AndroidX.Compose.Button.Colors.set -> void
 AndroidX.Compose.Button.ContentPadding.get -> AndroidX.Compose.PaddingValues?
@@ -221,9 +221,9 @@ AndroidX.Compose.Crossfade<T>
 AndroidX.Compose.Crossfade<T>.Crossfade(T targetState, System.Func<T, AndroidX.Compose.ComposableNode!>! content) -> void
 AndroidX.Compose.Crossfade<T>.TargetState.get -> T
 AndroidX.Compose.CustomTab
-AndroidX.Compose.CustomTab.CustomTab(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.CustomTab.CustomTab(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.DatePicker
-AndroidX.Compose.DatePicker.DatePicker(AndroidX.Compose.DatePickerState? state = null) -> void
+AndroidX.Compose.DatePicker.DatePicker(AndroidX.Compose.DatePickerState? state = null, bool showModeToggle = true) -> void
 AndroidX.Compose.DatePickerDialog
 AndroidX.Compose.DatePickerDialog.Body.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.DatePickerDialog.Body.set -> void
@@ -250,7 +250,7 @@ AndroidX.Compose.DatePickerState.InitialYearRange.set -> void
 AndroidX.Compose.DatePickerState.SelectedDateMillis.get -> long?
 AndroidX.Compose.DatePickerState.SelectedDateMillis.set -> void
 AndroidX.Compose.DateRangePicker
-AndroidX.Compose.DateRangePicker.DateRangePicker(AndroidX.Compose.DateRangePickerState? state = null) -> void
+AndroidX.Compose.DateRangePicker.DateRangePicker(AndroidX.Compose.DateRangePickerState? state = null, bool showModeToggle = true) -> void
 AndroidX.Compose.DateRangePickerDialog
 AndroidX.Compose.DateRangePickerDialog.Body.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.DateRangePickerDialog.Body.set -> void
@@ -367,7 +367,7 @@ AndroidX.Compose.DropdownMenuItem.LeadingIcon.set -> void
 AndroidX.Compose.DropdownMenuItem.TrailingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.DropdownMenuItem.TrailingIcon.set -> void
 AndroidX.Compose.ElevatedAssistChip
-AndroidX.Compose.ElevatedAssistChip.ElevatedAssistChip(System.Action! onClick) -> void
+AndroidX.Compose.ElevatedAssistChip.ElevatedAssistChip(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.ElevatedAssistChip.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.ElevatedAssistChip.Label.set -> void
 AndroidX.Compose.ElevatedAssistChip.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
@@ -381,7 +381,7 @@ AndroidX.Compose.ElevatedButton.Colors.get -> AndroidX.Compose.Material3.ButtonC
 AndroidX.Compose.ElevatedButton.Colors.set -> void
 AndroidX.Compose.ElevatedButton.ContentPadding.get -> AndroidX.Compose.PaddingValues?
 AndroidX.Compose.ElevatedButton.ContentPadding.set -> void
-AndroidX.Compose.ElevatedButton.ElevatedButton(System.Action! onClick) -> void
+AndroidX.Compose.ElevatedButton.ElevatedButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.ElevatedButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.ElevatedButton.Shape.set -> void
 AndroidX.Compose.ElevatedCard
@@ -389,7 +389,7 @@ AndroidX.Compose.ElevatedCard.ElevatedCard() -> void
 AndroidX.Compose.ElevatedCard.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.ElevatedCard.Shape.set -> void
 AndroidX.Compose.ElevatedFilterChip
-AndroidX.Compose.ElevatedFilterChip.ElevatedFilterChip(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.ElevatedFilterChip.ElevatedFilterChip(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.ElevatedFilterChip.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.ElevatedFilterChip.Label.set -> void
 AndroidX.Compose.ElevatedFilterChip.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
@@ -399,7 +399,7 @@ AndroidX.Compose.ElevatedFilterChip.Shape.set -> void
 AndroidX.Compose.ElevatedFilterChip.TrailingIcon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.ElevatedFilterChip.TrailingIcon.set -> void
 AndroidX.Compose.ElevatedSuggestionChip
-AndroidX.Compose.ElevatedSuggestionChip.ElevatedSuggestionChip(System.Action! onClick) -> void
+AndroidX.Compose.ElevatedSuggestionChip.ElevatedSuggestionChip(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.ElevatedSuggestionChip.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.ElevatedSuggestionChip.Icon.set -> void
 AndroidX.Compose.ElevatedSuggestionChip.Label.get -> AndroidX.Compose.ComposableNode?
@@ -427,11 +427,11 @@ AndroidX.Compose.ExtendedFloatingActionButton.Shape.set -> void
 AndroidX.Compose.ExtendedFloatingActionButton.Text.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.ExtendedFloatingActionButton.Text.set -> void
 AndroidX.Compose.FilledIconButton
-AndroidX.Compose.FilledIconButton.FilledIconButton(System.Action! onClick) -> void
+AndroidX.Compose.FilledIconButton.FilledIconButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.FilledIconButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.FilledIconButton.Shape.set -> void
 AndroidX.Compose.FilledIconToggleButton
-AndroidX.Compose.FilledIconToggleButton.FilledIconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
+AndroidX.Compose.FilledIconToggleButton.FilledIconToggleButton(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
 AndroidX.Compose.FilledIconToggleButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.FilledIconToggleButton.Shape.set -> void
 AndroidX.Compose.FilledTonalButton
@@ -439,19 +439,19 @@ AndroidX.Compose.FilledTonalButton.Colors.get -> AndroidX.Compose.Material3.Butt
 AndroidX.Compose.FilledTonalButton.Colors.set -> void
 AndroidX.Compose.FilledTonalButton.ContentPadding.get -> AndroidX.Compose.PaddingValues?
 AndroidX.Compose.FilledTonalButton.ContentPadding.set -> void
-AndroidX.Compose.FilledTonalButton.FilledTonalButton(System.Action! onClick) -> void
+AndroidX.Compose.FilledTonalButton.FilledTonalButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.FilledTonalButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.FilledTonalButton.Shape.set -> void
 AndroidX.Compose.FilledTonalIconButton
-AndroidX.Compose.FilledTonalIconButton.FilledTonalIconButton(System.Action! onClick) -> void
+AndroidX.Compose.FilledTonalIconButton.FilledTonalIconButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.FilledTonalIconButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.FilledTonalIconButton.Shape.set -> void
 AndroidX.Compose.FilledTonalIconToggleButton
-AndroidX.Compose.FilledTonalIconToggleButton.FilledTonalIconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
+AndroidX.Compose.FilledTonalIconToggleButton.FilledTonalIconToggleButton(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
 AndroidX.Compose.FilledTonalIconToggleButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.FilledTonalIconToggleButton.Shape.set -> void
 AndroidX.Compose.FilterChip
-AndroidX.Compose.FilterChip.FilterChip(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.FilterChip.FilterChip(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.FilterChip.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.FilterChip.Label.set -> void
 AndroidX.Compose.FilterChip.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
@@ -467,9 +467,9 @@ AndroidX.Compose.FloatingActionButton.FloatingActionButton(System.Action! onClic
 AndroidX.Compose.FloatingActionButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.FloatingActionButton.Shape.set -> void
 AndroidX.Compose.FlowColumn
-AndroidX.Compose.FlowColumn.FlowColumn() -> void
+AndroidX.Compose.FlowColumn.FlowColumn(int maxItemsInEachColumn = 2147483647, int maxLines = 2147483647) -> void
 AndroidX.Compose.FlowRow
-AndroidX.Compose.FlowRow.FlowRow() -> void
+AndroidX.Compose.FlowRow.FlowRow(int maxItemsInEachRow = 2147483647, int maxLines = 2147483647) -> void
 AndroidX.Compose.FocusRequester
 AndroidX.Compose.FocusRequester.CaptureFocus() -> bool
 AndroidX.Compose.FocusRequester.FocusRequester() -> void
@@ -530,7 +530,7 @@ AndroidX.Compose.Icon.Icon(int drawableResourceId, string? contentDescription) -
 AndroidX.Compose.Icon.Tint.get -> AndroidX.Compose.Color?
 AndroidX.Compose.Icon.Tint.set -> void
 AndroidX.Compose.IconButton
-AndroidX.Compose.IconButton.IconButton(System.Action! onClick) -> void
+AndroidX.Compose.IconButton.IconButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.Icons
 AndroidX.Compose.Icons.AutoMirrored
 AndroidX.Compose.Icons.AutoMirrored.Default
@@ -546,7 +546,7 @@ AndroidX.Compose.Icons.Rounded
 AndroidX.Compose.Icons.Sharp
 AndroidX.Compose.Icons.TwoTone
 AndroidX.Compose.IconToggleButton
-AndroidX.Compose.IconToggleButton.IconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
+AndroidX.Compose.IconToggleButton.IconToggleButton(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
 AndroidX.Compose.Image
 AndroidX.Compose.Image.Alignment.get -> AndroidX.Compose.Alignment?
 AndroidX.Compose.Image.Alignment.set -> void
@@ -562,7 +562,7 @@ AndroidX.Compose.ImeAction
 AndroidX.Compose.InputChip
 AndroidX.Compose.InputChip.Avatar.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.InputChip.Avatar.set -> void
-AndroidX.Compose.InputChip.InputChip(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.InputChip.InputChip(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.InputChip.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.InputChip.Label.set -> void
 AndroidX.Compose.InputChip.LeadingIcon.get -> AndroidX.Compose.ComposableNode?
@@ -671,7 +671,7 @@ AndroidX.Compose.LazyVerticalStaggeredGrid<T>.State.set -> void
 AndroidX.Compose.LeadingIconTab
 AndroidX.Compose.LeadingIconTab.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.LeadingIconTab.Icon.set -> void
-AndroidX.Compose.LeadingIconTab.LeadingIconTab(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.LeadingIconTab.LeadingIconTab(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.LeadingIconTab.Text.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.LeadingIconTab.Text.set -> void
 AndroidX.Compose.LinearProgressIndicator
@@ -870,7 +870,7 @@ AndroidX.Compose.NavigationRailItem.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.NavigationRailItem.Icon.set -> void
 AndroidX.Compose.NavigationRailItem.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.NavigationRailItem.Label.set -> void
-AndroidX.Compose.NavigationRailItem.NavigationRailItem(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.NavigationRailItem.NavigationRailItem(bool selected, System.Action! onClick, bool enabled = true, bool alwaysShowLabel = true) -> void
 AndroidX.Compose.NavOptions
 AndroidX.Compose.NavOptions.LaunchSingleTop.get -> bool
 AndroidX.Compose.NavOptions.LaunchSingleTop.set -> void
@@ -897,7 +897,7 @@ AndroidX.Compose.OutlinedButton.Colors.get -> AndroidX.Compose.Material3.ButtonC
 AndroidX.Compose.OutlinedButton.Colors.set -> void
 AndroidX.Compose.OutlinedButton.ContentPadding.get -> AndroidX.Compose.PaddingValues?
 AndroidX.Compose.OutlinedButton.ContentPadding.set -> void
-AndroidX.Compose.OutlinedButton.OutlinedButton(System.Action! onClick) -> void
+AndroidX.Compose.OutlinedButton.OutlinedButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.OutlinedButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.OutlinedButton.Shape.set -> void
 AndroidX.Compose.OutlinedCard
@@ -905,11 +905,11 @@ AndroidX.Compose.OutlinedCard.OutlinedCard() -> void
 AndroidX.Compose.OutlinedCard.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.OutlinedCard.Shape.set -> void
 AndroidX.Compose.OutlinedIconButton
-AndroidX.Compose.OutlinedIconButton.OutlinedIconButton(System.Action! onClick) -> void
+AndroidX.Compose.OutlinedIconButton.OutlinedIconButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.OutlinedIconButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.OutlinedIconButton.Shape.set -> void
 AndroidX.Compose.OutlinedIconToggleButton
-AndroidX.Compose.OutlinedIconToggleButton.OutlinedIconToggleButton(bool checked, System.Action<bool>! onCheckedChange) -> void
+AndroidX.Compose.OutlinedIconToggleButton.OutlinedIconToggleButton(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true) -> void
 AndroidX.Compose.OutlinedIconToggleButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.OutlinedIconToggleButton.Shape.set -> void
 AndroidX.Compose.OutlinedSecureTextField
@@ -1172,7 +1172,7 @@ AndroidX.Compose.Snackbar.Body.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Snackbar.Body.set -> void
 AndroidX.Compose.Snackbar.DismissAction.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Snackbar.DismissAction.set -> void
-AndroidX.Compose.Snackbar.Snackbar() -> void
+AndroidX.Compose.Snackbar.Snackbar(bool actionOnNewLine = false) -> void
 AndroidX.Compose.SnackbarHost
 AndroidX.Compose.SnackbarHost.SnackbarHost(AndroidX.Compose.SnackbarHostState! hostState) -> void
 AndroidX.Compose.SnackbarHostState
@@ -1215,7 +1215,7 @@ AndroidX.Compose.SuggestionChip.Label.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.SuggestionChip.Label.set -> void
 AndroidX.Compose.SuggestionChip.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.SuggestionChip.Shape.set -> void
-AndroidX.Compose.SuggestionChip.SuggestionChip(System.Action! onClick) -> void
+AndroidX.Compose.SuggestionChip.SuggestionChip(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.Surface
 AndroidX.Compose.Surface.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.Surface.Shape.set -> void
@@ -1227,7 +1227,7 @@ AndroidX.Compose.Switch.Switch(bool checked, System.Action<bool>! onCheckedChang
 AndroidX.Compose.Tab
 AndroidX.Compose.Tab.Icon.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Tab.Icon.set -> void
-AndroidX.Compose.Tab.Tab(bool selected, System.Action! onClick) -> void
+AndroidX.Compose.Tab.Tab(bool selected, System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.Tab.Text.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.Tab.Text.set -> void
 AndroidX.Compose.TabRow
@@ -1268,7 +1268,7 @@ AndroidX.Compose.TextButton.ContentPadding.get -> AndroidX.Compose.PaddingValues
 AndroidX.Compose.TextButton.ContentPadding.set -> void
 AndroidX.Compose.TextButton.Shape.get -> AndroidX.Compose.Shape?
 AndroidX.Compose.TextButton.Shape.set -> void
-AndroidX.Compose.TextButton.TextButton(System.Action! onClick) -> void
+AndroidX.Compose.TextButton.TextButton(System.Action! onClick, bool enabled = true) -> void
 AndroidX.Compose.TextDecoration
 AndroidX.Compose.TextField
 AndroidX.Compose.TextField.Enabled.get -> bool?


### PR DESCRIPTION
Generated facades omitted several ordinary primitive parameters that have Kotlin defaults, preventing callers from controlling supported states such as `enabled`, picker mode toggles, label visibility, Snackbar action layout, Box constraint propagation, and Flow limits.

This change audits every relevant `[ComposeFacade]` surface and exposes the missing primitive defaults across 30 generated constructor signatures. It also fixes the underlying `$changed` mask generation: Kotlin parameter positions now come from the authoritative `ComposeDefaults` map, so C# optional-parameter reordering cannot assign change bits to the wrong Kotlin slot. Regression tests cover reordered primitive parameters and wrapper-passthrough masks.

Public API declarations and Gallery acceptance coverage are updated, including new Snackbar and navigation rail demos.

## Validation

- 165 source-generator tests pass
- Facade and Gallery builds succeed with zero warnings or errors
- Gallery, Jetchat, and JetNews deployed successfully to a Pixel 10
- All 11 changed Gallery demos rendered without fatal logcat entries
- Interactive disabled, new-line action, label visibility, DatePicker, and DateRangePicker states were exercised on-device

![Pixel 10 Gallery audit](https://github.com/user-attachments/assets/6667a98f-86e8-4f0e-9205-44d08fbf3b56)

Fixes: #243