### PR TITLE
Generate stable composable lambda adapters

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -539,7 +539,8 @@ Applying `[ComposeFacade]` to an unsupported bridge emits CN3002 (unsupported
 param), CN3003 (scope misuse), CN3005 (invalid callback type), CN3006 (slot
 conflict), CN3007 (color theme bind failed), CN3008 (painter misuse), CN3009
 (state-holder misuse), CN3010 (branching misuse), CN3011
-(confirmStateChange misuse), or CN3012 (secondary-ctor misuse).
+(confirmStateChange misuse), CN3012 (secondary-ctor misuse), or CN3013
+(ambiguous or invalid lambda execution mode).
 
 ### Adding a new generated facade
 
@@ -554,7 +555,7 @@ conflict), CN3007 (color theme bind failed), CN3008 (painter misuse), CN3009
    `public sealed partial class <ClassName>;` and a `<summary>`. Use
    `Button.cs`/`IconButton.cs`/`Card.cs` as templates. **Do not omit the
    stub** — without it no XML docs.
-4. Build `dotnet build src/Microsoft.AndroidX.Compose.Gallery` to verify. CN3001-CN3012 fire
+4. Build `dotnet build src/Microsoft.AndroidX.Compose.Gallery` to verify. CN3001-CN3013 fire
    on rejection.
 5. If CN3002 fires, add the right marker attribute
    (`[Callback]`/`[Slot]`/`[PainterResource]`) or back out and write by hand.
@@ -577,6 +578,7 @@ conflict), CN3007 (color theme bind failed), CN3008 (painter misuse), CN3009
 | CN3010 | `BranchOn`/`AlternateBridge` invalid: only one set, primary/alternate missing trailing `int defaults`, named alternate not resolvable/ambiguous on `ComposeBridges`, alternate not a strict superset (missing a primary param or > 1 extra), extra param's PascalCased name doesn't match `BranchOn`, extra param isn't `IFunction2`/`IFunction3`, shared param has incompatible types, branching used on hybrid container shape, or alternate has no resolvable `[ComposeBridge].Defaults` enum. |
 | CN3011 | `[ConfirmStateChange(typeof(T))]` invalid: not on `IFunction1` param, missing `typeof(T)` ctor arg, convention adapter `Microsoft.AndroidX.Compose.<TName>ConfirmStateChange` missing (override with `AdapterType = typeof(...)`), adapter doesn't implement `Kotlin.Jvm.Functions.IFunction1`, lacks public parameterless ctor, or no writable `Callback` property of type `System.Func<T, bool>?`.                                                                                                              |
 | CN3012 | `SecondaryCtor`/`SecondaryDefaults` invalid: only one set, named secondary not resolvable/ambiguous on `ComposeBridges`, secondary missing trailing `int defaults`, secondary's user params don't share names with the primary, the discriminating extra param is value-type / nullable / not a reference type / there's > 1 unique param / there's none, primary has no slot missing from the secondary (no primary-only discriminator), `SecondaryDefaults` enum unresolvable, or combined with `BranchOn`/`AlternateBridge`.                                                                                                                                                                                                                                                                              |
+| CN3013 | Lambda execution mode is ambiguous, conflicting, or invalid. Mark `IFunction1` as `[Callback(typeof(T))]` or `[RawCallback]`; mark `IFunction4` as `[ComposableContent]` or `[DeferredComposableContent]`. |
 
 ### Migration rule
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -272,6 +272,28 @@ There is no migration pressure. Hot composables that recompose often
 (animation, list items, drag handles) are the natural candidates for
 Tier 2; one-shot screens can stay tree-style indefinitely.
 
+### Lambda adapter lowering
+
+Generated rendering uses one shared execution-mode classifier instead of
+inferring behavior from delegate arity alone:
+
+- synchronous `IFunction2`/`IFunction3` content uses composer-owned
+  `ComposableLambdas.Wrap2`/`Wrap3`;
+- synchronous `IFunction4` content must opt in with `[ComposableContent]`
+  and lowers to `Wrap4`;
+- lazy item `IFunction4` content must use
+  `[DeferredComposableContent]` and lowers to composerless `Instantiate4`;
+- events use `RememberAction`, retaining JNI peer identity while rebinding
+  the managed target each composition;
+- non-composable DSL callbacks use `[RawCallback]` and raw
+  `ComposableLambda0`/`ComposableLambda1` adapters.
+
+Unmarked `IFunction1` and `IFunction4` parameters are rejected because their
+execution timing cannot be determined safely from arity. Deferred and raw
+shapes are available to direct bridge and hand-written-holdout lowering; the
+tree-facade generator continues to reject them until those public delegate
+surfaces are modeled.
+
 ### Diagnostics
 
 | ID     | Meaning                                                          |

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Tier2/Tier2CounterDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Tier2/Tier2CounterDemo.cs
@@ -5,8 +5,9 @@ namespace AndroidX.Compose.Gallery.Demos.Tier2;
 
 /// <summary>
 /// Tier 2 demo: a counter rendered by a <c>[Composable]</c> static
