### PR TITLE
Use typed Color values in public APIs

### DIFF
--- a/samples/Jetchat/Conversation.cs
+++ b/samples/Jetchat/Conversation.cs
@@ -68,12 +68,12 @@ public static class Conversation
                 {
                     FontSize   = 16,
                     FontWeight = FontWeight.Medium,
-                    Color      = scheme.OnSurface,
+                    Color      = Color.FromPacked(scheme.OnSurface),
                 },
                 new Text($"{ui.ChannelMembers} members")
                 {
                     FontSize = 12,
-                    Color    = scheme.OnSurfaceVariant,
+                    Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                     Modifier = Modifier.Padding(top: 2),
                 },
             },
@@ -85,7 +85,7 @@ public static class Conversation
                         .Clickable(() => popupOpen.Value = true)
                         .Padding(horizontal: 12, vertical: 16)
                         .Height(24),
-                    Tint = scheme.OnSurfaceVariant,
+                    Tint = Color.FromPacked(scheme.OnSurfaceVariant),
                 },
                 new Icon(Resource.Drawable.ic_info, "Information")
                 {
@@ -93,7 +93,7 @@ public static class Conversation
                         .Clickable(() => popupOpen.Value = true)
                         .Padding(horizontal: 12, vertical: 16)
                         .Height(24),
-                    Tint = scheme.OnSurfaceVariant,
+                    Tint = Color.FromPacked(scheme.OnSurfaceVariant),
                 },
             },
         };
@@ -223,19 +223,19 @@ public static class Conversation
             new HorizontalDivider
             {
                 Modifier  = Modifier.Weight(1f),
-                Color = scheme.OnSurface,
+                Color = Color.FromPacked(scheme.OnSurface),
             },
             new Text(label)
             {
                 FontSize   = 11,
                 FontWeight = FontWeight.Medium,
-                Color      = scheme.OnSurfaceVariant,
+                Color      = Color.FromPacked(scheme.OnSurfaceVariant),
                 Modifier   = Modifier.Padding(horizontal: 16),
             },
             new HorizontalDivider
             {
                 Modifier  = Modifier.Weight(1f),
-                Color = scheme.OnSurface,
+                Color = Color.FromPacked(scheme.OnSurface),
             },
         };
 
@@ -258,7 +258,7 @@ public static class Conversation
     static Image BuildAvatar(Message m, ColorScheme scheme, Action<string> onAuthorClicked)
     {
         bool isMe = m.Author == MyName;
-        long accent = isMe ? scheme.Primary : scheme.Tertiary;
+        var accent = Color.FromPacked(isMe ? scheme.Primary : scheme.Tertiary);
         string userId = isMe ? Profiles.MeProfile.UserId : Profiles.ColleagueProfile.UserId;
         return new Image(m.AuthorImage, "Profile photo")
         {
@@ -266,7 +266,7 @@ public static class Conversation
                 .Padding(horizontal: 16)
                 .Size(42)
                 .Border(1.5f, accent,         Shape.Circle())
-                .Border(3,    scheme.Surface, Shape.Circle())
+                .Border(3, Color.FromPacked(scheme.Surface), Shape.Circle())
                 .Clip(21)
                 .Clickable(() => onAuthorClicked(userId)),
         };
@@ -292,14 +292,14 @@ public static class Conversation
             {
                 FontSize   = 16,
                 FontWeight = FontWeight.Medium,
-                Color      = scheme.OnSurface,
+                Color      = Color.FromPacked(scheme.OnSurface),
                 Modifier   = Modifier.Padding(bottom: 8),
             },
             Spacer.Width(8),
             new Text(m.Timestamp)
             {
                 FontSize = 12,
-                Color    = scheme.OnSurfaceVariant,
+                Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                 Modifier = Modifier.Padding(bottom: 8),
             },
         };
@@ -307,8 +307,8 @@ public static class Conversation
     static ComposableNode BuildChatItemBubble(Message m, ColorScheme scheme, MutableState<bool> popupOpen)
     {
         bool isMe = m.Author == MyName;
-        long bg   = isMe ? scheme.Primary : scheme.SurfaceVariant;
-        long fg   = isMe ? scheme.OnPrimary : scheme.OnSurface;
+        var bg = Color.FromPacked(isMe ? scheme.Primary : scheme.SurfaceVariant);
+        var fg = Color.FromPacked(isMe ? scheme.OnPrimary : scheme.OnSurface);
         var formatted = MessageFormatter.Format(m.Content, isMe, scheme, _ => popupOpen.Value = true);
         return new AnnotatedText(formatted)
         {
@@ -409,7 +409,7 @@ public static class Conversation
             new Text("Send")
             {
                 FontWeight = FontWeight.SemiBold,
-                Color      = enabled ? scheme.Primary : scheme.OnSurfaceVariant,
+                Color      = Color.FromPacked(enabled ? scheme.Primary : scheme.OnSurfaceVariant),
             },
         });
         return row;
@@ -428,11 +428,13 @@ public static class Conversation
         {
             new Icon(drawableId, contentDescription)
             {
-                Tint = selected ? scheme.OnSecondary : scheme.OnSurface,
+                Tint = Color.FromPacked(selected ? scheme.OnSecondary : scheme.OnSurface),
             },
         };
         if (selected)
-            button.Modifier = Modifier.Background(scheme.Secondary, new RoundedCornerShape(14.Dp()));
+            button.Modifier = Modifier.Background(
+                Color.FromPacked(scheme.Secondary),
+                new RoundedCornerShape(14.Dp()));
         return button;
     }
 
@@ -448,20 +450,21 @@ public static class Conversation
         string subtitle = "Grab a beverage and check back later!";
         return new Column
         {
-            Modifier.FillMaxWidth().Height(320).Background(scheme.SurfaceVariant),
+            Modifier.FillMaxWidth().Height(320)
+                .Background(Color.FromPacked(scheme.SurfaceVariant)),
             Spacer.Height(96),
             new Text(title)
             {
                 FontSize   = 16,
                 FontWeight = FontWeight.Medium,
-                Color      = scheme.OnSurfaceVariant,
+                Color      = Color.FromPacked(scheme.OnSurfaceVariant),
                 Modifier   = Modifier.Padding(horizontal: 16),
             },
             Spacer.Height(8),
             new Text(subtitle)
             {
                 FontSize = 14,
-                Color    = scheme.OnSurfaceVariant,
+                Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                 Modifier = Modifier.Padding(horizontal: 16),
             },
         };

--- a/samples/Jetchat/EmojiSelector.cs
+++ b/samples/Jetchat/EmojiSelector.cs
@@ -80,7 +80,7 @@ public static class EmojiSelector
             {
                 Modifier
                     .FillMaxWidth()
-                    .Background(scheme.SurfaceVariant),
+                    .Background(Color.FromPacked(scheme.SurfaceVariant)),
                 new PrimaryTabRow(selectedTabIndex: selected.Value)
                 {
                     new Tab(selected: selected.Value == 0, onClick: () => selected.Value = 0)
@@ -116,7 +116,7 @@ public static class EmojiSelector
                 rowNode.Add(new Text(emoji)
                 {
                     FontSize = 18,
-                    Color    = scheme.OnSurface,
+                    Color    = Color.FromPacked(scheme.OnSurface),
                     Modifier = Modifier
                         .Clickable(() =>
                         {
@@ -147,7 +147,7 @@ public static class EmojiSelector
             new Text("Stickers not yet implemented in this port.")
             {
                 FontSize = 14,
-                Color    = scheme.OnSurfaceVariant,
+                Color    = Color.FromPacked(scheme.OnSurfaceVariant),
             },
         };
 }

--- a/samples/Jetchat/JetchatDrawer.cs
+++ b/samples/Jetchat/JetchatDrawer.cs
@@ -25,7 +25,10 @@ public static class JetchatDrawer
         Action<string> onChatClicked,
         Action<string> onProfileClicked)
     {
-        var sheet = new ModalDrawerSheet { ContainerColor = scheme.Surface };
+        var sheet = new ModalDrawerSheet
+        {
+            ContainerColor = Color.FromPacked(scheme.Surface),
+        };
         sheet.Add(new Column
         {
             Modifier.FillMaxWidth().VerticalScroll(scroll),
@@ -53,7 +56,7 @@ public static class JetchatDrawer
             {
                 FontSize   = 18,
                 FontWeight = FontWeight.SemiBold,
-                Color      = scheme.OnSurface,
+                Color      = Color.FromPacked(scheme.OnSurface),
             },
         };
 
@@ -72,7 +75,7 @@ public static class JetchatDrawer
             new Text(label)
             {
                 FontSize = 14,
-                Color    = scheme.OnSurfaceVariant,
+                Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                 Modifier = Modifier.Padding(top: 16),
             },
         };
@@ -96,10 +99,12 @@ public static class JetchatDrawer
                 _ = drawerState.CloseAsync();
             });
         if (selected)
-            modifier = modifier.Background(scheme.PrimaryContainer);
+            modifier = modifier.Background(Color.FromPacked(scheme.PrimaryContainer));
 
-        long iconTint  = selected ? scheme.Primary : scheme.OnSurfaceVariant;
-        long textColor = selected ? scheme.Primary : scheme.OnSurface;
+        var iconTint = Color.FromPacked(
+            selected ? scheme.Primary : scheme.OnSurfaceVariant);
+        var textColor = Color.FromPacked(
+            selected ? scheme.Primary : scheme.OnSurface);
 
         return new Row
         {
@@ -140,7 +145,7 @@ public static class JetchatDrawer
                 _ = drawerState.CloseAsync();
             });
         if (selected)
-            modifier = modifier.Background(scheme.PrimaryContainer);
+            modifier = modifier.Background(Color.FromPacked(scheme.PrimaryContainer));
 
         return new Row
         {
@@ -155,7 +160,7 @@ public static class JetchatDrawer
             new Text(name)
             {
                 FontSize = 14,
-                Color    = scheme.OnSurface,
+                Color    = Color.FromPacked(scheme.OnSurface),
                 Modifier = Modifier.Padding(top: 16, bottom: 16, start: 12),
             },
         };

--- a/samples/Jetchat/JetchatIcon.cs
+++ b/samples/Jetchat/JetchatIcon.cs
@@ -40,12 +40,12 @@ public static class JetchatIcon
                 new Icon(Resource.Drawable.ic_jetchat_back, null)
                 {
                     Modifier = Modifier.Size(sizeDp),
-                    Tint = scheme.PrimaryContainer,
+                    Tint = Color.FromPacked(scheme.PrimaryContainer),
                 },
                 new Icon(Resource.Drawable.ic_jetchat_front, contentDescription)
                 {
                     Modifier = Modifier.Size(sizeDp),
-                    Tint = scheme.Primary,
+                    Tint = Color.FromPacked(scheme.Primary),
                 },
             };
         });

--- a/samples/Jetchat/MessageFormatter.cs
+++ b/samples/Jetchat/MessageFormatter.cs
@@ -37,8 +37,10 @@ public static partial class MessageFormatter
         ArgumentNullException.ThrowIfNull(scheme);
 
         var builder = new AnnotatedStringBuilder();
-        long codeSnippetBackground = primary ? scheme.Secondary : scheme.Surface;
-        long accent                = primary ? scheme.InversePrimary : scheme.Primary;
+        var codeSnippetBackground = Color.FromPacked(
+            primary ? scheme.Secondary : scheme.Surface);
+        var accent = Color.FromPacked(
+            primary ? scheme.InversePrimary : scheme.Primary);
 
         int cursor = 0;
         bool any = false;

--- a/samples/Jetchat/Profile.cs
+++ b/samples/Jetchat/Profile.cs
@@ -46,7 +46,7 @@ public static class Profile
             {
                 new Icon(Resource.Drawable.ic_arrow_back, "Back")
                 {
-                    Tint = scheme.OnSurfaceVariant,
+                    Tint = Color.FromPacked(scheme.OnSurfaceVariant),
                 },
             },
             Title   = new Text(""),
@@ -58,7 +58,7 @@ public static class Profile
                         .Clickable(() => popupOpen.Value = true)
                         .Padding(horizontal: 12, vertical: 16)
                         .Height(24),
-                    Tint = scheme.OnSurfaceVariant,
+                    Tint = Color.FromPacked(scheme.OnSurfaceVariant),
                 },
             },
         };
@@ -130,13 +130,13 @@ public static class Profile
             {
                 FontSize   = 24,
                 FontWeight = FontWeight.Medium,
-                Color      = scheme.OnSurface,
+                Color      = Color.FromPacked(scheme.OnSurface),
                 Modifier   = Modifier.Padding(top: 8),
             },
             new Text(state.Position)
             {
                 FontSize = 16,
-                Color    = scheme.OnSurfaceVariant,
+                Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                 Modifier = Modifier.Padding(top: 4, bottom: 20),
             },
         };
