### PR TITLE
Fix picker state-holder lifecycle and managed APIs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -337,7 +337,7 @@ slots surface as `Action` instead of `Action<IComposer>`.
 
   Three sub-shapes:
   - **Phase 4** — zero-user-param Remember (`(IComposer) -> IntPtr`, e.g.
-    `RememberDatePickerState`). `_state` stays nullable; `Jvm` populated only
+    `RememberPullToRefreshState`). `_state` stays nullable; `Jvm` populated only
     when caller supplies non-null wrapper.
   - **Phase 4b** — parameterised Remember (`(arg1, …, IComposer) -> IntPtr`,
     e.g. `RememberTimePickerState(int initialHour, int initialMinute, bool
@@ -348,7 +348,11 @@ slots surface as `Action` instead of `Action<IComposer>`.
     guaranteed non-null in `Render`; `Jvm` population unguarded. The
     PascalCase-first rule lets a wrapper's live getter that falls back to its
     initial-value backing field (`Is24Hour => Jvm?.Is24hour() ?? InitialIs24Hour`)
-    be the natural match. Requires `StateType` constructible with no args.
+    be the natural match. The resolved member type must be implicitly
+    convertible to the Remember parameter type; use a managed wrapper method
+    around a generated JNI bridge when conversion is required (for example,
+    `long?` to boxed `Java.Lang.Long?` or `DatePickerYearRange?` to
+    `Kotlin.Ranges.IntRange?`). Requires `StateType` constructible with no args.
   - **Phase 4c** — `SharedState = true` opts in to shared-state caching for
     sibling facades sharing a `StateType` (e.g. `TimePicker` + `TimeInput`).
     Render preamble first checks `_state.Jvm` and reuses the cached JNI handle

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -334,6 +334,11 @@ slots surface as `Action` instead of `Action<IComposer>`.
   ctor slot `T? state = null`, calls named Remember, populates `state.Jvm` via
   `Java.Lang.Object.GetObject<TJvm>(handle, JniHandleOwnership.DoNotTransfer)`,
   forwards handle to this param.
+  Set `Bind = nameof(T.BindJvm)` when the wrapper must perform work as the
+  peer is attached (for example, flushing live-value writes made before
+  first composition). The named accessible instance method must accept the
+  binding-generated `Jvm` field type and return `void`; the generator calls
+  it instead of assigning `Jvm` directly.
 
   Three sub-shapes:
   - **Phase 4** — zero-user-param Remember (`(IComposer) -> IntPtr`, e.g.

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -1829,14 +1829,19 @@ recompose. The same shape unblocks a future
 name and implicit type compatibility. `DatePickerState` exposes managed
 `long?` values and `DatePickerYearRange?`; a managed
 `RememberDatePickerState` wrapper boxes longs and creates Kotlin's
-`IntRange` immediately before calling the generated JNI bridge. Nulls
-flow through unchanged, so the bridge generator still leaves the
-matching Kotlin `$default` bits set. The bridge generator can't skip
+`IntRange` immediately before calling the official generated binding. Nulls
+flow through unchanged, and the wrapper preserves the matching Kotlin
+`$default` bits with the generated mask enum. The binding can't skip
 non-trailing slots, so even though only three of the five Kotlin slots are MAUI-relevant
 (`initialSelectedDateMillis`, `yearRange`, `selectableDates`), the
 bridge surfaces all five — the unused two are left `null` by the
 handler and the auto-default-mask machinery clears their
 `$default` bits.
+
+Picker wrappers keep constructor configuration separate from pending live
+values. `[StateHolder(Bind = nameof(...))]` routes first peer attachment
+through `BindJvm`, which flushes only explicit pre-bind writes; ordinary
+constructor values continue through Kotlin's remember/default-mask path.
 
 **Lessons learned (Slice 12):**
 

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -1835,7 +1835,7 @@ flow through unchanged, and the wrapper preserves the matching Kotlin
 non-trailing slots, so even though only three of the five Kotlin slots are MAUI-relevant
 (`initialSelectedDateMillis`, `yearRange`, `selectableDates`), the
 bridge surfaces all five — the unused two are left `null` by the
-handler and the auto-default-mask machinery clears their
+handler and the generated omission mask keeps their
 `$default` bits.
 
 Picker wrappers keep constructor configuration separate from pending live

--- a/docs/maui-backend.md
+++ b/docs/maui-backend.md
@@ -1064,13 +1064,11 @@ No facade extensions were needed — `DatePickerDialog`,
   inside `BuildNode`. Subscriptions live and die with `SetVirtualView`
   / `DisconnectHandler` so we never leak a CollectionChanged handler
   past the virtual view.
-- **`DatePickerState.Jvm` is `internal`**, so the MAUI handler can't
-  null-check it before pushing values into the wrapper. The state's
-  setter (`SelectedDateMillis = ms`) is already a silent no-op until
-  Compose binds the JVM peer on the first call to `DatePicker(state)`.
-  We seed the state from `MutableState<long?> _ticks` inside a
-  `LaunchedEffect` *sibling* to the `DatePickerDialog` — by the time
-  the effect runs, `Jvm` is non-null and the assignment lands.
+- **`DatePickerState.Jvm` remains internal**, but callers no longer need
+  to inspect it. `SelectedDateMillis` retains a pending value before
+  binding and updates the live JVM state afterward. The handler can
+  therefore seed from `MutableState<long?> _ticks` in a
+  `LaunchedEffect` sibling whether or not the dialog has mounted yet.
 - **`TimePickerState` is Phase 4b** — the wrapper takes
   `initialHour`, `initialMinute`, `is24Hour` as ctor args. We re-key
   `c.Remember(factory, ticks, is24Hour)` so external `Time` writes
@@ -1827,15 +1825,14 @@ recompose. The same shape unblocks a future
 `DateRangePickerHandler` (Phase 3+) which can reuse
 `DateRangeSelectableDates` to clamp the picker range.
 
-**Phase 4b lift trade-off.** The wrapper-member resolution rules
-(see `.github/copilot-instructions.md`) match by name only, not by
-type — so `DatePickerState.InitialSelectedDateMillis` had to be
-typed `Java.Lang.Long?` (matching the JNI slot) rather than the
-user-friendly `long?`. The conversion happens inside the
-`DatePickerState(long? initialSelectedDateMillis, ...)` ctor; users
-get an ergonomic API while the generator still lowers cleanly. The
-bridge generator can't skip non-trailing slots, so even though only
-three of the five Kotlin slots are MAUI-relevant
+**Phase 4b managed boundary.** Wrapper-member resolution now requires
+name and implicit type compatibility. `DatePickerState` exposes managed
+`long?` values and `DatePickerYearRange?`; a managed
+`RememberDatePickerState` wrapper boxes longs and creates Kotlin's
+`IntRange` immediately before calling the generated JNI bridge. Nulls
+flow through unchanged, so the bridge generator still leaves the
+matching Kotlin `$default` bits set. The bridge generator can't skip
+non-trailing slots, so even though only three of the five Kotlin slots are MAUI-relevant
 (`initialSelectedDateMillis`, `yearRange`, `selectableDates`), the
 bridge surfaces all five — the unused two are left `null` by the
 handler and the auto-default-mask machinery clears their
@@ -1864,9 +1861,9 @@ handler and the auto-default-mask machinery clears their
   so MAUI write-throughs from `dp.Date = picked` survive — they just
   bump `_ticks.Value` and let the adapter's mutable fields drive
   greying.
-- **Wrapper-member resolution matches by name, not type.** Surfaced
-  `Java.Lang.Long?` directly on the wrapper to align with the JNI
-  slot type; ergonomic conversion happens in the wrapper's ctor.
+- **Wrapper-member resolution validates both name and type.** Managed
+  state-holder APIs use a typed wrapper method when JNI boxing or range
+  conversion is required.
 - **MAUI's `DatePicker` clamps `Date` assignments outside the
   Min/Max range.** The Reset button on the `PickersPage` sample had
   to use `DateTime.Today` (within the seeded Today..Today+30 window)

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/DateRangeStateBinder.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/DateRangeStateBinder.cs
@@ -1,0 +1,30 @@
+using Android.Runtime;
+using AndroidX.Compose;
+using AndroidX.Compose.Material3;
+using AndroidX.Compose.Runtime;
+
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+sealed class DateRangeStateBinder(DateRangePickerState state) : ComposableNode
+{
+    public override void Render(IComposer composer)
+    {
+        if (state.Jvm is not null)
+            return;
+
+        var handle = ComposeBridges.RememberDateRangePickerState(
+            state.RememberSelectedStartDateMillis,
+            state.RememberSelectedEndDateMillis,
+            state.RememberDisplayedMonthMillis,
+            state.InitialYearRange,
+            state.InitialDisplayMode,
+            state.InitialSelectableDates,
+            composer);
+        var jvm = Java.Lang.Object.GetObject<IDateRangePickerState>(
+            handle,
+            JniHandleOwnership.DoNotTransfer)
+            ?? throw new InvalidOperationException(
+                "DateRangePickerState Remember bridge returned no state peer.");
+        state.BindJvm(jvm);
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/LifecycleRenderMarker.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/LifecycleRenderMarker.cs
@@ -1,0 +1,13 @@
+using AndroidX.Compose;
+using AndroidX.Compose.Runtime;
+
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+sealed class LifecycleRenderMarker(ComposableNode? child) : ComposableNode
+{
+    public override void Render(IComposer composer)
+    {
+        child?.Render(composer);
+        PickerStateLifecycleTestActivity.MarkRenderCompleted();
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/Microsoft.AndroidX.Compose.DeviceTests.csproj
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/Microsoft.AndroidX.Compose.DeviceTests.csproj
@@ -25,10 +25,10 @@
 
         dotnet build src\Microsoft.AndroidX.Compose.DeviceTests -t:Install
         adb shell am instrument -w net.compose.devicetests/net.compose.devicetests.TestInstrumentation
-
         Run one test class with:
 
           adb shell am instrument -w -e filter FullyQualifiedName~CarouselDefaultsTests net.compose.devicetests/net.compose.devicetests.TestInstrumentation
+          adb shell am instrument -w -e filter FullyQualifiedName~StateHolderLifecycleTests net.compose.devicetests/net.compose.devicetests.TestInstrumentation
     -->
   </PropertyGroup>
 

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/PickerStateLifecycleTestActivity.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/PickerStateLifecycleTestActivity.cs
@@ -137,9 +137,12 @@ public class PickerStateLifecycleTestActivity : ComponentActivity
             ?? throw new InvalidOperationException("Default date-range state not set on PickerStateLifecycleTestActivity.");
         var showDefault = ShowDefault
             ?? throw new InvalidOperationException("Picker variant not set on PickerStateLifecycleTestActivity.");
-        return showDefault.Value
-            ? new Box { new DateRangeStateBinder(defaultState) }
-            : new Column { new DateRangeStateBinder(state) };
+        if (showDefault.Value)
+            return new Box { new DateRangeStateBinder(defaultState) };
+
+        return state.Jvm is null
+            ? new Column { new DateRangeStateBinder(state) }
+            : new Column { new DateRangePicker(state) };
     }
 
     static ComposableNode BuildTimePickers()

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/PickerStateLifecycleTestActivity.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/PickerStateLifecycleTestActivity.cs
@@ -1,0 +1,155 @@
+using Android.Runtime;
+using AndroidX.Activity;
+using AndroidX.Compose;
+using ComposeDatePicker = AndroidX.Compose.DatePicker;
+using ComposeTimePicker = AndroidX.Compose.TimePicker;
+
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+/// <summary>
+/// Hosts picker state holders in a real composition so instrumentation tests
+/// can verify first binding and removal/re-entry lifecycle behavior.
+/// </summary>
+[Activity(Theme = "@android:style/Theme.Material.Light.NoActionBar")]
+[Register("net/compose/devicetests/PickerStateLifecycleTestActivity")]
+public class PickerStateLifecycleTestActivity : ComponentActivity
+{
+    internal enum PickerKind
+    {
+        Date,
+        DateRange,
+        Time,
+    }
+
+    static int s_completedRenderPasses;
+
+    internal static PickerStateLifecycleTestActivity? Current { get; private set; }
+    internal static PickerKind Kind { get; private set; }
+    internal static MutableState<bool>? Visible { get; private set; }
+    internal static MutableState<bool>? ShowDefault { get; private set; }
+    internal static DatePickerState? DateState { get; private set; }
+    internal static DatePickerState? DefaultDateState { get; private set; }
+    internal static DateRangePickerState? DateRangeState { get; private set; }
+    internal static DateRangePickerState? DefaultDateRangeState { get; private set; }
+    internal static TimePickerState? TimeState { get; private set; }
+    internal static int CompletedRenderPasses => Volatile.Read(ref s_completedRenderPasses);
+
+    internal static void MarkRenderCompleted() =>
+        Interlocked.Increment(ref s_completedRenderPasses);
+
+    internal static void Reset(PickerKind kind)
+    {
+        Current = null;
+        Kind = kind;
+        Visible = null;
+        ShowDefault = null;
+        DateState = null;
+        DefaultDateState = null;
+        DateRangeState = null;
+        DefaultDateRangeState = null;
+        TimeState = null;
+        Volatile.Write(ref s_completedRenderPasses, 0);
+
+        switch (kind)
+        {
+            case PickerKind.Date:
+                DateState = new DatePickerState(
+                    initialSelectedDateMillis: 1_704_067_200_000L,
+                    initialDisplayedMonthMillis: 1_704_067_200_000L,
+                    initialYearRange: new DatePickerYearRange(2020, 2030));
+                DateState.SelectedDateMillis = 1_706_745_600_000L;
+                DateState.DisplayedMonthMillis = 1_709_251_200_000L;
+                DefaultDateState = new DatePickerState();
+                break;
+            case PickerKind.DateRange:
+                DateRangeState = new DateRangePickerState(
+                    initialSelectedStartDateMillis: 1_735_689_600_000L,
+                    initialSelectedEndDateMillis: 1_736_035_200_000L,
+                    initialDisplayedMonthMillis: 1_735_689_600_000L,
+                    initialYearRange: new DatePickerYearRange(2020, 2030));
+                DateRangeState.SetSelection(1_746_057_600_000L, 1_746_403_200_000L);
+                DateRangeState.DisplayedMonthMillis = 1_746_057_600_000L;
+                DefaultDateRangeState = new DateRangePickerState();
+                break;
+            case PickerKind.Time:
+                TimeState = new TimePickerState(initialHour: 7, initialMinute: 15, is24Hour: false)
+                {
+                    Hour = 8,
+                    Minute = 46,
+                };
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported picker kind.");
+        }
+    }
+
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+        Visible = new MutableState<bool>(true);
+        ShowDefault = new MutableState<bool>(false);
+        this.SetContent(_ => new Composed(_ =>
+        {
+            var visible = Visible
+                ?? throw new InvalidOperationException("Visibility state not set on PickerStateLifecycleTestActivity.");
+            if (!visible.Value)
+                return new LifecycleRenderMarker(null);
+
+            var picker = Kind switch
+            {
+                PickerKind.Date => BuildDatePickers(),
+                PickerKind.DateRange => BuildDateRangePickers(),
+                PickerKind.Time => BuildTimePickers(),
+                _ => throw new InvalidOperationException("Picker kind not set on PickerStateLifecycleTestActivity."),
+            };
+            return new LifecycleRenderMarker(picker);
+        }));
+        Current = this;
+    }
+
+    protected override void OnDestroy()
+    {
+        if (ReferenceEquals(Current, this))
+            Current = null;
+        Visible = null;
+        ShowDefault = null;
+        base.OnDestroy();
+    }
+
+    static ComposableNode BuildDatePickers()
+    {
+        var state = DateState
+            ?? throw new InvalidOperationException("Date state not set on PickerStateLifecycleTestActivity.");
+        var defaultState = DefaultDateState
+            ?? throw new InvalidOperationException("Default date state not set on PickerStateLifecycleTestActivity.");
+        var showDefault = ShowDefault
+            ?? throw new InvalidOperationException("Picker variant not set on PickerStateLifecycleTestActivity.");
+        return showDefault.Value
+            ? new Box { new ComposeDatePicker(defaultState) }
+            : new Column { new ComposeDatePicker(state) };
+    }
+
+    static ComposableNode BuildDateRangePickers()
+    {
+        var state = DateRangeState
+            ?? throw new InvalidOperationException("Date-range state not set on PickerStateLifecycleTestActivity.");
+        var defaultState = DefaultDateRangeState
+            ?? throw new InvalidOperationException("Default date-range state not set on PickerStateLifecycleTestActivity.");
+        var showDefault = ShowDefault
+            ?? throw new InvalidOperationException("Picker variant not set on PickerStateLifecycleTestActivity.");
+        return showDefault.Value
+            ? new Box { new DateRangeStateBinder(defaultState) }
+            : new Column { new DateRangeStateBinder(state) };
+    }
+
+    static ComposableNode BuildTimePickers()
+    {
+        var state = TimeState
+            ?? throw new InvalidOperationException("Time state not set on PickerStateLifecycleTestActivity.");
+        return new Box
+        {
+            new ComposeTimePicker(state),
+            new TimeInput(state),
+        };
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/StateHolderLifecycleTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/StateHolderLifecycleTests.cs
@@ -1,0 +1,256 @@
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+/// <summary>
+/// Verifies picker state-holder pending values, live JVM state, Kotlin
+/// defaults, and peer reuse across composition removal and re-entry.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class StateHolderLifecycleTests
+{
+    [TestMethod]
+    public async Task DatePickerState_PreservesPendingValuesAndPeer()
+    {
+        var activity = await StartActivity(PickerStateLifecycleTestActivity.PickerKind.Date);
+        try
+        {
+            var state = PickerStateLifecycleTestActivity.DateState
+                ?? throw new InvalidOperationException("Date state was not initialized.");
+            var jvm = await WaitFor(
+                () => state.Jvm,
+                static value => value is not null,
+                "DatePickerState did not bind to a JVM peer.")
+                ?? throw new InvalidOperationException("DatePickerState JVM peer was unavailable.");
+
+            Assert.AreEqual(1_706_745_600_000L, jvm.SelectedDateMillis?.LongValue());
+            Assert.AreEqual(1_709_251_200_000L, jvm.DisplayedMonthMillis);
+            AssertYearRange(jvm.YearRange, 2020, 2030);
+
+            await HidePicker(activity);
+            state.SelectedDateMillis = null;
+            Assert.IsNull(state.SelectedDateMillis);
+            Assert.IsNull(jvm.SelectedDateMillis);
+            state.SelectedDateMillis = 1_712_275_200_000L;
+            state.DisplayedMonthMillis = 1_711_929_600_000L;
+            Assert.AreEqual(1_712_275_200_000L, jvm.SelectedDateMillis?.LongValue());
+            Assert.AreEqual(1_711_929_600_000L, jvm.DisplayedMonthMillis);
+
+            await ShowPickerAndAssertPeerReused(activity, () => state.Jvm);
+
+            var defaultState = PickerStateLifecycleTestActivity.DefaultDateState
+                ?? throw new InvalidOperationException("Default date state was not initialized.");
+            await ShowDefaultPicker(activity);
+            var defaultJvm = await WaitFor(
+                () => defaultState.Jvm,
+                static value => value is not null,
+                "Default DatePickerState did not bind to a JVM peer.")
+                ?? throw new InvalidOperationException("Default DatePickerState JVM peer was unavailable.");
+            Assert.IsNull(defaultJvm.SelectedDateMillis);
+            AssertYearRange(defaultJvm.YearRange, 1900, 2100);
+        }
+        finally
+        {
+            await FinishActivity(activity);
+        }
+    }
+
+    [TestMethod]
+    public async Task DateRangePickerState_PreservesPendingValuesAndPeer()
+    {
+        var activity = await StartActivity(PickerStateLifecycleTestActivity.PickerKind.DateRange);
+        try
+        {
+            var state = PickerStateLifecycleTestActivity.DateRangeState
+                ?? throw new InvalidOperationException("Date-range state was not initialized.");
+            var jvm = await WaitFor(
+                () => state.Jvm,
+                static value => value is not null,
+                "DateRangePickerState did not bind to a JVM peer.")
+                ?? throw new InvalidOperationException("DateRangePickerState JVM peer was unavailable.");
+
+            Assert.AreEqual(1_746_057_600_000L, jvm.SelectedStartDateMillis?.LongValue());
+            Assert.AreEqual(1_746_403_200_000L, jvm.SelectedEndDateMillis?.LongValue());
+            Assert.AreEqual(1_746_057_600_000L, jvm.DisplayedMonthMillis);
+            AssertYearRange(jvm.YearRange, 2020, 2030);
+
+            await HidePicker(activity);
+            state.SetSelection(null, null);
+            Assert.IsNull(state.SelectedStartDateMillis);
+            Assert.IsNull(state.SelectedEndDateMillis);
+            state.SetSelection(1_748_736_000_000L, 1_749_081_600_000L);
+            state.DisplayedMonthMillis = 1_748_736_000_000L;
+            Assert.AreEqual(1_748_736_000_000L, jvm.SelectedStartDateMillis?.LongValue());
+            Assert.AreEqual(1_749_081_600_000L, jvm.SelectedEndDateMillis?.LongValue());
+            Assert.AreEqual(1_748_736_000_000L, jvm.DisplayedMonthMillis);
+
+            await ShowPickerAndAssertPeerReused(activity, () => state.Jvm);
+
+            var defaultState = PickerStateLifecycleTestActivity.DefaultDateRangeState
+                ?? throw new InvalidOperationException("Default date-range state was not initialized.");
+            await ShowDefaultPicker(activity);
+            var defaultJvm = await WaitFor(
+                () => defaultState.Jvm,
+                static value => value is not null,
+                "Default DateRangePickerState did not bind to a JVM peer.")
+                ?? throw new InvalidOperationException("Default DateRangePickerState JVM peer was unavailable.");
+            Assert.IsNull(defaultJvm.SelectedStartDateMillis);
+            Assert.IsNull(defaultJvm.SelectedEndDateMillis);
+            AssertYearRange(defaultJvm.YearRange, 1900, 2100);
+        }
+        finally
+        {
+            await FinishActivity(activity);
+        }
+    }
+
+    [TestMethod]
+    public async Task TimePickerState_PreservesPendingValuesAndPeer()
+    {
+        var activity = await StartActivity(PickerStateLifecycleTestActivity.PickerKind.Time);
+        try
+        {
+            var state = PickerStateLifecycleTestActivity.TimeState
+                ?? throw new InvalidOperationException("Time state was not initialized.");
+            var jvm = await WaitFor(
+                () => state.Jvm,
+                static value => value is not null,
+                "TimePickerState did not bind to a JVM peer.")
+                ?? throw new InvalidOperationException("TimePickerState JVM peer was unavailable.");
+
+            Assert.AreEqual(8, jvm.Hour);
+            Assert.AreEqual(46, jvm.Minute);
+            Assert.IsFalse(jvm.Is24hour());
+
+            await HidePicker(activity);
+            state.Hour = 19;
+            state.Minute = 27;
+            Assert.AreEqual(19, jvm.Hour);
+            Assert.AreEqual(27, jvm.Minute);
+
+            await ShowPickerAndAssertPeerReused(activity, () => state.Jvm);
+        }
+        finally
+        {
+            await FinishActivity(activity);
+        }
+    }
+
+    static async Task FinishActivity(PickerStateLifecycleTestActivity activity)
+    {
+        activity.RunOnUiThread(activity.Finish);
+        await WaitFor(
+            static () => PickerStateLifecycleTestActivity.Current,
+            current => !ReferenceEquals(current, activity),
+            "Picker lifecycle test activity did not finish.");
+    }
+
+    static async Task<PickerStateLifecycleTestActivity> StartActivity(
+        PickerStateLifecycleTestActivity.PickerKind kind)
+    {
+        var context = global::Android.App.Application.Context
+            ?? throw new InvalidOperationException(
+                "Application.Context not set for picker lifecycle tests.");
+        PickerStateLifecycleTestActivity.Reset(kind);
+        using var intent = new global::Android.Content.Intent(
+            context,
+            typeof(PickerStateLifecycleTestActivity));
+        intent.AddFlags(global::Android.Content.ActivityFlags.NewTask);
+        context.StartActivity(intent);
+
+        return await WaitFor(
+            static () => PickerStateLifecycleTestActivity.Current,
+            static value => value is not null,
+            "Picker lifecycle test activity did not start.")
+            ?? throw new InvalidOperationException(
+                "Picker lifecycle test activity was unavailable.");
+    }
+
+    static async Task HidePicker(PickerStateLifecycleTestActivity activity)
+    {
+        int hiddenPass = PickerStateLifecycleTestActivity.CompletedRenderPasses;
+        activity.RunOnUiThread(() =>
+        {
+            var visible = PickerStateLifecycleTestActivity.Visible
+                ?? throw new InvalidOperationException(
+                    "Visibility state not set on PickerStateLifecycleTestActivity.");
+            visible.Value = false;
+        });
+        await WaitFor(
+            static () => PickerStateLifecycleTestActivity.CompletedRenderPasses,
+            value => value > hiddenPass,
+            "Picker did not leave composition.");
+    }
+
+    static async Task ShowPickerAndAssertPeerReused<TJvm>(
+        PickerStateLifecycleTestActivity activity,
+        Func<TJvm?> readJvm)
+        where TJvm : class, global::Android.Runtime.IJavaObject
+    {
+        var before = readJvm()
+            ?? throw new InvalidOperationException("Picker state JVM peer was unavailable before removal.");
+        var handle = before.Handle;
+
+        int shownPass = PickerStateLifecycleTestActivity.CompletedRenderPasses;
+        activity.RunOnUiThread(() =>
+        {
+            var visible = PickerStateLifecycleTestActivity.Visible
+                ?? throw new InvalidOperationException(
+                    "Visibility state not set on PickerStateLifecycleTestActivity.");
+            visible.Value = true;
+        });
+        await WaitFor(
+            static () => PickerStateLifecycleTestActivity.CompletedRenderPasses,
+            value => value > shownPass,
+            "Picker did not re-enter composition.");
+
+        var after = readJvm()
+            ?? throw new InvalidOperationException("Picker state JVM peer was unavailable after re-entry.");
+        Assert.AreEqual(handle, after.Handle);
+    }
+
+    static async Task ShowDefaultPicker(PickerStateLifecycleTestActivity activity)
+    {
+        int priorPass = PickerStateLifecycleTestActivity.CompletedRenderPasses;
+        activity.RunOnUiThread(() =>
+        {
+            var showDefault = PickerStateLifecycleTestActivity.ShowDefault
+                ?? throw new InvalidOperationException(
+                    "Picker variant not set on PickerStateLifecycleTestActivity.");
+            showDefault.Value = true;
+        });
+        await WaitFor(
+            static () => PickerStateLifecycleTestActivity.CompletedRenderPasses,
+            value => value > priorPass,
+            "Default picker did not enter composition.");
+    }
+
+    static void AssertYearRange(Kotlin.Ranges.IntRange range, int startYear, int endYear)
+    {
+        var start = range.Start
+            ?? throw new InvalidOperationException("Kotlin year range had no start.");
+        var end = range.EndInclusive
+            ?? throw new InvalidOperationException("Kotlin year range had no inclusive end.");
+        Assert.AreEqual(startYear, start.IntValue());
+        Assert.AreEqual(endYear, end.IntValue());
+    }
+
+    static async Task<T> WaitFor<T>(
+        Func<T> read,
+        Func<T, bool> predicate,
+        string message)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        T value;
+        do
+        {
+            value = read();
+            if (predicate(value))
+                return value;
+            await Task.Delay(20);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        Assert.Fail(message);
+        return value;
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DatePickerDialogDemo.cs
@@ -20,11 +20,16 @@ public static class DatePickerDialogDemo
             // of the rememberDatePickerState cache key.
             var bounds    = c.Remember(() => new DateRangeSelectableDates());
             var todayUtc  = DateTimeOffset.UtcNow.Date;
-            bounds.MinUtcMillis = new DateTimeOffset(todayUtc).ToUnixTimeMilliseconds();
-            bounds.MaxUtcMillis = new DateTimeOffset(todayUtc.AddDays(30)).ToUnixTimeMilliseconds();
-            var state     = c.Remember(() => new DatePickerState(
-                initialSelectedDateMillis: bounds.MinUtcMillis,
-                initialSelectableDates:    bounds));
+            bounds.MinUtcMillis = new DateTimeOffset(todayUtc, TimeSpan.Zero).ToUnixTimeMilliseconds();
+            bounds.MaxUtcMillis = new DateTimeOffset(todayUtc.AddDays(30), TimeSpan.Zero).ToUnixTimeMilliseconds();
+            var state     = c.Remember(() =>
+            {
+                var pending = new DatePickerState(
+                    initialYearRange:       new DatePickerYearRange(todayUtc.Year, todayUtc.Year + 1),
+                    initialSelectableDates: bounds);
+                pending.SelectedDateMillis = bounds.MinUtcMillis;
+                return pending;
+            });
             return new Column
             {
                 new Text($"Picked date: {picked}"),

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DateRangePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/DateRangePickerDialogDemo.cs
@@ -15,7 +15,16 @@ public static class DateRangePickerDialogDemo
         {
             var open   = c.MutableStateOf(false);
             var picked = c.MutableStateOf("(none)");
-            var state  = c.Remember(() => new DateRangePickerState());
+            var state  = c.Remember(() =>
+            {
+                var today = DateTimeOffset.UtcNow.Date;
+                var start = new DateTimeOffset(today, TimeSpan.Zero).ToUnixTimeMilliseconds();
+                var end = new DateTimeOffset(today.AddDays(3), TimeSpan.Zero).ToUnixTimeMilliseconds();
+                var pending = new DateRangePickerState(
+                    initialYearRange: new DatePickerYearRange(today.Year, today.Year + 1));
+                pending.SetSelection(start, end);
+                return pending;
+            });
             var showModes = c.MutableStateOf(true);
             return new Column
             {

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/TimePickerDialogDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/DialogsSheets/TimePickerDialogDemo.cs
@@ -15,7 +15,12 @@ public static class TimePickerDialogDemo
         {
             var open   = c.MutableStateOf(false);
             var picked = c.MutableStateOf("(none)");
-            var state  = c.Remember(() => new TimePickerState(initialHour: 9, initialMinute: 30));
+            var state  = c.Remember(() =>
+            {
+                var pending = new TimePickerState(initialHour: 9);
+                pending.Minute = 30;
+                return pending;
+            });
             return new Column
             {
                 new Text($"Picked time: {picked}"),

--- a/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
+++ b/src/Microsoft.AndroidX.Compose.Maui/Handlers/DatePickerHandler.cs
@@ -201,15 +201,11 @@ public partial class DatePickerHandler : ComposeElementHandler<IDatePicker>
                 }
                 : (ComposableNode?)null;
 
-            // Seed the JVM state from MAUI's current Date once
-            // composition has wired it up. Keyed on _ticks so external
-            // changes to MAUI's Date re-sync; user-driven picks update
-            // SelectedDateMillis directly without re-keying so this
-            // doesn't fight the user. Setting SelectedDateMillis before
-            // the wrapper is bound is a silent no-op, so this runs
-            // unconditionally — once the first dialog opens and the
-            // DatePicker mounts, the next external Date push will
-            // re-fire the LE and the seeding sticks.
+            // Seed the state from MAUI's current Date. Before the dialog
+            // binds the JVM peer this becomes the pending initial value;
+            // afterward it updates the live state. Keying on _ticks keeps
+            // external Date changes synchronized without fighting
+            // user-driven picks.
             var seed = new LaunchedEffect((object?)ticks, ct =>
             {
                 if (ticks is long localTicks)

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -2688,6 +2688,58 @@ public class FacadeGeneratorTests
     }
 
     [Fact]
+    public void ParameterisedStateHolder_IncompatibleMemberType_FailsCN3009()
+    {
+        var code = $$"""
+            using global::AndroidX.Compose.Runtime;
+            using global::AndroidX.Compose.UI;
+            using AndroidX.Compose;
+            using System;
+
+            [assembly: ComposeDefaults("TimePickerDefault",
+                "!state", "modifier", "colors", "layoutType")]
+
+            namespace AndroidX.Compose.Material3
+            {
+                public interface ITimePickerState { }
+            }
+
+            namespace AndroidX.Compose
+            {
+                public sealed class BadState
+                {
+                    internal global::AndroidX.Compose.Material3.ITimePickerState? Jvm;
+                    public string InitialHour => "12";
+                }
+
+                public static partial class ComposeBridges
+                {
+                    [ComposeBridge(Class="x/y/TimePickerKt", JvmName="TimePicker-mT9BvqQ",
+                                   Signature="{{TimePickerSig}}",
+                                   Defaults=typeof(TimePickerDefault))]
+                    [ComposeFacade]
+                    public static partial void TimePicker(
+                        [StateHolder(Remember = nameof(RememberTimePickerState),
+                                     StateType = typeof(BadState))]
+                        IntPtr state,
+                        IModifier? modifier,
+                        int defaults,
+                        IComposer composer);
+
+                    public static IntPtr RememberTimePickerState(int initialHour, IComposer composer) => default;
+                }
+            }
+            """;
+
+        var (_, diags, emitted) = Run(code, "TimePicker");
+        Assert.Null(emitted);
+        Assert.Contains(diags, d => d.Id == "CN3009"
+            && d.GetMessage().Contains("member 'InitialHour' has type 'string'")
+            && d.GetMessage().Contains("not implicitly convertible")
+            && d.GetMessage().Contains("parameter 'initialHour' of type 'int'"));
+    }
+
+    [Fact]
     public void ParameterisedStateHolder_NoParameterlessCtor_FailsCN3009()
     {
         // StateType only has an all-required-params ctor, so the

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -2294,6 +2294,9 @@ public class FacadeGeneratorTests
                 internal int InitialHour { get; }
                 internal int InitialMinute { get; }
                 internal bool InitialIs24Hour { get; }
+                internal int RememberHour => InitialHour;
+                internal int RememberMinute => InitialMinute;
+                internal void BindJvm(global::AndroidX.Compose.Material3.ITimePickerState jvm) => Jvm = jvm;
                 public int Hour => Jvm?.Hour ?? InitialHour;
                 public int Minute => Jvm?.Minute ?? InitialMinute;
                 public bool Is24Hour => Jvm?.Is24hour() ?? InitialIs24Hour;
@@ -2336,7 +2339,7 @@ public class FacadeGeneratorTests
                         int defaults,
                         IComposer composer);
 
-                    public static IntPtr RememberTimePickerState(int initialHour, int initialMinute,
+                    public static IntPtr RememberTimePickerState(int rememberHour, int rememberMinute,
                                                                  bool is24Hour, IComposer composer) => default;
                 }
             }
@@ -2356,12 +2359,12 @@ public class FacadeGeneratorTests
         Assert.Contains("public TimePicker(global::AndroidX.Compose.TimePickerState? state = null)", emitted);
         Assert.Contains("_state = state ?? new global::AndroidX.Compose.TimePickerState();", emitted);
 
-        // Render: Remember called with wrapper-sourced init args.
-        // InitialHour/InitialMinute resolve via Pascal match;
+        // Render: Remember called with wrapper-sourced pending args.
+        // RememberHour/RememberMinute resolve via Pascal match;
         // is24Hour falls back to Is24Hour (live getter), which returns
         // InitialIs24Hour while Jvm is still null on first render.
         Assert.Contains(
-            "var __state = global::AndroidX.Compose.ComposeBridges.RememberTimePickerState(_state!.InitialHour, _state!.InitialMinute, _state!.Is24Hour, composer);",
+            "var __state = global::AndroidX.Compose.ComposeBridges.RememberTimePickerState(_state!.RememberHour, _state!.RememberMinute, _state!.Is24Hour, composer);",
             emitted);
         // Unguarded Jvm population — Phase 4b knows _state is non-null.
         Assert.Contains("if (_state.Jvm is null)", emitted);
@@ -2460,13 +2463,14 @@ public class FacadeGeneratorTests
                     public static partial void TimePicker(
                         [StateHolder(Remember = nameof(RememberTimePickerState),
                                      StateType = typeof(TimePickerState),
+                                     Bind = nameof(TimePickerState.BindJvm),
                                      SharedState = true)]
                         IntPtr state,
                         IModifier? modifier,
                         int defaults,
                         IComposer composer);
 
-                    public static IntPtr RememberTimePickerState(int initialHour, int initialMinute,
+                    public static IntPtr RememberTimePickerState(int rememberHour, int rememberMinute,
                                                                  bool is24Hour, IComposer composer) => default;
                 }
             }
@@ -2488,11 +2492,14 @@ public class FacadeGeneratorTests
         // Cache-miss branch — call Remember, populate Jvm so the next
         // sibling will hit the cached path.
         Assert.Contains(
-            "__state = global::AndroidX.Compose.ComposeBridges.RememberTimePickerState(_state!.InitialHour, _state!.InitialMinute, _state!.Is24Hour, composer);",
+            "__state = global::AndroidX.Compose.ComposeBridges.RememberTimePickerState(_state!.RememberHour, _state!.RememberMinute, _state!.Is24Hour, composer);",
             emitted);
         // Phase 4b assigns unguarded (ctor auto-create guarantees non-null).
         Assert.Contains(
-            "_state.Jvm = global::Java.Lang.Object.GetObject<global::AndroidX.Compose.Material3.ITimePickerState>(__state, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;",
+            "_state.BindJvm(",
+            emitted);
+        Assert.Contains(
+            "global::Java.Lang.Object.GetObject<global::AndroidX.Compose.Material3.ITimePickerState>(__state, global::Android.Runtime.JniHandleOwnership.DoNotTransfer)",
             emitted);
 
         // Must NOT emit the non-shared "always call Remember" preamble.

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/Attributes.cs
@@ -476,6 +476,7 @@ internal static class Attributes
                 public StateHolderAttribute() { }
                 public string Remember { get; set; } = "";
                 public global::System.Type StateType { get; set; } = null!;
+                public string Bind { get; set; } = "";
                 public bool SharedState { get; set; }
             }
 

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -1077,7 +1077,17 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                             $"[StateHolder] on '{p.Name}': cannot resolve Remember parameter '{up.Name}' on StateType '{stateType.ToDisplayString()}'; expected a readable instance member named '{Pascal(up.Name)}' or 'Initial{Pascal(up.Name)}'"));
                         return null;
                     }
-                    rememberArgExpressions[i] = "_" + p.Name + "!." + resolved;
+                    var resolvedType = resolved is IPropertySymbol property
+                        ? property.Type
+                        : ((IFieldSymbol)resolved).Type;
+                    var conversion = ((CSharpCompilation)c.Compilation).ClassifyConversion(resolvedType, up.Type);
+                    if (!conversion.IsImplicit)
+                    {
+                        diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                            $"[StateHolder] on '{p.Name}': StateType member '{resolved.Name}' has type '{resolvedType.ToDisplayString()}', which is not implicitly convertible to Remember parameter '{up.Name}' of type '{up.Type.ToDisplayString()}'"));
+                        return null;
+                    }
+                    rememberArgExpressions[i] = "_" + p.Name + "!." + resolved.Name;
                 }
             }
 
@@ -3998,9 +4008,9 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
     /// Kotlin convention where <c>initialX</c> remember args correspond
     /// to live wrapper property <c>X</c>. Looks at both properties and
     /// fields, accepting any readable, non-static, accessible member.
-    /// Returns the resolved C# identifier or <c>null</c> when no match.
+    /// Returns the resolved symbol or <c>null</c> when no match.
     /// </summary>
-    static string? ResolveStateMember(INamedTypeSymbol stateType, string paramName)
+    static ISymbol? ResolveStateMember(INamedTypeSymbol stateType, string paramName)
     {
         var pascal = Pascal(paramName);
         if (FindReadableMember(stateType, pascal) is { } direct) return direct;
@@ -4008,7 +4018,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         return null;
     }
 
-    static string? FindReadableMember(INamedTypeSymbol stateType, string name)
+    static ISymbol? FindReadableMember(INamedTypeSymbol stateType, string name)
     {
         // Walk the inheritance chain so inherited members count. We stop
         // at the first match — properties and fields share a name space
@@ -4021,8 +4031,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 if (m.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal
                     or Accessibility.ProtectedOrInternal))
                     continue;
-                if (m is IPropertySymbol prop && prop.GetMethod is not null) return prop.Name;
-                if (m is IFieldSymbol f) return f.Name;
+                if (m is IPropertySymbol prop && prop.GetMethod is not null) return prop;
+                if (m is IFieldSymbol f) return f;
             }
         }
         return null;

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -953,6 +953,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 return null;
             }
             string? remember = ReadString(stateAttr, "Remember");
+            string? bind = ReadString(stateAttr, "Bind");
             INamedTypeSymbol? stateType = ReadType(stateAttr, "StateType");
             if (string.IsNullOrEmpty(remember))
             {
@@ -970,6 +971,12 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
                     $"[StateHolder] on '{p.Name}': Remember value '{remember}' is not a valid C# identifier"));
+                return null;
+            }
+            if (!string.IsNullOrEmpty(bind) && !SyntaxFacts.IsValidIdentifier(bind!))
+            {
+                diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                    $"[StateHolder] on '{p.Name}': Bind value '{bind}' is not a valid C# identifier"));
                 return null;
             }
 
@@ -1021,6 +1028,21 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
                     $"[StateHolder] on '{p.Name}': StateType '{stateType.ToDisplayString()}'.Jvm must be accessible (public or internal)"));
                 return null;
+            }
+            if (!string.IsNullOrEmpty(bind))
+            {
+                var bindMethod = stateType.GetMembers(bind!).OfType<IMethodSymbol>().FirstOrDefault(m =>
+                    !m.IsStatic &&
+                    m.ReturnsVoid &&
+                    m.Parameters.Length == 1 &&
+                    SymbolEqualityComparer.Default.Equals(m.Parameters[0].Type, jvmMember.Type) &&
+                    m.DeclaredAccessibility is Accessibility.Public or Accessibility.Internal or Accessibility.ProtectedOrInternal);
+                if (bindMethod is null)
+                {
+                    diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
+                        $"[StateHolder] on '{p.Name}': StateType '{stateType.ToDisplayString()}' has no accessible instance method '{bind}' accepting '{jvmMember.Type.ToDisplayString()}' and returning void"));
+                    return null;
+                }
             }
 
             // Phase 4b — Remember has N user params before composer. Each
@@ -1096,6 +1118,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 stateWrapperType: stateType,
                 stateJvmType: jvmMember.Type,
                 rememberArgExpressions: rememberArgExpressions,
+                bindMethodName: string.IsNullOrEmpty(bind) ? null : bind,
                 sharedState: ReadBool(stateAttr, "SharedState"),
                 confirmStateChanges: confirmInfos.ToArray());
         }
@@ -1457,16 +1480,24 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 if (s.IsParameterisedStateHolder)
                 {
                     sb.Append("            if (_").Append(id).AppendLine(".Jvm is null)");
-                    sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
-                      .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
-                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+                    if (s.BindMethodName is not null)
+                        EmitConfiguredStateHolderBind(sb, s, "                ", "_" + id,
+                            jvmFqn, "__" + s.Param.Name);
+                    else
+                        sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                          .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                          .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
                 }
                 else
                 {
                     sb.Append("            if (_").Append(id).Append(" is not null && _").Append(id).AppendLine(".Jvm is null)");
-                    sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
-                      .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
-                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+                    if (s.BindMethodName is not null)
+                        EmitConfiguredStateHolderBind(sb, s, "                ", "_" + id,
+                            jvmFqn, "__" + s.Param.Name);
+                    else
+                        sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                          .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                          .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
                 }
             }
         }
@@ -2328,22 +2359,34 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 EmitComposableMethodRememberCall(sb, s, holder, "                ");
                 if (s.IsParameterisedStateHolder)
                 {
-                    sb.Append("                ").Append(holder)
-                      .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
-                      .Append(">(__").Append(s.Param.Name)
-                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
-                    sb.Append("                    ?? throw new global::System.InvalidOperationException(\"")
-                      .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    if (s.BindMethodName is not null)
+                        EmitConfiguredStateHolderBind(sb, s, "                ", holder,
+                            jvmType, "__" + s.Param.Name);
+                    else
+                    {
+                        sb.Append("                ").Append(holder)
+                          .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
+                          .Append(">(__").Append(s.Param.Name)
+                          .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
+                        sb.Append("                    ?? throw new global::System.InvalidOperationException(\"")
+                          .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    }
                 }
                 else
                 {
                     sb.Append("                if (").Append(holder).AppendLine(" is not null)");
-                    sb.Append("                    ").Append(holder)
-                      .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
-                      .Append(">(__").Append(s.Param.Name)
-                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
-                    sb.Append("                        ?? throw new global::System.InvalidOperationException(\"")
-                      .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    if (s.BindMethodName is not null)
+                        EmitConfiguredStateHolderBind(sb, s, "                    ", holder,
+                            jvmType, "__" + s.Param.Name);
+                    else
+                    {
+                        sb.Append("                    ").Append(holder)
+                          .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
+                          .Append(">(__").Append(s.Param.Name)
+                          .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
+                        sb.Append("                        ?? throw new global::System.InvalidOperationException(\"")
+                          .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    }
                 }
                 sb.AppendLine("            }");
             }
@@ -2353,23 +2396,35 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 if (s.IsParameterisedStateHolder)
                 {
                     sb.Append("            if (").Append(holder).AppendLine(".Jvm is null)");
-                    sb.Append("                ").Append(holder)
-                      .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
-                      .Append(">(__").Append(s.Param.Name)
-                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
-                    sb.Append("                    ?? throw new global::System.InvalidOperationException(\"")
-                      .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    if (s.BindMethodName is not null)
+                        EmitConfiguredStateHolderBind(sb, s, "                ", holder,
+                            jvmType, "__" + s.Param.Name);
+                    else
+                    {
+                        sb.Append("                ").Append(holder)
+                          .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
+                          .Append(">(__").Append(s.Param.Name)
+                          .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
+                        sb.Append("                    ?? throw new global::System.InvalidOperationException(\"")
+                          .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    }
                 }
                 else
                 {
                     sb.Append("            if (").Append(holder).Append(" is not null && ")
                       .Append(holder).AppendLine(".Jvm is null)");
-                    sb.Append("                ").Append(holder)
-                      .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
-                      .Append(">(__").Append(s.Param.Name)
-                      .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
-                    sb.Append("                    ?? throw new global::System.InvalidOperationException(\"")
-                      .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    if (s.BindMethodName is not null)
+                        EmitConfiguredStateHolderBind(sb, s, "                ", holder,
+                            jvmType, "__" + s.Param.Name);
+                    else
+                    {
+                        sb.Append("                ").Append(holder)
+                          .Append(".Jvm = global::Java.Lang.Object.GetObject<").Append(jvmType)
+                          .Append(">(__").Append(s.Param.Name)
+                          .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
+                        sb.Append("                    ?? throw new global::System.InvalidOperationException(\"")
+                          .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\");");
+                    }
                 }
             }
         }
@@ -3015,6 +3070,24 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
           .Append(" = ").Append(adapter).AppendLine(";");
     }
 
+    static void EmitConfiguredStateHolderBind(
+        StringBuilder sb,
+        FacadeSlot s,
+        string indent,
+        string holder,
+        string jvmType,
+        string handle)
+    {
+        var stateWrapperType = s.StateWrapperType
+            ?? throw new InvalidOperationException("State-holder slot is missing its wrapper type.");
+        sb.Append(indent).Append(holder).Append('.').Append(s.BindMethodName).AppendLine("(");
+        sb.Append(indent).Append("    global::Java.Lang.Object.GetObject<").Append(jvmType)
+          .Append(">(").Append(handle)
+          .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)");
+        sb.Append(indent).Append("        ?? throw new global::System.InvalidOperationException(\"")
+          .Append(stateWrapperType.Name).AppendLine(" Remember bridge returned no state peer.\"));");
+    }
+
     static void EmitStateHolderPreambleShared(StringBuilder sb, FacadeSlot s,
         string id, string jvmFqn, string composerName)
     {
@@ -3041,9 +3114,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             foreach (var argExpr in s.RememberArgExpressions)
                 sb.Append(argExpr).Append(", ");
             sb.Append(composerName).AppendLine(");");
-            sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
-              .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
-              .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+            if (s.BindMethodName is not null)
+                EmitConfiguredStateHolderBind(sb, s, "                ", "_" + id,
+                    jvmFqn, "__" + s.Param.Name);
+            else
+                sb.Append("                _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                  .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                  .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
             sb.AppendLine("            }");
         }
         else
@@ -3065,9 +3142,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 sb.Append(argExpr).Append(", ");
             sb.Append(composerName).AppendLine(");");
             sb.Append("                if (_").Append(id).AppendLine(" is not null)");
-            sb.Append("                    _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
-              .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
-              .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
+            if (s.BindMethodName is not null)
+                EmitConfiguredStateHolderBind(sb, s, "                    ", "_" + id,
+                    jvmFqn, "__" + s.Param.Name);
+            else
+                sb.Append("                    _").Append(id).Append(".Jvm = global::Java.Lang.Object.GetObject<")
+                  .Append(jvmFqn).Append(">(__").Append(s.Param.Name)
+                  .AppendLine(", global::Android.Runtime.JniHandleOwnership.DoNotTransfer)!;");
             sb.AppendLine("            }");
         }
     }
@@ -4181,7 +4262,8 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             ITypeSymbol? callbackType = null, string? slotPropertyName = null,
             string? rememberMethodName = null, INamedTypeSymbol? stateWrapperType = null,
             ITypeSymbol? stateJvmType = null, string[]? rememberArgExpressions = null,
-            bool sharedState = false, ConfirmStateChangeInfo[]? confirmStateChanges = null)
+            string? bindMethodName = null, bool sharedState = false,
+            ConfirmStateChangeInfo[]? confirmStateChanges = null)
         {
             Param = param;
             Kind = kind;
@@ -4191,6 +4273,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             StateWrapperType = stateWrapperType;
             StateJvmType = stateJvmType;
             RememberArgExpressions = rememberArgExpressions ?? [];
+            BindMethodName = bindMethodName;
             SharedState = sharedState;
             ConfirmStateChanges = confirmStateChanges ?? [];
         }
@@ -4201,6 +4284,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         public string? RememberMethodName { get; }
         public INamedTypeSymbol? StateWrapperType { get; }
         public ITypeSymbol? StateJvmType { get; }
+        public string? BindMethodName { get; }
         /// <summary>
         /// Phase 4b — one C# expression per user parameter of the
         /// <c>Remember*State</c> bridge (composer excluded). Each expression
@@ -4235,6 +4319,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
               or FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3;
         public FacadeSlot WithKind(FacadeSlotKind newKind) =>
             new(Param, newKind, CallbackType, SlotPropertyName, RememberMethodName,
-                StateWrapperType, StateJvmType, RememberArgExpressions, SharedState, ConfirmStateChanges);
+                StateWrapperType, StateJvmType, RememberArgExpressions, BindMethodName,
+                SharedState, ConfirmStateChanges);
     }
 }

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -955,7 +955,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             string? remember = ReadString(stateAttr, "Remember");
             string? bind = ReadString(stateAttr, "Bind");
             INamedTypeSymbol? stateType = ReadType(stateAttr, "StateType");
-            if (string.IsNullOrEmpty(remember))
+            if (remember is not { Length: > 0 })
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
                     $"[StateHolder] on '{p.Name}' is missing required property 'Remember'"));
@@ -967,13 +967,13 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                     $"[StateHolder] on '{p.Name}' is missing required property 'StateType'"));
                 return null;
             }
-            if (!SyntaxFacts.IsValidIdentifier(remember!))
+            if (!SyntaxFacts.IsValidIdentifier(remember))
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
                     $"[StateHolder] on '{p.Name}': Remember value '{remember}' is not a valid C# identifier"));
                 return null;
             }
-            if (!string.IsNullOrEmpty(bind) && !SyntaxFacts.IsValidIdentifier(bind!))
+            if (bind is { Length: > 0 } invalidBind && !SyntaxFacts.IsValidIdentifier(invalidBind))
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
                     $"[StateHolder] on '{p.Name}': Bind value '{bind}' is not a valid C# identifier"));
@@ -991,7 +991,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                     $"[StateHolder] on '{p.Name}': cannot resolve type 'AndroidX.Compose.ComposeBridges'"));
                 return null;
             }
-            var rememberMethods = bridgesType.GetMembers(remember!).OfType<IMethodSymbol>().ToArray();
+            var rememberMethods = bridgesType.GetMembers(remember).OfType<IMethodSymbol>().ToArray();
             if (rememberMethods.Length == 0)
             {
                 diags.Add(Diagnostic.Create(Diagnostics.FacadeStateHolderInvalid, loc, methodName,
@@ -1029,9 +1029,9 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                     $"[StateHolder] on '{p.Name}': StateType '{stateType.ToDisplayString()}'.Jvm must be accessible (public or internal)"));
                 return null;
             }
-            if (!string.IsNullOrEmpty(bind))
+            if (bind is { Length: > 0 } bindMethodName)
             {
-                var bindMethod = stateType.GetMembers(bind!).OfType<IMethodSymbol>().FirstOrDefault(m =>
+                var bindMethod = stateType.GetMembers(bindMethodName).OfType<IMethodSymbol>().FirstOrDefault(m =>
                     !m.IsStatic &&
                     m.ReturnsVoid &&
                     m.Parameters.Length == 1 &&

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1146,6 +1146,7 @@ internal static partial class ComposeBridges
     public static partial void TimePicker(
         [StateHolder(Remember = nameof(RememberTimePickerState),
                      StateType = typeof(TimePickerState),
+                     Bind = nameof(TimePickerState.BindJvm),
                      SharedState = true)] IntPtr state,
         IModifier? modifier,
         int defaults, IComposer composer, int _changed = 0);
@@ -1161,6 +1162,7 @@ internal static partial class ComposeBridges
     public static partial void TimeInput(
         [StateHolder(Remember = nameof(RememberTimePickerState),
                      StateType = typeof(TimePickerState),
+                     Bind = nameof(TimePickerState.BindJvm),
                      SharedState = true)] IntPtr state,
         IModifier? modifier,
         int defaults, IComposer composer, int _changed = 0);
@@ -1223,6 +1225,7 @@ internal static partial class ComposeBridges
     public static partial void DatePicker(
         [StateHolder(Remember = nameof(RememberDatePickerState),
                      StateType = typeof(DatePickerState),
+                     Bind = nameof(DatePickerState.BindJvm),
                      SharedState = true)]
         IntPtr      state,
         IModifier?  modifier,
@@ -1244,41 +1247,45 @@ internal static partial class ComposeBridges
     // the generated JNI bridge. Nulls remain null so the generated bridge
     // leaves the corresponding Kotlin $default bits set.
     public static IntPtr RememberDatePickerState(
-        long?                initialSelectedDateMillis,
-        long?                initialDisplayedMonthMillis,
+        long?                rememberSelectedDateMillis,
+        long?                rememberDisplayedMonthMillis,
         DatePickerYearRange? initialYearRange,
         int?                 initialDisplayMode,
         AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates,
         IComposer composer)
     {
-        using var selectedDate = initialSelectedDateMillis is long selected
+        using var selectedDate = rememberSelectedDateMillis is long selected
             ? Java.Lang.Long.ValueOf(selected)
             : null;
-        using var displayedMonth = initialDisplayedMonthMillis is long displayed
+        using var displayedMonth = rememberDisplayedMonthMillis is long displayed
             ? Java.Lang.Long.ValueOf(displayed)
             : null;
         using var yearRange = initialYearRange is DatePickerYearRange years
             ? new IntRange(years.StartYear, years.EndYear)
             : null;
-        return RememberDatePickerStateJvm(
-            selectedDate, displayedMonth, yearRange, initialDisplayMode,
-            initialSelectableDates, composer);
-    }
+        var defaults = RememberDatePickerStateDefault.All;
+        if (selectedDate is not null)
+            defaults &= ~RememberDatePickerStateDefault.InitialSelectedDateMillis;
+        if (displayedMonth is not null)
+            defaults &= ~RememberDatePickerStateDefault.InitialDisplayedMonthMillis;
+        if (yearRange is not null)
+            defaults &= ~RememberDatePickerStateDefault.YearRange;
+        if (initialDisplayMode is not null)
+            defaults &= ~RememberDatePickerStateDefault.InitialDisplayMode;
+        if (initialSelectableDates is not null)
+            defaults &= ~RememberDatePickerStateDefault.SelectableDates;
 
-    [ComposeBridge(
-        Class     = "androidx/compose/material3/DatePickerKt",
-        JvmName   = "rememberDatePickerState-EU0dCGE",
-        Signature = "(Ljava/lang/Long;Ljava/lang/Long;Lkotlin/ranges/IntRange;I" +
-                    "Landroidx/compose/material3/SelectableDates;" +
-                    "Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/DatePickerState;",
-        Defaults  = typeof(RememberDatePickerStateDefault))]
-    internal static partial IntPtr RememberDatePickerStateJvm(
-        Java.Lang.Long?                                  initialSelectedDateMillis,
-        Java.Lang.Long?                                  initialDisplayedMonthMillis,
-        IntRange?                                        yearRange,
-        int?                                             initialDisplayMode,
-        AndroidX.Compose.Material3.ISelectableDates?     selectableDates,
-        IComposer                                        composer);
+        var state = DatePickerKt.RememberDatePickerState(
+            selectedDate,
+            displayedMonth,
+            yearRange,
+            initialDisplayMode.GetValueOrDefault(),
+            initialSelectableDates,
+            composer,
+            0,
+            (int)defaults);
+        return ((Java.Lang.Object)state).Handle;
+    }
 
     // androidx.compose.material3.DateRangePickerKt.DateRangePicker
     [ComposeBridge(
@@ -1295,6 +1302,7 @@ internal static partial class ComposeBridges
     public static partial void DateRangePicker(
         [StateHolder(Remember = nameof(RememberDateRangePickerState),
                      StateType = typeof(DateRangePickerState),
+                     Bind = nameof(DateRangePickerState.BindJvm),
                      SharedState = true)]
         IntPtr      state,
         IModifier?  modifier,
@@ -1304,46 +1312,52 @@ internal static partial class ComposeBridges
 
     // androidx.compose.material3.DateRangePickerKt.rememberDateRangePickerState-IlFM19s
     public static IntPtr RememberDateRangePickerState(
-        long?                initialSelectedStartDateMillis,
-        long?                initialSelectedEndDateMillis,
-        long?                initialDisplayedMonthMillis,
+        long?                rememberSelectedStartDateMillis,
+        long?                rememberSelectedEndDateMillis,
+        long?                rememberDisplayedMonthMillis,
         DatePickerYearRange? initialYearRange,
         int?                 initialDisplayMode,
         AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates,
         IComposer composer)
     {
-        using var selectedStart = initialSelectedStartDateMillis is long start
+        using var selectedStart = rememberSelectedStartDateMillis is long start
             ? Java.Lang.Long.ValueOf(start)
             : null;
-        using var selectedEnd = initialSelectedEndDateMillis is long end
+        using var selectedEnd = rememberSelectedEndDateMillis is long end
             ? Java.Lang.Long.ValueOf(end)
             : null;
-        using var displayedMonth = initialDisplayedMonthMillis is long displayed
+        using var displayedMonth = rememberDisplayedMonthMillis is long displayed
             ? Java.Lang.Long.ValueOf(displayed)
             : null;
         using var yearRange = initialYearRange is DatePickerYearRange years
             ? new IntRange(years.StartYear, years.EndYear)
             : null;
-        return RememberDateRangePickerStateJvm(
-            selectedStart, selectedEnd, displayedMonth, yearRange,
-            initialDisplayMode, initialSelectableDates, composer);
-    }
+        var defaults = RememberDateRangePickerStateDefault.All;
+        if (selectedStart is not null)
+            defaults &= ~RememberDateRangePickerStateDefault.InitialSelectedStartDateMillis;
+        if (selectedEnd is not null)
+            defaults &= ~RememberDateRangePickerStateDefault.InitialSelectedEndDateMillis;
+        if (displayedMonth is not null)
+            defaults &= ~RememberDateRangePickerStateDefault.InitialDisplayedMonthMillis;
+        if (yearRange is not null)
+            defaults &= ~RememberDateRangePickerStateDefault.YearRange;
+        if (initialDisplayMode is not null)
+            defaults &= ~RememberDateRangePickerStateDefault.InitialDisplayMode;
+        if (initialSelectableDates is not null)
+            defaults &= ~RememberDateRangePickerStateDefault.SelectableDates;
 
-    [ComposeBridge(
-        Class     = "androidx/compose/material3/DateRangePickerKt",
-        JvmName   = "rememberDateRangePickerState-IlFM19s",
-        Signature = "(Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lkotlin/ranges/IntRange;I" +
-                    "Landroidx/compose/material3/SelectableDates;" +
-                    "Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/DateRangePickerState;",
-        Defaults  = typeof(RememberDateRangePickerStateDefault))]
-    internal static partial IntPtr RememberDateRangePickerStateJvm(
-        Java.Lang.Long?                              initialSelectedStartDateMillis,
-        Java.Lang.Long?                              initialSelectedEndDateMillis,
-        Java.Lang.Long?                              initialDisplayedMonthMillis,
-        IntRange?                                    yearRange,
-        int?                                         initialDisplayMode,
-        AndroidX.Compose.Material3.ISelectableDates? selectableDates,
-        IComposer                                    composer);
+        var state = DateRangePickerKt.RememberDateRangePickerState(
+            selectedStart,
+            selectedEnd,
+            displayedMonth,
+            yearRange,
+            initialDisplayMode.GetValueOrDefault(),
+            initialSelectableDates,
+            composer,
+            0,
+            (int)defaults);
+        return ((Java.Lang.Object)state).Handle;
+    }
 
     // androidx.compose.material3.TimePickerKt.rememberTimePickerState
     [ComposeBridge(
@@ -1351,8 +1365,12 @@ internal static partial class ComposeBridges
         JvmName   = "rememberTimePickerState",
         Signature = "(IIZLandroidx/compose/runtime/Composer;II)Landroidx/compose/material3/TimePickerState;",
         Defaults  = typeof(RememberTimePickerStateDefault))]
-    public static partial IntPtr RememberTimePickerState(int initialHour, int initialMinute,
-                                                         bool is24Hour, IComposer composer);
+    internal static partial IntPtr RememberTimePickerStateJvm(int initialHour, int initialMinute,
+                                                              bool is24Hour, IComposer composer);
+
+    public static IntPtr RememberTimePickerState(int rememberHour, int rememberMinute,
+                                                 bool is24Hour, IComposer composer) =>
+        RememberTimePickerStateJvm(rememberHour, rememberMinute, is24Hour, composer);
 
     // androidx.compose.material3.NavigationDrawerKt.rememberDrawerState.
     // The Kotlin function is bound natively so we go through it instead

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -1222,7 +1222,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void DatePicker(
         [StateHolder(Remember = nameof(RememberDatePickerState),
-                     StateType = typeof(DatePickerState))]
+                     StateType = typeof(DatePickerState),
+                     SharedState = true)]
         IntPtr      state,
         IModifier?  modifier,
         [FacadeDefault(true)] bool showModeToggle,
@@ -1238,18 +1239,32 @@ internal static partial class ComposeBridges
     // place (the matching `RememberDatePickerStateDefault` bit stays
     // set).
     //
-    // Wrapper-member resolution (StateType = DatePickerState):
-    //   initialSelectedDateMillis  -> InitialSelectedDateMillis    (Java.Lang.Long?)
-    //   initialDisplayedMonthMillis-> InitialDisplayedMonthMillis  (Java.Lang.Long?)
-    //   yearRange                  -> InitialYearRange             (IntRange?)
-    //   initialDisplayMode         -> InitialDisplayMode           (int?)
-    //   selectableDates            -> InitialSelectableDates       (ISelectableDates?)
-    //
-    // The JNI slot for `Long`/`IntRange`/`SelectableDates` is `L…;`,
-    // so the C# bridge param types must be reference (boxed Long,
-    // IntRange, ISelectableDates). The `initialDisplayMode` slot is
-    // `I` so `int?` is correct (auto-mask passes 0 + sets the bit
-    // when caller leaves it null).
+    // The public state holder stays fully managed. This wrapper converts
+    // nullable longs and DatePickerYearRange immediately before entering
+    // the generated JNI bridge. Nulls remain null so the generated bridge
+    // leaves the corresponding Kotlin $default bits set.
+    public static IntPtr RememberDatePickerState(
+        long?                initialSelectedDateMillis,
+        long?                initialDisplayedMonthMillis,
+        DatePickerYearRange? initialYearRange,
+        int?                 initialDisplayMode,
+        AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates,
+        IComposer composer)
+    {
+        using var selectedDate = initialSelectedDateMillis is long selected
+            ? Java.Lang.Long.ValueOf(selected)
+            : null;
+        using var displayedMonth = initialDisplayedMonthMillis is long displayed
+            ? Java.Lang.Long.ValueOf(displayed)
+            : null;
+        using var yearRange = initialYearRange is DatePickerYearRange years
+            ? new IntRange(years.StartYear, years.EndYear)
+            : null;
+        return RememberDatePickerStateJvm(
+            selectedDate, displayedMonth, yearRange, initialDisplayMode,
+            initialSelectableDates, composer);
+    }
+
     [ComposeBridge(
         Class     = "androidx/compose/material3/DatePickerKt",
         JvmName   = "rememberDatePickerState-EU0dCGE",
@@ -1257,7 +1272,7 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/material3/SelectableDates;" +
                     "Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/DatePickerState;",
         Defaults  = typeof(RememberDatePickerStateDefault))]
-    public static partial IntPtr RememberDatePickerState(
+    internal static partial IntPtr RememberDatePickerStateJvm(
         Java.Lang.Long?                                  initialSelectedDateMillis,
         Java.Lang.Long?                                  initialDisplayedMonthMillis,
         IntRange?                                        yearRange,
@@ -1279,7 +1294,8 @@ internal static partial class ComposeBridges
     [ComposeFacade]
     public static partial void DateRangePicker(
         [StateHolder(Remember = nameof(RememberDateRangePickerState),
-                     StateType = typeof(DateRangePickerState))]
+                     StateType = typeof(DateRangePickerState),
+                     SharedState = true)]
         IntPtr      state,
         IModifier?  modifier,
         [FacadeDefault(true)] bool showModeToggle,
@@ -1287,6 +1303,32 @@ internal static partial class ComposeBridges
         IComposer   composer, int _changed = 0);
 
     // androidx.compose.material3.DateRangePickerKt.rememberDateRangePickerState-IlFM19s
+    public static IntPtr RememberDateRangePickerState(
+        long?                initialSelectedStartDateMillis,
+        long?                initialSelectedEndDateMillis,
+        long?                initialDisplayedMonthMillis,
+        DatePickerYearRange? initialYearRange,
+        int?                 initialDisplayMode,
+        AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates,
+        IComposer composer)
+    {
+        using var selectedStart = initialSelectedStartDateMillis is long start
+            ? Java.Lang.Long.ValueOf(start)
+            : null;
+        using var selectedEnd = initialSelectedEndDateMillis is long end
+            ? Java.Lang.Long.ValueOf(end)
+            : null;
+        using var displayedMonth = initialDisplayedMonthMillis is long displayed
+            ? Java.Lang.Long.ValueOf(displayed)
+            : null;
+        using var yearRange = initialYearRange is DatePickerYearRange years
+            ? new IntRange(years.StartYear, years.EndYear)
+            : null;
+        return RememberDateRangePickerStateJvm(
+            selectedStart, selectedEnd, displayedMonth, yearRange,
+            initialDisplayMode, initialSelectableDates, composer);
+    }
+
     [ComposeBridge(
         Class     = "androidx/compose/material3/DateRangePickerKt",
         JvmName   = "rememberDateRangePickerState-IlFM19s",
@@ -1294,7 +1336,14 @@ internal static partial class ComposeBridges
                     "Landroidx/compose/material3/SelectableDates;" +
                     "Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/DateRangePickerState;",
         Defaults  = typeof(RememberDateRangePickerStateDefault))]
-    public static partial IntPtr RememberDateRangePickerState(IComposer composer);
+    internal static partial IntPtr RememberDateRangePickerStateJvm(
+        Java.Lang.Long?                              initialSelectedStartDateMillis,
+        Java.Lang.Long?                              initialSelectedEndDateMillis,
+        Java.Lang.Long?                              initialDisplayedMonthMillis,
+        IntRange?                                    yearRange,
+        int?                                         initialDisplayMode,
+        AndroidX.Compose.Material3.ISelectableDates? selectableDates,
+        IComposer                                    composer);
 
     // androidx.compose.material3.TimePickerKt.rememberTimePickerState
     [ComposeBridge(

--- a/src/Microsoft.AndroidX.Compose/DatePicker.cs
+++ b/src/Microsoft.AndroidX.Compose/DatePicker.cs
@@ -10,8 +10,9 @@ namespace AndroidX.Compose;
 /// The generated <c>Render()</c> calls
 /// <c>ComposeBridges.RememberDatePickerState</c> to obtain the JVM
 /// state handle, populates the wrapper's <c>Jvm</c> field on first
-/// render (so subsequent property reads on the wrapper hit the live
-/// state), and forwards the handle into the
+/// render, and reuses that peer when the picker leaves and later
+/// re-enters composition. Subsequent property reads on the wrapper hit
+/// the same live state forwarded into the
 /// <c>androidx.compose.material3.DatePickerKt.DatePicker</c> composable.
 /// </remarks>
 public sealed partial class DatePicker;

--- a/src/Microsoft.AndroidX.Compose/DatePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/DatePickerState.cs
@@ -1,5 +1,4 @@
 using AndroidX.Compose.Material3;
-using Kotlin.Ranges;
 
 namespace AndroidX.Compose;
 
@@ -8,8 +7,8 @@ namespace AndroidX.Compose;
 /// <see cref="DatePickerDialog"/>. The underlying JVM
 /// <c>androidx.compose.material3.DatePickerState</c> is created lazily
 /// the first time a <see cref="DatePicker"/> bound to this state is
-/// rendered; reads/writes to <see cref="SelectedDateMillis"/> before
-/// that point are no-ops/fallbacks.
+/// rendered. Live-value writes made before that point are retained and
+/// seed the JVM state when it is created.
 /// </summary>
 /// <remarks>
 /// Typical usage — <c>Remember</c> a state instance, pass it to a
@@ -31,25 +30,15 @@ namespace AndroidX.Compose;
 /// </code>
 ///
 /// The constructor's optional parameters seed the underlying state on
-/// first composition (via the Phase 4b <c>RememberDatePickerState</c>
-/// bridge). They're read once when the JVM state is first allocated;
-/// mutating <see cref="InitialSelectedDateMillis"/> /
-/// <see cref="InitialYearRange"/> / <see cref="InitialSelectableDates"/>
-/// after binding has no effect unless the host re-keys the surrounding
-/// <c>composer.Remember(...)</c> to force a fresh allocation.
+/// first composition. After binding, live properties read and write the
+/// JVM state directly.
 /// </remarks>
 public sealed class DatePickerState
 {
-    internal IDatePickerState? Jvm;
+    long? _initialSelectedDateMillis;
+    long? _initialDisplayedMonthMillis;
 
-    /// <summary>
-    /// Constructs an empty state holder. The underlying JVM
-    /// <c>DatePickerState</c> is allocated on first <see cref="DatePicker"/>
-    /// render with all values left at Kotlin's defaults.
-    /// </summary>
-    public DatePickerState()
-    {
-    }
+    internal IDatePickerState? Jvm;
 
     /// <summary>
     /// Constructs a state holder seeded with the supplied initial values.
@@ -59,33 +48,39 @@ public sealed class DatePickerState
     /// </summary>
     /// <param name="initialSelectedDateMillis">Initial selection as Unix
     /// epoch milliseconds (UTC), or <c>null</c> for "no initial selection".</param>
-    /// <param name="initialYearRange">Inclusive range of selectable years
+    /// <param name="initialDisplayedMonthMillis">First-of-month milliseconds
+    /// for the initially displayed month, or <c>null</c> to let Kotlin
+    /// derive it from the selected date.</param>
+    /// <param name="initialYearRange">Inclusive managed range of selectable years
     /// shown in the year-grid. <c>null</c> keeps Kotlin's default
     /// (1900–2100).</param>
+    /// <param name="initialDisplayMode">Initial packed Material 3 display
+    /// mode, or <c>null</c> for calendar mode.</param>
     /// <param name="initialSelectableDates">Per-day enable/disable
     /// adapter. <c>null</c> keeps Kotlin's default (every date
     /// selectable).</param>
     public DatePickerState(
-        long?              initialSelectedDateMillis = null,
-        IntRange?          initialYearRange          = null,
-        ISelectableDates?  initialSelectableDates    = null)
+        long?                initialSelectedDateMillis   = null,
+        long?                initialDisplayedMonthMillis = null,
+        DatePickerYearRange? initialYearRange            = null,
+        int?                 initialDisplayMode           = null,
+        ISelectableDates?    initialSelectableDates       = null)
     {
-        if (initialSelectedDateMillis is long ms)
-            InitialSelectedDateMillis = Java.Lang.Long.ValueOf(ms);
-        InitialYearRange       = initialYearRange;
+        _initialSelectedDateMillis = initialSelectedDateMillis;
+        _initialDisplayedMonthMillis = initialDisplayedMonthMillis;
+        InitialYearRange = initialYearRange;
+        InitialDisplayMode = initialDisplayMode;
         InitialSelectableDates = initialSelectableDates;
     }
 
     /// <summary>
-    /// Initial selection as a boxed <see cref="Java.Lang.Long"/>
-    /// (Kotlin's <c>Long?</c>). Read by the Phase 4b
-    /// <c>RememberDatePickerState</c> bridge on first composition;
-    /// mutating after binding has no effect (the live value lives in
-    /// <see cref="SelectedDateMillis"/>). Most callers should use the
-    /// <c>long?</c> constructor parameter instead of touching this
-    /// directly.
+    /// Initial selection as Unix epoch milliseconds (UTC). This value can
+    /// only be configured while constructing the holder.
     /// </summary>
-    public Java.Lang.Long? InitialSelectedDateMillis { get; set; }
+    public long? InitialSelectedDateMillis
+    {
+        get => _initialSelectedDateMillis;
+    }
 
     /// <summary>
     /// First-of-month milliseconds for the initial month shown by the
@@ -93,21 +88,22 @@ public sealed class DatePickerState
     /// usually left <c>null</c> so Kotlin defaults to the month
     /// containing <see cref="InitialSelectedDateMillis"/>.
     /// </summary>
-    public Java.Lang.Long? InitialDisplayedMonthMillis { get; set; }
+    public long? InitialDisplayedMonthMillis
+    {
+        get => _initialDisplayedMonthMillis;
+    }
 
     /// <summary>
-    /// Inclusive year range for the year-grid view. Read once by the
-    /// Phase 4b <c>RememberDatePickerState</c> bridge on first
-    /// composition.
+    /// Inclusive managed year range for the year-grid view.
     /// </summary>
-    public IntRange? InitialYearRange { get; set; }
+    public DatePickerYearRange? InitialYearRange { get; }
 
     /// <summary>
     /// Initial display mode (<c>DatePicker</c> or <c>Input</c>). Maps
     /// to Kotlin's <c>DisplayMode</c> packed-int enum. <c>null</c> uses
     /// Kotlin's default (calendar mode).
     /// </summary>
-    public int? InitialDisplayMode { get; set; }
+    public int? InitialDisplayMode { get; }
 
     /// <summary>
     /// Per-day / per-year enable/disable adapter. Read once by the
@@ -120,33 +116,49 @@ public sealed class DatePickerState
     /// as a <c>readonly</c> field, mirroring the Phase 10
     /// <c>ConfirmStateChange</c> pattern).
     /// </summary>
-    public ISelectableDates? InitialSelectableDates { get; set; }
+    public ISelectableDates? InitialSelectableDates { get; }
 
     /// <summary>
     /// The currently selected date as Unix epoch milliseconds (UTC), or
     /// <c>null</c> if no date is selected. Mirrors Kotlin's
-    /// <c>DatePickerState.selectedDateMillis: Long?</c>. Returns
-    /// <c>null</c> until the first <see cref="DatePicker"/> render binds
-    /// this state to the JVM picker.
+    /// <c>DatePickerState.selectedDateMillis: Long?</c>. Before binding,
+    /// reads and writes use the pending value that will seed the JVM state.
     /// </summary>
     public long? SelectedDateMillis
     {
-        get => Jvm?.SelectedDateMillis?.LongValue();
+        get => Jvm is { } jvm
+            ? jvm.SelectedDateMillis?.LongValue()
+            : _initialSelectedDateMillis;
         set
         {
-            if (Jvm is not null)
-                Jvm.SelectedDateMillis = value is long ms ? Java.Lang.Long.ValueOf(ms) : null;
+            if (Jvm is null)
+            {
+                _initialSelectedDateMillis = value;
+                return;
+            }
+
+            using var boxed = value is long milliseconds
+                ? Java.Lang.Long.ValueOf(milliseconds)
+                : null;
+            Jvm.SelectedDateMillis = boxed;
         }
     }
 
     /// <summary>
     /// First-of-month milliseconds for the month currently shown by the
     /// picker. Mirrors Kotlin's <c>DatePickerState.displayedMonthMillis</c>.
-    /// Returns <c>0</c> until the state is bound.
+    /// Before binding, reads and writes use the pending initial month.
+    /// Returns <c>0</c> when no initial month was supplied.
     /// </summary>
     public long DisplayedMonthMillis
     {
-        get => Jvm?.DisplayedMonthMillis ?? 0L;
-        set { if (Jvm is not null) Jvm.DisplayedMonthMillis = value; }
+        get => Jvm?.DisplayedMonthMillis ?? _initialDisplayedMonthMillis ?? 0L;
+        set
+        {
+            if (Jvm is null)
+                _initialDisplayedMonthMillis = value;
+            else
+                Jvm.DisplayedMonthMillis = value;
+        }
     }
 }

--- a/src/Microsoft.AndroidX.Compose/DatePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/DatePickerState.cs
@@ -35,10 +35,16 @@ namespace AndroidX.Compose;
 /// </remarks>
 public sealed class DatePickerState
 {
-    long? _initialSelectedDateMillis;
-    long? _initialDisplayedMonthMillis;
+    readonly long? _initialSelectedDateMillis;
+    readonly long? _initialDisplayedMonthMillis;
+    long? _selectedDateMillis;
+    long? _displayedMonthMillis;
+    bool _hasPendingSelectedDate;
+    bool _hasPendingDisplayedMonth;
 
     internal IDatePickerState? Jvm;
+    internal long? RememberSelectedDateMillis => _selectedDateMillis;
+    internal long? RememberDisplayedMonthMillis => _displayedMonthMillis;
 
     /// <summary>
     /// Constructs a state holder seeded with the supplied initial values.
@@ -68,6 +74,8 @@ public sealed class DatePickerState
     {
         _initialSelectedDateMillis = initialSelectedDateMillis;
         _initialDisplayedMonthMillis = initialDisplayedMonthMillis;
+        _selectedDateMillis = initialSelectedDateMillis;
+        _displayedMonthMillis = initialDisplayedMonthMillis;
         InitialYearRange = initialYearRange;
         InitialDisplayMode = initialDisplayMode;
         InitialSelectableDates = initialSelectableDates;
@@ -128,12 +136,13 @@ public sealed class DatePickerState
     {
         get => Jvm is { } jvm
             ? jvm.SelectedDateMillis?.LongValue()
-            : _initialSelectedDateMillis;
+            : _selectedDateMillis;
         set
         {
             if (Jvm is null)
             {
-                _initialSelectedDateMillis = value;
+                _selectedDateMillis = value;
+                _hasPendingSelectedDate = true;
                 return;
             }
 
@@ -152,13 +161,25 @@ public sealed class DatePickerState
     /// </summary>
     public long DisplayedMonthMillis
     {
-        get => Jvm?.DisplayedMonthMillis ?? _initialDisplayedMonthMillis ?? 0L;
+        get => Jvm?.DisplayedMonthMillis ?? _displayedMonthMillis ?? 0L;
         set
         {
             if (Jvm is null)
-                _initialDisplayedMonthMillis = value;
+            {
+                _displayedMonthMillis = value;
+                _hasPendingDisplayedMonth = true;
+            }
             else
                 Jvm.DisplayedMonthMillis = value;
         }
+    }
+
+    internal void BindJvm(IDatePickerState jvm)
+    {
+        Jvm = jvm;
+        if (_hasPendingSelectedDate)
+            SelectedDateMillis = _selectedDateMillis;
+        if (_hasPendingDisplayedMonth && _displayedMonthMillis is long displayedMonthMillis)
+            DisplayedMonthMillis = displayedMonthMillis;
     }
 }

--- a/src/Microsoft.AndroidX.Compose/DatePickerYearRange.cs
+++ b/src/Microsoft.AndroidX.Compose/DatePickerYearRange.cs
@@ -1,0 +1,26 @@
+namespace AndroidX.Compose;
+
+/// <summary>
+/// Inclusive range of years displayed by a <see cref="DatePicker"/> or
+/// <see cref="DateRangePicker"/>.
+/// </summary>
+public readonly struct DatePickerYearRange
+{
+    /// <summary>Creates an inclusive year range.</summary>
+    /// <param name="startYear">First selectable year.</param>
+    /// <param name="endYear">Last selectable year.</param>
+    public DatePickerYearRange(int startYear, int endYear)
+    {
+        if (endYear < startYear)
+            throw new ArgumentOutOfRangeException(nameof(endYear), endYear, "End year must be greater than or equal to start year.");
+
+        StartYear = startYear;
+        EndYear = endYear;
+    }
+
+    /// <summary>First selectable year.</summary>
+    public int StartYear { get; }
+
+    /// <summary>Last selectable year.</summary>
+    public int EndYear { get; }
+}

--- a/src/Microsoft.AndroidX.Compose/DateRangePicker.cs
+++ b/src/Microsoft.AndroidX.Compose/DateRangePicker.cs
@@ -12,8 +12,9 @@ namespace AndroidX.Compose;
 /// The generated <c>Render()</c> calls
 /// <c>ComposeBridges.RememberDateRangePickerState</c> to obtain the JVM
 /// state handle, populates the wrapper's <c>Jvm</c> field on first
-/// render (so subsequent property reads on the wrapper hit the live
-/// state), and forwards the handle into the
+/// render, and reuses that peer when the picker leaves and later
+/// re-enters composition. Subsequent property reads on the wrapper hit
+/// the same live state forwarded into the
 /// <c>androidx.compose.material3.DateRangePickerKt.DateRangePicker</c>
 /// composable.
 /// </remarks>

--- a/src/Microsoft.AndroidX.Compose/DateRangePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/DateRangePickerState.cs
@@ -31,11 +31,19 @@ namespace AndroidX.Compose;
 /// </remarks>
 public sealed class DateRangePickerState
 {
-    long? _initialSelectedStartDateMillis;
-    long? _initialSelectedEndDateMillis;
-    long? _initialDisplayedMonthMillis;
+    readonly long? _initialSelectedStartDateMillis;
+    readonly long? _initialSelectedEndDateMillis;
+    readonly long? _initialDisplayedMonthMillis;
+    long? _selectedStartDateMillis;
+    long? _selectedEndDateMillis;
+    long? _displayedMonthMillis;
+    bool _hasPendingSelection;
+    bool _hasPendingDisplayedMonth;
 
     internal IDateRangePickerState? Jvm;
+    internal long? RememberSelectedStartDateMillis => _selectedStartDateMillis;
+    internal long? RememberSelectedEndDateMillis => _selectedEndDateMillis;
+    internal long? RememberDisplayedMonthMillis => _displayedMonthMillis;
 
     /// <summary>Creates a range-picker state with managed initial values.</summary>
     /// <param name="initialSelectedStartDateMillis">Initial range start as
@@ -62,6 +70,9 @@ public sealed class DateRangePickerState
         _initialSelectedStartDateMillis = initialSelectedStartDateMillis;
         _initialSelectedEndDateMillis = initialSelectedEndDateMillis;
         _initialDisplayedMonthMillis = initialDisplayedMonthMillis;
+        _selectedStartDateMillis = initialSelectedStartDateMillis;
+        _selectedEndDateMillis = initialSelectedEndDateMillis;
+        _displayedMonthMillis = initialDisplayedMonthMillis;
         InitialYearRange = initialYearRange;
         InitialDisplayMode = initialDisplayMode;
         InitialSelectableDates = initialSelectableDates;
@@ -107,7 +118,7 @@ public sealed class DateRangePickerState
     {
         get => Jvm is { } jvm
             ? jvm.SelectedStartDateMillis?.LongValue()
-            : _initialSelectedStartDateMillis;
+            : _selectedStartDateMillis;
         set => SetSelection(value, SelectedEndDateMillis);
     }
 
@@ -121,7 +132,7 @@ public sealed class DateRangePickerState
     {
         get => Jvm is { } jvm
             ? jvm.SelectedEndDateMillis?.LongValue()
-            : _initialSelectedEndDateMillis;
+            : _selectedEndDateMillis;
         set => SetSelection(SelectedStartDateMillis, value);
     }
 
@@ -133,11 +144,14 @@ public sealed class DateRangePickerState
     /// </summary>
     public long DisplayedMonthMillis
     {
-        get => Jvm?.DisplayedMonthMillis ?? _initialDisplayedMonthMillis ?? 0L;
+        get => Jvm?.DisplayedMonthMillis ?? _displayedMonthMillis ?? 0L;
         set
         {
             if (Jvm is null)
-                _initialDisplayedMonthMillis = value;
+            {
+                _displayedMonthMillis = value;
+                _hasPendingDisplayedMonth = true;
+            }
             else
                 Jvm.DisplayedMonthMillis = value;
         }
@@ -154,8 +168,9 @@ public sealed class DateRangePickerState
         ValidateSelection(startDateMillis, endDateMillis);
         if (Jvm is null)
         {
-            _initialSelectedStartDateMillis = startDateMillis;
-            _initialSelectedEndDateMillis = endDateMillis;
+            _selectedStartDateMillis = startDateMillis;
+            _selectedEndDateMillis = endDateMillis;
+            _hasPendingSelection = true;
             return;
         }
 
@@ -170,6 +185,15 @@ public sealed class DateRangePickerState
             start?.Dispose();
             end?.Dispose();
         }
+    }
+
+    internal void BindJvm(IDateRangePickerState jvm)
+    {
+        Jvm = jvm;
+        if (_hasPendingSelection)
+            SetSelection(_selectedStartDateMillis, _selectedEndDateMillis);
+        if (_hasPendingDisplayedMonth && _displayedMonthMillis is long displayedMonthMillis)
+            DisplayedMonthMillis = displayedMonthMillis;
     }
 
     static void ValidateSelection(long? startDateMillis, long? endDateMillis)

--- a/src/Microsoft.AndroidX.Compose/DateRangePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/DateRangePickerState.cs
@@ -6,10 +6,8 @@ namespace AndroidX.Compose;
 /// Caller-supplied state holder for <see cref="DateRangePicker"/>. The
 /// underlying JVM <c>androidx.compose.material3.DateRangePickerState</c>
 /// is created lazily the first time a <see cref="DateRangePicker"/>
-/// bound to this state is rendered; before that point reads from
-/// <see cref="SelectedStartDateMillis"/> /
-/// <see cref="SelectedEndDateMillis"/> return <c>null</c> and calls to
-/// <see cref="SetSelection"/> are no-ops.
+/// bound to this state is rendered. Before that point, selection and
+/// displayed-month writes are retained and seed the JVM state.
 /// </summary>
 /// <remarks>
 /// Typical usage — <c>Remember</c> a state instance, pass it to a
@@ -33,20 +31,83 @@ namespace AndroidX.Compose;
 /// </remarks>
 public sealed class DateRangePickerState
 {
+    long? _initialSelectedStartDateMillis;
+    long? _initialSelectedEndDateMillis;
+    long? _initialDisplayedMonthMillis;
+
     internal IDateRangePickerState? Jvm;
+
+    /// <summary>Creates a range-picker state with managed initial values.</summary>
+    /// <param name="initialSelectedStartDateMillis">Initial range start as
+    /// Unix epoch milliseconds (UTC).</param>
+    /// <param name="initialSelectedEndDateMillis">Initial range end as
+    /// Unix epoch milliseconds (UTC).</param>
+    /// <param name="initialDisplayedMonthMillis">First-of-month milliseconds
+    /// for the initially displayed month.</param>
+    /// <param name="initialYearRange">Inclusive managed year range, or
+    /// <c>null</c> for Kotlin's default.</param>
+    /// <param name="initialDisplayMode">Initial packed Material 3 display
+    /// mode, or <c>null</c> for calendar mode.</param>
+    /// <param name="initialSelectableDates">Date-selection policy, or
+    /// <c>null</c> to allow every date.</param>
+    public DateRangePickerState(
+        long?                initialSelectedStartDateMillis = null,
+        long?                initialSelectedEndDateMillis   = null,
+        long?                initialDisplayedMonthMillis    = null,
+        DatePickerYearRange? initialYearRange               = null,
+        int?                 initialDisplayMode              = null,
+        ISelectableDates?    initialSelectableDates          = null)
+    {
+        ValidateSelection(initialSelectedStartDateMillis, initialSelectedEndDateMillis);
+        _initialSelectedStartDateMillis = initialSelectedStartDateMillis;
+        _initialSelectedEndDateMillis = initialSelectedEndDateMillis;
+        _initialDisplayedMonthMillis = initialDisplayedMonthMillis;
+        InitialYearRange = initialYearRange;
+        InitialDisplayMode = initialDisplayMode;
+        InitialSelectableDates = initialSelectableDates;
+    }
+
+    /// <summary>Initial selected range start as Unix epoch milliseconds.</summary>
+    public long? InitialSelectedStartDateMillis
+    {
+        get => _initialSelectedStartDateMillis;
+    }
+
+    /// <summary>Initial selected range end as Unix epoch milliseconds.</summary>
+    public long? InitialSelectedEndDateMillis
+    {
+        get => _initialSelectedEndDateMillis;
+    }
+
+    /// <summary>Initial displayed month as first-of-month epoch milliseconds.</summary>
+    public long? InitialDisplayedMonthMillis
+    {
+        get => _initialDisplayedMonthMillis;
+    }
+
+    /// <summary>Inclusive managed year range for the year-grid view.</summary>
+    public DatePickerYearRange? InitialYearRange { get; }
+
+    /// <summary>Initial packed Material 3 display mode.</summary>
+    public int? InitialDisplayMode { get; }
+
+    /// <summary>Initial date-selection policy.</summary>
+    public ISelectableDates? InitialSelectableDates { get; }
 
     /// <summary>
     /// The start of the currently selected range as Unix epoch
     /// milliseconds (UTC), or <c>null</c> if no start date is selected.
     /// Mirrors Kotlin's <c>DateRangePickerState.selectedStartDateMillis: Long?</c>.
-    /// Returns <c>null</c> until the first <see cref="DateRangePicker"/>
-    /// render binds this state to the JVM picker. Setting either end of
+    /// Before binding, reads and writes use the pending range that will
+    /// seed the JVM state. Setting either end of
     /// the range goes through the JVM <c>setSelection</c> helper to keep
     /// the start/end pair consistent.
     /// </summary>
     public long? SelectedStartDateMillis
     {
-        get => Jvm?.SelectedStartDateMillis?.LongValue();
+        get => Jvm is { } jvm
+            ? jvm.SelectedStartDateMillis?.LongValue()
+            : _initialSelectedStartDateMillis;
         set => SetSelection(value, SelectedEndDateMillis);
     }
 
@@ -54,23 +115,32 @@ public sealed class DateRangePickerState
     /// The end of the currently selected range as Unix epoch
     /// milliseconds (UTC), or <c>null</c> if no end date is selected.
     /// Mirrors Kotlin's <c>DateRangePickerState.selectedEndDateMillis: Long?</c>.
-    /// Returns <c>null</c> until the state is bound.
+    /// Before binding, reads and writes use the pending range.
     /// </summary>
     public long? SelectedEndDateMillis
     {
-        get => Jvm?.SelectedEndDateMillis?.LongValue();
+        get => Jvm is { } jvm
+            ? jvm.SelectedEndDateMillis?.LongValue()
+            : _initialSelectedEndDateMillis;
         set => SetSelection(SelectedStartDateMillis, value);
     }
 
     /// <summary>
     /// First-of-month milliseconds for the month currently shown by the
     /// picker. Mirrors Kotlin's <c>DateRangePickerState.displayedMonthMillis</c>.
-    /// Returns <c>0</c> until the state is bound.
+    /// Before binding, reads and writes use the pending initial month.
+    /// Returns <c>0</c> when no initial month was supplied.
     /// </summary>
     public long DisplayedMonthMillis
     {
-        get => Jvm?.DisplayedMonthMillis ?? 0L;
-        set { if (Jvm is not null) Jvm.DisplayedMonthMillis = value; }
+        get => Jvm?.DisplayedMonthMillis ?? _initialDisplayedMonthMillis ?? 0L;
+        set
+        {
+            if (Jvm is null)
+                _initialDisplayedMonthMillis = value;
+            else
+                Jvm.DisplayedMonthMillis = value;
+        }
     }
 
     /// <summary>
@@ -81,9 +151,34 @@ public sealed class DateRangePickerState
     /// </summary>
     public void SetSelection(long? startDateMillis, long? endDateMillis)
     {
-        if (Jvm is null) return;
+        ValidateSelection(startDateMillis, endDateMillis);
+        if (Jvm is null)
+        {
+            _initialSelectedStartDateMillis = startDateMillis;
+            _initialSelectedEndDateMillis = endDateMillis;
+            return;
+        }
+
         var start = startDateMillis is long s ? Java.Lang.Long.ValueOf(s) : null;
         var end   = endDateMillis   is long e ? Java.Lang.Long.ValueOf(e) : null;
-        Jvm.SetSelection(start, end);
+        try
+        {
+            Jvm.SetSelection(start, end);
+        }
+        finally
+        {
+            start?.Dispose();
+            end?.Dispose();
+        }
+    }
+
+    static void ValidateSelection(long? startDateMillis, long? endDateMillis)
+    {
+        if (endDateMillis is not long end)
+            return;
+        if (startDateMillis is not long start)
+            throw new ArgumentException("An end date requires a start date.", nameof(endDateMillis));
+        if (end < start)
+            throw new ArgumentOutOfRangeException(nameof(endDateMillis), end, "End date must be greater than or equal to start date.");
     }
 }

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -260,22 +260,21 @@ AndroidX.Compose.DatePickerDialog.DatePickerDialog(System.Action! onDismissReque
 AndroidX.Compose.DatePickerDialog.DismissButton.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.DatePickerDialog.DismissButton.set -> void
 AndroidX.Compose.DatePickerState
-AndroidX.Compose.DatePickerState.DatePickerState() -> void
-AndroidX.Compose.DatePickerState.DatePickerState(long? initialSelectedDateMillis = null, Kotlin.Ranges.IntRange? initialYearRange = null, AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates = null) -> void
+AndroidX.Compose.DatePickerState.DatePickerState(long? initialSelectedDateMillis = null, long? initialDisplayedMonthMillis = null, AndroidX.Compose.DatePickerYearRange? initialYearRange = null, int? initialDisplayMode = null, AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates = null) -> void
 AndroidX.Compose.DatePickerState.DisplayedMonthMillis.get -> long
 AndroidX.Compose.DatePickerState.DisplayedMonthMillis.set -> void
 AndroidX.Compose.DatePickerState.InitialDisplayMode.get -> int?
-AndroidX.Compose.DatePickerState.InitialDisplayMode.set -> void
-AndroidX.Compose.DatePickerState.InitialDisplayedMonthMillis.get -> Java.Lang.Long?
-AndroidX.Compose.DatePickerState.InitialDisplayedMonthMillis.set -> void
+AndroidX.Compose.DatePickerState.InitialDisplayedMonthMillis.get -> long?
 AndroidX.Compose.DatePickerState.InitialSelectableDates.get -> AndroidX.Compose.Material3.ISelectableDates?
-AndroidX.Compose.DatePickerState.InitialSelectableDates.set -> void
-AndroidX.Compose.DatePickerState.InitialSelectedDateMillis.get -> Java.Lang.Long?
-AndroidX.Compose.DatePickerState.InitialSelectedDateMillis.set -> void
-AndroidX.Compose.DatePickerState.InitialYearRange.get -> Kotlin.Ranges.IntRange?
-AndroidX.Compose.DatePickerState.InitialYearRange.set -> void
+AndroidX.Compose.DatePickerState.InitialSelectedDateMillis.get -> long?
+AndroidX.Compose.DatePickerState.InitialYearRange.get -> AndroidX.Compose.DatePickerYearRange?
 AndroidX.Compose.DatePickerState.SelectedDateMillis.get -> long?
 AndroidX.Compose.DatePickerState.SelectedDateMillis.set -> void
+AndroidX.Compose.DatePickerYearRange
+AndroidX.Compose.DatePickerYearRange.DatePickerYearRange() -> void
+AndroidX.Compose.DatePickerYearRange.DatePickerYearRange(int startYear, int endYear) -> void
+AndroidX.Compose.DatePickerYearRange.EndYear.get -> int
+AndroidX.Compose.DatePickerYearRange.StartYear.get -> int
 AndroidX.Compose.DateRangePicker
 AndroidX.Compose.DateRangePicker.DateRangePicker(AndroidX.Compose.DateRangePickerState? state = null, bool showModeToggle = true) -> void
 AndroidX.Compose.DateRangePickerDialog
@@ -287,9 +286,15 @@ AndroidX.Compose.DateRangePickerDialog.DateRangePickerDialog(System.Action! onDi
 AndroidX.Compose.DateRangePickerDialog.DismissButton.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.DateRangePickerDialog.DismissButton.set -> void
 AndroidX.Compose.DateRangePickerState
-AndroidX.Compose.DateRangePickerState.DateRangePickerState() -> void
+AndroidX.Compose.DateRangePickerState.DateRangePickerState(long? initialSelectedStartDateMillis = null, long? initialSelectedEndDateMillis = null, long? initialDisplayedMonthMillis = null, AndroidX.Compose.DatePickerYearRange? initialYearRange = null, int? initialDisplayMode = null, AndroidX.Compose.Material3.ISelectableDates? initialSelectableDates = null) -> void
 AndroidX.Compose.DateRangePickerState.DisplayedMonthMillis.get -> long
 AndroidX.Compose.DateRangePickerState.DisplayedMonthMillis.set -> void
+AndroidX.Compose.DateRangePickerState.InitialDisplayMode.get -> int?
+AndroidX.Compose.DateRangePickerState.InitialDisplayedMonthMillis.get -> long?
+AndroidX.Compose.DateRangePickerState.InitialSelectableDates.get -> AndroidX.Compose.Material3.ISelectableDates?
+AndroidX.Compose.DateRangePickerState.InitialSelectedEndDateMillis.get -> long?
+AndroidX.Compose.DateRangePickerState.InitialSelectedStartDateMillis.get -> long?
+AndroidX.Compose.DateRangePickerState.InitialYearRange.get -> AndroidX.Compose.DatePickerYearRange?
 AndroidX.Compose.DateRangePickerState.SelectedEndDateMillis.get -> long?
 AndroidX.Compose.DateRangePickerState.SelectedEndDateMillis.set -> void
 AndroidX.Compose.DateRangePickerState.SelectedStartDateMillis.get -> long?

--- a/src/Microsoft.AndroidX.Compose/TimePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/TimePickerState.cs
@@ -29,14 +29,20 @@ namespace AndroidX.Compose;
 /// </remarks>
 public sealed class TimePickerState
 {
-    int _initialHour;
-    int _initialMinute;
+    readonly int _initialHour;
+    readonly int _initialMinute;
+    int _hour;
+    int _minute;
+    bool _hasPendingHour;
+    bool _hasPendingMinute;
 
     internal ITimePickerState? Jvm;
 
     internal int InitialHour => _initialHour;
     internal int InitialMinute => _initialMinute;
     internal bool InitialIs24Hour { get; }
+    internal int RememberHour => _hour;
+    internal int RememberMinute => _minute;
 
     /// <summary>Creates a time-picker state with constructor-only initial values.</summary>
     /// <param name="initialHour">Initial hour from 0 through 23.</param>
@@ -48,6 +54,8 @@ public sealed class TimePickerState
         ValidateMinute(initialMinute);
         _initialHour = initialHour;
         _initialMinute = initialMinute;
+        _hour = initialHour;
+        _minute = initialMinute;
         InitialIs24Hour = is24Hour;
     }
 
@@ -55,12 +63,15 @@ public sealed class TimePickerState
     /// constructor's <c>initialHour</c> until bound.</summary>
     public int Hour
     {
-        get => Jvm?.Hour ?? _initialHour;
+        get => Jvm?.Hour ?? _hour;
         set
         {
             ValidateHour(value);
             if (Jvm is null)
-                _initialHour = value;
+            {
+                _hour = value;
+                _hasPendingHour = true;
+            }
             else
                 Jvm.Hour = value;
         }
@@ -70,12 +81,15 @@ public sealed class TimePickerState
     /// constructor's <c>initialMinute</c> until bound.</summary>
     public int Minute
     {
-        get => Jvm?.Minute ?? _initialMinute;
+        get => Jvm?.Minute ?? _minute;
         set
         {
             ValidateMinute(value);
             if (Jvm is null)
-                _initialMinute = value;
+            {
+                _minute = value;
+                _hasPendingMinute = true;
+            }
             else
                 Jvm.Minute = value;
         }
@@ -85,6 +99,15 @@ public sealed class TimePickerState
     /// AM/PM). Falls back to the constructor's <c>is24Hour</c> until
     /// bound.</summary>
     public bool Is24Hour => Jvm?.Is24hour() ?? InitialIs24Hour;
+
+    internal void BindJvm(ITimePickerState jvm)
+    {
+        Jvm = jvm;
+        if (_hasPendingHour)
+            Hour = _hour;
+        if (_hasPendingMinute)
+            Minute = _minute;
+    }
 
     static void ValidateHour(int value)
     {

--- a/src/Microsoft.AndroidX.Compose/TimePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/TimePickerState.cs
@@ -29,16 +29,25 @@ namespace AndroidX.Compose;
 /// </remarks>
 public sealed class TimePickerState
 {
+    int _initialHour;
+    int _initialMinute;
+
     internal ITimePickerState? Jvm;
 
-    internal int  InitialHour   { get; }
-    internal int  InitialMinute { get; }
+    internal int InitialHour => _initialHour;
+    internal int InitialMinute => _initialMinute;
     internal bool InitialIs24Hour { get; }
 
+    /// <summary>Creates a time-picker state with constructor-only initial values.</summary>
+    /// <param name="initialHour">Initial hour from 0 through 23.</param>
+    /// <param name="initialMinute">Initial minute from 0 through 59.</param>
+    /// <param name="is24Hour">Whether to use 24-hour presentation.</param>
     public TimePickerState(int initialHour = 12, int initialMinute = 0, bool is24Hour = true)
     {
-        InitialHour     = initialHour;
-        InitialMinute   = initialMinute;
+        ValidateHour(initialHour);
+        ValidateMinute(initialMinute);
+        _initialHour = initialHour;
+        _initialMinute = initialMinute;
         InitialIs24Hour = is24Hour;
     }
 
@@ -46,20 +55,46 @@ public sealed class TimePickerState
     /// constructor's <c>initialHour</c> until bound.</summary>
     public int Hour
     {
-        get => Jvm?.Hour ?? InitialHour;
-        set { if (Jvm is not null) Jvm.Hour = value; }
+        get => Jvm?.Hour ?? _initialHour;
+        set
+        {
+            ValidateHour(value);
+            if (Jvm is null)
+                _initialHour = value;
+            else
+                Jvm.Hour = value;
+        }
     }
 
     /// <summary>Currently displayed minute (0–59). Falls back to the
     /// constructor's <c>initialMinute</c> until bound.</summary>
     public int Minute
     {
-        get => Jvm?.Minute ?? InitialMinute;
-        set { if (Jvm is not null) Jvm.Minute = value; }
+        get => Jvm?.Minute ?? _initialMinute;
+        set
+        {
+            ValidateMinute(value);
+            if (Jvm is null)
+                _initialMinute = value;
+            else
+                Jvm.Minute = value;
+        }
     }
 
     /// <summary>Whether the picker is in 24-hour mode (vs. 12-hour with
     /// AM/PM). Falls back to the constructor's <c>is24Hour</c> until
     /// bound.</summary>
     public bool Is24Hour => Jvm?.Is24hour() ?? InitialIs24Hour;
+
+    static void ValidateHour(int value)
+    {
+        if ((uint)value > 23)
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Hour must be from 0 through 23.");
+    }
+
+    static void ValidateMinute(int value)
+    {
+        if ((uint)value > 59)
+            throw new ArgumentOutOfRangeException(nameof(value), value, "Minute must be from 0 through 59.");
+    }
 }

--- a/src/Microsoft.AndroidX.Compose/TimePickerState.cs
+++ b/src/Microsoft.AndroidX.Compose/TimePickerState.cs
@@ -50,8 +50,8 @@ public sealed class TimePickerState
     /// <param name="is24Hour">Whether to use 24-hour presentation.</param>
     public TimePickerState(int initialHour = 12, int initialMinute = 0, bool is24Hour = true)
     {
-        ValidateHour(initialHour);
-        ValidateMinute(initialMinute);
+        ValidateHour(initialHour, nameof(initialHour));
+        ValidateMinute(initialMinute, nameof(initialMinute));
         _initialHour = initialHour;
         _initialMinute = initialMinute;
         _hour = initialHour;
@@ -59,14 +59,14 @@ public sealed class TimePickerState
         InitialIs24Hour = is24Hour;
     }
 
-    /// <summary>Currently displayed hour (0–23). Falls back to the
-    /// constructor's <c>initialHour</c> until bound.</summary>
+    /// <summary>Currently displayed hour (0–23). Before binding, returns
+    /// the constructor value or the latest pending write.</summary>
     public int Hour
     {
         get => Jvm?.Hour ?? _hour;
         set
         {
-            ValidateHour(value);
+            ValidateHour(value, nameof(value));
             if (Jvm is null)
             {
                 _hour = value;
@@ -77,14 +77,14 @@ public sealed class TimePickerState
         }
     }
 
-    /// <summary>Currently displayed minute (0–59). Falls back to the
-    /// constructor's <c>initialMinute</c> until bound.</summary>
+    /// <summary>Currently displayed minute (0–59). Before binding, returns
+    /// the constructor value or the latest pending write.</summary>
     public int Minute
     {
         get => Jvm?.Minute ?? _minute;
         set
         {
-            ValidateMinute(value);
+            ValidateMinute(value, nameof(value));
             if (Jvm is null)
             {
                 _minute = value;
@@ -109,15 +109,15 @@ public sealed class TimePickerState
             Minute = _minute;
     }
 
-    static void ValidateHour(int value)
+    static void ValidateHour(int value, string paramName)
     {
         if ((uint)value > 23)
-            throw new ArgumentOutOfRangeException(nameof(value), value, "Hour must be from 0 through 23.");
+            throw new ArgumentOutOfRangeException(paramName, value, "Hour must be from 0 through 23.");
     }
 
-    static void ValidateMinute(int value)
+    static void ValidateMinute(int value, string paramName)
     {
         if ((uint)value > 59)
-            throw new ArgumentOutOfRangeException(nameof(value), value, "Minute must be from 0 through 59.");
+            throw new ArgumentOutOfRangeException(paramName, value, "Minute must be from 0 through 59.");
     }
 }


### PR DESCRIPTION
Picker state holders currently blur immutable initialization with mutable live state, silently lose some writes around first binding, and expose Kotlin/Java implementation types in otherwise managed APIs. This makes pre-bind behavior surprising and can produce different state after first composition.

This change:

- separates immutable constructor configuration from pending live values for `DatePickerState`, `DateRangePickerState`, and `TimePickerState`
- adds generator-driven peer binding that flushes explicit pre-bind writes while preserving Kotlin default masks and shared peer identity
- replaces public `Java.Lang.Long?` and Kotlin range concepts with managed `long?` and `DatePickerYearRange`
- routes date remember helpers through the official bindings with generated omission masks
- updates gallery, MAUI integration, documentation, generator coverage, and the sorted public API baseline
- adds real-composition device tests for pending writes, nullable resets, Kotlin defaults, live mutation, and peer reuse after removal/re-entry

## Validation

- Source generator tests: 308 passed
- Facade, Gallery, and MAUI builds: passed
- Pixel 10 picker lifecycle instrumentation: 3 passed
- Full device suite: 65 passed, 1 unrelated `CoroutineScopeTests` activity-start timeout; that class passed 4/4 when run independently