### PR TITLE
Fix generic composable restart-group keys

### DIFF
--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
@@ -826,7 +826,7 @@ public class ComposableMethodGeneratorTests
     [Fact]
     public void GenericMethod_RestartKeysIncludeConstructedSignature()
     {
-        var (output, diags, emitted) = Run("""
+        var src = CSharpSyntaxTree.ParseText(Preamble + """
             namespace App
             {
                 public static class Screens
@@ -836,27 +836,34 @@ public class ComposableMethodGeneratorTests
 
                     [AndroidX.Compose.Composable]
                     public static void Foo<T>(T value, int count) { }
-
-                    public static void CallSite()
-                    {
-                        Foo(42);
-                        Foo<string>("value");
-                        Foo(42, 1);
-                    }
                 }
             }
-            """);
+            """, ParseOpts);
+        var compilation = CSharpCompilation.Create(
+            "ComposableMethodTest",
+            [src],
+            references: Net.Sdk.References,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        var methods = compilation.GetTypeByMetadataName("App.Screens")
+            ?.GetMembers("Foo")
+            .OfType<IMethodSymbol>()
+            .ToArray()
+            ?? throw new System.InvalidOperationException("Generic composable methods not found.");
+        var single = methods.Single(method => method.Parameters.Length == 1);
+        var overload = methods.Single(method => method.Parameters.Length == 2);
+        var intType = compilation.GetSpecialType(SpecialType.System_Int32);
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        int[] keys =
+        [
+            ComposableMethodGenerator.GetRestartGroupKey(single.Construct(intType)),
+            ComposableMethodGenerator.GetRestartGroupKey(single.Construct(stringType)),
+            ComposableMethodGenerator.GetRestartGroupKey(overload.Construct(intType)),
+        ];
 
-        Assert.Empty(diags);
-        Assert.NotNull(emitted);
-        var keys = System.Text.RegularExpressions.Regex.Matches(
-                emitted,
-                @"StartRestartGroup\(unchecked\(\(int\)0x([0-9A-F]{8})\)\)")
-            .Select(match => match.Groups[1].Value)
-            .ToArray();
-        Assert.Equal(3, keys.Length);
-        Assert.Equal(3, keys.Distinct().Count());
-        AssertNoCompileErrors(output);
+        Assert.NotEqual(keys[0], keys[1]);
+        Assert.NotEqual(keys[0], keys[2]);
+        Assert.NotEqual(keys[1], keys[2]);
     }
 
     [Fact]
@@ -882,7 +889,7 @@ public class ComposableMethodGeneratorTests
             ?.GetMembers("Foo")
             .OfType<IMethodSymbol>()
             .Single()
-            ?? throw new InvalidOperationException("Generic composable method not found.");
+            ?? throw new System.InvalidOperationException("Generic composable method not found.");
         var stringType = compilation.GetSpecialType(SpecialType.System_String);
         var nonNullable = method.Construct(
             stringType.WithNullableAnnotation(NullableAnnotation.NotAnnotated));

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
@@ -824,6 +824,42 @@ public class ComposableMethodGeneratorTests
     }
 
     [Fact]
+    public void GenericMethod_RestartKeysIncludeConstructedSignature()
+    {
+        var (output, diags, emitted) = Run("""
+            namespace App
+            {
+                public static class Screens
+                {
+                    [AndroidX.Compose.Composable]
+                    public static void Foo<T>(T value) { }
+
+                    [AndroidX.Compose.Composable]
+                    public static void Foo<T>(T value, int count) { }
+
+                    public static void CallSite()
+                    {
+                        Foo(42);
+                        Foo<string?>(null);
+                        Foo(42, 1);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diags);
+        Assert.NotNull(emitted);
+        var keys = System.Text.RegularExpressions.Regex.Matches(
+                emitted,
+                @"StartRestartGroup\(unchecked\(\(int\)0x([0-9A-F]{8})\)\)")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+        Assert.Equal(3, keys.Length);
+        Assert.Equal(3, keys.Distinct().Count());
+        AssertNoCompileErrors(output);
+    }
+
+    [Fact]
     public void GenericMethod_PreservesTypeParameterConstraints()
     {
         var (output, diags, emitted) = Run("""

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
@@ -840,6 +840,7 @@ public class ComposableMethodGeneratorTests
                     public static void CallSite()
                     {
                         Foo(42);
+                        Foo<string>("value");
                         Foo<string?>(null);
                         Foo(42, 1);
                     }
@@ -854,8 +855,8 @@ public class ComposableMethodGeneratorTests
                 @"StartRestartGroup\(unchecked\(\(int\)0x([0-9A-F]{8})\)\)")
             .Select(match => match.Groups[1].Value)
             .ToArray();
-        Assert.Equal(3, keys.Length);
-        Assert.Equal(3, keys.Distinct().Count());
+        Assert.Equal(4, keys.Length);
+        Assert.Equal(4, keys.Distinct().Count());
         AssertNoCompileErrors(output);
     }
 

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
@@ -839,9 +839,10 @@ public class ComposableMethodGeneratorTests
 
                     public static void CallSite()
                     {
+                        string? nullable = null;
                         Foo(42);
                         Foo<string>("value");
-                        Foo<string?>(null);
+                        Foo(nullable);
                         Foo(42, 1);
                     }
                 }

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
@@ -839,10 +839,8 @@ public class ComposableMethodGeneratorTests
 
                     public static void CallSite()
                     {
-                        string? nullable = null;
                         Foo(42);
                         Foo<string>("value");
-                        Foo(nullable);
                         Foo(42, 1);
                     }
                 }