-/// method. The button click flips a <see cref="MutableNumberState{T}"/>
-/// the body reads; the generator-emitted call-site interceptor around
+/// method. The button callback captures the next count on each composition,
+/// proving its remembered JNI adapter rebinds to the latest managed target.
+/// The generator-emitted call-site interceptor around
 /// <see cref="Counter"/> runs without an explicit composer parameter;
 /// generated interceptors recover the active composer for restart groups
 /// and nested calls.
@@ -27,7 +28,7 @@ public static class Tier2CounterDemo
         Id:          "tier2-counter",
         CategoryId:  "tier2",
         Title:       "[Composable] counter",
-        Description: "A counter rendered by a composerless Tier 2 [Composable] static method.",
+        Description: "A Tier 2 counter proving stable content identity and callback target rebinding.",
         Build:       static _ => new Tier2Adapter(() => Counter()));
 
     /// <summary>
@@ -40,6 +41,7 @@ public static class Tier2CounterDemo
     public static void Counter()
     {
         var count = Remember(() => new MutableNumberState<int>(0));
+        int nextCount = count.Value + 1;
 
         // Tier 2 all the way down — every call here is itself an
         // intercepted [Composable] call site with its own restart
@@ -48,7 +50,7 @@ public static class Tier2CounterDemo
         {
             Text($"Tier 2 count: {count.Value}");
             Button(
-                () => count.Value++,
+                () => count.Value = nextCount,
                 () => Text("Tap to increment"));
         });
     }

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -102,6 +102,7 @@ public class FacadeGeneratorTests
             public interface IFunction1 { }
             public interface IFunction2 { }
             public interface IFunction3 { }
+            public interface IFunction4 { }
         }
         namespace AndroidX.Compose
         {
@@ -305,7 +306,7 @@ public class FacadeGeneratorTests
         Assert.Contains("node.Add(new global::AndroidX.Compose.Tier2InlineContent(content));", emitted);
         Assert.Contains("readonly global::System.Action _onClick;", emitted);
         Assert.Contains("public Button(global::System.Action onClick)", emitted);
-        Assert.Contains("var __onClick = new global::AndroidX.Compose.ComposableLambda0(_onClick);", emitted);
+        Assert.Contains("var __onClick = composer.RememberAction(_onClick);", emitted);
         Assert.Contains("var __content = global::AndroidX.Compose.ComposableLambdas.Wrap3(composer, c => RenderChildren(c));", emitted);
         Assert.Contains("global::AndroidX.Compose.ComposeBridges.Button(__onClick, BuildModifier(), __content, composer);", emitted);
 
@@ -804,7 +805,7 @@ public class FacadeGeneratorTests
     }
 
     [Fact]
-    public void UnsupportedCallback_EmitsCN3002()
+    public void AmbiguousCallback_EmitsCN3013()
     {
         var code = $$"""
             using global::AndroidX.Compose.Runtime;
@@ -829,8 +830,7 @@ public class FacadeGeneratorTests
             """;
 
         var (_, diags, _) = Run(code, "Checkbox");
-        var cn3002 = diags.Where(d => d.Id == "CN3002").ToArray();
-        Assert.NotEmpty(cn3002);
+        Assert.Contains(diags, d => d.Id == "CN3013");
     }
 
     [Fact]
@@ -1125,7 +1125,7 @@ public class FacadeGeneratorTests
         Assert.NotNull(emitted);
         Assert.Contains("readonly global::System.Action<bool> _onCheckedChange;", emitted);
         Assert.Contains("public IconToggleButton(bool @checked, global::System.Action<bool> onCheckedChange)", emitted);
