### PR TITLE
Use stable MSTest 4.3.2

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,7 +17,7 @@
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
 
     <!-- Test runners -->
-    <PackageReference Update="MSTest" Version="4.3.0-preview.26314.12" />
+    <PackageReference Update="MSTest" Version="4.3.2" />
 
     <!-- Kotlin / KotlinX -->
     <PackageReference Update="Xamarin.Kotlin.StdLib" Version="2.3.21" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,5 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <!-- MSTest preview builds (e.g. 4.3.0-preview) used by Microsoft.AndroidX.Compose.DeviceTests. -->
-    <add key="dotnet-test-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
MSTest 4.3.2 is now available from NuGet.org, so the device tests no longer need a preview package or the dotnet-test-tools feed.

This updates the central MSTest version to 4.3.2 and removes the preview-only package source from `NuGet.config`.

Device test result: 60 passed, 0 failed, 0 skipped.