@@ -147,18 +147,19 @@ public static class Profile
             Modifier.Padding(start: 16, end: 16, bottom: 16),
             new HorizontalDivider
             {
-                Color = scheme.OnSurface,
+                Color = Color.FromPacked(scheme.OnSurface),
             },
             new Text(label)
             {
                 FontSize = 12,
-                Color    = scheme.OnSurfaceVariant,
+                Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                 Modifier = Modifier.Padding(top: 8),
             },
             new Text(value)
             {
                 FontSize = 16,
-                Color    = isLink ? scheme.Primary : scheme.OnSurface,
+                Color = Color.FromPacked(
+                    isLink ? scheme.Primary : scheme.OnSurface),
                 Modifier = Modifier.Padding(top: 4),
             },
         };
@@ -186,11 +187,11 @@ public static class Profile
                 .WidthIn(min: 48),
             Icon = new Icon(iconRes, label)
             {
-                Tint = scheme.OnTertiaryContainer,
+                Tint = Color.FromPacked(scheme.OnTertiaryContainer),
             },
             Text = new Text(label)
             {
-                Color = scheme.OnTertiaryContainer,
+                Color = Color.FromPacked(scheme.OnTertiaryContainer),
             },
         };
     }

--- a/samples/Jetchat/RecordButton.cs
+++ b/samples/Jetchat/RecordButton.cs
@@ -61,7 +61,8 @@ public static class RecordButton
                     innerModifier,
                     new Icon(Resource.Drawable.ic_mic, "Record voice message")
                     {
-                        Tint = recording ? scheme.OnPrimary : scheme.OnSurfaceVariant,
+                        Tint = Color.FromPacked(
+                            recording ? scheme.OnPrimary : scheme.OnSurfaceVariant),
                         Modifier = Modifier.FillMaxSize(),
                     },
                 },
@@ -136,7 +137,7 @@ public static class RecordButton
                     Modifier   = Modifier.Align(Alignment.Vertical.CenterVertically),
                     FontSize   = 22,
                     FontWeight = FontWeight.Medium,
-                    Color      = scheme.OnSurface,
+                    Color      = Color.FromPacked(scheme.OnSurface),
                 },
 
                 Spacer.Width(16),
@@ -151,7 +152,7 @@ public static class RecordButton
 
                     new Icon(Resource.Drawable.ic_arrow_back, "Slide to cancel")
                     {
-                        Tint = scheme.OnSurfaceVariant,
+                        Tint = Color.FromPacked(scheme.OnSurfaceVariant),
                         Modifier = Modifier.Align(Alignment.Vertical.CenterVertically).Size(24),
                     },
                     Spacer.Width(8),
@@ -159,7 +160,7 @@ public static class RecordButton
                     {
                         Modifier = Modifier.Align(Alignment.Vertical.CenterVertically),
                         FontSize = 16,
-                        Color    = scheme.OnSurfaceVariant,
+                        Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                     },
                 },
             };

--- a/samples/Reply/EmailDetailAppBar.cs
+++ b/samples/Reply/EmailDetailAppBar.cs
@@ -19,12 +19,12 @@ public static class EmailDetailAppBar
                     new Text(email.Subject)
                     {
                         FontSize = 16,
-                        Color    = scheme.OnSurfaceVariant,
+                        Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                     },
                     new Text($"{email.Threads.Count} Messages")
                     {
                         FontSize = 12,
-                        Color    = scheme.Outline,
+                        Color    = Color.FromPacked(scheme.Outline),
                         Modifier = Modifier.Padding(top: 4),
                     },
                 };
@@ -44,7 +44,7 @@ public static class EmailDetailAppBar
                 {
                     new Icon(Resource.Drawable.ic_more_vert, "More options")
                     {
-                        Tint = scheme.OnSurfaceVariant,
+                        Tint = Color.FromPacked(scheme.OnSurfaceVariant),
                     },
                 };
             }),

--- a/samples/Reply/EmptyComingSoon.cs
+++ b/samples/Reply/EmptyComingSoon.cs
@@ -19,14 +19,14 @@ public static class EmptyComingSoon
                 {
                     FontSize   = 18,
                     FontWeight = FontWeight.SemiBold,
-                    Color      = scheme.Primary,
+                    Color      = Color.FromPacked(scheme.Primary),
                     Modifier   = Modifier.FillMaxWidth(),
                 },
                 Spacer.Height(8),
                 new Text("This screen is still under construction. This sample will help you learn about adaptive layouts in Jetpack Compose")
                 {
                     FontSize = 14,
-                    Color    = scheme.OnSurfaceVariant,
+                    Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                     Modifier = Modifier.Padding(horizontal: 16),
                 },
             };

--- a/samples/Reply/ReplyEmailListItem.cs
+++ b/samples/Reply/ReplyEmailListItem.cs
@@ -16,10 +16,10 @@ public static class ReplyEmailListItem
         new Composed(c =>
         {
             var scheme = c.ColorScheme();
-            long bg =
+            var bg = Color.FromPacked(
                 isSelected ? scheme.PrimaryContainer :
                 isOpened   ? scheme.SecondaryContainer :
-                             scheme.SurfaceVariant;
+                             scheme.SurfaceVariant);
 
             return new Card
             {
@@ -77,10 +77,10 @@ public static class ReplyEmailListItem
             {
                 Modifier
                     .Clip(Shape.Circle())
-                    .Background(scheme.SurfaceVariant),
+                    .Background(Color.FromPacked(scheme.SurfaceVariant)),
                 new Icon(Resource.Drawable.ic_star_border, "Favorite")
                 {
-                    Tint = scheme.Outline,
+                    Tint = Color.FromPacked(scheme.Outline),
                 },
             },
         };

--- a/samples/Reply/ReplyEmailThreadItem.cs
+++ b/samples/Reply/ReplyEmailThreadItem.cs
@@ -15,7 +15,7 @@ public static class ReplyEmailThreadItem
             {
                 Modifier
                     .Padding(horizontal: 16, vertical: 4)
-                    .Background(scheme.SurfaceVariant),
+                    .Background(Color.FromPacked(scheme.SurfaceVariant)),
                 new Column
                 {
                     Modifier.FillMaxWidth().Padding(20),
@@ -23,13 +23,13 @@ public static class ReplyEmailThreadItem
                     new Text(email.Subject)
                     {
                         FontSize  = 14,
-                        Color     = scheme.Outline,
+                        Color     = Color.FromPacked(scheme.Outline),
                         Modifier  = Modifier.Padding(top: 12, bottom: 8),
                     },
                     new Text(email.Body)
                     {
                         FontSize = 16,
-                        Color    = scheme.OnSurfaceVariant,
+                        Color    = Color.FromPacked(scheme.OnSurfaceVariant),
                     },
                     BuildActionRow(scheme),
                 },
@@ -53,17 +53,17 @@ public static class ReplyEmailThreadItem
                 new Text("20 mins ago")
                 {
                     FontSize = 12,
-                    Color    = scheme.Outline,
+                    Color    = Color.FromPacked(scheme.Outline),
                 },
             },
             new IconButton(onClick: NoOp)
             {
                 Modifier
                     .Clip(Shape.Circle())
-                    .Background(scheme.SurfaceVariant),
+                    .Background(Color.FromPacked(scheme.SurfaceVariant)),
                 new Icon(Resource.Drawable.ic_star_border, "Favorite")
                 {
-                    Tint = scheme.Outline,
+                    Tint = Color.FromPacked(scheme.Outline),
                 },
             },
         };
@@ -79,7 +79,7 @@ public static class ReplyEmailThreadItem
                 Modifier.Weight(1f),
                 new Text("Reply")
                 {
-                    Color = scheme.OnSurface,
+                    Color = Color.FromPacked(scheme.OnSurface),
                 },
             },
             new Button(onClick: NoOp)
@@ -87,7 +87,7 @@ public static class ReplyEmailThreadItem
                 Modifier.Weight(1f),
                 new Text("Reply All")
                 {
-                    Color = scheme.OnSurface,
+                    Color = Color.FromPacked(scheme.OnSurface),
                 },
             },
         };

--- a/samples/Reply/ReplyProfileImage.cs
+++ b/samples/Reply/ReplyProfileImage.cs
@@ -28,11 +28,11 @@ public static class ReplyProfileImage
                 Modifier
                     .Size(40)
                     .Clip(Shape.Circle())
-                    .Background(scheme.Primary),
+                    .Background(Color.FromPacked(scheme.Primary)),
                 new Icon(Resource.Drawable.ic_check, null)
                 {
                     Modifier = Modifier.Size(24),
-                    Tint = scheme.OnPrimary,
+                    Tint = Color.FromPacked(scheme.OnPrimary),
                 },
             };
         });

--- a/samples/Reply/ReplySearchBar.cs
+++ b/samples/Reply/ReplySearchBar.cs
@@ -23,19 +23,19 @@ public sealed class ReplySearchBar : ComposableNode
                     .FillMaxWidth()
                     .Padding(horizontal: 16, vertical: 8)
                     .Clip(new RoundedCornerShape(28.Dp()))