-        Assert.Contains("new global::AndroidX.Compose.ComposableLambda1(v => _onCheckedChange(v is global::Java.Lang.Boolean __b && __b.BooleanValue()));", emitted);
+        Assert.Contains("composer.RememberAction(v => _onCheckedChange(v is global::Java.Lang.Boolean __b && __b.BooleanValue()));", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
@@ -1162,7 +1162,7 @@ public class FacadeGeneratorTests
         Assert.NotNull(emitted);
         Assert.Contains("readonly global::System.Action<string> _onValueChange;", emitted);
         Assert.Contains("public TextField(string value, global::System.Action<string> onValueChange)", emitted);
-        Assert.Contains("new global::AndroidX.Compose.ComposableLambda1(v => _onValueChange(v?.ToString() ?? string.Empty));", emitted);
+        Assert.Contains("composer.RememberAction(v => _onValueChange(v?.ToString() ?? string.Empty));", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
@@ -4138,10 +4138,9 @@ public class FacadeGeneratorTests
     [Fact]
     public void Changed_NoChangedParam_EmitsLegacyPositionalCall()
     {
-        // Back-compat — bridges without the trailing `_changed` param
-        // still emit the legacy positional bridge call (no named-arg
-        // overhead, no RememberAction hoist, no __changed local). This
-        // test guards against accidental regression of the old shape.
+        // Bridges without the trailing `_changed` param still emit the
+        // legacy positional bridge call and no __changed local. Event
+        // callbacks nevertheless retain stable JNI identity.
         var code = $$"""
             using global::AndroidX.Compose.Runtime;
             using global::AndroidX.Compose.UI;
@@ -4167,7 +4166,7 @@ public class FacadeGeneratorTests
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
         Assert.DoesNotContain("__changed", emitted);
-        Assert.DoesNotContain("RememberAction", emitted);
+        Assert.Contains("var __onClick = composer.RememberAction(_onClick);", emitted);
         Assert.Contains("global::AndroidX.Compose.ComposeBridges.Button(__onClick, BuildModifier(), __content, composer);", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
@@ -4573,5 +4572,46 @@ public class FacadeGeneratorTests
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
+    }
+
+    [Theory]
+    [InlineData("", "IFunction1", "CN3013")]
+    [InlineData("", "IFunction4", "CN3013")]
+    [InlineData("[DeferredComposableContent] ", "IFunction4", "CN3002")]
+    [InlineData("[RawCallback] ", "IFunction1", "CN3002")]
+    [InlineData("[Callback(typeof(string)), RawCallback] ", "IFunction1", "CN3013")]
+    public void LambdaExecutionMode_RejectsAmbiguousOrFacadeUnsupportedShapes(
+        string attribute,
+        string functionType,
+        string expectedDiagnostic)
+    {
+        string signatureType = functionType == "IFunction1"
+            ? "Function1"
+            : "Function4";
+        var code = $$"""
+            using global::AndroidX.Compose.Runtime;
+            using AndroidX.Compose;
+            using Kotlin.Jvm.Functions;
+
+            namespace AndroidX.Compose
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class="x/WidgetKt",
+                        JvmName="Widget",
+                        Signature="(Lkotlin/jvm/functions/{{signatureType}};Landroidx/compose/runtime/Composer;I)V")]
+                    [ComposeFacade]
+                    public static partial void Widget(
+                        {{attribute}}{{functionType}} callback,
+                        IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "Widget");
+
+        Assert.Contains(diags, d => d.Id == expectedDiagnostic);
+        Assert.Null(emitted);
     }
 }

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/LambdaAdapterLoweringTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/LambdaAdapterLoweringTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace AndroidX.Compose.SourceGenerators.Tests;
+
+public class LambdaAdapterLoweringTests
+{
+    const string Preamble = """
+        namespace Kotlin.Jvm.Functions
+        {
+            public interface IFunction0 { }
+            public interface IFunction1 { }
+            public interface IFunction2 { }
+            public interface IFunction3 { }
+            public interface IFunction4 { }
+        }
+
+        namespace AndroidX.Compose
+        {
+            [System.AttributeUsage(System.AttributeTargets.Parameter)]
+            public sealed class CallbackAttribute : System.Attribute
+            {
+                public CallbackAttribute(System.Type valueType) { }
+            }
+
+            [System.AttributeUsage(System.AttributeTargets.Parameter)]
+            public sealed class ComposableContentAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Parameter)]
+            public sealed class DeferredComposableContentAttribute : System.Attribute { }
+
+            [System.AttributeUsage(System.AttributeTargets.Parameter)]
+            public sealed class RawCallbackAttribute : System.Attribute { }
+        }
+        """;
+
+    [Theory]
+    [InlineData("Kotlin.Jvm.Functions.IFunction2 content", nameof(LambdaExecutionMode.SynchronousComposable), 2)]
+    [InlineData("Kotlin.Jvm.Functions.IFunction3 content", nameof(LambdaExecutionMode.SynchronousComposable), 3)]
+    [InlineData("Kotlin.Jvm.Functions.IFunction0 onClick", nameof(LambdaExecutionMode.Event), 0)]
+    [InlineData("[AndroidX.Compose.Callback(typeof(string))] Kotlin.Jvm.Functions.IFunction1 onValueChange", nameof(LambdaExecutionMode.Event), 1)]
+    [InlineData("[AndroidX.Compose.RawCallback] Kotlin.Jvm.Functions.IFunction1 builder", nameof(LambdaExecutionMode.Raw), 1)]
+    [InlineData("[AndroidX.Compose.ComposableContent] Kotlin.Jvm.Functions.IFunction4 content", nameof(LambdaExecutionMode.SynchronousComposable), 4)]
+    [InlineData("[AndroidX.Compose.DeferredComposableContent] Kotlin.Jvm.Functions.IFunction4 itemContent", nameof(LambdaExecutionMode.DeferredComposable), 4)]
+    public void Classify_RecognizesExplicitExecutionModes(
+        string parameter,
+        string expectedMode,
+        int expectedArity)
+    {
+        var result = LambdaAdapterLowering.Classify(GetParameter(parameter));
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal(expectedMode, result.Classification.Mode.ToString());
+        Assert.Equal(expectedArity, result.Classification.Arity);
+    }
+
+    [Theory]
+    [InlineData(
+        nameof(LambdaExecutionMode.SynchronousComposable),
+        2,
+        "global::AndroidX.Compose.ComposableLambdas.Wrap2(composer, body)")]
+    [InlineData(
+        nameof(LambdaExecutionMode.SynchronousComposable),
+        3,
+        "global::AndroidX.Compose.ComposableLambdas.Wrap3(composer, body)")]
+    [InlineData(
+        nameof(LambdaExecutionMode.SynchronousComposable),
+        4,
+        "global::AndroidX.Compose.ComposableLambdas.Wrap4(composer, body)")]
+    [InlineData(
+        nameof(LambdaExecutionMode.DeferredComposable),
+        4,
+        "global::AndroidX.Compose.ComposableLambdas.Instantiate4(body)")]
+    [InlineData(
+        nameof(LambdaExecutionMode.Event),
+        0,
+        "composer.RememberAction(body)")]
+    [InlineData(
+        nameof(LambdaExecutionMode.Event),
+        1,
+        "composer.RememberAction(body)")]
+    [InlineData(
+        nameof(LambdaExecutionMode.Raw),
+        1,
+        "new global::AndroidX.Compose.ComposableLambda1(body)")]
+    public void EmitExpression_UsesIdentitySafeFactory(
+        string mode,
+        int arity,
+        string expected)
+    {
+        var actual = LambdaAdapterLowering.EmitExpression(
+            new LambdaAdapterClassification(
+                Enum.Parse<LambdaExecutionMode>(mode),
+                arity),
+            "composer",
+            "body");
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(
+        "Kotlin.Jvm.Functions.IFunction1 callback",
+        "IFunction1 parameter 'callback' is ambiguous")]
+    [InlineData(
+        "Kotlin.Jvm.Functions.IFunction4 content",
+        "IFunction4 parameter 'content' is ambiguous")]
+    [InlineData(
+        "[AndroidX.Compose.RawCallback, AndroidX.Compose.Callback(typeof(string))] Kotlin.Jvm.Functions.IFunction1 callback",
+        "conflicting lambda execution-mode attributes")]
+    [InlineData(
+        "[AndroidX.Compose.DeferredComposableContent] Kotlin.Jvm.Functions.IFunction3 content",
+        "must be IFunction4 lazy item content")]
+    public void Classify_RejectsAmbiguousOrInvalidModes(
+        string parameter,
+        string expectedError)
+    {
+        var result = LambdaAdapterLowering.Classify(GetParameter(parameter));
+
+        Assert.False(result.Success);
+        Assert.Contains(expectedError, result.Error);
+    }
+
+    static IParameterSymbol GetParameter(string parameter)
+    {
+        var tree = CSharpSyntaxTree.ParseText(
+            Preamble
+            + "\npublic static class C { public static void M("
+            + parameter
+            + ") { } }");
+        var compilation = CSharpCompilation.Create(
+            "LambdaAdapterTest",
+            [tree],
+            Net.Sdk.References,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        var method = compilation.GetTypeByMetadataName("C")
+            ?.GetMembers("M")
+            .OfType<IMethodSymbol>()
+            .Single()
+            ?? throw new InvalidOperationException(
+                "Synthetic lambda adapter test method was not compiled.");
+        return method.Parameters.Single();
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/AssemblyInfo.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.AndroidX.Compose.SourceGenerators.Tests")]

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
@@ -336,8 +336,8 @@ internal static class Attributes
             /// Phase 2 — apply to an <c>IFunction1</c> bridge parameter
             /// to mark it as a typed C# callback. The facade gets an
             /// <c>Action&lt;T&gt;</c> ctor parameter; the generated
-            /// <c>Render</c> body wraps it in a <c>ComposableLambda1</c>
-            /// that un-boxes the Kotlin value for <c>T</c>.
+            /// <c>Render</c> body routes it through <c>RememberAction</c>
+            /// and un-boxes the Kotlin value for <c>T</c>.
             /// Supported <c>T</c>: <c>bool</c>, <c>string</c>, <c>float</c>.
             /// </summary>
             [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
@@ -345,6 +345,33 @@ internal static class Attributes
             internal sealed class CallbackAttribute : global::System.Attribute
             {
                 public CallbackAttribute(global::System.Type valueType) { }
+            }
+
+            /// <summary>
+            /// Marks an <c>IFunction4</c> bridge parameter as deferred
+            /// lazy-item content. Generated lowering uses
+            /// <c>ComposableLambdas.Instantiate4</c> so the adapter never
+            /// captures an outer composer that is stale when measure-time
+            /// item composition runs.
+            /// </summary>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class DeferredComposableContentAttribute
+                : global::System.Attribute
+            {
+            }
+
+            /// <summary>
+            /// Marks an <c>IFunction0</c> or <c>IFunction1</c> bridge
+            /// parameter as a raw, non-composable DSL callback. Generated
+            /// lowering constructs the corresponding raw adapter and does
+            /// not use a Compose lambda factory or remember slot.
+            /// </summary>
+            [global::System.AttributeUsage(global::System.AttributeTargets.Parameter,
+                                           AllowMultiple = false)]
+            internal sealed class RawCallbackAttribute
+                : global::System.Attribute
+            {
             }
 
             /// <summary>

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -15,7 +15,7 @@ namespace AndroidX.Compose.SourceGenerators;
 /// the JNI plumbing; the facade is a thin
 /// <see cref="ComposableNode"/> / <see cref="ComposableContainer"/>
 /// wrapper that builds the bridge's user-controlled args (Action →
-/// <c>ComposableLambda0</c>, modifier → <c>BuildModifier()</c>, content
+/// <c>RememberAction</c>, modifier → <c>BuildModifier()</c>, content
 /// → <c>ComposableLambdas.Wrap2/3</c>) and forwards through.
 ///
 /// Phases supported (see issue #78):
@@ -1126,6 +1126,16 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                         $"[Callback] on parameter '{p.Name}' requires a Kotlin.Jvm.Functions.IFunction1 parameter type; was '{p.Type.ToDisplayString()}'"));
                     return null;
                 }
+                var lambda = LambdaAdapterLowering.Classify(p);
+                if (!lambda.Success)
+                {
+                    diags.Add(Diagnostic.Create(
+                        Diagnostics.FacadeLambdaExecutionModeInvalid,
+                        loc,
+                        methodName,
+                        lambda.Error));
+                    return null;
+                }
                 var typeArg = cba.ConstructorArguments.Length > 0 ? cba.ConstructorArguments[0].Value as INamedTypeSymbol : null;
                 if (typeArg is null)
                 {
@@ -1154,20 +1164,45 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             return new FacadeSlot(p, FacadeSlotKind.ScopeReceiver);
 
         var funcArity = KotlinFunctionArity(p.Type);
-        if (funcArity == 0)
-            return new FacadeSlot(p, FacadeSlotKind.OnClick);
-
-        if (funcArity == 2 || funcArity == 3)
+        if (funcArity >= 0)
         {
-            string? slotName = ReadSlotAttribute(p, c.SlotAttr);
-            return new FacadeSlot(p, funcArity == 2 ? FacadeSlotKind.Content2 : FacadeSlotKind.Content3,
-                slotPropertyName: slotName);
-        }
+            var lambda = LambdaAdapterLowering.Classify(p);
+            if (!lambda.Success)
+            {
+                diags.Add(Diagnostic.Create(
+                    Diagnostics.FacadeLambdaExecutionModeInvalid,
+                    loc,
+                    methodName,
+                    lambda.Error));
+                return null;
+            }
 
-        if (funcArity > 0)
-        {
-            diags.Add(Diagnostic.Create(Diagnostics.FacadeUnsupportedParameter, loc, methodName, p.Name,
-                $"IFunction{funcArity} (mark with [Callback(typeof(T))] for a typed Action<T> ctor slot)"));
+            var classification = lambda.Classification;
+            if (classification.Mode == LambdaExecutionMode.Event
+                && classification.Arity == 0)
+            {
+                return new FacadeSlot(p, FacadeSlotKind.OnClick);
+            }
+
+            if (classification.Mode
+                    == LambdaExecutionMode.SynchronousComposable
+                && classification.Arity is 2 or 3)
+            {
+                string? slotName = ReadSlotAttribute(p, c.SlotAttr);
+                return new FacadeSlot(
+                    p,
+                    classification.Arity == 2
+                        ? FacadeSlotKind.Content2
+                        : FacadeSlotKind.Content3,
+                    slotPropertyName: slotName);
+            }
+
+            diags.Add(Diagnostic.Create(
+                Diagnostics.FacadeUnsupportedParameter,
+                loc,
+                methodName,
+                p.Name,
+                $"IFunction{classification.Arity} classified as {classification.Mode}; this mode is reserved for direct bridge or holdout lowering"));
             return null;
         }
 
@@ -1434,27 +1469,23 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         }
 
         // OnClick wrappers — one per line so slot-table keys stay distinct.
-        // When _changed plumbing is on, allocate via RememberAction so the
-        // JCW peer's JNI handle stays identity-stable across recompositions
-        // (otherwise its slot reads Different and the runtime never skips).
+        // RememberAction rebinds the target while keeping the JNI peer stable.
         foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.OnClick))
         {
-            if (callerProvidesChanged)
-            {
-                sb.Append("            var __").Append(s.Param.Name)
-                  .Append(" = ").Append(composerName).Append(".RememberAction(_").Append(s.Param.Name).AppendLine(");");
-            }
-            else
-            {
-                sb.Append("            var __").Append(s.Param.Name)
-                  .Append(" = new global::AndroidX.Compose.ComposableLambda0(_").Append(s.Param.Name).AppendLine(");");
-            }
+            var adapter = LambdaAdapterLowering.EmitExpression(
+                new LambdaAdapterClassification(
+                    LambdaExecutionMode.Event,
+                    arity: 0),
+                composerName,
+                "_" + s.Param.Name);
+            sb.Append("            var __").Append(s.Param.Name)
+              .Append(" = ").Append(adapter).AppendLine(";");
         }
 
         // Callback wrappers (Phase 2).
         foreach (var s in slots.Where(s => s.Kind == FacadeSlotKind.Callback))
         {
-            EmitCallbackWrapper(sb, s, composerName, callerProvidesChanged);
+            EmitCallbackWrapper(sb, s, composerName);
         }
 
         // Modifier evaluation. Only hoist to a local when needed for
