### PR TITLE
Support Tier 2 composable extension methods

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1039,9 +1039,10 @@ Rules:
   (CN5002). It may omit `IComposer`; when declared explicitly,
   `IComposer` must be the **first** parameter (CN5003).
 - It must be accessible from the generated interceptor (CN5004) and
-  cannot be `async` (CN5005), an extension method (CN5006), or use
-  `ref`/`out`/`in` parameters (CN5008). Generic methods are supported;
-  generated wrappers preserve their type parameters and constraints.
+  cannot be `async` (CN5005) or use `ref`/`out`/`in` parameters (CN5008).
+  Generic and extension methods are supported; generated wrappers preserve
+  their type parameters and constraints. An `IComposer` extension receiver is
+  the composer slot; any other receiver is a diffed user parameter.
 - Composerless APIs may only be called from a `[Composable]` method or a
   delegate that flows synchronously to a parameter marked
   `[ComposableContent]` (CN5009). Bounded analysis follows local variables,
@@ -1214,7 +1215,6 @@ are generated while compiling the runtime assembly.
 | CN5003 | When present, a `[Composable]` method's `AndroidX.Compose.Runtime.IComposer` must be its first and only composer parameter. |
 | CN5004 | `[Composable]` method and its containing types must be accessible from the generated interceptor.                       |
 | CN5005 | `[Composable]` method cannot be `async`; continuations would resume after the restart group closes.                     |