-                    .Background(scheme.SurfaceVariant),
+                    .Background(Color.FromPacked(scheme.SurfaceVariant)),
                 new Row
                 {
                     Modifier.FillMaxWidth().Padding(horizontal: 16, vertical: 12),
                     new Icon(Resource.Drawable.ic_search, "Search")
                     {
-                        Tint = scheme.OnSurface,
+                        Tint = Color.FromPacked(scheme.OnSurface),
                         Modifier = Modifier.Align(Alignment.Vertical.CenterVertically),
                     },
                     new Text("Search replies")
                     {
                         FontSize = 14,
-                        Color    = scheme.OnSurface,
+                        Color    = Color.FromPacked(scheme.OnSurface),
                         Modifier = Modifier
                             .Align(Alignment.Vertical.CenterVertically)
                             .Padding(start: 16)

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/ColorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/ColorTests.cs
@@ -1,0 +1,28 @@
+using ComposeBrush = AndroidX.Compose.Brush;
+using ComposeColor = AndroidX.Compose.Color;
+using SolidColor = AndroidX.Compose.UI.Graphics.SolidColor;
+
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+/// <summary>Verifies typed Compose colors preserve their packed JNI representation.</summary>
+[TestClass]
+public class ColorTests
+{
+    [TestMethod]
+    public void FromPacked_ToPacked_PreservesAllBits()
+    {
+        const long packed = unchecked((long)0x89ABCDEF_01234567UL);
+
+        Assert.AreEqual(packed, ComposeColor.FromPacked(packed).ToPacked());
+    }
+
+    [TestMethod]
+    public void SolidColor_RoundTripsThroughBindingBoundary()
+    {
+        var color = ComposeColor.FromArgb(0xFF, 0x12, 0x34, 0x56);
+        using var brush = ComposeBrush.SolidColor(color);
+        var solidColor = (SolidColor)brush;
+
+        Assert.AreEqual(color.ToPacked(), solidColor.Value);
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/Microsoft.AndroidX.Compose.DeviceTests.csproj
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/Microsoft.AndroidX.Compose.DeviceTests.csproj
@@ -20,7 +20,8 @@
       Tests cover post-build runtime behaviour we can't assert from source-
       generator unit tests: Modifier.StructuralKey equality, DiffSlot bit
       contributions, RememberAction identity stability, ConfirmStateChange
-      JCW veto, and Offset.Unbox JNI marshalling. Run with:
+      JCW veto, Offset.Unbox JNI marshalling, and Color packing across a
+      bound SolidColor constructor/getter. Run with:
 
         dotnet build src\Microsoft.AndroidX.Compose.DeviceTests -t:Install
         adb shell am instrument -w net.compose.devicetests/net.compose.devicetests.TestInstrumentation

--- a/src/Microsoft.AndroidX.Compose.Maui/ColorMapping.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/ColorMapping.cs
@@ -5,10 +5,7 @@ namespace Microsoft.AndroidX.Compose.Maui;
 
 /// <summary>
 /// Conversion helpers between MAUI's normalised <c>0..1</c>
-/// <see cref="MauiColor"/> and Compose's packed
-/// <see cref="ComposeColor"/> (an <c>@JvmInline value class</c> over
-/// a <c>ulong</c>, surfaced in C# via the implicit <c>long</c>
-/// conversion accepted by the generated bindings).
+/// <see cref="MauiColor"/> and <see cref="ComposeColor"/>.
 /// </summary>
 /// <remarks>
 /// Shared across every handler that needs to push a colour into a
@@ -34,7 +31,7 @@ internal static class ColorMapping
     /// a null input so a mapper can clear the slot.
     /// </summary>
     public static long? ToPackedLong(MauiColor? c) =>
-        c is null ? null : (long)ToCompose(c);
+        c is null ? null : ToCompose(c).ToPacked();
 
     /// <summary>
     /// Convert a MAUI <see cref="MauiColor"/> to a packed 32-bit

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ActivityIndicatorHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ActivityIndicatorHandler.cs
@@ -70,7 +70,7 @@ public partial class ActivityIndicatorHandler : ComposeElementHandler<IActivityI
         var packed = _color.Value;
         return new ComposeCircularProgressIndicator
         {
-            Color = packed.HasValue ? new ComposeColor(packed.Value) : null,
+            Color = packed.HasValue ? ComposeColor.FromPacked(packed.Value) : null,
             Modifier = gestureModifier,
         };
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/BorderHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/BorderHandler.cs
@@ -138,7 +138,7 @@ public partial class BorderHandler : ComposeElementHandler<MauiBorder>
             modifier = (modifier ?? Modifier.Companion).Clip(shape);
         if (bg.HasValue)
             modifier = (modifier ?? Modifier.Companion)
-                .Background(new ComposeColor(bg.Value), shape);
+                .Background(ComposeColor.FromPacked(bg.Value), shape);
         if (stroke.HasValue && width > 0f)
         {
             // Custom geometry (dashes / non-default cap / join / miter)
@@ -154,7 +154,7 @@ public partial class BorderHandler : ComposeElementHandler<MauiBorder>
             else
             {
                 modifier = (modifier ?? Modifier.Companion)
-                    .Border(new Dp(width), new ComposeColor(stroke.Value), shape);
+                    .Border(new Dp(width), ComposeColor.FromPacked(stroke.Value), shape);
             }
         }
         if (padding != Thickness.Zero)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/BoxViewHandler.cs
@@ -114,7 +114,7 @@ public partial class BoxViewHandler : ComposeElementHandler<MauiBoxView>
         if (shape is not null)
             modifier = modifier.Clip(shape);
         if (color.HasValue)
-            modifier = modifier.Background(new ComposeColor(color.Value), shape);
+            modifier = modifier.Background(ComposeColor.FromPacked(color.Value), shape);
         modifier = modifier.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
 
         return new Box { Modifier = modifier };

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ButtonHandler.cs
@@ -137,8 +137,12 @@ public partial class ButtonHandler : ComposeElementHandler<IButton>
 
         if (container is not null || content is not null)
             button.Colors = composer.ButtonColors(
-                containerColor: container,
-                contentColor:   content);
+                containerColor: container is { } containerValue
+                    ? ComposeColor.FromPacked(containerValue)
+                    : null,
+                contentColor: content is { } contentValue
+                    ? ComposeColor.FromPacked(contentValue)
+                    : null);
         if (cornerRadius >= 0)
             button.Shape = new RoundedCornerShape(new Dp(cornerRadius));
         if (padding != Thickness.Zero)
@@ -150,10 +154,10 @@ public partial class ButtonHandler : ComposeElementHandler<IButton>
         // Optional stroke chain — Compose Button has no built-in border slot.
         // Wrap the outer Modifier with Modifier.Border when a stroke is set.
         var outer = (_fillWidth.Value ? Modifier.FillMaxWidth() : Modifier.Companion);
-        if (strokeColor.HasValue && strokeThickness > 0f)
+        if (strokeColor is { } stroke && strokeThickness > 0f)
             outer = outer.Border(
                 new Dp(strokeThickness),
-                new ComposeColor(strokeColor.Value),
+                ComposeColor.FromPacked(stroke),
                 button.Shape);
         outer = outer
             .ApplyViewProperties(virtualView)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/CheckBoxHandler.cs
@@ -3,6 +3,7 @@ using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
+using ComposeColor = AndroidX.Compose.Color;
 using ComposeCheckbox = AndroidX.Compose.Checkbox;
 
 namespace Microsoft.AndroidX.Compose.Maui.Handlers;
@@ -50,7 +51,7 @@ public partial class CheckBoxHandler : ComposeElementHandler<ICheckBox>
         new(ViewCommandMapper);
 
     readonly MutableState<bool>  _checked = new(false);
-    readonly MutableState<long?> _color   = new((long?)null);
+    readonly MutableState<long?> _color = new((long?)null);
 
     /// <summary>Construct a handler with the default mappers.</summary>
     public CheckBoxHandler() : base(Mapper, CommandMapper) { }
@@ -68,8 +69,9 @@ public partial class CheckBoxHandler : ComposeElementHandler<ICheckBox>
         var color = _color.Value;
         var box   = new ComposeCheckbox(@checked: _checked.Value,
                                         onCheckedChange: OnCheckedChanged);
-        if (color is not null)
-            box.Colors = composer.CheckboxColors(checkedColor: color);
+        if (color is { } packedColor)
+            box.Colors = composer.CheckboxColors(
+                checkedColor: ComposeColor.FromPacked(packedColor));
         box.PrependModifier(Modifier.Companion.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return box;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ContentViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ContentViewHandler.cs
@@ -77,7 +77,7 @@ public partial class ContentViewHandler : ComposeElementHandler<IContentView>
 
         Modifier modifier = Modifier.Companion.FillMaxSize();
         if (_backgroundColor.Value is long bg)
-            modifier = modifier.Background(new ComposeColor(bg));
+            modifier = modifier.Background(ComposeColor.FromPacked(bg));
         if (padding != Thickness.Zero)
         {
             modifier = modifier.Padding(

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
@@ -248,7 +248,7 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
     {
         var node = new ComposeText(text);
         if (packed.HasValue)
-            node.Color = new ComposeColor(packed.Value);
+            node.Color = ComposeColor.FromPacked(packed.Value);
         if (size.HasValue)
             node.FontSize = new Sp(size.Value);
         if (bold)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EditorHandler.cs
@@ -121,13 +121,13 @@ public partial class EditorHandler : ComposeElementHandler<IEditor>
         if (!string.IsNullOrEmpty(placeholder))
             field.Placeholder = new ComposeText(placeholder)
             {
-                Color = placeholderInk.HasValue ? new ComposeColor(placeholderInk.Value) : null,
+                Color = placeholderInk.HasValue ? ComposeColor.FromPacked(placeholderInk.Value) : null,
             };
         if (packed.HasValue || size.HasValue || bold || letterSpacing.HasValue
             || hTextAlign != TextAlignment.Start)
             field.TextStyle = new ComposeTextStyle
             {
-                Color         = packed.HasValue ? new ComposeColor(packed.Value) : null,
+                Color         = packed.HasValue ? ComposeColor.FromPacked(packed.Value) : null,
                 FontSize      = size.HasValue   ? new Sp(size.Value) : null,
                 FontWeight    = bold ? ComposeFontWeight.Bold : null,
                 LetterSpacing = letterSpacing.HasValue ? new Sp(1) * letterSpacing.Value : null,

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/EntryHandler.cs
@@ -133,13 +133,13 @@ public partial class EntryHandler : ComposeElementHandler<IEntry>
         if (!string.IsNullOrEmpty(placeholder))
             field.Placeholder = new ComposeText(placeholder)
             {
-                Color = placeholderInk.HasValue ? new ComposeColor(placeholderInk.Value) : null,
+                Color = placeholderInk.HasValue ? ComposeColor.FromPacked(placeholderInk.Value) : null,
             };
         if (packed.HasValue || size.HasValue || bold || letterSpacing.HasValue
             || hTextAlign != TextAlignment.Start)
             field.TextStyle = new ComposeTextStyle
             {
-                Color         = packed.HasValue ? new ComposeColor(packed.Value) : null,
+                Color         = packed.HasValue ? ComposeColor.FromPacked(packed.Value) : null,
                 FontSize      = size.HasValue   ? new Sp(size.Value) : null,
                 FontWeight    = bold ? ComposeFontWeight.Bold : null,
                 LetterSpacing = letterSpacing.HasValue ? new Sp(1) * letterSpacing.Value : null,

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ImageButtonHandler.cs
@@ -127,7 +127,7 @@ public partial class ImageButtonHandler : ComposeElementHandler<MauiIImageButton
             modifier = (modifier ?? Modifier.Companion).Clip(new Dp(corner));
         if (stroke.HasValue && width > 0f)
         {
-            var color = new ComposeColor(stroke.Value);
+            var color = ComposeColor.FromPacked(stroke.Value);
             modifier = corner > 0
                 ? (modifier ?? Modifier.Companion).Border(new Dp(width), color, new Dp(corner))
                 : (modifier ?? Modifier.Companion).Border(new Dp(width), color);

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/IndicatorViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/IndicatorViewHandler.cs
@@ -167,7 +167,7 @@ public partial class IndicatorViewHandler : ComposeElementHandler<MauiIndicatorV
                 Modifier = Modifier
                     .Size(new Dp((float)sizeDp))
                     .Clip(shape)
-                    .Background(new ComposeColor(color)),
+                    .Background(ComposeColor.FromPacked(color)),
             });
         }
 

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/LabelHandler.cs
@@ -140,7 +140,7 @@ public partial class LabelHandler : ComposeElementHandler<ILabel>
         ComposeColor? color;
         if (packed.HasValue)
         {
-            color = new ComposeColor(packed.Value);
+            color = ComposeColor.FromPacked(packed.Value);
         }
         else
         {

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/PickerHandler.cs
@@ -178,14 +178,14 @@ public partial class PickerHandler : ComposeElementHandler<IPicker>
         if (!string.IsNullOrEmpty(title))
         {
             trigger.Label = packedTitleColor.HasValue
-                ? new ComposeText(title) { Color = new ComposeColor(packedTitleColor.Value) }
+                ? new ComposeText(title) { Color = ComposeColor.FromPacked(packedTitleColor.Value) }
                 : new ComposeText(title);
         }
         if (packedTextColor.HasValue || size.HasValue || bold || letterSpacing.HasValue || hAlign != TextAlignment.Start)
         {
             trigger.TextStyle = new ComposeTextStyle
             {
-                Color         = packedTextColor.HasValue ? new ComposeColor(packedTextColor.Value) : null,
+                Color         = packedTextColor.HasValue ? ComposeColor.FromPacked(packedTextColor.Value) : null,
                 FontSize      = size.HasValue   ? new Sp(size.Value) : null,
                 FontWeight    = bold ? ComposeFontWeight.Bold : null,
                 LetterSpacing = letterSpacing.HasValue ? new Sp(1) * letterSpacing.Value : null,

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/ProgressBarHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/ProgressBarHandler.cs
@@ -67,7 +67,7 @@ public partial class ProgressBarHandler : ComposeElementHandler<IProgress>
         var bar = new ComposeLinearProgressIndicator
         {
             Progress = _progress.Value,
-            Color    = packed.HasValue ? new ComposeColor(packed.Value) : null,
+            Color    = packed.HasValue ? ComposeColor.FromPacked(packed.Value) : null,
         };
         bar.PrependModifier(Modifier.FillMaxWidth().ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return bar;

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RadioButtonHandler.cs
@@ -114,10 +114,10 @@ public partial class RadioButtonHandler : ComposeElementHandler<IRadioButton>
         var stroke = _strokeColor.Value;
 
         var radio = new ComposeRadioButton(selected: _checked.Value, onClick: OnSelected);
-        if (stroke is not null)
+        if (stroke is { } strokeColor)
             radio.Colors = composer.RadioButtonColors(
-                selectedColor:   stroke,
-                unselectedColor: stroke);
+                selectedColor:   ComposeColor.FromPacked(strokeColor),
+                unselectedColor: ComposeColor.FromPacked(strokeColor));
         var gestureModifier = Modifier.Companion.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView);
         if (string.IsNullOrEmpty(label))
         {
@@ -126,8 +126,8 @@ public partial class RadioButtonHandler : ComposeElementHandler<IRadioButton>
         }
 
         var text = new ComposeText(label);
-        if (packed.HasValue)
-            text.Color = new ComposeColor(packed.Value);
+        if (packed is { } textColor)
+            text.Color = ComposeColor.FromPacked(textColor);
         if (size.HasValue)
             text.FontSize = new Sp(size.Value);
         if (bold)

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/RefreshViewHandler.cs
@@ -3,6 +3,7 @@ using AndroidX.Compose.Runtime;
 using AndroidX.Compose.UI.Platform;
 using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
+using ComposeColor = AndroidX.Compose.Color;
 using ComposePullToRefreshBox = AndroidX.Compose.PullToRefreshBox;
 using MauiRefreshView         = Microsoft.Maui.Controls.RefreshView;
 
@@ -129,11 +130,11 @@ public partial class RefreshViewHandler : ComposeElementHandler<IRefreshView>
         // RefreshColor → spinner glyph tint. null/non-SolidPaint
         // falls through to Material 3's default; non-null swaps in
         // the public PullToRefreshIndicator facade.
-        if (_refreshColor.Value is long packedColor)
+        if (_refreshColor.Value is { } packedColor)
         {
             box.Indicator = new PullToRefreshIndicator(state, isRefreshing)
             {
-                Color = packedColor,
+                Color = ComposeColor.FromPacked(packedColor),
             };
         }
 
@@ -176,7 +177,7 @@ public partial class RefreshViewHandler : ComposeElementHandler<IRefreshView>
     /// glyph color. <c>null</c> (or a non-<see cref="SolidPaint"/>
     /// brush) falls back to Material 3's default theme tint; a
     /// non-null solid color swaps in a
-    /// <see cref="PullToRefreshIndicator"/> with the packed color.
+    /// <see cref="PullToRefreshIndicator"/> with the typed color.
     /// </summary>
     /// <remarks>
     /// <see cref="IRefreshView.RefreshColor"/> is a

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SearchBarHandler.cs
@@ -140,19 +140,19 @@ public partial class SearchBarHandler : ComposeElementHandler<ISearchBar>
             // via SearchIconColor when set.
             LeadingIcon  = new ComposeText("\U0001F50D")
             {
-                Color = searchIconInk.HasValue ? new ComposeColor(searchIconInk.Value) : null,
+                Color = searchIconInk.HasValue ? ComposeColor.FromPacked(searchIconInk.Value) : null,
             },
         };
         if (!string.IsNullOrEmpty(placeholder))
             field.Placeholder = new ComposeText(placeholder)
             {
-                Color = placeholderInk.HasValue ? new ComposeColor(placeholderInk.Value) : null,
+                Color = placeholderInk.HasValue ? ComposeColor.FromPacked(placeholderInk.Value) : null,
             };
         if (packed.HasValue || size.HasValue || bold || letterSpacing.HasValue
             || hTextAlign != TextAlignment.Start)
             field.TextStyle = new ComposeTextStyle
             {
-                Color         = packed.HasValue ? new ComposeColor(packed.Value) : null,
+                Color         = packed.HasValue ? ComposeColor.FromPacked(packed.Value) : null,
                 FontSize      = size.HasValue   ? new Sp(size.Value) : null,
                 FontWeight    = bold ? ComposeFontWeight.Bold : null,
                 LetterSpacing = letterSpacing.HasValue ? new Sp(1) * letterSpacing.Value : null,
@@ -177,7 +177,7 @@ public partial class SearchBarHandler : ComposeElementHandler<ISearchBar>
             {
                 new ComposeText("\u2715")
                 {
-                    Color = cancelButtonInk.HasValue ? new ComposeColor(cancelButtonInk.Value) : null,
+                    Color = cancelButtonInk.HasValue ? ComposeColor.FromPacked(cancelButtonInk.Value) : null,
                 },
             };
         }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SliderHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SliderHandler.cs
@@ -6,6 +6,7 @@ using Kotlin.Ranges;
 using Microsoft.AndroidX.Compose.Maui.Loaders;
 using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
+using ComposeColor   = AndroidX.Compose.Color;
 using ComposeImage   = AndroidX.Compose.Image;
 using ComposeSlider  = AndroidX.Compose.Slider;
 
@@ -130,9 +131,15 @@ public partial class SliderHandler : ComposeElementHandler<ISlider>
         // populated — otherwise let M3's theme defaults apply.
         if (thumb is not null || minTrack is not null || maxTrack is not null)
             slider.Colors = composer.SliderColors(
-                thumbColor:         thumb,
-                activeTrackColor:   minTrack,
-                inactiveTrackColor: maxTrack);
+                thumbColor: thumb is { } thumbValue
+                    ? ComposeColor.FromPacked(thumbValue)
+                    : null,
+                activeTrackColor: minTrack is { } minTrackValue
+                    ? ComposeColor.FromPacked(minTrackValue)
+                    : null,
+                inactiveTrackColor: maxTrack is { } maxTrackValue
+                    ? ComposeColor.FromPacked(maxTrackValue)
+                    : null);
 
         slider.PrependModifier(Modifier.FillMaxWidth().ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return slider;

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/SwitchHandler.cs
@@ -3,6 +3,7 @@ using AndroidX.Compose.Material3;
 using AndroidX.Compose.Runtime;
 using Microsoft.AndroidX.Compose.Maui.Platform;
 using Microsoft.Maui.Handlers;
+using ComposeColor  = AndroidX.Compose.Color;
 using ComposeSwitch = AndroidX.Compose.Switch;
 
 namespace Microsoft.AndroidX.Compose.Maui.Handlers;
@@ -73,10 +74,18 @@ public partial class SwitchHandler : ComposeElementHandler<ISwitch>
                                    onCheckedChange: OnCheckedChanged);
         if (track is not null || thumb is not null)
             sw.Colors = composer.SwitchColors(
-                checkedThumbColor:   thumb,
-                checkedTrackColor:   track,
-                uncheckedThumbColor: thumb,
-                uncheckedTrackColor: track);
+                checkedThumbColor: thumb is { } thumbValue
+                    ? ComposeColor.FromPacked(thumbValue)
+                    : null,
+                checkedTrackColor: track is { } trackValue
+                    ? ComposeColor.FromPacked(trackValue)
+                    : null,
+                uncheckedThumbColor: thumb is { } uncheckedThumbValue
+                    ? ComposeColor.FromPacked(uncheckedThumbValue)
+                    : null,
+                uncheckedTrackColor: track is { } uncheckedTrackValue
+                    ? ComposeColor.FromPacked(uncheckedTrackValue)
+                    : null);
         sw.PrependModifier(Modifier.Companion.ApplyGestures(virtualView, MauiContext).ApplySemantics(virtualView));
         return sw;
     }

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/TimePickerHandler.cs
@@ -177,7 +177,7 @@ public partial class TimePickerHandler : ComposeElementHandler<ITimePicker>
     {
         var node = new ComposeText(text);
         if (packed.HasValue)
-            node.Color = new ComposeColor(packed.Value);
+            node.Color = ComposeColor.FromPacked(packed.Value);
         if (size.HasValue)
             node.FontSize = new Sp(size.Value);
         if (bold)

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/BridgeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/BridgeGeneratorTests.cs
@@ -74,9 +74,9 @@ public class BridgeGeneratorTests
             {
                 public static float Pack(Dp? value) => value?.Value ?? 0f;
             }
-            public readonly record struct Color(ulong PackedValue)
+            public readonly struct Color
             {
-                public static implicit operator long(Color c) => (long)c.PackedValue;
+                public long ToPacked() => default;
             }
             public readonly record struct Sp(float Value)
             {
@@ -1411,6 +1411,38 @@ public class BridgeGeneratorTests
         Assert.NotNull(emitted);
         Assert.Contains("global::AndroidX.Compose.Sp.Pack(fontSize)", emitted);
         Assert.Contains("global::AndroidX.Compose.TextOverflow.Pack(overflow)", emitted);
+    }
+
+    [Fact]
+    public void ValueType_Color_LowersThroughExplicitPackedBoundary()
+    {
+        var code = """
+            using AndroidX.Compose;
+            using global::AndroidX.Compose.Runtime;
+
+            [assembly: ComposeDefaults("TintDefault", "tint")]
+
+            namespace AndroidX.Compose
+            {
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(
+                        Class = "x/Y",
+                        JvmName = "f",
+                        Signature = "(JLandroidx/compose/runtime/Composer;II)V",
+                        Defaults = typeof(TintDefault))]
+                    public static partial void F(Color? tint, IComposer composer);
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code);
+        Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(emitted);
+        Assert.Contains("tint.GetValueOrDefault().ToPacked()", emitted);
+        Assert.Contains(
+            "if (tint is not null) defaults &= ~(int)global::AndroidX.Compose.TintDefault.Tint",
+            emitted);
     }
 
     [Fact]

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -136,9 +136,7 @@ public class FacadeGeneratorTests
             }
             public readonly struct Color
             {
-                public Color(long v) { PackedValue = (ulong)v; }
-                public ulong PackedValue { get; }
-                public static implicit operator long(Color c) => (long)c.PackedValue;
+                public long ToPacked() => default;
             }
             public readonly struct Sp
             {
@@ -1516,9 +1514,9 @@ public class FacadeGeneratorTests
         Assert.Empty(diags.Where(d => d.Severity == DiagnosticSeverity.Error));
         Assert.NotNull(emitted);
         Assert.Contains("public global::AndroidX.Compose.Color ContainerColor { get; set; }", emitted);
-        Assert.Contains("long __color = (long)ContainerColor != 0L ? (long)ContainerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;", emitted);
+        Assert.Contains("long __color = ContainerColor.ToPacked() != 0L ? ContainerColor.ToPacked() : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(composer, 0).SecondaryContainer;", emitted);
         Assert.Contains("global::AndroidX.Compose.ComposeBridges.ModalDrawerSheet(__content, __color, composer);", emitted);
-        Assert.Contains("long __color = (long)containerColor != 0L ? (long)containerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(__composer, 0).SecondaryContainer;", emitted);
+        Assert.Contains("long __color = containerColor.ToPacked() != 0L ? containerColor.ToPacked() : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(__composer, 0).SecondaryContainer;", emitted);
         Assert.Contains("global::AndroidX.Compose.ComposeBridges.ModalDrawerSheetExplicitDefaults(__content, __color, (int)__defaults, __composer);", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
@@ -4384,7 +4382,7 @@ public class FacadeGeneratorTests
         Assert.Contains("public static void Combined(global::AndroidX.Compose.Runtime.IComposer composer, global::AndroidX.Compose.UI.Graphics.Vector.ImageVector imageVector, int drawableResourceId,", emitted);
         Assert.Contains("global::AndroidX.Compose.RenderContext.PushScope(__scope, global::AndroidX.Compose.ScopeKind.Row);", emitted);
         Assert.Contains("global::AndroidX.Compose.ComposableContentNode.RenderDirect(c, content, true);", emitted);
-        Assert.Contains("long __color = (long)containerColor != 0L ? (long)containerColor", emitted);
+        Assert.Contains("long __color = containerColor.ToPacked() != 0L ? containerColor.ToPacked()", emitted);
         Assert.Contains("var __painterRef = global::AndroidX.Compose.ComposeBridges.PainterResource(drawableResourceId, __composer);", emitted);
         Assert.Contains("global::AndroidX.Compose.ComposeBridges.Secondary(imageVector, __painterPeer, __content, __color, (int)__defaults, __composer);", emitted);
         Assert.DoesNotContain("var node = new global::AndroidX.Compose.Combined", emitted);

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
@@ -187,7 +187,7 @@ internal static class Attributes
                 /// <c>"secondaryContainer"</c>) to use as a runtime fallback
                 /// when the user leaves the bridge's container-color
                 /// parameter at its sentinel <c>0L</c>. The generator
-                /// emits a <c>long ContainerColor { get; set; }</c>
+                /// emits a <c>Color ContainerColor { get; set; }</c>
                 /// property and binds the named bridge param (see
                 /// <see cref="ColorParameter"/>) to
                 /// <c>ContainerColor != 0L ? ContainerColor :

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -1582,7 +1582,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         // Phase 6 — theme color resolution.
         if (themeColor is not null && colorSlot is not null)
         {
-            sb.Append("            long __color = (long)ContainerColor != 0L ? (long)ContainerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(")
+            sb.Append("            long __color = ContainerColor.ToPacked() != 0L ? ContainerColor.ToPacked() : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(")
               .Append(composerName).Append(", 0).").Append(Pascal(themeColor)).AppendLine(";");
         }
 
@@ -2016,7 +2016,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         foreach (var slot in optionalValueSlots)
             terms.Add(OmittedBitTerm(EscapeIdent(slot.Param.Name) + " is null", index++));
         if (themeColor is not null)
-            terms.Add(OmittedBitTerm("(long)containerColor == 0L", index++));
+            terms.Add(OmittedBitTerm("containerColor.ToPacked() == 0L", index++));
         foreach (var info in stateConfirmSlots)
         {
             string name = EscapeIdent(char.ToLowerInvariant(info.PropertyName[0])
@@ -2206,7 +2206,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
         if (themeColor is not null)
         {
-            sb.Append("            long __color = (long)containerColor != 0L ? (long)containerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(__composer, 0).")
+            sb.Append("            long __color = containerColor.ToPacked() != 0L ? containerColor.ToPacked() : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(__composer, 0).")
               .Append(Pascal(themeColor)).AppendLine(";");
         }
 
@@ -2756,7 +2756,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
         if (themeColor is not null)
         {
-            sb.Append("            long __color = (long)containerColor != 0L ? (long)containerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(__composer, 0).")
+            sb.Append("            long __color = containerColor.ToPacked() != 0L ? containerColor.ToPacked() : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(__composer, 0).")
               .Append(Pascal(themeColor)).AppendLine(";");
         }
 
@@ -3537,7 +3537,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
 
         if (themeColor is not null)
         {
-            sb.Append("                long __secColor = (long)ContainerColor != 0L ? (long)ContainerColor : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(")
+            sb.Append("                long __secColor = ContainerColor.ToPacked() != 0L ? ContainerColor.ToPacked() : global::AndroidX.Compose.Material3.MaterialTheme.Instance.GetColorScheme(")
               .Append(composerName).Append(", 0).").Append(Pascal(themeColor)).AppendLine(";");
         }
 

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeValueTypes.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeValueTypes.cs
@@ -54,11 +54,10 @@ internal static class ComposeValueTypes
             // managed-side `AndroidX.Compose.Color` is a value-type wrapper
             // over the same packed ULong. The Kotlin
             // `@JvmInline value class Color(val value: ULong)` surfaces
-            // as a packed `long` at the JNI boundary; the implicit
-            // `Color -> long` operator turns the C# struct into the
-            // bridge's actual `long` JNI slot.
+            // as a packed `long` at the JNI boundary. Keep that conversion
+            // explicit so packed values do not leak into user-facing APIs.
             ["AndroidX.Compose.Color"] =
-                ('J', "(long)({0}.GetValueOrDefault())"),
+                ('J', "{0}.GetValueOrDefault().ToPacked()"),
         };
 
     /// <summary>

--- a/src/Microsoft.AndroidX.Compose/Brush.cs
+++ b/src/Microsoft.AndroidX.Compose/Brush.cs
@@ -41,7 +41,7 @@ public static class Brush
     /// </summary>
     public static BoundBrush SolidColor(Color color) =>
         Java.Lang.Object.GetObject<BoundSolidColor>(
-            ComposeBridges.BrushSolidColor(color),
+            ComposeBridges.BrushSolidColor(color.ToPacked()),
             JniHandleOwnership.TransferLocalRef)!;
 
     /// <summary>

--- a/src/Microsoft.AndroidX.Compose/BrushBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/BrushBridges.cs
@@ -85,7 +85,7 @@ internal static partial class ComposeBridges
                 "Gradient must have at least one color stop.", nameof(colors));
         var list = new JavaList<BoundColor>();
         foreach (var c in colors)
-            list.Add(BoxColor(c));
+            list.Add(BoxColor(c.ToPacked()));
         return list;
     }
 

--- a/src/Microsoft.AndroidX.Compose/CircularProgressIndicator.cs
+++ b/src/Microsoft.AndroidX.Compose/CircularProgressIndicator.cs
@@ -36,9 +36,9 @@ public sealed class CircularProgressIndicator : ComposableNode
 
         ProgressIndicatorKt.CircularProgressIndicator(
             modifier:    modifier,
-            color:       Color      is { } c ? c : 0L,
+            color:       Color      is { } c ? c.ToPacked() : 0L,
             strokeWidth: StrokeWidthDp   ?? 0f,
-            trackColor:  TrackColor is { } t ? t : 0L,
+            trackColor:  TrackColor is { } t ? t.ToPacked() : 0L,
             p4:          0,
             gapSize:     0f,
             _composer:   composer,

--- a/src/Microsoft.AndroidX.Compose/Color.cs
+++ b/src/Microsoft.AndroidX.Compose/Color.cs
@@ -10,9 +10,9 @@ namespace AndroidX.Compose;
 /// <remarks>
 /// <para>
 /// Compose's <c>Color</c> is an inline value class around an unsigned 64-bit
-/// integer; the wire representation crossing JNI is just the underlying
-/// <see cref="long"/>. This struct preserves that wire shape while giving
-/// the C# facade a typed, ergonomic surface to express colors in.
+/// integer. This struct keeps that packed representation behind a typed API;
+/// use <see cref="FromPacked(long)"/> and <see cref="ToPacked"/> only at
+/// interop boundaries.
 /// </para>
 /// <para>
 /// For the sRGB color space (the only one in common use) the packed layout
@@ -21,36 +21,12 @@ namespace AndroidX.Compose;
 /// for sRGB). <see cref="FromArgb(byte, byte, byte, byte)"/> and the
 /// named constants follow this layout.
 /// </para>
-/// <para>
-/// An implicit conversion to <see cref="long"/> means every bridge and
-/// binding method that already accepts a packed color value
-/// (<c>Modifier.Background(long)</c>, <c>Text.Color</c>,
-/// <c>ColorSchemeKt.LightColorScheme(...)</c>, etc.) accepts a
-/// <see cref="Color"/> directly without any conversion ceremony at the
-/// call site.
-/// </para>
 /// </remarks>
 public readonly struct Color : IEquatable<Color>
 {
-    /// <summary>The underlying 64-bit packed value (matches Kotlin's <c>ULong</c>).</summary>
-    public ulong PackedValue { get; }
+    readonly ulong _packedValue;
 
-    /// <summary>Construct a <see cref="Color"/> from a raw packed value.</summary>
-    /// <param name="packedValue">
-    /// Packed sRGB layout: <c>0xAARRGGBB_00000000UL</c>. Use the
-    /// <see cref="FromArgb(byte, byte, byte, byte)"/> /
-    /// <see cref="FromHex(string)"/> factories for typical construction.
-    /// </param>
-    public Color(ulong packedValue)
-    {
-        PackedValue = packedValue;
-    }
-
-    /// <summary>Construct a <see cref="Color"/> from the packed value as a signed long.</summary>
-    public Color(long packedValue)
-    {
-        PackedValue = unchecked((ulong)packedValue);
-    }
+    Color(ulong packedValue) => _packedValue = packedValue;
 
     /// <summary>Construct an opaque sRGB color from 8-bit RGB components.</summary>
     public Color(byte red, byte green, byte blue) : this(0xFF, red, green, blue) { }
@@ -59,20 +35,20 @@ public readonly struct Color : IEquatable<Color>
     public Color(byte alpha, byte red, byte green, byte blue)
     {
         uint argb = ((uint)alpha << 24) | ((uint)red << 16) | ((uint)green << 8) | blue;
-        PackedValue = (ulong)argb << 32;
+        _packedValue = (ulong)argb << 32;
     }
 
     /// <summary>The 8-bit alpha channel (0-255).</summary>
-    public byte A => (byte)(PackedValue >> 56);
+    public byte A => (byte)(_packedValue >> 56);
 
     /// <summary>The 8-bit red channel (0-255).</summary>
-    public byte R => (byte)(PackedValue >> 48);
+    public byte R => (byte)(_packedValue >> 48);
 
     /// <summary>The 8-bit green channel (0-255).</summary>
-    public byte G => (byte)(PackedValue >> 40);
+    public byte G => (byte)(_packedValue >> 40);
 
     /// <summary>The 8-bit blue channel (0-255).</summary>
-    public byte B => (byte)(PackedValue >> 32);
+    public byte B => (byte)(_packedValue >> 32);
 
     /// <summary>Construct an sRGB color from 8-bit ARGB components.</summary>
     public static Color FromArgb(byte alpha, byte red, byte green, byte blue)
@@ -84,6 +60,24 @@ public readonly struct Color : IEquatable<Color>
 
     /// <summary>Construct an sRGB color from a packed 32-bit ARGB integer (<c>0xAARRGGBB</c>).</summary>
     public static Color FromArgb(uint argb) => new((ulong)argb << 32);
+
+    /// <summary>
+    /// Construct a color from Compose's signed 64-bit binding representation.
+    /// </summary>
+    /// <remarks>
+    /// Prefer the component and hex factories for application colors. This
+    /// method is intended for values returned by generated Compose bindings.
+    /// </remarks>
+    public static Color FromPacked(long packedValue) =>
+        new(unchecked((ulong)packedValue));
+
+    /// <summary>
+    /// Return Compose's signed 64-bit binding representation for this color.
+    /// </summary>
+    /// <remarks>
+    /// This method is intended for calls into generated Compose bindings.
+    /// </remarks>
+    public long ToPacked() => unchecked((long)_packedValue);
 
     /// <summary>
     /// Parse a CSS-style hex color literal. Accepts <c>#RGB</c>, <c>#RRGGBB</c>,
@@ -147,33 +141,17 @@ public readonly struct Color : IEquatable<Color>
     }
 
     /// <summary>
-    /// Implicit conversion to the packed <see cref="long"/> the Compose
-    /// bridges and bindings accept directly.
-    /// </summary>
-    public static implicit operator long(Color c) => unchecked((long)c.PackedValue);
-
-    /// <summary>
-    /// Implicit conversion from the packed <see cref="long"/> the Compose
-    /// bindings surface (the Kotlin
-    /// <c>@JvmInline value class Color(val value: ULong)</c> lowers to a
-    /// packed long across JNI). Lets callers pass <c>scheme.OnSurface</c>
-    /// directly anywhere a <see cref="Color"/> is expected without
-    /// wrapping in <c>new Color(...)</c>.
-    /// </summary>
-    public static implicit operator Color(long packedValue) => new(packedValue);
-
-    /// <summary>
     /// Whether this color carries a real value. Matches Kotlin's
     /// <c>Color.isSpecified</c> &#8212; useful for "fall back to theme"
     /// branches where <see cref="Unspecified"/> is the sentinel.
     /// </summary>
-    public bool IsSpecified => PackedValue != Unspecified.PackedValue;
+    public bool IsSpecified => _packedValue != Unspecified._packedValue;
 
     /// <summary>
     /// Inverse of <see cref="IsSpecified"/> &#8212; matches Kotlin's
     /// <c>Color.isUnspecified</c>.
     /// </summary>
-    public bool IsUnspecified => PackedValue == Unspecified.PackedValue;
+    public bool IsUnspecified => _packedValue == Unspecified._packedValue;
 
     // ----- Named constants matching androidx.compose.ui.graphics.Color.Companion -----
 
@@ -221,13 +199,13 @@ public readonly struct Color : IEquatable<Color>
     public static Color Unspecified => new(0x10UL);
 
     /// <inheritdoc/>
-    public bool Equals(Color other) => PackedValue == other.PackedValue;
+    public bool Equals(Color other) => _packedValue == other._packedValue;
 
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is Color c && Equals(c);
 
     /// <inheritdoc/>
-    public override int GetHashCode() => PackedValue.GetHashCode();
+    public override int GetHashCode() => _packedValue.GetHashCode();
 
     /// <summary>Equality operator.</summary>
     public static bool operator ==(Color left, Color right) => left.Equals(right);
@@ -238,10 +216,10 @@ public readonly struct Color : IEquatable<Color>
     /// <inheritdoc/>
     public override string ToString()
     {
-        if (PackedValue == Unspecified.PackedValue)
+        if (_packedValue == Unspecified._packedValue)
             return "Color.Unspecified";
-        if ((PackedValue & 0xFFFFFFFFUL) != 0)
-            return $"Color(0x{PackedValue:X16})";
+        if ((_packedValue & 0xFFFFFFFFUL) != 0)
+            return $"Color(0x{_packedValue:X16})";
         return $"Color(0x{A:X2}{R:X2}{G:X2}{B:X2})";
     }
 }

--- a/src/Microsoft.AndroidX.Compose/Composables.Resources.cs
+++ b/src/Microsoft.AndroidX.Compose/Composables.Resources.cs
@@ -47,7 +47,7 @@ public static partial class Composables
         ComposeExtensions.DimensionResource(ComposableContext.Current, id);
 
     /// <summary>Loads a color resource.</summary>
-    public static long ColorResource(int id) =>
+    public static Color ColorResource(int id) =>
         ComposeExtensions.ColorResource(ComposableContext.Current, id);
 
     /// <summary>Loads a painter resource.</summary>

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -753,7 +753,7 @@ internal static partial class ComposeBridges
     // SecondaryDefaults pointing at the IconDefault enum.
     //
     // `tint` is `Color?` (a registered Compose value type, lowered to
-    // the JNI `J` slot via the implicit `Color -> long` conversion) so
+    // the JNI `J` slot via `Color.ToPacked()`) so
     // the facade generator classifies it as OptionalValue and only
     // clears the `$default` bit when the caller assigns a non-null
     // Tint — otherwise Kotlin falls back to `LocalContentColor.current`.
@@ -771,7 +771,7 @@ internal static partial class ComposeBridges
             imageVector:        imageVector,
             contentDescription: contentDescription!,
             modifier:           modifier,
-            tint:               tint.GetValueOrDefault(),
+            tint:               tint.GetValueOrDefault().ToPacked(),
             _composer:          composer,
             p5:                 0,
             _changed:           defaults);

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.ButtonDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.ButtonDefaults.cs
@@ -27,19 +27,16 @@ public static partial class ComposeExtensions
     /// <c>ButtonDefaults.buttonColors(containerColor = …, contentColor = …,
     /// disabledContainerColor = …, disabledContentColor = …)</c>.
     ///
-    /// The Compose lowering takes a packed <c>Color</c> (a <c>long</c>)
-    /// per slot plus a <c>$default</c> bitmask flagging which slots the
-    /// caller actually supplied — that's the bridge's <c>p5</c> arg.
-    /// Each non-<c>null</c> argument here clears the corresponding bit
-    /// so Compose adopts your color; <c>null</c> leaves the bit set so
-    /// Kotlin's default (the theme's color-scheme slot) wins.
+    /// Each non-<c>null</c> argument clears the corresponding Kotlin
+    /// <c>$default</c> bit and is packed only when calling the generated
+    /// binding. <c>null</c> leaves the bit set so the theme default wins.
     /// </summary>
     public static ButtonColors ButtonColors(
         this IComposer composer,
-        long? containerColor = null,
-        long? contentColor = null,
-        long? disabledContainerColor = null,
-        long? disabledContentColor = null,
+        Color? containerColor = null,
+        Color? contentColor = null,
+        Color? disabledContainerColor = null,
+        Color? disabledContentColor = null,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
     {
@@ -57,10 +54,10 @@ public static partial class ComposeExtensions
         try
         {
             return AndroidX.Compose.Material3.ButtonDefaults.Instance.ButtonColors(
-                containerColor        ?? 0L,
-                contentColor          ?? 0L,
-                disabledContainerColor ?? 0L,
-                disabledContentColor   ?? 0L,
+                containerColor?.ToPacked()         ?? 0L,
+                contentColor?.ToPacked()           ?? 0L,
+                disabledContainerColor?.ToPacked() ?? 0L,
+                disabledContentColor?.ToPacked()   ?? 0L,
                 composer,
                 defaults,
                 0);

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.CheckboxDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.CheckboxDefaults.cs
@@ -35,9 +35,9 @@ public static partial class ComposeExtensions
     /// </summary>
     public static CheckboxColors CheckboxColors(
         this IComposer composer,
-        long? checkedColor = null,
-        long? uncheckedColor = null,
-        long? checkmarkColor = null,
+        Color? checkedColor = null,
+        Color? uncheckedColor = null,
+        Color? checkmarkColor = null,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
     {
@@ -51,15 +51,15 @@ public static partial class ComposeExtensions
                 return d;
 
             return d.Copy(
-                checkedCheckmarkColor:            checkmarkColor ?? d.CheckedCheckmarkColor,
+                checkedCheckmarkColor:            checkmarkColor?.ToPacked() ?? d.CheckedCheckmarkColor,
                 uncheckedCheckmarkColor:          d.UncheckedCheckmarkColor,
-                checkedBoxColor:                  checkedColor   ?? d.CheckedBoxColor,
-                uncheckedBoxColor:                uncheckedColor ?? d.UncheckedBoxColor,
+                checkedBoxColor:                  checkedColor?.ToPacked()   ?? d.CheckedBoxColor,
+                uncheckedBoxColor:                uncheckedColor?.ToPacked() ?? d.UncheckedBoxColor,
                 disabledCheckedBoxColor:          d.DisabledCheckedBoxColor,
                 disabledUncheckedBoxColor:        d.DisabledUncheckedBoxColor,
                 disabledIndeterminateBoxColor:    d.DisabledIndeterminateBoxColor,
-                checkedBorderColor:               checkedColor   ?? d.CheckedBorderColor,
-                uncheckedBorderColor:             uncheckedColor ?? d.UncheckedBorderColor,
+                checkedBorderColor:               checkedColor?.ToPacked()   ?? d.CheckedBorderColor,
+                uncheckedBorderColor:             uncheckedColor?.ToPacked() ?? d.UncheckedBorderColor,
                 disabledBorderColor:              d.DisabledBorderColor,
                 disabledUncheckedBorderColor:     d.DisabledUncheckedBorderColor,
                 disabledIndeterminateBorderColor: d.DisabledIndeterminateBorderColor);

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.RadioButtonDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.RadioButtonDefaults.cs
@@ -32,10 +32,10 @@ public static partial class ComposeExtensions
     /// </summary>
     public static RadioButtonColors RadioButtonColors(
         this IComposer composer,
-        long? selectedColor = null,
-        long? unselectedColor = null,
-        long? disabledSelectedColor = null,
-        long? disabledUnselectedColor = null,
+        Color? selectedColor = null,
+        Color? unselectedColor = null,
+        Color? disabledSelectedColor = null,
+        Color? disabledUnselectedColor = null,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
     {
@@ -50,10 +50,10 @@ public static partial class ComposeExtensions
                 return d;
 
             return d.Copy(
-                selectedColor:           selectedColor           ?? d.SelectedColor,
-                unselectedColor:         unselectedColor         ?? d.UnselectedColor,
-                disabledSelectedColor:   disabledSelectedColor   ?? d.DisabledSelectedColor,
-                disabledUnselectedColor: disabledUnselectedColor ?? d.DisabledUnselectedColor);
+                selectedColor:           selectedColor?.ToPacked()           ?? d.SelectedColor,
+                unselectedColor:         unselectedColor?.ToPacked()         ?? d.UnselectedColor,
+                disabledSelectedColor:   disabledSelectedColor?.ToPacked()   ?? d.DisabledSelectedColor,
+                disabledUnselectedColor: disabledUnselectedColor?.ToPacked() ?? d.DisabledUnselectedColor);
         }
         finally
         {

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.Resources.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.Resources.cs
@@ -126,13 +126,14 @@ public static partial class ComposeExtensions
     }
 
     /// <summary>
-    /// Load a color resource as a packed Compose <c>Color</c> long. Mirrors
+    /// Load a color resource as a <see cref="Color"/>. Mirrors
     /// Kotlin's <c>colorResource(@ColorRes id: Int): Color</c>.
     /// </summary>
-    public static long ColorResource(this IComposer composer, int id)
+    public static Color ColorResource(this IComposer composer, int id)
     {
         ArgumentNullException.ThrowIfNull(composer);
-        return ColorResources_androidKt.ColorResource(id, composer, _changed: 0);
+        return Color.FromPacked(
+            ColorResources_androidKt.ColorResource(id, composer, _changed: 0));
     }
 
     /// <summary>

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.SliderDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.SliderDefaults.cs
@@ -25,25 +25,22 @@ public static partial class ComposeExtensions
     /// Mirrors Kotlin's
     /// <c>SliderDefaults.colors(thumbColor = …, activeTrackColor = …, …)</c>.
     ///
-    /// The Compose lowering takes a packed <c>Color</c> (a <c>long</c>)
-    /// per slot plus a <c>$default</c> bitmask flagging which slots the
-    /// caller actually supplied. Each non-<c>null</c> argument here
-    /// clears the corresponding bit so Compose adopts your color;
-    /// <c>null</c> leaves the bit set so Kotlin's default (the theme's
-    /// color-scheme slot) wins.
+    /// Each non-<c>null</c> argument clears the corresponding Kotlin
+    /// <c>$default</c> bit and is packed only when calling the generated
+    /// binding. <c>null</c> leaves the bit set so the theme default wins.
     /// </summary>
     public static SliderColors SliderColors(
         this IComposer composer,
-        long? thumbColor = null,
-        long? activeTrackColor = null,
-        long? activeTickColor = null,
-        long? inactiveTrackColor = null,
-        long? inactiveTickColor = null,
-        long? disabledThumbColor = null,
-        long? disabledActiveTrackColor = null,
-        long? disabledActiveTickColor = null,
-        long? disabledInactiveTrackColor = null,
-        long? disabledInactiveTickColor = null,
+        Color? thumbColor = null,
+        Color? activeTrackColor = null,
+        Color? activeTickColor = null,
+        Color? inactiveTrackColor = null,
+        Color? inactiveTickColor = null,
+        Color? disabledThumbColor = null,
+        Color? disabledActiveTrackColor = null,
+        Color? disabledActiveTickColor = null,
+        Color? disabledInactiveTrackColor = null,
+        Color? disabledInactiveTickColor = null,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
     {
@@ -78,16 +75,16 @@ public static partial class ComposeExtensions
             // default semantics — so unset slots still pick up the
             // current MaterialTheme color.)
             return AndroidX.Compose.Material3.SliderDefaults.Instance.Colors(
-                thumbColor                 ?? 0L,
-                activeTrackColor           ?? 0L,
-                activeTickColor            ?? 0L,
-                inactiveTrackColor         ?? 0L,
-                inactiveTickColor          ?? 0L,
-                disabledThumbColor         ?? 0L,
-                disabledActiveTrackColor   ?? 0L,
-                disabledActiveTickColor    ?? 0L,
-                disabledInactiveTrackColor ?? 0L,
-                disabledInactiveTickColor  ?? 0L,
+                thumbColor?.ToPacked()                 ?? 0L,
+                activeTrackColor?.ToPacked()           ?? 0L,
+                activeTickColor?.ToPacked()            ?? 0L,
+                inactiveTrackColor?.ToPacked()         ?? 0L,
+                inactiveTickColor?.ToPacked()          ?? 0L,
+                disabledThumbColor?.ToPacked()         ?? 0L,
+                disabledActiveTrackColor?.ToPacked()   ?? 0L,
+                disabledActiveTickColor?.ToPacked()    ?? 0L,
+                disabledInactiveTrackColor?.ToPacked() ?? 0L,
+                disabledInactiveTickColor?.ToPacked()  ?? 0L,
                 composer,
                 p11:       0,
                 _changed:  0,

--- a/src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeExtensions.SwitchDefaults.cs
@@ -29,10 +29,10 @@ public static partial class ComposeExtensions
     /// </summary>
     public static SwitchColors SwitchColors(
         this IComposer composer,
-        long? checkedThumbColor   = null,
-        long? checkedTrackColor   = null,
-        long? uncheckedThumbColor = null,
-        long? uncheckedTrackColor = null,
+        Color? checkedThumbColor   = null,
+        Color? checkedTrackColor   = null,
+        Color? uncheckedThumbColor = null,
+        Color? uncheckedTrackColor = null,
         [CallerLineNumber] int line = 0,
         [CallerFilePath] string file = "")
     {
@@ -53,12 +53,12 @@ public static partial class ComposeExtensions
         try
         {
             return AndroidX.Compose.Material3.SwitchDefaults.Instance.Colors(
-                checkedThumbColor:            checkedThumbColor   ?? 0L,
-                checkedTrackColor:            checkedTrackColor   ?? 0L,
+                checkedThumbColor:            checkedThumbColor?.ToPacked()   ?? 0L,
+                checkedTrackColor:            checkedTrackColor?.ToPacked()   ?? 0L,
                 checkedBorderColor:           0L,
                 checkedIconColor:             0L,
-                uncheckedThumbColor:          uncheckedThumbColor ?? 0L,
-                uncheckedTrackColor:          uncheckedTrackColor ?? 0L,
+                uncheckedThumbColor:          uncheckedThumbColor?.ToPacked() ?? 0L,
+                uncheckedTrackColor:          uncheckedTrackColor?.ToPacked() ?? 0L,
                 uncheckedBorderColor:         0L,
                 uncheckedIconColor:           0L,
                 disabledCheckedThumbColor:    0L,

--- a/src/Microsoft.AndroidX.Compose/DrawScope.cs
+++ b/src/Microsoft.AndroidX.Compose/DrawScope.cs
@@ -52,7 +52,7 @@ public class DrawScope
     {
         var origin = topLeft ?? Offset.Zero;
         var extent = size ?? RemainingSize(origin);
-        _jvm.DrawRect(color, origin.Packed, extent.Packed, alpha,
+        _jvm.DrawRect(color.ToPacked(), origin.Packed, extent.Packed, alpha,
             style ?? DrawingStyle.Fill, null, SrcOverBlendMode);
     }
 
@@ -80,7 +80,7 @@ public class DrawScope
         BoundDrawStyle? style = null)
     {
         var extent = Size;
-        _jvm.DrawCircle(color,
+        _jvm.DrawCircle(color.ToPacked(),
             radius ?? MathF.Min(extent.Width, extent.Height) / 2f,
             (center ?? Center).Packed,
             alpha, style ?? DrawingStyle.Fill, null, SrcOverBlendMode);
@@ -110,7 +110,7 @@ public class DrawScope
         float strokeWidth = 0f,
         StrokeCap cap = StrokeCap.Butt,
         float alpha = 1f) =>
-        _jvm.DrawLine(color, start.Packed, end.Packed, strokeWidth, (int)cap,
+        _jvm.DrawLine(color.ToPacked(), start.Packed, end.Packed, strokeWidth, (int)cap,
             null, alpha, null, SrcOverBlendMode);
 
     /// <summary>Draws a line with a brush.</summary>
@@ -136,7 +136,7 @@ public class DrawScope
         BoundDrawStyle? style = null)
     {
         var origin = topLeft ?? Offset.Zero;
-        _jvm.DrawOval(color, origin.Packed, (size ?? RemainingSize(origin)).Packed,
+        _jvm.DrawOval(color.ToPacked(), origin.Packed, (size ?? RemainingSize(origin)).Packed,
             alpha, style ?? DrawingStyle.Fill, null, SrcOverBlendMode);
     }
 
@@ -166,7 +166,7 @@ public class DrawScope
         BoundDrawStyle? style = null)
     {
         var origin = topLeft ?? Offset.Zero;
-        _jvm.DrawArc(color, startAngle, sweepAngle, useCenter, origin.Packed,
+        _jvm.DrawArc(color.ToPacked(), startAngle, sweepAngle, useCenter, origin.Packed,
             (size ?? RemainingSize(origin)).Packed, alpha,
             style ?? DrawingStyle.Fill, null, SrcOverBlendMode);
     }
@@ -199,7 +199,7 @@ public class DrawScope
         BoundDrawStyle? style = null)
     {
         var origin = topLeft ?? Offset.Zero;
-        _jvm.DrawRoundRect(color, origin.Packed,
+        _jvm.DrawRoundRect(color.ToPacked(), origin.Packed,
             (size ?? RemainingSize(origin)).Packed, cornerRadius.Packed,
             style ?? DrawingStyle.Fill, alpha, null, SrcOverBlendMode);
     }
@@ -228,7 +228,7 @@ public class DrawScope
         BoundDrawStyle? style = null)
     {
         ArgumentNullException.ThrowIfNull(path);
-        _jvm.DrawPath(path.Jvm, color, alpha,
+        _jvm.DrawPath(path.Jvm, color.ToPacked(), alpha,
             style ?? DrawingStyle.Fill, null, SrcOverBlendMode);
     }
 

--- a/src/Microsoft.AndroidX.Compose/HorizontalDivider.cs
+++ b/src/Microsoft.AndroidX.Compose/HorizontalDivider.cs
@@ -28,7 +28,7 @@ public sealed class HorizontalDivider : ComposableNode
         DividerKt.HorizontalDivider(
             modifier:  modifier,
             thickness: ThicknessDp ?? 0f,
-            color:     Color is { } c ? c : 0L,
+            color:     Color is { } c ? c.ToPacked() : 0L,
             _composer: composer,
             p4:        0,
             _changed:  defaults);

--- a/src/Microsoft.AndroidX.Compose/Icon.cs
+++ b/src/Microsoft.AndroidX.Compose/Icon.cs
@@ -23,8 +23,7 @@ namespace AndroidX.Compose;
 /// </list>
 /// </summary>
 /// <remarks>
-/// Set the <c>Tint</c> property to a packed <see cref="Color"/>
-/// (implicit-converted to <c>long</c>) to override the icon color.
+/// Set the <c>Tint</c> property to a <see cref="Color"/> to override the icon color.
 /// Leave it unset (<c>null</c>) to inherit the surrounding Material
 /// content color (Compose's <c>LocalContentColor</c>).
 /// </remarks>

--- a/src/Microsoft.AndroidX.Compose/LinearProgressIndicator.cs
+++ b/src/Microsoft.AndroidX.Compose/LinearProgressIndicator.cs
@@ -53,8 +53,8 @@ public sealed class LinearProgressIndicator : ComposableNode
             ProgressIndicatorKt.LinearProgressIndicator(
                 progress:   progress,
                 modifier:   modifier,
-                color:      Color      is { } pc ? pc : 0L,
-                trackColor: TrackColor is { } pt ? pt : 0L,
+                color:      Color      is { } pc ? pc.ToPacked() : 0L,
+                trackColor: TrackColor is { } pt ? pt.ToPacked() : 0L,
                 p4:         0,
                 _composer:  composer,
                 strokeCap:  0,
@@ -70,8 +70,8 @@ public sealed class LinearProgressIndicator : ComposableNode
 
         ProgressIndicatorKt.LinearProgressIndicator(
             modifier:   modifier,
-            color:      Color      is { } c ? c : 0L,
-            trackColor: TrackColor is { } t ? t : 0L,
+            color:      Color      is { } c ? c.ToPacked() : 0L,
+            trackColor: TrackColor is { } t ? t.ToPacked() : 0L,
             p3:         0,
             gapSize:    0f,
             _composer:  composer,

--- a/src/Microsoft.AndroidX.Compose/MaterialTheme.cs
+++ b/src/Microsoft.AndroidX.Compose/MaterialTheme.cs
@@ -279,7 +279,7 @@ public sealed class MaterialTheme : ComposableContainer
         for (int i = 0; i < slots.Length; i++)
         {
             if (slots[i] is Color c)
-                colors[i] = c;
+                colors[i] = c.ToPacked();
             else
                 defaults |= (ColorSchemeDefault)(1L << i);
         }

--- a/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
@@ -276,18 +276,15 @@ public static class ModifierExtensions
 
     /// <summary>
     /// <c>Modifier.background(color)</c> — paints a flat fill behind the
-    /// composable using a <c>RectangleShape</c>. Takes a packed Compose
-    /// <c>androidx.compose.ui.graphics.Color</c> value (a <c>ULong</c>
-    /// surfaced as a <c>long</c> in the binding because Color is a Kotlin
-    /// <c>@JvmInline value class</c>). Build one via
+    /// composable using a <c>RectangleShape</c>. Build the color via
     /// <see cref="Color.FromRgb(byte, byte, byte)"/>,
     /// <see cref="Color.FromHex(string)"/>, or one of the
     /// named constants on <see cref="Color"/> (e.g.
     /// <see cref="Color.Black"/>).
     /// </summary>
     public static Modifier Background(this Modifier modifier, Color color) =>
-        modifier.Append(curr => ComposeBridges.ModifierBackground(curr, color, null),
-            new ModifierOpKey(nameof(Background), ValueTuple.Create((long)color)));
+        modifier.Append(curr => ComposeBridges.ModifierBackground(curr, color.ToPacked(), null),
+            new ModifierOpKey(nameof(Background), ValueTuple.Create(color.ToPacked())));
 
     /// <summary>
     /// <c>Modifier.background(color, shape)</c> — paints a flat fill
@@ -300,8 +297,8 @@ public static class ModifierExtensions
     /// recompositions.
     /// </summary>
     public static Modifier Background(this Modifier modifier, Color color, Shape? shape) =>
-        modifier.Append(curr => ComposeBridges.ModifierBackground(curr, color, shape?.Handle),
-            new ModifierOpKey("BackgroundShape", ((long)color, (object?)shape)));
+        modifier.Append(curr => ComposeBridges.ModifierBackground(curr, color.ToPacked(), shape?.Handle),
+            new ModifierOpKey("BackgroundShape", (color.ToPacked(), (object?)shape)));
 
     /// <summary>
     /// <c>Modifier.border(width, color)</c> — draws a rectangular stroke
@@ -313,7 +310,7 @@ public static class ModifierExtensions
     public static Modifier Border(this Modifier modifier, Dp width, Color color)
     {
         var w = width.Value;
-        long c = color;
+        long c = color.ToPacked();
         return modifier.Append(curr => ComposeBridges.ModifierBorder(curr, w, c, null),
             new ModifierOpKey(nameof(Border), (w, c)));
     }
@@ -330,7 +327,7 @@ public static class ModifierExtensions
     {
         var w = width.Value;
         var r = cornerRadius.Value;
-        long c = color;
+        long c = color.ToPacked();
         if (r <= 0f)
             return modifier.Append(curr => ComposeBridges.ModifierBorder(curr, w, c, null),
                 new ModifierOpKey(nameof(Border), (w, c)));
@@ -360,7 +357,7 @@ public static class ModifierExtensions
     public static Modifier Border(this Modifier modifier, Dp width, Color color, Shape? shape)
     {
         var w = width.Value;
-        long c = color;
+        long c = color.ToPacked();
         return modifier.Append(curr => ComposeBridges.ModifierBorder(curr, w, c, shape?.Handle),
             new ModifierOpKey("BorderShape", (w, c, (object?)shape)));
     }

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -170,14 +170,12 @@ AndroidX.Compose.Color.B.get -> byte
 AndroidX.Compose.Color.Color() -> void
 AndroidX.Compose.Color.Color(byte alpha, byte red, byte green, byte blue) -> void
 AndroidX.Compose.Color.Color(byte red, byte green, byte blue) -> void
-AndroidX.Compose.Color.Color(long packedValue) -> void
-AndroidX.Compose.Color.Color(ulong packedValue) -> void
 AndroidX.Compose.Color.Equals(AndroidX.Compose.Color other) -> bool
 AndroidX.Compose.Color.G.get -> byte
 AndroidX.Compose.Color.IsSpecified.get -> bool
 AndroidX.Compose.Color.IsUnspecified.get -> bool
-AndroidX.Compose.Color.PackedValue.get -> ulong
 AndroidX.Compose.Color.R.get -> byte
+AndroidX.Compose.Color.ToPacked() -> long
 AndroidX.Compose.Color.WithAlpha(byte alpha) -> AndroidX.Compose.Color
 AndroidX.Compose.Color.WithOpacity(float opacity) -> AndroidX.Compose.Color
 AndroidX.Compose.Column
@@ -1094,9 +1092,9 @@ AndroidX.Compose.PullToRefreshBox.Indicator.get -> AndroidX.Compose.ComposableNo
 AndroidX.Compose.PullToRefreshBox.Indicator.set -> void
 AndroidX.Compose.PullToRefreshBox.PullToRefreshBox(bool isRefreshing, System.Action! onRefresh, AndroidX.Compose.PullToRefreshState? state = null) -> void
 AndroidX.Compose.PullToRefreshIndicator
-AndroidX.Compose.PullToRefreshIndicator.Color.get -> long
+AndroidX.Compose.PullToRefreshIndicator.Color.get -> AndroidX.Compose.Color?
 AndroidX.Compose.PullToRefreshIndicator.Color.set -> void
-AndroidX.Compose.PullToRefreshIndicator.ContainerColor.get -> long
+AndroidX.Compose.PullToRefreshIndicator.ContainerColor.get -> AndroidX.Compose.Color?
 AndroidX.Compose.PullToRefreshIndicator.ContainerColor.set -> void
 AndroidX.Compose.PullToRefreshIndicator.MaxDistance.get -> AndroidX.Compose.Dp?
 AndroidX.Compose.PullToRefreshIndicator.MaxDistance.set -> void
@@ -1748,6 +1746,7 @@ static AndroidX.Compose.Color.DarkGray.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.FromArgb(byte alpha, byte red, byte green, byte blue) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.FromArgb(uint argb) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.FromHex(string! hex) -> AndroidX.Compose.Color
+static AndroidX.Compose.Color.FromPacked(long packedValue) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.FromRgb(byte red, byte green, byte blue) -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Gray.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Green.get -> AndroidX.Compose.Color
@@ -1758,8 +1757,6 @@ static AndroidX.Compose.Color.Transparent.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Unspecified.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.White.get -> AndroidX.Compose.Color
 static AndroidX.Compose.Color.Yellow.get -> AndroidX.Compose.Color
-static AndroidX.Compose.Color.implicit operator AndroidX.Compose.Color(long packedValue) -> AndroidX.Compose.Color
-static AndroidX.Compose.Color.implicit operator long(AndroidX.Compose.Color c) -> long
 static AndroidX.Compose.Color.operator !=(AndroidX.Compose.Color left, AndroidX.Compose.Color right) -> bool
 static AndroidX.Compose.Color.operator ==(AndroidX.Compose.Color left, AndroidX.Compose.Color right) -> bool
 static AndroidX.Compose.ComposableContext.Current.get -> AndroidX.Compose.Runtime.IComposer!
@@ -1793,7 +1790,7 @@ static AndroidX.Compose.Composables.Checkbox(AndroidX.Compose.Runtime.IComposer!
 static AndroidX.Compose.Composables.Checkbox(bool checked, System.Action<bool>! onCheckedChange, bool enabled = true, AndroidX.Compose.Modifier? modifier = null, AndroidX.Compose.Material3.CheckboxColors? colors = null) -> void
 static AndroidX.Compose.Composables.CollectAsStateWithLifecycle<T>(Xamarin.KotlinX.Coroutines.Flow.IFlow! flow, T initialValue) -> AndroidX.Compose.CollectedState<T>!
 static AndroidX.Compose.Composables.CollectAsStateWithLifecycle<T>(Xamarin.KotlinX.Coroutines.Flow.IStateFlow! stateFlow) -> AndroidX.Compose.CollectedState<T>!
-static AndroidX.Compose.Composables.ColorResource(int id) -> long
+static AndroidX.Compose.Composables.ColorResource(int id) -> AndroidX.Compose.Color
 static AndroidX.Compose.Composables.ColorScheme() -> AndroidX.Compose.Material3.ColorScheme!
 static AndroidX.Compose.Composables.Column(AndroidX.Compose.Runtime.IComposer! composer, System.Action<AndroidX.Compose.Runtime.IComposer!>! content) -> void
 static AndroidX.Compose.Composables.Column(System.Action! content) -> void
@@ -2080,11 +2077,11 @@ static AndroidX.Compose.Composables.WideNavigationRail(System.Action! content, A
 static AndroidX.Compose.Composables.WideNavigationRailItem(AndroidX.Compose.Runtime.IComposer! composer, bool selected, System.Action! onClick, System.Action<AndroidX.Compose.Runtime.IComposer!>! icon, bool enabled = true, AndroidX.Compose.Modifier? modifier = null, System.Action<AndroidX.Compose.Runtime.IComposer!>? label = null) -> void
 static AndroidX.Compose.Composables.WideNavigationRailItem(bool selected, System.Action! onClick, System.Action! icon, bool enabled = true, AndroidX.Compose.Modifier? modifier = null, System.Action? label = null) -> void
 static AndroidX.Compose.ComposeExtensions.BooleanResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> bool
-static AndroidX.Compose.ComposeExtensions.ButtonColors(this AndroidX.Compose.Runtime.IComposer! composer, long? containerColor = null, long? contentColor = null, long? disabledContainerColor = null, long? disabledContentColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.ButtonColors!
-static AndroidX.Compose.ComposeExtensions.CheckboxColors(this AndroidX.Compose.Runtime.IComposer! composer, long? checkedColor = null, long? uncheckedColor = null, long? checkmarkColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.CheckboxColors!
+static AndroidX.Compose.ComposeExtensions.ButtonColors(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Color? containerColor = null, AndroidX.Compose.Color? contentColor = null, AndroidX.Compose.Color? disabledContainerColor = null, AndroidX.Compose.Color? disabledContentColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.ButtonColors!
+static AndroidX.Compose.ComposeExtensions.CheckboxColors(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Color? checkedColor = null, AndroidX.Compose.Color? uncheckedColor = null, AndroidX.Compose.Color? checkmarkColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.CheckboxColors!
 static AndroidX.Compose.ComposeExtensions.CollectAsStateWithLifecycle<T>(this Xamarin.KotlinX.Coroutines.Flow.IFlow! flow, T initialValue, AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.CollectedState<T>!
 static AndroidX.Compose.ComposeExtensions.CollectAsStateWithLifecycle<T>(this Xamarin.KotlinX.Coroutines.Flow.IStateFlow! stateFlow, AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.CollectedState<T>!
-static AndroidX.Compose.ComposeExtensions.ColorResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> long
+static AndroidX.Compose.ComposeExtensions.ColorResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> AndroidX.Compose.Color
 static AndroidX.Compose.ComposeExtensions.ColorScheme(this AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.Material3.ColorScheme!
 static AndroidX.Compose.ComposeExtensions.CurrentWindowAdaptiveInfo(this AndroidX.Compose.Runtime.IComposer! composer, bool supportLargeAndXLargeWidth = false) -> AndroidX.Compose.Material3.Adaptive.WindowAdaptiveInfo!
 static AndroidX.Compose.ComposeExtensions.DerivedStateOf<T>(System.Func<T>! calculation) -> AndroidX.Compose.DerivedState<T>!
@@ -2120,7 +2117,7 @@ static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.
 static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object? key1, object? key2, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
 static AndroidX.Compose.ComposeExtensions.ProduceState<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object? key1, object? key2, object? key3, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
 static AndroidX.Compose.ComposeExtensions.ProduceStateKeyed<T>(this AndroidX.Compose.Runtime.IComposer! composer, T initialValue, object?[]! keys, System.Func<AndroidX.Compose.MutableState<T>!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! producer, int line = 0, string! file = "") -> AndroidX.Compose.MutableState<T>!
-static AndroidX.Compose.ComposeExtensions.RadioButtonColors(this AndroidX.Compose.Runtime.IComposer! composer, long? selectedColor = null, long? unselectedColor = null, long? disabledSelectedColor = null, long? disabledUnselectedColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.RadioButtonColors!
+static AndroidX.Compose.ComposeExtensions.RadioButtonColors(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Color? selectedColor = null, AndroidX.Compose.Color? unselectedColor = null, AndroidX.Compose.Color? disabledSelectedColor = null, AndroidX.Compose.Color? disabledUnselectedColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.RadioButtonColors!
 static AndroidX.Compose.ComposeExtensions.Remember<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T>! factory, int line = 0, string! file = "") -> T
 static AndroidX.Compose.ComposeExtensions.Remember<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T>! factory, object? key1, int line = 0, string! file = "") -> T
 static AndroidX.Compose.ComposeExtensions.Remember<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T>! factory, object? key1, object? key2, int line = 0, string! file = "") -> T
@@ -2147,12 +2144,12 @@ static AndroidX.Compose.ComposeExtensions.SetContent(this AndroidX.Compose.UI.Pl
 static AndroidX.Compose.ComposeExtensions.SetContent(this AndroidX.Compose.UI.Platform.ComposeView! view, System.Func<AndroidX.Compose.Runtime.IComposer!, AndroidX.Compose.ComposableNode!>! content) -> void
 static AndroidX.Compose.ComposeExtensions.Shapes(this AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.Material3.Shapes!
 static AndroidX.Compose.ComposeExtensions.SideEffect(this AndroidX.Compose.Runtime.IComposer! composer, System.Action! effect) -> void
-static AndroidX.Compose.ComposeExtensions.SliderColors(this AndroidX.Compose.Runtime.IComposer! composer, long? thumbColor = null, long? activeTrackColor = null, long? activeTickColor = null, long? inactiveTrackColor = null, long? inactiveTickColor = null, long? disabledThumbColor = null, long? disabledActiveTrackColor = null, long? disabledActiveTickColor = null, long? disabledInactiveTrackColor = null, long? disabledInactiveTickColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.SliderColors!
+static AndroidX.Compose.ComposeExtensions.SliderColors(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Color? thumbColor = null, AndroidX.Compose.Color? activeTrackColor = null, AndroidX.Compose.Color? activeTickColor = null, AndroidX.Compose.Color? inactiveTrackColor = null, AndroidX.Compose.Color? inactiveTickColor = null, AndroidX.Compose.Color? disabledThumbColor = null, AndroidX.Compose.Color? disabledActiveTrackColor = null, AndroidX.Compose.Color? disabledActiveTickColor = null, AndroidX.Compose.Color? disabledInactiveTrackColor = null, AndroidX.Compose.Color? disabledInactiveTickColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.SliderColors!
 static AndroidX.Compose.ComposeExtensions.SnapshotFlow<T>(System.Func<T>! producer) -> System.Collections.Generic.IAsyncEnumerable<T>!
 static AndroidX.Compose.ComposeExtensions.StringArrayResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> string![]!
 static AndroidX.Compose.ComposeExtensions.StringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id) -> string!
 static AndroidX.Compose.ComposeExtensions.StringResource(this AndroidX.Compose.Runtime.IComposer! composer, int id, params object?[]! formatArgs) -> string!
-static AndroidX.Compose.ComposeExtensions.SwitchColors(this AndroidX.Compose.Runtime.IComposer! composer, long? checkedThumbColor = null, long? checkedTrackColor = null, long? uncheckedThumbColor = null, long? uncheckedTrackColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.SwitchColors!
+static AndroidX.Compose.ComposeExtensions.SwitchColors(this AndroidX.Compose.Runtime.IComposer! composer, AndroidX.Compose.Color? checkedThumbColor = null, AndroidX.Compose.Color? checkedTrackColor = null, AndroidX.Compose.Color? uncheckedThumbColor = null, AndroidX.Compose.Color? uncheckedTrackColor = null, int line = 0, string! file = "") -> AndroidX.Compose.Material3.SwitchColors!
 static AndroidX.Compose.ComposeExtensions.Typography(this AndroidX.Compose.Runtime.IComposer! composer) -> AndroidX.Compose.Material3.Typography!
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, int line = 0, string! file = "") -> T!
 static AndroidX.Compose.ComposeExtensions.ViewModel<T>(this AndroidX.Compose.Runtime.IComposer! composer, System.Func<T!>! factory, object? key1, int line = 0, string! file = "") -> T!

--- a/src/Microsoft.AndroidX.Compose/PullToRefreshIndicator.cs
+++ b/src/Microsoft.AndroidX.Compose/PullToRefreshIndicator.cs
@@ -19,13 +19,13 @@ namespace AndroidX.Compose;
 /// var state = new PullToRefreshState();
 /// new PullToRefreshBox(isRefreshing, onRefresh, state: state)
 /// {
-///     Indicator = new PullToRefreshIndicator(state, isRefreshing) { Color = 0xFFFF0000L },
+///     Indicator = new PullToRefreshIndicator(state, isRefreshing) { Color = Color.Red },
 /// };
 /// </code>
 /// <para>Material 3's stock indicator picks up colors from the active
 /// <c>ColorScheme</c>; supply <see cref="ContainerColor"/> /
 /// <see cref="Color"/> only to override one (or both) of those slots.
-/// Any color left at <c>0L</c> falls through to the theme default.</para>
+/// Any color left <see langword="null"/> falls through to the theme default.</para>
 /// </remarks>
 public sealed class PullToRefreshIndicator : ComposableNode
 {
@@ -55,16 +55,16 @@ public sealed class PullToRefreshIndicator : ComposableNode
     }
 
     /// <summary>
-    /// ARGB-packed background color (Compose <c>Color</c> long packing).
-    /// <c>0L</c> falls through to <c>ColorScheme.surfaceContainerHighest</c>.
+    /// Optional background color. <see langword="null"/> falls through to
+    /// <c>ColorScheme.surfaceContainerHighest</c>.
     /// </summary>
-    public long ContainerColor { get; set; }
+    public Color? ContainerColor { get; set; }
 
     /// <summary>
-    /// ARGB-packed glyph color (Compose <c>Color</c> long packing).
-    /// <c>0L</c> falls through to <c>ColorScheme.onSurfaceVariant</c>.
+    /// Optional glyph color. <see langword="null"/> falls through to
+    /// <c>ColorScheme.onSurfaceVariant</c>.
     /// </summary>
-    public long Color { get; set; }
+    public Color? Color { get; set; }
 
     /// <summary>
     /// Optional drag-distance threshold in dp. <c>null</c> falls through
@@ -85,8 +85,8 @@ public sealed class PullToRefreshIndicator : ComposableNode
         int mask = 0;
         var modifier = BuildModifier();
         if (modifier is null)         mask |= BitModifier;
-        if (ContainerColor == 0L)     mask |= BitContainerColor;
-        if (Color          == 0L)     mask |= BitColor;
+        if (ContainerColor is null)   mask |= BitContainerColor;
+        if (Color          is null)   mask |= BitColor;
         if (MaxDistance    is null)   mask |= BitMaxDistance;
 
         // $changed bitmask. Bit positions over user params:
@@ -110,8 +110,8 @@ public sealed class PullToRefreshIndicator : ComposableNode
             state:          jvm,
             isRefreshing:   _isRefreshing,
             modifier:       modifier,
-            containerColor: ContainerColor,
-            color:          Color,
+            containerColor: ContainerColor?.ToPacked() ?? 0L,
+            color:          Color?.ToPacked()          ?? 0L,
             maxDistance:    MaxDistance?.Value ?? 0f,
             _composer:      composer,
             p7:             __changed,

--- a/src/Microsoft.AndroidX.Compose/SpanStyle.cs
+++ b/src/Microsoft.AndroidX.Compose/SpanStyle.cs
@@ -59,7 +59,7 @@ public sealed class SpanStyle
     {
         var d = TextStyleCompanion.DefaultSpan;
         return d.Copy(
-            color:                  Color is { } c ? (long)c : d.Color,
+            color:                  Color is { } c ? c.ToPacked() : d.Color,
             fontSize:               FontSize is { } fs ? Sp.Pack(fs) : d.FontSize,
             fontWeight:             FontWeight is null ? d.FontWeight : Cast<AndroidX.Compose.UI.Text.Font.FontWeight>(FontWeight),
             fontStyle:              FontStyle is null  ? d.FontStyle  : Cast<AndroidX.Compose.UI.Text.Font.FontStyle>(FontStyle),
@@ -70,7 +70,7 @@ public sealed class SpanStyle
             baselineShift:          d.BaselineShift,
             textGeometricTransform: d.TextGeometricTransform,
             localeList:             d.LocaleList,
-            background:             Background is { } bg ? (long)bg : d.Background,
+            background:             Background is { } bg ? bg.ToPacked() : d.Background,
             textDecoration:         Decoration is null ? d.TextDecoration : Cast<AndroidX.Compose.UI.Text.Style.TextDecoration>(Decoration),
             shadow:                 d.Shadow,
             platformStyle:          d.PlatformStyle,

--- a/src/Microsoft.AndroidX.Compose/TextStyle.cs
+++ b/src/Microsoft.AndroidX.Compose/TextStyle.cs
@@ -65,7 +65,7 @@ public sealed class TextStyle
     {
         var d = TextStyleCompanion.Default;
         return d.Copy(
-            color:                  Color is { } c   ? (long)c            : d.Color,
+            color:                  Color is { } c   ? c.ToPacked()       : d.Color,
             fontSize:               FontSize is { } fs ? Sp.Pack(fs)      : d.FontSize,
             fontWeight:             FontWeight is null ? d.FontWeight     : Cast<AndroidX.Compose.UI.Text.Font.FontWeight>(FontWeight),
             fontStyle:              FontStyle is null  ? d.FontStyle      : Cast<AndroidX.Compose.UI.Text.Font.FontStyle>(FontStyle),

--- a/src/Microsoft.AndroidX.Compose/VerticalDivider.cs
+++ b/src/Microsoft.AndroidX.Compose/VerticalDivider.cs
@@ -27,7 +27,7 @@ public sealed class VerticalDivider : ComposableNode
         DividerKt.VerticalDivider(
             modifier:  modifier,
             thickness: ThicknessDp ?? 0f,
-            color:     Color is { } c ? c : 0L,
+            color:     Color is { } c ? c.ToPacked() : 0L,
             _composer: composer,
             p4:        0,
             _changed:  defaults);


### PR DESCRIPTION
Packed `long` values were leaking through public color factories and resource APIs, making callers depend on Compose's JNI representation instead of the typed C# facade.

This change:
- updates Button, Checkbox, RadioButton, Slider, and Switch color factories to accept `Color?`, preserving Kotlin default-mask behavior while packing only at binding boundaries
- returns `Color` from `ColorResource` and exposes typed colors on `PullToRefreshIndicator`
- removes raw packed constructors, `PackedValue`, and implicit `long` conversions from `Color` in favor of explicit `FromPacked` and `ToPacked` interop methods
- migrates runtime, generated facade lowering, MAUI handlers, gallery usage, XML docs, and public API tracking
- adds device coverage for bit-exact packed conversion and a real `SolidColor` JNI constructor/getter round trip

Validation:
- source generator tests
- Compose runtime build
- MAUI backend build
- gallery build
- device test project build
- both new color tests passed on a connected Android device

The full parallel device suite later encountered its existing unrelated process crash around scroll/coroutine coverage; both new color tests had already reported passing.