@@ -1487,20 +1518,33 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 continue;
             }
             var name = PropertyName(s);
-            string wrap = s.Kind is FacadeSlotKind.NamedFunction3 or FacadeSlotKind.RequiredFunction3
-                ? "Wrap3"
-                : "Wrap2";
+            int arity = s.Kind is FacadeSlotKind.NamedFunction3
+                or FacadeSlotKind.RequiredFunction3
+                ? 3
+                : 2;
             bool nullable = s.Kind is FacadeSlotKind.NamedFunction2 or FacadeSlotKind.NamedFunction3;
+            string body = "c => " + name + ".Render(c)";
+            string adapter = LambdaAdapterLowering.EmitExpression(
+                new LambdaAdapterClassification(
+                    LambdaExecutionMode.SynchronousComposable,
+                    arity),
+                composerName,
+                body);
             if (nullable)
             {
                 sb.Append("            var __").Append(s.Param.Name).Append(" = ").Append(name)
-                  .Append(" is null ? null : global::AndroidX.Compose.ComposableLambdas.").Append(wrap)
-                  .Append('(').Append(composerName).Append(", c => ").Append(name).AppendLine(".Render(c));");
+                  .Append(" is null ? null : ").Append(adapter).AppendLine(";");
             }
             else
             {
-                sb.Append("            var __").Append(s.Param.Name).Append(" = global::AndroidX.Compose.ComposableLambdas.")
-                  .Append(wrap).Append('(').Append(composerName).Append(", c => ").Append(name).AppendLine("!.Render(c));");
+                string requiredAdapter = LambdaAdapterLowering.EmitExpression(
+                    new LambdaAdapterClassification(
+                        LambdaExecutionMode.SynchronousComposable,
+                        arity),
+                    composerName,
+                    "c => " + name + "!.Render(c)");
+                sb.Append("            var __").Append(s.Param.Name)
+                  .Append(" = ").Append(requiredAdapter).AppendLine(";");
             }
         }
 