-| CN5006 | `[Composable]` extension methods are unsupported; use a regular static method.                                          |
 | CN5008 | `[Composable]` parameters cannot use `ref`, `out`, or `in`.                                                              |
 | CN5009 | A composerless API may execute outside a `[Composable]` method or `[ComposableContent]` callback; the diagnostic identifies the unsafe delegate escape. |
 | CN5010 | `[GenerateImplicitComposable]` targets an unsupported explicit-composer adapter shape.                                |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,6 +200,19 @@ public static class Screens
 }
 ```
 
+Extension composables are supported in both extension and explicit-static
+syntax. An `IComposer` receiver is the composer slot and is excluded from
+argument diffing; any other extension receiver is an ordinary first user
+parameter and is diffed:
+
+```csharp
+[Composable]
+public static void Greeting(this IComposer composer, string name) { }
+
+composer.Greeting("Ada");
+Screens.Greeting(composer, "Ada");
+```
+
 ### What the generator emits
 
 The generator emits a single
@@ -352,7 +365,6 @@ surfaces are modeled.
 | CN5003 | If `[Composable]` declares `IComposer`, it must be the first and only composer parameter. |
 | CN5004 | Method and containing types must be interceptor-accessible.     |
 | CN5005 | `async` composables are unsupported.                            |
-| CN5006 | Extension-method composables are unsupported.                   |
 | CN5008 | `ref`, `out`, and `in` parameters are unsupported.              |
 | CN5009 | A composerless API may execute outside `[Composable]` code or a `[ComposableContent]` callback; the diagnostic points to the unsafe delegate escape. |
 | CN5010 | `[GenerateImplicitComposable]` was applied to an unsupported explicit-composer adapter shape. |

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
@@ -453,6 +453,43 @@ public class ComposableMethodGeneratorTests
     }
 
     [Fact]
+    public void DirectTarget_NonComposerExtensionReceiver_PreservesOmittedBitPosition()
+    {
+        var (output, diags, emitted) = Run("""
+            namespace App
+            {
+                public sealed class Model { }
+
+                public static class Direct
+                {
+                    public static void Widget(
+                        AndroidX.Compose.Runtime.IComposer composer,
+                        Model model,
+                        int setting,
+                        ulong omittedArguments,
+                        int changed) { }
+                }
+
+                public static class Screens
+                {
+                    [AndroidX.Compose.Composable]
+                    [AndroidX.Compose.ComposableDirectTarget(typeof(Direct), nameof(Direct.Widget))]
+                    public static void Widget(this Model model, int setting = 0) { }
+
+                    public static void CallSite(Model model) => model.Widget();
+                }
+            }
+            """);
+
+        Assert.Empty(diags);
+        Assert.NotNull(emitted);
+        Assert.Contains(
+            "global::App.Direct.Widget(__c, model, setting, 0x2UL, __dirty)",
+            emitted);
+        AssertNoCompileErrors(output);
+    }
+
+    [Fact]
     public void GenericDirectTarget_ForwardsTypeArguments()
     {
         var (output, diags, emitted) = Run("""

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/ComposableMethodGeneratorTests.cs
@@ -776,24 +776,138 @@ public class ComposableMethodGeneratorTests
     }
 
     [Fact]
-    public void ExtensionMethod_ReportsCN5006AndDoesNotEmitInterceptor()
+    public void ComposerExtensionMethod_ExtensionAndStaticSyntaxEmitInterceptors()
     {
-        var (_, diags, emitted) = Run("""
+        var (output, diags, emitted) = Run("""
             namespace App
             {
                 public static class Screens
                 {
                     [AndroidX.Compose.Composable]
                     public static void Foo(
-                        this AndroidX.Compose.Runtime.IComposer composer) { }
+                        this AndroidX.Compose.Runtime.IComposer composer,
+                        string value) { }
 
-                    public static void CallSite(AndroidX.Compose.Runtime.IComposer c) => c.Foo();
+                    public static void CallSite(AndroidX.Compose.Runtime.IComposer c)
+                    {
+                        c.Foo("extension");
+                        Screens.Foo(c, "static");
+                    }
                 }
             }
             """);
 
-        Assert.Contains(diags, d => d.Id == "CN5006");
-        Assert.Null(emitted);
+        Assert.Empty(diags);
+        Assert.NotNull(emitted);
+        Assert.Equal(2, emitted.Split("InterceptsLocationAttribute(").Length - 2);
+        Assert.Contains(
+            "global::AndroidX.Compose.Runtime.IComposer composer, string value",
+            emitted);
+        Assert.Contains("__dirty |= __c.DiffSlot<string>(value, 1)", emitted);
+        Assert.Contains("(__dirty & 0xB) != 0x2", emitted);
+        Assert.Contains("global::App.Screens.Foo(__c, value)", emitted);
+        Assert.Contains("_Core(__c2, value, __force | 0b1)", emitted);
+        AssertNoCompileErrors(output);
+    }
+
+    [Fact]
+    public void NonComposerExtensionReceiver_IsDiffedAsFirstUserParameter()
+    {
+        var (output, diags, emitted) = Run("""
+            namespace App
+            {
+                public sealed class Model { }
+
+                public static class Screens
+                {
+                    [AndroidX.Compose.Composable]
+                    public static void Show(this Model model, int value) { }
+
+                    public static void CallSite(Model model) => model.Show(42);
+                }
+            }
+            """);
+
+        Assert.Empty(diags);
+        Assert.NotNull(emitted);
+        Assert.Contains(
+            "global::App.Model model, int value",
+            emitted);
+        Assert.Contains("__dirty |= __c.DiffSlot<global::App.Model>(model, 1)", emitted);
+        Assert.Contains("__dirty |= __c.DiffSlot<int>(value, 4)", emitted);
+        Assert.Contains("global::App.Screens.Show(model, value)", emitted);
+        Assert.Contains("_Core(__c2, model, value, __force | 0b1)", emitted);
+        AssertNoCompileErrors(output);
+    }
+
+    [Fact]
+    public void OverloadedExtensionMethods_BindToResolvedTarget()
+    {
+        var (output, diags, emitted) = Run("""
+            namespace App
+            {
+                public static class Screens
+                {
+                    [AndroidX.Compose.Composable]
+                    public static void Show(
+                        this AndroidX.Compose.Runtime.IComposer composer,
+                        string? value) { }
+
+                    [AndroidX.Compose.Composable]
+                    public static void Show(
+                        this AndroidX.Compose.Runtime.IComposer composer,
+                        int value) { }
+
+                    public static void CallSite(AndroidX.Compose.Runtime.IComposer c)
+                    {
+                        c.Show("text");
+                        c.Show(42);
+                    }
+                }
+            }
+            """);
+
+        Assert.Empty(diags);
+        Assert.NotNull(emitted);
+        Assert.Contains(
+            "global::AndroidX.Compose.Runtime.IComposer composer, string? value",
+            emitted);
+        Assert.Contains(
+            "global::AndroidX.Compose.Runtime.IComposer composer, int value",
+            emitted);
+        Assert.Contains("__c.DiffSlot<string?>(value, 1)", emitted);
+        Assert.Contains("__c.DiffSlot<int>(value, 1)", emitted);
+        AssertNoCompileErrors(output);
+    }
+
+    [Fact]
+    public void GenericExtensionMethod_PreservesInferredTypeArgument()
+    {
+        var (output, diags, emitted) = Run("""
+            namespace App
+            {
+                public static class Screens
+                {
+                    [AndroidX.Compose.Composable]
+                    public static void Show<T>(
+                        this AndroidX.Compose.Runtime.IComposer composer,
+                        T value)
+                        where T : class { }
+
+                    public static void CallSite(AndroidX.Compose.Runtime.IComposer c) =>
+                        c.Show("text");
+                }
+            }
+            """);
+
+        Assert.Empty(diags);
+        Assert.NotNull(emitted);
+        Assert.Contains(
+            "<T>(global::AndroidX.Compose.Runtime.IComposer composer, T value)",
+            emitted);
+        Assert.Contains("where T : class", emitted);
+        Assert.Contains("global::App.Screens.Show<T>(__c, value)", emitted);
+        AssertNoCompileErrors(output);
     }
 
     [Fact]

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
@@ -207,7 +207,7 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
         var directTarget = TryReadDirectTarget(actual);
         ulong omittedArguments = directTarget is null
             ? 0
-            : ReadOmittedArguments(ctx.SemanticModel, invocation, target, ct);
+            : ReadOmittedArguments(ctx.SemanticModel, invocation, target, actual, ct);
 
         return new CallSite(
             actual,
@@ -239,33 +239,39 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
         SemanticModel semanticModel,
         InvocationExpressionSyntax invocation,
         IMethodSymbol target,
+        IMethodSymbol actual,
         System.Threading.CancellationToken ct)
     {
         if (semanticModel.GetOperation(invocation, ct) is not IInvocationOperation operation)
             return 0;
 
-        bool hasExplicitComposer = target.Parameters.Length > 0
-            && IsComposer(target.Parameters[0].Type);
+        bool hasExplicitComposer = actual.Parameters.Length > 0
+            && IsComposer(actual.Parameters[0].Type);
         int composerOffset = hasExplicitComposer ? 1 : 0;
+        int receiverOffset = target.ReducedFrom is null ? 0 : 1;
         var suppliedParameters = new System.Collections.Generic.HashSet<int>();
+        if (receiverOffset != 0)
+            suppliedParameters.Add(0);
         foreach (var argument in operation.Arguments)
         {
-            if (argument.ArgumentKind != ArgumentKind.DefaultValue
+            if (!argument.IsImplicit
+                && argument.ArgumentKind != ArgumentKind.DefaultValue
                 && argument.Parameter is { } parameter)
             {
-                suppliedParameters.Add(parameter.Ordinal);
+                suppliedParameters.Add(parameter.Ordinal + receiverOffset);
             }
         }
 
         ulong omitted = 0;
-        foreach (var parameter in target.Parameters)
+        foreach (var parameter in actual.Parameters)
         {
             if (parameter.Ordinal < composerOffset
-                || !parameter.HasExplicitDefaultValue
+                || parameter.IsParams
                 || suppliedParameters.Contains(parameter.Ordinal))
             {
                 continue;
             }
+
             int userIndex = parameter.Ordinal - composerOffset;
             if ((uint)userIndex < 64)
                 omitted |= 1UL << userIndex;

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposableMethodGenerator.cs
@@ -149,12 +149,6 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
                 Diagnostics.ComposableAsyncUnsupported, loc, method.ToDisplayString()));
             return;
         }
-        if (method.IsExtensionMethod)
-        {
-            spc.ReportDiagnostic(Diagnostic.Create(
-                Diagnostics.ComposableExtensionUnsupported, loc, method.ToDisplayString()));
-            return;
-        }
         var byRefParameter = method.Parameters.FirstOrDefault(
             static p => p.RefKind != RefKind.None);
         if (byRefParameter is not null)
@@ -193,10 +187,11 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
         if (symbolInfo.Symbol is not IMethodSymbol target)
             return null;
 
-        // Lookup [Composable] by metadata name on the resolved method.
-        // Reduced (extension-method-style) calls resolve to the reduced
-        // form; the attribute lives on the original definition.
-        var actual = target.ReducedFrom ?? target.OriginalDefinition;
+        // Reduced extension calls omit the receiver from their parameter
+        // list. Reopen the constructed static method so both extension and
+        // explicit-static syntax produce the declaration-shaped interceptor
+        // signature expected by the compiler.
+        var actual = target.ReducedFrom ?? target;
         if (!HasComposableAttribute(actual))
             return null;
 
@@ -215,7 +210,7 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
             : ReadOmittedArguments(ctx.SemanticModel, invocation, target, ct);
 
         return new CallSite(
-            target,
+            actual,
             path ?? string.Empty,
             loc.Version,
             loc.Data,
@@ -325,7 +320,6 @@ public sealed class ComposableMethodGenerator : IIncrementalGenerator
                 IsComposer(method.Parameters[0].Type))) &&
         IsAccessibleFromGeneratedType(method) &&
         !method.IsAsync &&
-        !method.IsExtensionMethod &&
         !method.Parameters.Any(static p => p.RefKind != RefKind.None);
 
     static bool IsAccessibleFromGeneratedType(IMethodSymbol method)

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/Diagnostics.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/Diagnostics.cs
@@ -316,14 +316,6 @@ internal static class Diagnostics
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    public static readonly DiagnosticDescriptor ComposableExtensionUnsupported = new(
-        id: "CN5006",
-        title: "[Composable] extension methods are not supported",
-        messageFormat: "Method '{0}' carries [Composable] but is an extension method — declare a regular static method instead",
-        category: "AndroidX.Compose",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
-
     public static readonly DiagnosticDescriptor ComposableByRefUnsupported = new(
         id: "CN5008",
         title: "[Composable] by-reference parameters are not supported",


### PR DESCRIPTION
Tier 2 currently rejects `[Composable]` extension methods, preventing natural C# helper APIs and focused `IComposer` extensions from participating in restart-group lowering.

This change normalizes Roslyn's reduced extension symbols back to their constructed static declarations before interceptor emission. Both extension syntax and explicit-static syntax now share the correct signature, overload resolution, nullable annotations, generic substitutions, changed-mask diffing, skip behavior, and `UpdateScope` re-entry. An `IComposer` receiver is treated as the composer slot; other extension receivers remain ordinary diffed user parameters.

The obsolete CN5006 diagnostic and unsupported-shape documentation are removed, with generator coverage for both invocation forms, non-composer receivers, overloads, nullability, and generic inference.

Closes #297