### PR TITLE
Clean up Compose value type APIs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,15 +138,17 @@ declarative attribute can be swapped one-for-one to the generic form.
 ## Compose value types
 
 The Kotlin `@JvmInline value class` types that surface as primitives
-across JNI (`Color`, `Dp`, `Sp`, `FontWeight`, `TextAlign`) are
+across JNI (`Color`, `Dp`, `Sp`, `TextOverflow`, `TransformOrigin`) are
 mirrored as typed C# structs in
 [`Microsoft.AndroidX.Compose`](../src/Microsoft.AndroidX.Compose). The bridge generator
 keeps a tiny registry in
 [`ComposeValueTypes.cs`](../src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeValueTypes.cs)
-that maps each value type to its JNI slot (`F` / `J` / `I`) and a
-`Pack(T?)` helper, so a bridge can declare `Dp? width` or `Sp? size`
-and the generator emits the correct primitive lowering plus the
-`$default`-bit clear on non-null. `Color` is a 64-bit packed ULong with
+that maps each value type to its JNI slot (`F` / `J` / `I`) and an
+internal lowering expression, so a bridge can declare `Dp? width`,
+`Sp? size`, or `TransformOrigin? origin` and the generator emits the
+correct primitive lowering plus the `$default`-bit clear on non-null.
+The packed representation stays out of the user-facing API. `Color` is
+a 64-bit packed ULong with
 an implicit conversion to `long`, so call sites pass `Color.FromRgb(…)`
 or one of the named constants straight through to bridges and bound
 binding methods that already take a packed color — no per-call

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -624,7 +624,7 @@ pokes a view that never paints.
 | `TranslationX/Y`                                                 | `Modifier.Offset(x.dp, y.dp)`                                                                                |
 | `Scale * ScaleX/ScaleY` (multiplied)                             | `Modifier.Scale((float)sx)` (uniform) or `Modifier.Scale(sx, sy)` (asymmetric)                                |
 | `Rotation` only                                                  | `Modifier.Rotate(rotation)` (cheaper, no `GraphicsLayer`)                                                    |
-| `Rotation` + any of `RotationX/Y` / `AnchorX/Y != 0.5`           | `Modifier.GraphicsLayer(rotationX, rotationY, rotationZ, transformOrigin: TransformOrigin.Pack(ax, ay))`     |
+| `Rotation` + any of `RotationX/Y` / `AnchorX/Y != 0.5`           | `Modifier.GraphicsLayer(rotationX, rotationY, rotationZ, transformOrigin: new TransformOrigin(ax, ay))`     |
 | `Clip` is `RoundRectangleGeometry`                               | `Modifier.Clip(new RoundedCornerShape(corner.dp))` (or per-corner `RoundedCornerShape(topStart, …)`)         |
 | `Clip` is `RectangleGeometry`                                    | `Modifier.Clip(Shape.Rectangle)`                                                                             |
 | `Clip` is `EllipseGeometry` (`RadiusX == RadiusY`)               | `Modifier.Clip(Shape.Circle())`                                                                              |

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/ComposeValueTypeTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/ComposeValueTypeTests.cs
@@ -1,0 +1,40 @@
+using AndroidX.Compose;
+
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+/// <summary>Verifies the semantic surface and JNI packing of Compose value types.</summary>
+[TestClass]
+public class ComposeValueTypeTests
+{
+    [TestMethod]
+    public void Sp_ToStringUsesReadableUnit()
+    {
+        Assert.AreEqual("16.sp", new Sp(16).ToString());
+        Assert.AreEqual("Unspecified", default(Sp).ToString());
+        Assert.AreEqual("InvalidSp(0x000000023F800000)", new Sp(0x000000023F800000L).ToString());
+    }
+
+    [TestMethod]
+    public void TextOverflow_UsesNamedClosedValues()
+    {
+        Assert.AreEqual("Clip", TextOverflow.Clip.ToString());
+        Assert.AreEqual("Ellipsis", TextOverflow.Ellipsis.ToString());
+        Assert.AreNotEqual(TextOverflow.Clip, TextOverflow.Ellipsis);
+        Assert.AreEqual(TextOverflow.Clip, default(TextOverflow));
+        Assert.AreEqual(1, TextOverflow.Pack(default(TextOverflow)));
+        Assert.IsNull(typeof(TextOverflow).GetConstructor([typeof(int)]));
+    }
+
+    [TestMethod]
+    public void TransformOrigin_ExposesFractionsAndPacksForJni()
+    {
+        var origin = new TransformOrigin(0.25f, 0.75f);
+        long x = unchecked((uint)BitConverter.SingleToInt32Bits(0.25f));
+        long y = unchecked((uint)BitConverter.SingleToInt32Bits(0.75f));
+
+        Assert.AreEqual(0.25f, origin.PivotFractionX);
+        Assert.AreEqual(0.75f, origin.PivotFractionY);
+        Assert.AreEqual((x << 32) | y, TransformOrigin.Pack(origin));
+        Assert.AreEqual(new TransformOrigin(0.5f, 0.5f), TransformOrigin.Center);
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/GraphicsLayerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/GraphicsLayerDemo.cs
@@ -44,7 +44,7 @@ public static class GraphicsLayerDemo
                             .GraphicsLayer(
                                 rotationZ:       dragX.Value,
                                 alpha:           0.6f + 0.4f * MathF.Min(1f, MathF.Abs(dragX.Value) / 90f),
-                                transformOrigin: TransformOrigin.Pack(0f, 0f))
+                                transformOrigin: new TransformOrigin(0f, 0f))
                             .Background(Color.FromRgb(0xAB, 0x47, 0xBC)),
                         new Text("⟲") { Modifier = Modifier.Padding(20) },
                     },