@@ -1510,14 +1554,21 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             string renderChildrenCall = indexedChildren ? "RenderChildrenIndexed(c)" : "RenderChildren(c)";
             var contentSlot = slots.First(s => s.Kind is FacadeSlotKind.Content2 or FacadeSlotKind.Content3);
             int arity = contentSlot.Kind == FacadeSlotKind.Content3 ? 3 : 2;
-            sb.Append("            var __").Append(contentSlot.Param.Name).Append(" = global::AndroidX.Compose.ComposableLambdas.");
+            sb.Append("            var __").Append(contentSlot.Param.Name)
+              .Append(" = ");
             if (arity == 2)
             {
-                sb.Append("Wrap2(").Append(composerName).Append(", c => ").Append(renderChildrenCall).AppendLine(");");
+                sb.Append(LambdaAdapterLowering.EmitExpression(
+                    new LambdaAdapterClassification(
+                        LambdaExecutionMode.SynchronousComposable,
+                        arity),
+                    composerName,
+                    "c => " + renderChildrenCall)).AppendLine(";");
             }
             else if (!string.IsNullOrEmpty(scope))
             {
-                sb.Append("Wrap3(").Append(composerName).AppendLine(", (__scope, c) =>");
+                sb.Append("global::AndroidX.Compose.ComposableLambdas.Wrap3(")
+                  .Append(composerName).AppendLine(", (__scope, c) =>");
                 sb.AppendLine("            {");
                 sb.Append("                using var __scopeFrame = global::AndroidX.Compose.RenderContext.PushScope(__scope, global::AndroidX.Compose.ScopeKind.")
                   .Append(scope).AppendLine(");");
@@ -1526,7 +1577,12 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             }
             else
             {
-                sb.Append("Wrap3(").Append(composerName).Append(", c => ").Append(renderChildrenCall).AppendLine(");");
+                sb.Append(LambdaAdapterLowering.EmitExpression(
+                    new LambdaAdapterClassification(
+                        LambdaExecutionMode.SynchronousComposable,
+                        arity),
+                    composerName,
+                    "c => " + renderChildrenCall)).AppendLine(";");
             }
         }
 