@@ -856,9 +854,44 @@ public class ComposableMethodGeneratorTests
                 @"StartRestartGroup\(unchecked\(\(int\)0x([0-9A-F]{8})\)\)")
             .Select(match => match.Groups[1].Value)
             .ToArray();
-        Assert.Equal(4, keys.Length);
-        Assert.Equal(4, keys.Distinct().Count());
+        Assert.Equal(3, keys.Length);
+        Assert.Equal(3, keys.Distinct().Count());
         AssertNoCompileErrors(output);
+    }
+
+    [Fact]
+    public void GenericMethod_RestartIdentityIncludesNullableTypeArguments()
+    {
+        var src = CSharpSyntaxTree.ParseText(Preamble + """
+            namespace App
+            {
+                public static class Screens
+                {
+                    [AndroidX.Compose.Composable]
+                    public static void Foo<T>(T value) { }
+                }
+            }
+            """, ParseOpts);
+        var compilation = CSharpCompilation.Create(
+            "ComposableMethodTest",
+            [src],
+            references: Net.Sdk.References,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        var method = compilation.GetTypeByMetadataName("App.Screens")
+            ?.GetMembers("Foo")
+            .OfType<IMethodSymbol>()
+            .Single()
+            ?? throw new InvalidOperationException("Generic composable method not found.");
+        var stringType = compilation.GetSpecialType(SpecialType.System_String);
+        var nonNullable = method.Construct(
+            stringType.WithNullableAnnotation(NullableAnnotation.NotAnnotated));
+        var nullable = method.Construct(
+            stringType.WithNullableAnnotation(NullableAnnotation.Annotated));
+
+        Assert.NotEqual(
+            ComposableMethodGenerator.GetRestartGroupIdentity(nonNullable),
+            ComposableMethodGenerator.GetRestartGroupIdentity(nullable));
     }
 
     [Fact]

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
@@ -401,7 +401,7 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
         var containingType = method.ContainingType
             ?? throw new InvalidOperationException(
                 $"Composable method '{method.Name}' has no containing type.");
-        int key = FnvHash(GetRestartGroupIdentity(site.Target));
+        int key = GetRestartGroupKey(site.Target);
         bool hasExplicitComposer = method.Parameters.Length > 0
             && IsComposer(method.Parameters[0].Type);
         string? obsoleteDiagnosticId = GetObsoleteDiagnosticId(method);
@@ -798,8 +798,35 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
         }
     }
 
-    internal static string GetRestartGroupIdentity(IMethodSymbol method) =>
-        method.ToDisplayString(ParameterTypeFormat);
+    internal static string GetRestartGroupIdentity(IMethodSymbol method)
+    {
+        var sb = new StringBuilder();
+        sb.Append(method.ContainingType.ToDisplayString(ParameterTypeFormat))
+          .Append('.')
+          .Append(method.MetadataName);
+        if (method.TypeArguments.Length > 0)
+        {
+            sb.Append('<');
+            for (int i = 0; i < method.TypeArguments.Length; i++)
+            {
+                if (i > 0)
+                    sb.Append(',');
+                sb.Append(method.TypeArguments[i].ToDisplayString(ParameterTypeFormat));
+            }
+            sb.Append('>');
+        }
+        sb.Append('(');
+        for (int i = 0; i < method.Parameters.Length; i++)
+        {
+            if (i > 0)
+                sb.Append(',');
+            sb.Append(method.Parameters[i].Type.ToDisplayString(ParameterTypeFormat));
+        }
+        return sb.Append(')').ToString();
+    }
+
+    internal static int GetRestartGroupKey(IMethodSymbol method) =>
+        FnvHash(GetRestartGroupIdentity(method));
 
     static int FnvHash(string s)
     {

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
@@ -799,7 +799,7 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
     }
 
     static string GetRestartGroupIdentity(IMethodSymbol method) =>
-        method.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        method.ToDisplayString(ParameterTypeFormat);
 
     static int FnvHash(string s)
     {

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
@@ -401,8 +401,7 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
         var containingType = method.ContainingType
             ?? throw new InvalidOperationException(
                 $"Composable method '{method.Name}' has no containing type.");
-        var methodFqn = containingType.ToDisplayString() + "." + method.Name;
-        int key = FnvHash(methodFqn);
+        int key = FnvHash(GetRestartGroupIdentity(site.Target));
         bool hasExplicitComposer = method.Parameters.Length > 0
             && IsComposer(method.Parameters[0].Type);
         string? obsoleteDiagnosticId = GetObsoleteDiagnosticId(method);
@@ -798,6 +797,9 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
               .AppendLine(string.Join(", ", constraints));
         }
     }
+
+    static string GetRestartGroupIdentity(IMethodSymbol method) =>
+        method.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
     static int FnvHash(string s)
     {

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
@@ -798,7 +798,7 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
         }
     }
 
-    static string GetRestartGroupIdentity(IMethodSymbol method) =>
+    internal static string GetRestartGroupIdentity(IMethodSymbol method) =>
         method.ToDisplayString(ParameterTypeFormat);
 
     static int FnvHash(string s)


### PR DESCRIPTION
Generic Tier 2 composables need distinct Compose restart-group identities for each constructed method and overload. Hashing only the containing type and method name allowed unrelated generic forms to collide.

This changes restart-key generation to hash the fully qualified constructed method signature, preserving type arguments and overload parameter identity. Regression coverage combines inferred, explicit, nullable, constructed, and overloaded generic calls and verifies that each form receives a distinct key.

Closes #296