--- a/src/Microsoft.AndroidX.Compose.Maui/Platform/ModifierBridge.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Platform/ModifierBridge.cs
@@ -148,8 +148,8 @@ internal static class ModifierBridge
 
         if (needsLayer)
         {
-            long? origin = (Math.Abs(anchorX - 0.5d) > 1e-6 || Math.Abs(anchorY - 0.5d) > 1e-6)
-                ? TransformOrigin.Pack((float)anchorX, (float)anchorY)
+            TransformOrigin? origin = (Math.Abs(anchorX - 0.5d) > 1e-6 || Math.Abs(anchorY - 0.5d) > 1e-6)
+                ? new TransformOrigin((float)anchorX, (float)anchorY)
                 : null;
             modifier = modifier.GraphicsLayer(
                 rotationX:       rotationX != 0d ? (float)rotationX : null,

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -72,7 +72,7 @@ public class BridgeGeneratorTests
             }
             public readonly record struct Dp(float Value)
             {
-                public static float Pack(Dp? value) => value?.Value ?? 0f;
+                internal static float Pack(Dp? value) => value?.Value ?? 0f;
             }
             public readonly record struct Color(ulong PackedValue)
             {
@@ -80,7 +80,7 @@ public class BridgeGeneratorTests
             }
             public readonly record struct Sp(float Value)
             {
-                public static long Pack(Sp? value) => default;
+                internal static long Pack(Sp? value) => default;
             }
             public readonly record struct Em(float Value)
             {
@@ -94,7 +94,11 @@ public class BridgeGeneratorTests
             public sealed class TextDecoration : Java.Lang.Object { }
             public readonly record struct TextOverflow(int Value)
             {
-                public static int Pack(TextOverflow? value) => value?.Value ?? 0;
+                internal static int Pack(TextOverflow? value) => value?.Value ?? 0;
+            }
+            public readonly record struct TransformOrigin(float PivotFractionX, float PivotFractionY)
+            {
+                internal static long Pack(TransformOrigin? value) => default;
             }
         }
         """;
@@ -1378,19 +1382,16 @@ public class BridgeGeneratorTests
     }
 
     [Fact]
-    public void ValueType_SpTextOverflow_LowerCorrectly()
+    public void ValueType_SpTextOverflowTransformOrigin_LowerCorrectly()
     {
-        // @Composable bridge: (Sp fontSize, TextOverflow overflow, Composer).
-        // JNI: 2 user slots (J/I) + Composer (L) + 1 $changed (I) + 1 $default (I).
-        // Sp lowers to packed long; TextOverflow lowers to packed int —
-        // both are non-nullable in their real-world Compose @Composable
-        // declarations, so they travel as primitives rather than boxed
-        // references.
+        // @Composable bridge: (Sp fontSize, TextOverflow overflow,
+        // TransformOrigin origin, Composer). JNI: 3 user slots (J/I/J) +
+        // Composer (L) + 1 $changed (I) + 1 $default (I).
         var code = """
             using AndroidX.Compose;
             using global::AndroidX.Compose.Runtime;
 
-            [assembly: ComposeDefaults("FontDefault", "fontSize", "overflow")]
+            [assembly: ComposeDefaults("FontDefault", "fontSize", "overflow", "origin")]
 
             namespace AndroidX.Compose
             {
@@ -1399,9 +1400,13 @@ public class BridgeGeneratorTests
                     [ComposeBridge(
                         Class = "x/Y",
                         JvmName = "f",
-                        Signature = "(JILandroidx/compose/runtime/Composer;II)V",
+                        Signature = "(JIJLandroidx/compose/runtime/Composer;II)V",
                         Defaults = typeof(FontDefault))]
-                    public static partial void F(Sp? fontSize, TextOverflow? overflow, IComposer composer);
+                    public static partial void F(
+                        Sp? fontSize,
+                        TextOverflow? overflow,
+                        TransformOrigin? origin,
+                        IComposer composer);
                 }
             }
             """;
@@ -1411,6 +1416,8 @@ public class BridgeGeneratorTests
         Assert.NotNull(emitted);
         Assert.Contains("global::AndroidX.Compose.Sp.Pack(fontSize)", emitted);
         Assert.Contains("global::AndroidX.Compose.TextOverflow.Pack(overflow)", emitted);
+        Assert.Contains("global::AndroidX.Compose.TransformOrigin.Pack(origin)", emitted);
+        Assert.Contains("if (origin is not null) defaults &= ~(int)global::AndroidX.Compose.FontDefault.Origin", emitted);
     }
 
     [Fact]

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -132,7 +132,7 @@ public class FacadeGeneratorTests
             {
                 public Dp(float v) { Value = v; }
                 public float Value { get; }
-                public static float Pack(Dp? d) => d?.Value ?? 0f;
+                internal static float Pack(Dp? d) => d?.Value ?? 0f;
             }
             public readonly struct Color
             {
@@ -144,7 +144,7 @@ public class FacadeGeneratorTests
             {
                 public Sp(float v) { Value = v; }
                 public float Value { get; }
-                public static long Pack(Sp? s) => 0L;
+                internal static long Pack(Sp? s) => 0L;
             }
             public readonly struct Em
             {
@@ -156,7 +156,7 @@ public class FacadeGeneratorTests
             {
                 public TextOverflow(int v) { Value = v; }
                 public int Value { get; }
-                public static int Pack(TextOverflow? a) => 0;
+                internal static int Pack(TextOverflow? a) => 0;
             }
             public class FontWeight : Java.Lang.Object { }
             public class FontStyle : Java.Lang.Object { }

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeBridgeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeBridgeGenerator.cs
@@ -478,7 +478,8 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         if (diags.Count > 0)
             return new GenerationResult(null, null, diags.ToArray());
 
-        // CN2007: recognized Compose value types (Color/Dp/Sp/Em/TextAlign)
+        // CN2007: recognized Compose value types (Color/Dp/Sp/TextOverflow/
+        // TransformOrigin)
         // rely on the auto-default-mask logic to leave the $default bit
         // set when null. Without a $default slot there's no way to
         // signal "use Kotlin default" to the call, so reject them up
@@ -537,7 +538,8 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
         }
 
         // CN2008: each recognized Compose value type lowers to a specific
-        // JNI primitive slot (Dp -> F, Sp -> J, TextAlign -> I). Validate
+        // JNI primitive slot (Dp -> F, Sp/TransformOrigin -> J,
+        // TextOverflow -> I). Validate
         // that the bridge's JNI signature actually has that slot at the
         // bit's position — otherwise EmitUserArgValue would silently
         // route a packed long / float into the wrong JValue field and
@@ -1146,7 +1148,7 @@ public sealed class ComposeBridgeGenerator : IIncrementalGenerator
             return false;
         if (IsNullableIntPtr(p.Type)) return false;
         if (IsNullablePrimitive(p.Type)) return false;
-        // Recognized Compose value types (Dp/Sp/Em/TextOverflow) lower
+        // Recognized Compose value types lower
         // to JNI primitives — no managed handle to keep alive.
         if (ComposeValueTypes.TryGet(p.Type, out _, out _)) return false;
         return true;

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -3707,7 +3707,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
     /// <summary>
     /// C# type display for an <see cref="FacadeSlotKind.OptionalValue"/>
-    /// property declaration. For value-class types (Dp/Sp/Em/TextAlign)
+    /// property declaration. For recognized value-class types
     /// the param is already <c>Nullable&lt;T&gt;</c> and round-trips
     /// fine with <c>FullyQualifiedFormat</c>. For reference-typed
     /// wrappers (FontWeight/TextDecoration/Shape) we have to append
@@ -3776,8 +3776,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
     /// <summary>
     /// True for parameters typed as <c>Nullable&lt;T&gt;</c> where <c>T</c>
-    /// is a recognized Compose <c>@JvmInline value class</c> (Dp/Sp/Em/
-    /// TextOverflow), for <em>nullable</em> reference-typed wrappers in
+    /// is a recognized Compose <c>@JvmInline value class</c>, for
+    /// <em>nullable</em> reference-typed wrappers in
     /// <see cref="ComposeReferenceTypes"/> (FontWeight/FontStyle/
     /// FontFamily/TextAlign/TextDecoration/Shape), or for
     /// <c>Nullable&lt;T&gt;</c> where <c>T</c> is a JNI-friendly

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeValueTypes.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeValueTypes.cs
@@ -49,6 +49,10 @@ internal static class ComposeValueTypes
             ["AndroidX.Compose.TextOverflow"] =
                 ('I', "global::AndroidX.Compose.TextOverflow.Pack({0})"),
 
+            // androidx.compose.ui.graphics.TransformOrigin → JNI long.
+            ["AndroidX.Compose.TransformOrigin"] =
+                ('J', "global::AndroidX.Compose.TransformOrigin.Pack({0})"),
+
             // androidx.compose.ui.graphics.Color is bound by
             // Xamarin.AndroidX.Compose.UI.Graphics 1.11.2.1, and the
             // managed-side `AndroidX.Compose.Color` is a value-type wrapper

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -2371,7 +2371,7 @@ internal static partial class ComposeBridges
     // F rotationZ, F cameraDistance, J transformOrigin, Shape shape,
     // Z clip). 13 user params, all defaultable. Mangled because
     // `transformOrigin` is `@JvmInline value class TransformOrigin`
-    // packed as a `long`. The C# wrapper uses `float?`/`long?`/
+    // packed as a `long`. The C# wrapper uses `float?`/`TransformOrigin?`/
     // `IntPtr?`/`bool?` so the auto-mask clears each bit when a
     // value is supplied. This is the simplest of the three
     // graphicsLayer overloads — it omits the `RenderEffect`,
@@ -2398,7 +2398,7 @@ internal static partial class ComposeBridges
         float? rotationY,
         float? rotationZ,
         float? cameraDistance,
-        long? transformOrigin,
+        TransformOrigin? transformOrigin,
         IntPtr? shape,
         bool? clip);
 

--- a/src/Microsoft.AndroidX.Compose/Dp.cs
+++ b/src/Microsoft.AndroidX.Compose/Dp.cs
@@ -95,11 +95,5 @@ public readonly struct Dp : IEquatable<Dp>, IComparable<Dp>
     /// <inheritdoc/>
     public override string ToString() => $"{Value}.dp";
 
-    /// <summary>
-    /// Pack a nullable <see cref="Dp"/> into the raw <c>float</c> the
-    /// JNI slot expects. <c>null</c> -&gt; <c>0f</c>, which the auto-mask
-    /// in the bridge generator pairs with leaving the matching
-    /// <c>$default</c> bit set so Kotlin substitutes its real default.
-    /// </summary>
-    public static float Pack(Dp? value) => value?.Value ?? 0f;
+    internal static float Pack(Dp? value) => value?.Value ?? 0f;
 }

--- a/src/Microsoft.AndroidX.Compose/Modifier.cs
+++ b/src/Microsoft.AndroidX.Compose/Modifier.cs
@@ -308,8 +308,8 @@ public sealed class Modifier
     /// <inheritdoc cref="ModifierExtensions.Shadow(Dp, Shape?)"/>
     public static Modifier Shadow(Dp elevation, Shape? shape = null) => _companion.Shadow(elevation, shape);
 
-    /// <inheritdoc cref="ModifierExtensions.GraphicsLayer(float?, float?, float?, float?, float?, float?, float?, float?, float?, float?, long?, Shape?, bool?)"/>
-    public static Modifier GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, long? transformOrigin = null, Shape? shape = null, bool? clip = null) => _companion.GraphicsLayer(scaleX, scaleY, alpha, translationX, translationY, shadowElevation, rotationX, rotationY, rotationZ, cameraDistance, transformOrigin, shape, clip);
+    /// <inheritdoc cref="ModifierExtensions.GraphicsLayer(float?, float?, float?, float?, float?, float?, float?, float?, float?, float?, TransformOrigin?, Shape?, bool?)"/>
+    public static Modifier GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, TransformOrigin? transformOrigin = null, Shape? shape = null, bool? clip = null) => _companion.GraphicsLayer(scaleX, scaleY, alpha, translationX, translationY, shadowElevation, rotationX, rotationY, rotationZ, cameraDistance, transformOrigin, shape, clip);
 
     /// <inheritdoc cref="ModifierExtensions.ImePadding()"/>
     public static Modifier ImePadding() => _companion.ImePadding();

--- a/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
@@ -972,7 +972,7 @@ public static class ModifierExtensions
     /// <param name="rotationY">Rotation around the Y axis in degrees.</param>
     /// <param name="rotationZ">Rotation around the Z axis in degrees (clockwise).</param>
     /// <param name="cameraDistance">Distance of the camera from the rotation pivot, in pixels.</param>
-    /// <param name="transformOrigin">Packed <c>TransformOrigin</c> value (use <see cref="TransformOrigin.Pack(float, float)"/>); the default is the center (0.5, 0.5).</param>
+    /// <param name="transformOrigin">Pivot used for scaling and rotation; the default is <see cref="TransformOrigin.Center"/>.</param>
     /// <param name="shape">Clip / shadow outline shape (default = rectangle).</param>
     /// <param name="clip">Whether to clip content to <paramref name="shape"/>.</param>
     public static Modifier GraphicsLayer(this Modifier modifier,
@@ -986,7 +986,7 @@ public static class ModifierExtensions
         float? rotationY = null,
         float? rotationZ = null,
         float? cameraDistance = null,
-        long? transformOrigin = null,
+        TransformOrigin? transformOrigin = null,
         Shape? shape = null,
         bool? clip = null)
     {

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -1407,12 +1407,8 @@ AndroidX.Compose.TextField.TrailingIcon.set -> void
 AndroidX.Compose.TextField.VisualTransformation.get -> AndroidX.Compose.UI.Text.Input.IVisualTransformation?
 AndroidX.Compose.TextField.VisualTransformation.set -> void
 AndroidX.Compose.TextOverflow
-AndroidX.Compose.TextOverflow.Deconstruct(out int Value) -> void
 AndroidX.Compose.TextOverflow.Equals(AndroidX.Compose.TextOverflow other) -> bool
 AndroidX.Compose.TextOverflow.TextOverflow() -> void
-AndroidX.Compose.TextOverflow.TextOverflow(int Value) -> void
-AndroidX.Compose.TextOverflow.Value.get -> int
-AndroidX.Compose.TextOverflow.Value.init -> void
 AndroidX.Compose.TextStyle
 AndroidX.Compose.TextStyle.Color.get -> AndroidX.Compose.Color?
 AndroidX.Compose.TextStyle.Color.set -> void
@@ -1484,6 +1480,11 @@ AndroidX.Compose.TopSearchBar.InputField.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.TopSearchBar.InputField.set -> void
 AndroidX.Compose.TopSearchBar.TopSearchBar(AndroidX.Compose.SearchBarState! state) -> void
 AndroidX.Compose.TransformOrigin
+AndroidX.Compose.TransformOrigin.Equals(AndroidX.Compose.TransformOrigin other) -> bool
+AndroidX.Compose.TransformOrigin.PivotFractionX.get -> float
+AndroidX.Compose.TransformOrigin.PivotFractionY.get -> float
+AndroidX.Compose.TransformOrigin.TransformOrigin() -> void
+AndroidX.Compose.TransformOrigin.TransformOrigin(float pivotFractionX, float pivotFractionY) -> void
 AndroidX.Compose.Transitions
 AndroidX.Compose.TriStateCheckbox
 AndroidX.Compose.TriStateCheckbox.TriStateCheckbox(AndroidX.Compose.UI.State.ToggleableState! state, System.Action! onClick, bool enabled = true) -> void
@@ -1692,13 +1693,18 @@ override AndroidX.Compose.TabRow.Render(AndroidX.Compose.Runtime.IComposer! comp
 override AndroidX.Compose.Text.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.TextButton.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.TextField.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
+override AndroidX.Compose.TextOverflow.Equals(object? obj) -> bool
 override AndroidX.Compose.TextOverflow.GetHashCode() -> int
+override AndroidX.Compose.TextOverflow.ToString() -> string!
 override AndroidX.Compose.TimeInput.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.TimePicker.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.TimePickerDialog.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.Tooltip.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.TopAppBar.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.TopSearchBar.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
+override AndroidX.Compose.TransformOrigin.Equals(object? obj) -> bool
+override AndroidX.Compose.TransformOrigin.GetHashCode() -> int
+override AndroidX.Compose.TransformOrigin.ToString() -> string!
 override AndroidX.Compose.TriStateCheckbox.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.VerticalDivider.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.VerticalPager<T>.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
@@ -2177,7 +2183,6 @@ static AndroidX.Compose.ContentScale.None.get -> AndroidX.Compose.ContentScale!
 static AndroidX.Compose.CornerRadius.Zero.get -> AndroidX.Compose.CornerRadius
 static AndroidX.Compose.CornerRadius.operator !=(AndroidX.Compose.CornerRadius left, AndroidX.Compose.CornerRadius right) -> bool
 static AndroidX.Compose.CornerRadius.operator ==(AndroidX.Compose.CornerRadius left, AndroidX.Compose.CornerRadius right) -> bool
-static AndroidX.Compose.Dp.Pack(AndroidX.Compose.Dp? value) -> float
 static AndroidX.Compose.Dp.Zero.get -> AndroidX.Compose.Dp
 static AndroidX.Compose.Dp.implicit operator AndroidX.Compose.Dp(float value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.Dp.implicit operator AndroidX.Compose.Dp(int value) -> AndroidX.Compose.Dp
@@ -2595,7 +2600,7 @@ static AndroidX.Compose.Modifier.FillMaxWidth(float fraction = 1) -> AndroidX.Co
 static AndroidX.Compose.Modifier.FocusGroup() -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.FocusRequester(AndroidX.Compose.FocusRequester! requester) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Focusable(bool enabled = true) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, long? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, AndroidX.Compose.TransformOrigin? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Height(AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.HeightIn(AndroidX.Compose.Dp? min = null, AndroidX.Compose.Dp? max = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.HorizontalScroll(AndroidX.Compose.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> AndroidX.Compose.Modifier!
@@ -2692,7 +2697,7 @@ static AndroidX.Compose.ModifierExtensions.FillMaxWidth(this AndroidX.Compose.Mo
 static AndroidX.Compose.ModifierExtensions.FocusGroup(this AndroidX.Compose.Modifier! modifier) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.FocusRequester(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.FocusRequester! requester) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Focusable(this AndroidX.Compose.Modifier! modifier, bool enabled = true) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.GraphicsLayer(this AndroidX.Compose.Modifier! modifier, float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, long? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.GraphicsLayer(this AndroidX.Compose.Modifier! modifier, float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, AndroidX.Compose.TransformOrigin? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Height(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.HeightIn(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp? min = null, AndroidX.Compose.Dp? max = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.HorizontalScroll(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> AndroidX.Compose.Modifier!
@@ -2770,7 +2775,6 @@ static AndroidX.Compose.Shape.RoundedPercent(int percent) -> AndroidX.Compose.Sh
 static AndroidX.Compose.Size.Zero.get -> AndroidX.Compose.Size
 static AndroidX.Compose.Size.operator !=(AndroidX.Compose.Size left, AndroidX.Compose.Size right) -> bool
 static AndroidX.Compose.Size.operator ==(AndroidX.Compose.Size left, AndroidX.Compose.Size right) -> bool
-static AndroidX.Compose.Sp.Pack(AndroidX.Compose.Sp? value) -> long
 static AndroidX.Compose.Sp.Zero.get -> AndroidX.Compose.Sp
 static AndroidX.Compose.Sp.implicit operator AndroidX.Compose.Sp(int value) -> AndroidX.Compose.Sp
 static AndroidX.Compose.Sp.operator !=(AndroidX.Compose.Sp left, AndroidX.Compose.Sp right) -> bool
@@ -2807,13 +2811,13 @@ static AndroidX.Compose.TextDecoration.Underline.get -> AndroidX.Compose.TextDec
 static AndroidX.Compose.TextOverflow.Clip.get -> AndroidX.Compose.TextOverflow
 static AndroidX.Compose.TextOverflow.Ellipsis.get -> AndroidX.Compose.TextOverflow
 static AndroidX.Compose.TextOverflow.MiddleEllipsis.get -> AndroidX.Compose.TextOverflow
-static AndroidX.Compose.TextOverflow.Pack(AndroidX.Compose.TextOverflow? value) -> int
 static AndroidX.Compose.TextOverflow.StartEllipsis.get -> AndroidX.Compose.TextOverflow
 static AndroidX.Compose.TextOverflow.Visible.get -> AndroidX.Compose.TextOverflow
 static AndroidX.Compose.TextOverflow.operator !=(AndroidX.Compose.TextOverflow left, AndroidX.Compose.TextOverflow right) -> bool
 static AndroidX.Compose.TextOverflow.operator ==(AndroidX.Compose.TextOverflow left, AndroidX.Compose.TextOverflow right) -> bool
-static AndroidX.Compose.TransformOrigin.Center.get -> long
-static AndroidX.Compose.TransformOrigin.Pack(float pivotFractionX, float pivotFractionY) -> long
+static AndroidX.Compose.TransformOrigin.Center.get -> AndroidX.Compose.TransformOrigin
+static AndroidX.Compose.TransformOrigin.operator !=(AndroidX.Compose.TransformOrigin left, AndroidX.Compose.TransformOrigin right) -> bool
+static AndroidX.Compose.TransformOrigin.operator ==(AndroidX.Compose.TransformOrigin left, AndroidX.Compose.TransformOrigin right) -> bool
 static AndroidX.Compose.Transitions.FadeIn(float initialAlpha = 0, AndroidX.Compose.Animation.Core.IFiniteAnimationSpec? animationSpec = null) -> AndroidX.Compose.Animation.EnterTransition!
 static AndroidX.Compose.Transitions.FadeOut(float targetAlpha = 0, AndroidX.Compose.Animation.Core.IFiniteAnimationSpec? animationSpec = null) -> AndroidX.Compose.Animation.ExitTransition!
 static AndroidX.Compose.Transitions.ScaleIn(float initialScale = 0, AndroidX.Compose.Animation.Core.IFiniteAnimationSpec? animationSpec = null) -> AndroidX.Compose.Animation.EnterTransition!
@@ -2838,5 +2842,3 @@ static AndroidX.Compose.WindowInsets.Waterfall(AndroidX.Compose.Runtime.ICompose
 virtual AndroidX.Compose.MutableState<T>.Value.get -> T
 virtual AndroidX.Compose.MutableState<T>.Value.set -> void
 virtual AndroidX.Compose.ViewModel.OnClearedCore() -> void
-~override AndroidX.Compose.TextOverflow.Equals(object obj) -> bool
-~override AndroidX.Compose.TextOverflow.ToString() -> string

--- a/src/Microsoft.AndroidX.Compose/Sp.cs
+++ b/src/Microsoft.AndroidX.Compose/Sp.cs
@@ -115,13 +115,17 @@ public readonly struct Sp : IEquatable<Sp>, IComparable<Sp>
     public static bool operator >=(Sp a, Sp b) => a.CompareTo(b) >= 0;
 
     /// <inheritdoc/>
-    public override string ToString() => $"Sp(0x{PackedValue:X16})";
+    public override string ToString()
+    {
+        var type = unchecked((uint)(PackedValue >> 32));
+        if (type == 0)
+            return "Unspecified";
+        if (type != 1)
+            return $"InvalidSp(0x{PackedValue:X16})";
 
-    /// <summary>
-    /// Pack a nullable <see cref="Sp"/> into the packed <c>TextUnit</c>
-    /// long the JNI slot expects. <c>null</c> -&gt; <c>0L</c>; the
-    /// auto-mask leaves the matching <c>$default</c> bit set so
-    /// Kotlin's real default applies.
-    /// </summary>
-    public static long Pack(Sp? value) => value?.PackedValue ?? 0L;
+        var value = BitConverter.Int32BitsToSingle(unchecked((int)PackedValue));
+        return $"{value}.sp";
+    }
+
+    internal static long Pack(Sp? value) => value?.PackedValue ?? 0L;
 }

--- a/src/Microsoft.AndroidX.Compose/TextOverflow.cs
+++ b/src/Microsoft.AndroidX.Compose/TextOverflow.cs
@@ -1,42 +1,61 @@
 namespace AndroidX.Compose;
 
 /// <summary>
-/// C# mirror of Kotlin's <c>androidx.compose.ui.text.style.TextOverflow</c>
-/// — a <c>@JvmInline value class</c> wrapping an <c>Int</c>. The bridge
-/// generator lowers <c>TextOverflow?</c> to the underlying <c>int</c>
-/// JNI slot.
-///
-/// Values mirror the Kotlin <c>TextOverflow.Companion</c> constants:
-/// <list type="bullet">
-///   <item><see cref="Clip"/> = 1 — truncate at the container edge.</item>
-///   <item><see cref="Ellipsis"/> = 2 — replace overflow with <c>"…"</c>.</item>
-///   <item><see cref="Visible"/> = 3 — render past the container bounds.</item>
-///   <item><see cref="StartEllipsis"/> = 4 — leading ellipsis.</item>
-///   <item><see cref="MiddleEllipsis"/> = 5 — middle ellipsis.</item>
-/// </list>
+/// Controls how text that exceeds its available space is rendered.
 /// </summary>
-public readonly record struct TextOverflow(int Value)
+public readonly struct TextOverflow : IEquatable<TextOverflow>
 {
+    readonly int _value;
+
+    TextOverflow(int value)
+    {
+        _value = value;
+    }
+
     /// <summary>Truncate the text at the edge of the container.</summary>
-    public static TextOverflow Clip => new(1);
+    public static TextOverflow Clip => new(0);
 
     /// <summary>Replace the overflowing text with an ellipsis (default for single-line).</summary>
-    public static TextOverflow Ellipsis => new(2);
+    public static TextOverflow Ellipsis => new(1);
 
     /// <summary>Render the text outside the container bounds (no clipping).</summary>
-    public static TextOverflow Visible => new(3);
+    public static TextOverflow Visible => new(2);
 
     /// <summary>Place the ellipsis at the start of the text.</summary>
-    public static TextOverflow StartEllipsis => new(4);
+    public static TextOverflow StartEllipsis => new(3);
 
     /// <summary>Place the ellipsis in the middle of the text.</summary>
-    public static TextOverflow MiddleEllipsis => new(5);
+    public static TextOverflow MiddleEllipsis => new(4);
 
-    /// <summary>
-    /// Pack a nullable <see cref="TextOverflow"/> into the raw
-    /// <c>int</c> the JNI slot expects. <c>null</c> → <c>0</c>; the
-    /// auto-mask leaves the <c>$default</c> bit set so Kotlin's real
-    /// default applies.
-    /// </summary>
-    public static int Pack(TextOverflow? value) => value?.Value ?? 0;
+    internal static int Pack(TextOverflow? value) =>
+        value is { } overflow ? overflow._value + 1 : 0;
+
+    /// <inheritdoc/>
+    public bool Equals(TextOverflow other) => _value == other._value;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is TextOverflow overflow && Equals(overflow);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => _value;
+
+    /// <summary>Equality operator.</summary>
+    public static bool operator ==(TextOverflow left, TextOverflow right) =>
+        left.Equals(right);
+
+    /// <summary>Inequality operator.</summary>
+    public static bool operator !=(TextOverflow left, TextOverflow right) =>
+        !left.Equals(right);
+
+    /// <inheritdoc/>
+    public override string ToString() => _value switch
+    {
+        0 => nameof(Clip),
+        1 => nameof(Ellipsis),
+        2 => nameof(Visible),
+        3 => nameof(StartEllipsis),
+        4 => nameof(MiddleEllipsis),
+        _ => "Invalid",
+    };
 }

--- a/src/Microsoft.AndroidX.Compose/TransformOrigin.cs
+++ b/src/Microsoft.AndroidX.Compose/TransformOrigin.cs
@@ -1,41 +1,71 @@
 namespace AndroidX.Compose;
 
 /// <summary>
-/// Mirror of Kotlin's <c>androidx.compose.ui.graphics.TransformOrigin</c> —
-/// the pivot point used by transform-aware modifiers such as
-/// <see cref="Modifier.GraphicsLayer"/> for scale and rotation. Compose
-/// defines it as a <c>@JvmInline value class TransformOrigin(val packedValue: Long)</c>
-/// that packs two <see cref="float"/>s (fractions in <c>[0, 1]</c>)
-/// into a single <see cref="long"/>: <c>x</c> in the upper 32 bits,
-/// <c>y</c> in the lower 32 bits. Because the binding generator
-/// strips inline value-class types, the <see cref="Modifier.GraphicsLayer"/>
-/// API takes the raw packed <see cref="long"/>; <see cref="Pack"/>
-/// builds one from a <c>(x, y)</c> pair and <see cref="Center"/>
-/// supplies the common (0.5, 0.5) default.
+/// Pivot point used by transform-aware modifiers such as
+/// <see cref="Modifier.GraphicsLayer"/> for scale and rotation.
 /// </summary>
-public static class TransformOrigin
+/// <remarks>
+/// Fractions normally range from <c>0</c> to <c>1</c>: <c>0</c> is the
+/// left or top edge, <c>0.5</c> is the center, and <c>1</c> is the right
+/// or bottom edge. Values outside that range are allowed.
+/// </remarks>
+public readonly struct TransformOrigin : IEquatable<TransformOrigin>
 {
     /// <summary>
-    /// Packed <see cref="long"/> equivalent to Compose's
-    /// <c>TransformOrigin.Center</c> — pivot (0.5, 0.5), i.e. the
-    /// geometric center of the composable. This is the default
-    /// pivot Compose uses when none is supplied.
+    /// Creates a transform origin from horizontal and vertical pivot
+    /// fractions.
     /// </summary>
-    public static long Center { get; } = Pack(0.5f, 0.5f);
-
-    /// <summary>
-    /// Pack a (<paramref name="pivotFractionX"/>,
-    /// <paramref name="pivotFractionY"/>) pair into the
-    /// <c>TransformOrigin</c> bit layout expected by
-    /// <see cref="Modifier.GraphicsLayer"/>. Both fractions are
-    /// typically in <c>[0, 1]</c>: <c>0</c> = left/top,
-    /// <c>0.5</c> = center, <c>1</c> = right/bottom. Values outside
-    /// that range are allowed but rarely useful.
-    /// </summary>
-    public static long Pack(float pivotFractionX, float pivotFractionY)
+    /// <param name="pivotFractionX">Horizontal pivot fraction.</param>
+    /// <param name="pivotFractionY">Vertical pivot fraction.</param>
+    public TransformOrigin(float pivotFractionX, float pivotFractionY)
     {
-        long x = unchecked((uint)BitConverter.SingleToInt32Bits(pivotFractionX));
-        long y = unchecked((uint)BitConverter.SingleToInt32Bits(pivotFractionY));
-        return (x << 32) | y;
+        PivotFractionX = pivotFractionX;
+        PivotFractionY = pivotFractionY;
     }
+
+    /// <summary>The horizontal pivot fraction.</summary>
+    public float PivotFractionX { get; }
+
+    /// <summary>The vertical pivot fraction.</summary>
+    public float PivotFractionY { get; }
+
+    /// <summary>The geometric center of the composable.</summary>
+    public static TransformOrigin Center => new(0.5f, 0.5f);
+
+    internal long PackedValue
+    {
+        get
+        {
+            long x = unchecked((uint)BitConverter.SingleToInt32Bits(PivotFractionX));
+            long y = unchecked((uint)BitConverter.SingleToInt32Bits(PivotFractionY));
+            return (x << 32) | y;
+        }
+    }
+
+    internal static long Pack(TransformOrigin? value) => value?.PackedValue ?? 0L;
+
+    /// <inheritdoc/>
+    public bool Equals(TransformOrigin other) =>
+        PivotFractionX.Equals(other.PivotFractionX) &&
+        PivotFractionY.Equals(other.PivotFractionY);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is TransformOrigin origin && Equals(origin);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        HashCode.Combine(PivotFractionX, PivotFractionY);
+
+    /// <summary>Equality operator.</summary>
+    public static bool operator ==(TransformOrigin left, TransformOrigin right) =>
+        left.Equals(right);
+
+    /// <summary>Inequality operator.</summary>
+    public static bool operator !=(TransformOrigin left, TransformOrigin right) =>
+        !left.Equals(right);
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"TransformOrigin({PivotFractionX}, {PivotFractionY})";
 }

--- a/src/Microsoft.AndroidX.Compose/Transitions.cs
+++ b/src/Microsoft.AndroidX.Compose/Transitions.cs
@@ -68,7 +68,7 @@ public static class Transitions
     /// <param name="animationSpec">Optional spec; <see langword="null"/> uses
     /// <c>spring(stiffness = StiffnessMediumLow)</c>.</param>
     public static EnterTransition ScaleIn(float initialScale = 0f, IFiniteAnimationSpec? animationSpec = null) =>
-        EnterExitTransitionKt.ScaleIn(animationSpec ?? DefaultSpec(), initialScale, TransformOrigin.Center);
+        EnterExitTransitionKt.ScaleIn(animationSpec ?? DefaultSpec(), initialScale, TransformOrigin.Center.PackedValue);
 
     /// <summary>
     /// Scales the content out from <c>1f</c> to
@@ -80,7 +80,7 @@ public static class Transitions
     /// <param name="animationSpec">Optional spec; <see langword="null"/> uses
     /// <c>spring(stiffness = StiffnessMediumLow)</c>.</param>
     public static ExitTransition ScaleOut(float targetScale = 0f, IFiniteAnimationSpec? animationSpec = null) =>
-        EnterExitTransitionKt.ScaleOut(animationSpec ?? DefaultSpec(), targetScale, TransformOrigin.Center);
+        EnterExitTransitionKt.ScaleOut(animationSpec ?? DefaultSpec(), targetScale, TransformOrigin.Center.PackedValue);
 
     /// <summary>
     /// Slides the content in horizontally from <paramref name="initialOffsetX"/>


### PR DESCRIPTION
Compose value types currently leak JNI packing details into the public API: `TransformOrigin` is a raw packed `long`, packing helpers appear as user-facing utilities, `TextOverflow` accepts arbitrary integers, and `Sp.ToString()` prints its wire representation.

This change replaces those implementation details with semantic value types and keeps packing at the generated bridge boundary:

- Redesigns `TransformOrigin` as a readonly value with pivot fractions and updates `GraphicsLayer` to accept `TransformOrigin?`.
- Makes the `Dp`, `Sp`, `TextOverflow`, and `TransformOrigin` packers internal and adds `TransformOrigin` to generated value-type lowering.
- Makes `TextOverflow` a closed set of named values. Its zero-based managed representation makes `default(TextOverflow)` safely map to Compose `Clip` while JNI lowering emits Compose's 1-based value.
- Makes `Sp.ToString()` display readable sp values while identifying unspecified or invalid packed tags.
- Updates MAUI integration, gallery coverage, architecture docs, device tests, and the sorted public API baseline.

Validation:

- 299 source-generator tests pass.
- Compose facade, MAUI backend, gallery, and device-test projects build successfully.
- All three new `ComposeValueTypeTests` passed on a Pixel 10.