@@ -1938,9 +1994,14 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             sb.Append(composerName).AppendLine(");");
     }
 
-    static void EmitCallbackWrapper(StringBuilder sb, FacadeSlot s, string composerName, bool stableIdentity)
+    static void EmitCallbackWrapper(
+        StringBuilder sb,
+        FacadeSlot s,
+        string composerName)
     {
-        var t = s.CallbackType!;
+        var t = s.CallbackType
+            ?? throw new InvalidOperationException(
+                $"Callback slot '{s.Param.Name}' has no callback type.");
         string expr = t.SpecialType switch
         {
             SpecialType.System_Boolean => "v is global::Java.Lang.Boolean __b && __b.BooleanValue()",
@@ -1948,18 +2009,14 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             SpecialType.System_String  => "v?.ToString() ?? string.Empty",
             _ => "default!",
         };
-        if (stableIdentity)
-        {
-            sb.Append("            var __").Append(s.Param.Name)
-              .Append(" = ").Append(composerName).Append(".RememberAction(v => _")
-              .Append(s.Param.Name).Append('(').Append(expr).AppendLine("));");
-        }
-        else
-        {
-            sb.Append("            var __").Append(s.Param.Name)
-              .Append(" = new global::AndroidX.Compose.ComposableLambda1(v => _")
-              .Append(s.Param.Name).Append('(').Append(expr).AppendLine("));");
-        }
+        var adapter = LambdaAdapterLowering.EmitExpression(
+            new LambdaAdapterClassification(
+                LambdaExecutionMode.Event,
+                arity: 1),
+            composerName,
+            "v => _" + s.Param.Name + "(" + expr + ")");
+        sb.Append("            var __").Append(s.Param.Name)
+          .Append(" = ").Append(adapter).AppendLine(";");
     }
 
     static void EmitStateHolderPreambleShared(StringBuilder sb, FacadeSlot s,
@@ -2582,15 +2639,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         n.Name == "Painter" &&
         n.ContainingNamespace?.ToDisplayString() == "AndroidX.Compose.UI.Graphics.Painter";
 
-    static int KotlinFunctionArity(ITypeSymbol type)
-    {
-        if (type is not INamedTypeSymbol n) return -1;
-        if (n.ContainingNamespace?.ToDisplayString() != "Kotlin.Jvm.Functions") return -1;
-        var name = n.Name;
-        if (!name.StartsWith("IFunction", StringComparison.Ordinal)) return -1;
-        var tail = name.Substring("IFunction".Length);
-        return int.TryParse(tail, out var arity) ? arity : -1;
-    }
+    static int KotlinFunctionArity(ITypeSymbol type) =>
+        LambdaAdapterLowering.KotlinFunctionArity(type);
 
     static bool IsPrimitiveCtorType(ITypeSymbol type) =>
         type.TypeKind == TypeKind.Enum ||

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/Diagnostics.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/Diagnostics.cs
@@ -212,6 +212,14 @@ internal static class Diagnostics
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    public static readonly DiagnosticDescriptor FacadeLambdaExecutionModeInvalid = new(
+        id: "CN3013",
+        title: "Lambda execution mode is ambiguous or invalid",
+        messageFormat: "Facade for bridge '{0}': {1}",
+        category: "AndroidX.Compose",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public static readonly DiagnosticDescriptor CompanionNotPartial = new(
         id: "CN4001",
         title: "[ComposeCompanion] target class must be partial",

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/LambdaAdapterLowering.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/LambdaAdapterLowering.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace AndroidX.Compose.SourceGenerators;
+
+internal enum LambdaExecutionMode
+{
+    SynchronousComposable,
+    DeferredComposable,
+    Event,
+    Raw,
+}
+
+internal readonly struct LambdaAdapterClassification
+{
+    public LambdaAdapterClassification(LambdaExecutionMode mode, int arity)
+    {
+        Mode = mode;
+        Arity = arity;
+    }
+
+    public LambdaExecutionMode Mode { get; }
+    public int Arity { get; }
+}
+
+internal readonly struct LambdaClassificationResult
+{
+    LambdaClassificationResult(
+        LambdaAdapterClassification classification,
+        string? error)
+    {
+        Classification = classification;
+        Error = error;
+    }
+
+    public LambdaAdapterClassification Classification { get; }
+    public string? Error { get; }
+    public bool Success => Error is null;
+
+    public static LambdaClassificationResult Valid(
+        LambdaExecutionMode mode,
+        int arity) =>
+        new(new LambdaAdapterClassification(mode, arity), error: null);
+
+    public static LambdaClassificationResult Invalid(string error) =>
+        new(default, error);
+}
+
+internal static class LambdaAdapterLowering
+{
+    const string CallbackAttributeMetadataName =
+        "AndroidX.Compose.CallbackAttribute";
+    const string ComposableContentAttributeMetadataName =
+        "AndroidX.Compose.ComposableContentAttribute";
+    const string DeferredComposableContentAttributeMetadataName =
+        "AndroidX.Compose.DeferredComposableContentAttribute";
+    const string RawCallbackAttributeMetadataName =
+        "AndroidX.Compose.RawCallbackAttribute";
+
+    public static LambdaClassificationResult Classify(IParameterSymbol parameter)
+    {
+        int arity = KotlinFunctionArity(parameter.Type);
+        if (arity < 0)
+            return LambdaClassificationResult.Invalid(
+                $"parameter '{parameter.Name}' is not a Kotlin IFunction type");
+
+        bool callback = HasAttribute(parameter, CallbackAttributeMetadataName);
+        bool synchronous = HasAttribute(
+            parameter,
+            ComposableContentAttributeMetadataName);
+        bool deferred = HasAttribute(
+            parameter,
+            DeferredComposableContentAttributeMetadataName);
+        bool raw = HasAttribute(parameter, RawCallbackAttributeMetadataName);
+        int markerCount = (callback ? 1 : 0)
+            + (synchronous ? 1 : 0)
+            + (deferred ? 1 : 0)
+            + (raw ? 1 : 0);
+
+        if (markerCount > 1)
+        {
+            return LambdaClassificationResult.Invalid(
+                $"parameter '{parameter.Name}' has conflicting lambda execution-mode attributes");
+        }
+
+        if (callback)
+        {
+            return arity == 1
+                ? LambdaClassificationResult.Valid(LambdaExecutionMode.Event, arity)
+                : LambdaClassificationResult.Invalid(
+                    $"[Callback] parameter '{parameter.Name}' must be IFunction1, not IFunction{arity}");
+        }
+
+        if (synchronous)
+        {
+            return arity is 2 or 3 or 4
+                ? LambdaClassificationResult.Valid(
+                    LambdaExecutionMode.SynchronousComposable,
+                    arity)
+                : LambdaClassificationResult.Invalid(
+                    $"[ComposableContent] parameter '{parameter.Name}' must be IFunction2, IFunction3, or IFunction4");
+        }
+
+        if (deferred)
+        {
+            return arity == 4
+                ? LambdaClassificationResult.Valid(
+                    LambdaExecutionMode.DeferredComposable,
+                    arity)
+                : LambdaClassificationResult.Invalid(
+                    $"[DeferredComposableContent] parameter '{parameter.Name}' must be IFunction4 lazy item content");
+        }
+
+        if (raw)
+        {
+            return arity is 0 or 1
+                ? LambdaClassificationResult.Valid(LambdaExecutionMode.Raw, arity)
+                : LambdaClassificationResult.Invalid(
+                    $"[RawCallback] parameter '{parameter.Name}' must be IFunction0 or IFunction1");
+        }
+
+        return arity switch
+        {
+            0 => LambdaClassificationResult.Valid(LambdaExecutionMode.Event, arity),
+            2 or 3 => LambdaClassificationResult.Valid(
+                LambdaExecutionMode.SynchronousComposable,
+                arity),
+            1 => LambdaClassificationResult.Invalid(
+                $"IFunction1 parameter '{parameter.Name}' is ambiguous; mark it [Callback(typeof(T))] for an identity-stable event or [RawCallback] for a non-composable DSL callback"),
+            4 => LambdaClassificationResult.Invalid(
+                $"IFunction4 parameter '{parameter.Name}' is ambiguous; mark it [ComposableContent] for synchronous content or [DeferredComposableContent] for lazy item content"),
+            _ => LambdaClassificationResult.Invalid(
+                $"IFunction{arity} parameter '{parameter.Name}' has no supported lambda adapter"),
+        };
+    }
+
+    public static string EmitExpression(
+        LambdaAdapterClassification classification,
+        string composerExpression,
+        string bodyExpression) =>
+        classification.Mode switch
+        {
+            LambdaExecutionMode.SynchronousComposable
+                when classification.Arity is 2 or 3 or 4 =>
+                $"global::AndroidX.Compose.ComposableLambdas.Wrap{classification.Arity}({composerExpression}, {bodyExpression})",
+            LambdaExecutionMode.DeferredComposable
+                when classification.Arity == 4 =>
+                $"global::AndroidX.Compose.ComposableLambdas.Instantiate{classification.Arity}({bodyExpression})",
+            LambdaExecutionMode.Event
+                when classification.Arity is 0 or 1 =>
+                $"{composerExpression}.RememberAction({bodyExpression})",
+            LambdaExecutionMode.Raw
+                when classification.Arity is 0 or 1 =>
+                $"new global::AndroidX.Compose.ComposableLambda{classification.Arity}({bodyExpression})",
+            _ => throw new InvalidOperationException(
+                $"Lambda execution mode '{classification.Mode}' does not support IFunction{classification.Arity}."),
+        };
+
+    public static int KotlinFunctionArity(ITypeSymbol type)
+    {
+        if (type is not INamedTypeSymbol named)
+            return -1;
+        if (named.ContainingNamespace?.ToDisplayString()
+            != "Kotlin.Jvm.Functions")
+        {
+            return -1;
+        }
+
+        const string prefix = "IFunction";
+        if (!named.Name.StartsWith(prefix, StringComparison.Ordinal))
+            return -1;
+
+        return int.TryParse(
+            named.Name.Substring(prefix.Length),
+            out int arity)
+            ? arity
+            : -1;
+    }
+
+    static bool HasAttribute(ISymbol symbol, string metadataName) =>
+        symbol.GetAttributes().Any(a =>
+            a.AttributeClass?.ToDisplayString() == metadataName);
+}


### PR DESCRIPTION
Compose correctness depends on selecting the lambda factory that matches when content executes and on preserving JNI peer identity across recompositions. This adds a shared generator contract so direct bridge lowering and facade generation do not infer execution timing from delegate arity alone.

- Classifies synchronous composable content, deferred lazy content, event callbacks, and raw DSL callbacks.
- Emits `Wrap2`/`Wrap3`/`Wrap4`, composerless `Instantiate4`, stable `RememberAction`, or raw adapters as appropriate.
- Adds explicit deferred/raw markers and CN3013 for ambiguous, conflicting, or invalid execution modes.
- Routes existing generated facade content and events through the shared lowering; events now retain their JNI peer while rebinding the latest managed target.
- Extends the Tier 2 counter demo so stale callback target capture is observable on repeated taps.

Deferred and raw classifications are ready for direct bridge lowering and handwritten-holdout modeling, but tree-facade generation still rejects those public shapes until their delegate surfaces are modeled.

Validation: 222 source-generator tests, facade build, and gallery build.

Closes #304