### PR TITLE
Use Dp for layout dimension APIs

### DIFF
--- a/samples/Jetchat/Profile.cs
+++ b/samples/Jetchat/Profile.cs
@@ -83,13 +83,13 @@ public static class Profile
             BuildProfileFab(state, scrollState, popupOpen, scheme),
         });
 
-    static ComposableNode BuildProfileHeader(ProfileScreenState state, float containerHeight)
+    static ComposableNode BuildProfileHeader(ProfileScreenState state, Dp containerHeight)
     {
         if (state.Photo is null)
             return Spacer.Width(0);
 
-        float heroMax = containerHeight / 2f;
-        if (heroMax < 1f) heroMax = 240f;
+        Dp heroMax = containerHeight / 2f;
+        if (heroMax < 1) heroMax = 240;
         return new Image(state.Photo.Value, "Profile photo")
         {
             Modifier = Modifier
@@ -101,7 +101,7 @@ public static class Profile
         };
     }
 
-    static Column BuildUserInfoFields(ProfileScreenState state, float containerHeight, ColorScheme scheme)
+    static Column BuildUserInfoFields(ProfileScreenState state, Dp containerHeight, ColorScheme scheme)
     {
         var col = new Column
         {
@@ -116,9 +116,9 @@ public static class Profile
 
         // Add a spacer that always shows part (320.dp) of the fields list regardless of
         // the device, in order to always leave some content at the top.
-        float trailing = containerHeight - 320f;
-        if (trailing < 0f) trailing = 0f;
-        col.Add(Spacer.Height((int)trailing));
+        Dp trailing = containerHeight - new Dp(320);
+        if (trailing < 0) trailing = Dp.Zero;
+        col.Add(Spacer.Height(trailing));
         return col;
     }
 

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/ComposeValueTypeTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/ComposeValueTypeTests.cs
@@ -37,4 +37,24 @@ public class ComposeValueTypeTests
         Assert.AreEqual((x << 32) | y, TransformOrigin.Pack(origin));
         Assert.AreEqual(new TransformOrigin(0.5f, 0.5f), TransformOrigin.Center);
     }
+
+    [TestMethod]
+    public void LayoutDimensions_ExposeDpAndPreserveInfinity()
+    {
+        var constraints = new BoxConstraints(1f, float.PositiveInfinity, 2f, 3f);
+        var progress = new CircularProgressIndicator { StrokeWidthDp = 4 };
+        var horizontal = new HorizontalDivider { ThicknessDp = 2 };
+        var vertical = new VerticalDivider { ThicknessDp = 3 };
+
+        Assert.AreEqual(new Dp(1), constraints.MinWidth);
+        Assert.IsTrue(float.IsPositiveInfinity(constraints.MaxWidth.Value));
+        Assert.AreEqual(new Dp(2), constraints.MinHeight);
+        Assert.AreEqual(new Dp(3), constraints.MaxHeight);
+        Assert.AreEqual(new Dp(4), progress.StrokeWidthDp);
+        Assert.AreEqual(new Dp(2), horizontal.ThicknessDp);
+        Assert.AreEqual(new Dp(3), vertical.ThicknessDp);
+        Assert.AreEqual(
+            typeof(Dp),
+            typeof(MeasureScope).GetMethod(nameof(MeasureScope.RoundToPx))?.GetParameters()[0].ParameterType);
+    }
 }

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/ModifierStructuralKeyTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/ModifierStructuralKeyTests.cs
@@ -97,4 +97,15 @@ public class ModifierStructuralKeyTests
         Assert.AreEqual(a, b);
         Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
     }
+
+    [TestMethod]
+    public void GraphicsLayer_ShadowElevationUsesDpStructuralValue()
+    {
+        var a = Modifier.GraphicsLayer(shadowElevation: new Dp(8)).StructuralKey;
+        var b = Modifier.GraphicsLayer(shadowElevation: 8).StructuralKey;
+        var c = Modifier.GraphicsLayer(shadowElevation: 12).StructuralKey;
+
+        Assert.AreEqual(a, b);
+        Assert.AreNotEqual(a, c);
+    }
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BoxWithConstraintsDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/BoxWithConstraintsDemo.cs
@@ -12,7 +12,7 @@ public static class BoxWithConstraintsDemo
         Title:       "BoxWithConstraints",
         Description: "Reports MaxWidth / MaxHeight in dp — branch your layout on screen size.",
         Build:       c => new BoxWithConstraints(c => new Text(
-            $"Max width = {c.MaxWidth:0.#} dp, max height = {c.MaxHeight:0.#} dp"))
+            $"Max width = {c.MaxWidth}, max height = {c.MaxHeight}"))
         {
             Modifier = Modifier.FillMaxWidth().Padding(8),
         });

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/CustomLayoutDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/CustomLayoutDemo.cs
@@ -51,9 +51,9 @@ public static class CustomLayoutDemo
 
             var layout = new Layout(measurePolicy: (scope, measurables, constraints) =>
             {
-                // Bin into N columns by available width. 220 px is the
+                // Bin into N columns by available width. 220 dp is the
                 // minimum desired column width.
-                int min = 220;
+                int min = scope.RoundToPx(220);
                 int max = constraints.HasBoundedWidth
                     ? constraints.MaxWidth
                     : min;

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/DividerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Containers/DividerDemo.cs
@@ -14,13 +14,21 @@ public static class DividerDemo
         Build:       _ => new Column
         {
             new Text("Above"),
-            new HorizontalDivider { Modifier = Modifier.Padding(vertical: 8) },
+            new HorizontalDivider
+            {
+                ThicknessDp = 2,
+                Modifier = Modifier.Padding(vertical: 8),
+            },
             new Text("Below"),
             new Spacer { Modifier = Modifier.Height(16) },
             new Row
             {
                 new Text("Left"),
-                new VerticalDivider { Modifier = Modifier.Padding(horizontal: 8) },
+                new VerticalDivider
+                {
+                    ThicknessDp = 2,
+                    Modifier = Modifier.Padding(horizontal: 8),
+                },
                 new Text("Right"),
             },
         });

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/LocalsMisc/CircularProgressIndicatorDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/LocalsMisc/CircularProgressIndicatorDemo.cs
@@ -14,6 +14,6 @@ public static class CircularProgressIndicatorDemo
         Build:       _ => new Column
         {
             new Text("Indeterminate circular spinner:"),
-            new CircularProgressIndicator(),
+            new CircularProgressIndicator { StrokeWidthDp = 6 },
         });
 }

--- a/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/GraphicsLayerDemo.cs
+++ b/src/Microsoft.AndroidX.Compose.Gallery/Demos/Modifiers/GraphicsLayerDemo.cs
@@ -44,6 +44,7 @@ public static class GraphicsLayerDemo
                             .GraphicsLayer(
                                 rotationZ:       dragX.Value,
                                 alpha:           0.6f + 0.4f * MathF.Min(1f, MathF.Abs(dragX.Value) / 90f),
+                                shadowElevation: 8,
                                 transformOrigin: new TransformOrigin(0f, 0f))
                             .Background(Color.FromRgb(0xAB, 0x47, 0xBC)),
                         new Text("⟲") { Modifier = Modifier.Padding(20) },

--- a/src/Microsoft.AndroidX.Compose/BoxConstraints.cs
+++ b/src/Microsoft.AndroidX.Compose/BoxConstraints.cs
@@ -4,7 +4,7 @@ namespace AndroidX.Compose;
 /// Constraints surfaced to <see cref="BoxWithConstraints"/>'s content
 /// callback. Mirrors <c>androidx.compose.foundation.layout.BoxWithConstraintsScope</c>:
 /// <see cref="MinWidth"/> / <see cref="MaxWidth"/> /
-/// <see cref="MinHeight"/> / <see cref="MaxHeight"/> are layout dp
+/// <see cref="MinHeight"/> / <see cref="MaxHeight"/> are layout <see cref="Dp"/>
 /// values measured during the current composition pass. Use them to
 /// pick a different child layout based on the available space (the
 /// idiomatic Compose alternative to runtime "is this a phone or a
@@ -13,9 +13,9 @@ namespace AndroidX.Compose;
 /// <remarks>
 /// <para>
 /// <see cref="MaxWidth"/> / <see cref="MaxHeight"/> may be
-/// <see cref="float.PositiveInfinity"/> when the parent imposes no
-/// upper bound — branch on <see cref="float.IsInfinity"/> before
-/// comparing against a fixed dp threshold.
+/// <see cref="Dp.Value"/> equal to <see cref="float.PositiveInfinity"/>
+/// when the parent imposes no upper bound. Branch on
+/// <see cref="float.IsInfinity(float)"/> before comparing against a fixed threshold.
 /// </para>
 /// <para>
 /// Constraints are only valid for the call that produced them; do not
@@ -24,17 +24,17 @@ namespace AndroidX.Compose;
 /// </remarks>
 public readonly struct BoxConstraints
 {
-    /// <summary>Minimum width the content may take, in dp. Always finite.</summary>
-    public float MinWidth { get; }
+    /// <summary>Minimum width the content may take. Always finite.</summary>
+    public Dp MinWidth { get; }
 
-    /// <summary>Maximum width the content may take, in dp. May be <see cref="float.PositiveInfinity"/>.</summary>
-    public float MaxWidth { get; }
+    /// <summary>Maximum width the content may take. Its value may be <see cref="float.PositiveInfinity"/>.</summary>
+    public Dp MaxWidth { get; }
 
-    /// <summary>Minimum height the content may take, in dp. Always finite.</summary>
-    public float MinHeight { get; }
+    /// <summary>Minimum height the content may take. Always finite.</summary>
+    public Dp MinHeight { get; }
 
-    /// <summary>Maximum height the content may take, in dp. May be <see cref="float.PositiveInfinity"/>.</summary>
-    public float MaxHeight { get; }
+    /// <summary>Maximum height the content may take. Its value may be <see cref="float.PositiveInfinity"/>.</summary>
+    public Dp MaxHeight { get; }
 
     internal BoxConstraints(float minWidth, float maxWidth, float minHeight, float maxHeight)
     {

--- a/src/Microsoft.AndroidX.Compose/BoxConstraints.cs
+++ b/src/Microsoft.AndroidX.Compose/BoxConstraints.cs
@@ -14,8 +14,9 @@ namespace AndroidX.Compose;
 /// <para>
 /// <see cref="MaxWidth"/> / <see cref="MaxHeight"/> may be
 /// <see cref="Dp.Value"/> equal to <see cref="float.PositiveInfinity"/>
-/// when the parent imposes no upper bound. Branch on
-/// <see cref="float.IsInfinity(float)"/> before comparing against a fixed threshold.
+/// when the parent imposes no upper bound. Check
+/// <c>float.IsInfinity(MaxWidth.Value)</c> or
+/// <c>float.IsInfinity(MaxHeight.Value)</c> before comparing against a fixed threshold.
 /// </para>
 /// <para>
 /// Constraints are only valid for the call that produced them; do not

--- a/src/Microsoft.AndroidX.Compose/BoxWithConstraints.cs
+++ b/src/Microsoft.AndroidX.Compose/BoxWithConstraints.cs
@@ -13,7 +13,7 @@ namespace AndroidX.Compose;
 ///
 /// <code>
 /// new BoxWithConstraints(c =&gt;
-///     c.MaxWidth &lt; 600
+///     c.MaxWidth &lt; new Dp(600)
 ///         ? new Column { /* compact */ }
 ///         : new Row    { /* wide   */ })
 /// </code>
@@ -47,7 +47,8 @@ public sealed class BoxWithConstraints : ComposableNode
             // DoNotTransfer so the local ref is freed by Compose, then
             // cast to the typed binding interface.
             var scope = Java.Lang.Object.GetObject<IBoxWithConstraintsScope>(
-                scopeHandle, JniHandleOwnership.DoNotTransfer)!;
+                scopeHandle, JniHandleOwnership.DoNotTransfer)
+                ?? throw new InvalidOperationException("BoxWithConstraints scope was not provided by Compose.");
             var constraints = new BoxConstraints(
                 minWidth:  scope.MinWidth,
                 maxWidth:  scope.MaxWidth,

--- a/src/Microsoft.AndroidX.Compose/CircularProgressIndicator.cs
+++ b/src/Microsoft.AndroidX.Compose/CircularProgressIndicator.cs
@@ -18,8 +18,8 @@ public sealed class CircularProgressIndicator : ComposableNode
     /// <summary>Optional explicit color. Leave null to use the Material default.</summary>
     public Color? Color { get; set; }
 
-    /// <summary>Optional stroke width in Dp. Leave null for the Material default.</summary>
-    public float? StrokeWidthDp { get; set; }
+    /// <summary>Optional stroke width. Leave null for the Material default.</summary>
+    public Dp? StrokeWidthDp { get; set; }
 
     /// <summary>Optional explicit track color. Leave null to use the Material default.</summary>
     public Color? TrackColor { get; set; }
@@ -37,7 +37,7 @@ public sealed class CircularProgressIndicator : ComposableNode
         ProgressIndicatorKt.CircularProgressIndicator(
             modifier:    modifier,
             color:       Color      is { } c ? c.ToPacked() : 0L,
-            strokeWidth: StrokeWidthDp   ?? 0f,
+            strokeWidth: Dp.Pack(StrokeWidthDp),
             trackColor:  TrackColor is { } t ? t.ToPacked() : 0L,
             p4:          0,
             gapSize:     0f,

--- a/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
+++ b/src/Microsoft.AndroidX.Compose/ComposeBridges.cs
@@ -2438,8 +2438,8 @@ internal static partial class ComposeBridges
     // F rotationZ, F cameraDistance, J transformOrigin, Shape shape,
     // Z clip). 13 user params, all defaultable. Mangled because
     // `transformOrigin` is `@JvmInline value class TransformOrigin`
-    // packed as a `long`. The C# wrapper uses `float?`/`TransformOrigin?`/
-    // `IntPtr?`/`bool?` so the auto-mask clears each bit when a
+    // packed as a `long`. The C# wrapper uses nullable value types,
+    // `IntPtr?`, and `bool?` so the auto-mask clears each bit when a
     // value is supplied. This is the simplest of the three
     // graphicsLayer overloads — it omits the `RenderEffect`,
     // `ambientShadowColor`, `spotShadowColor`, and
@@ -2460,7 +2460,7 @@ internal static partial class ComposeBridges
         float? alpha,
         float? translationX,
         float? translationY,
-        float? shadowElevation,
+        Dp? shadowElevation,
         float? rotationX,
         float? rotationY,
         float? rotationZ,

--- a/src/Microsoft.AndroidX.Compose/HorizontalDivider.cs
+++ b/src/Microsoft.AndroidX.Compose/HorizontalDivider.cs
@@ -10,8 +10,8 @@ namespace AndroidX.Compose;
 /// </summary>
 public sealed class HorizontalDivider : ComposableNode
 {
-    /// <summary>Optional explicit thickness in Dp. Leave null to use the Material default.</summary>
-    public float? ThicknessDp { get; set; }
+    /// <summary>Optional explicit thickness. Leave null to use the Material default.</summary>
+    public Dp? ThicknessDp { get; set; }
 
     /// <summary>Optional explicit color. Leave null to use the Material default.</summary>
     public Color? Color { get; set; }
@@ -27,7 +27,7 @@ public sealed class HorizontalDivider : ComposableNode
 
         DividerKt.HorizontalDivider(
             modifier:  modifier,
-            thickness: ThicknessDp ?? 0f,
+            thickness: Dp.Pack(ThicknessDp),
             color:     Color is { } c ? c.ToPacked() : 0L,
             _composer: composer,
             p4:        0,

--- a/src/Microsoft.AndroidX.Compose/MeasureScope.cs
+++ b/src/Microsoft.AndroidX.Compose/MeasureScope.cs
@@ -18,7 +18,7 @@ public sealed class MeasureScope
     /// <summary>
     /// Pixel-per-dp ratio of the surface this layout is measuring against.
     /// Multiply a Dp value by <see cref="Density"/> to get pixels; use
-    /// <see cref="RoundToPx(float)"/> when you want an <see cref="int"/>.
+    /// <see cref="RoundToPx(Dp)"/> when you want an <see cref="int"/>.
     /// </summary>
     public float Density => ComposeBridges.MeasureScopeGetDensity(Handle);
 
@@ -33,7 +33,8 @@ public sealed class MeasureScope
     /// <see cref="Density"/>, mirroring Kotlin's
     /// <c>Dp.roundToPx()</c> extension.
     /// </summary>
-    public int RoundToPx(float dp) => (int)Math.Round(dp * Density, MidpointRounding.AwayFromZero);
+    public int RoundToPx(Dp dp) =>
+        (int)Math.Round(dp.Value * Density, MidpointRounding.AwayFromZero);
 
     /// <summary>
     /// Declare that this layout is <paramref name="width"/> ×

--- a/src/Microsoft.AndroidX.Compose/MeasureScope.cs
+++ b/src/Microsoft.AndroidX.Compose/MeasureScope.cs
@@ -17,8 +17,9 @@ public sealed class MeasureScope
 
     /// <summary>
     /// Pixel-per-dp ratio of the surface this layout is measuring against.
-    /// Multiply a Dp value by <see cref="Density"/> to get pixels; use
-    /// <see cref="RoundToPx(Dp)"/> when you want an <see cref="int"/>.
+    /// Use <see cref="RoundToPx(Dp)"/> for integer pixels, or multiply
+    /// <see cref="Dp.Value"/> by <see cref="Density"/> for a floating-point
+    /// pixel value.
     /// </summary>
     public float Density => ComposeBridges.MeasureScopeGetDensity(Handle);
 

--- a/src/Microsoft.AndroidX.Compose/Modifier.cs
+++ b/src/Microsoft.AndroidX.Compose/Modifier.cs
@@ -308,8 +308,8 @@ public sealed class Modifier
     /// <inheritdoc cref="ModifierExtensions.Shadow(Dp, Shape?)"/>
     public static Modifier Shadow(Dp elevation, Shape? shape = null) => _companion.Shadow(elevation, shape);
 
-    /// <inheritdoc cref="ModifierExtensions.GraphicsLayer(float?, float?, float?, float?, float?, float?, float?, float?, float?, float?, TransformOrigin?, Shape?, bool?)"/>
-    public static Modifier GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, TransformOrigin? transformOrigin = null, Shape? shape = null, bool? clip = null) => _companion.GraphicsLayer(scaleX, scaleY, alpha, translationX, translationY, shadowElevation, rotationX, rotationY, rotationZ, cameraDistance, transformOrigin, shape, clip);
+    /// <inheritdoc cref="ModifierExtensions.GraphicsLayer(Modifier, float?, float?, float?, float?, float?, Dp?, float?, float?, float?, float?, TransformOrigin?, Shape?, bool?)"/>
+    public static Modifier GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, Dp? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, TransformOrigin? transformOrigin = null, Shape? shape = null, bool? clip = null) => _companion.GraphicsLayer(scaleX, scaleY, alpha, translationX, translationY, shadowElevation, rotationX, rotationY, rotationZ, cameraDistance, transformOrigin, shape, clip);
 
     /// <inheritdoc cref="ModifierExtensions.ImePadding()"/>
     public static Modifier ImePadding() => _companion.ImePadding();

--- a/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
@@ -939,7 +939,7 @@ public static class ModifierExtensions
     /// <param name="alpha">Opacity in [0, 1].</param>
     /// <param name="translationX">Horizontal translation in pixels.</param>
     /// <param name="translationY">Vertical translation in pixels.</param>
-    /// <param name="shadowElevation">Elevation in pixels (use <see cref="Shadow"/> to specify in Dp).</param>
+    /// <param name="shadowElevation">Elevation of the rendered shadow.</param>
     /// <param name="rotationX">Rotation around the X axis in degrees.</param>
     /// <param name="rotationY">Rotation around the Y axis in degrees.</param>
     /// <param name="rotationZ">Rotation around the Z axis in degrees (clockwise).</param>
@@ -953,7 +953,7 @@ public static class ModifierExtensions
         float? alpha = null,
         float? translationX = null,
         float? translationY = null,
-        float? shadowElevation = null,
+        Dp? shadowElevation = null,
         float? rotationX = null,
         float? rotationY = null,
         float? rotationZ = null,

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -110,10 +110,10 @@ AndroidX.Compose.Box
 AndroidX.Compose.Box.Box(bool propagateMinConstraints = false) -> void
 AndroidX.Compose.BoxConstraints
 AndroidX.Compose.BoxConstraints.BoxConstraints() -> void
-AndroidX.Compose.BoxConstraints.MaxHeight.get -> float
-AndroidX.Compose.BoxConstraints.MaxWidth.get -> float
-AndroidX.Compose.BoxConstraints.MinHeight.get -> float
-AndroidX.Compose.BoxConstraints.MinWidth.get -> float
+AndroidX.Compose.BoxConstraints.MaxHeight.get -> AndroidX.Compose.Dp
+AndroidX.Compose.BoxConstraints.MaxWidth.get -> AndroidX.Compose.Dp
+AndroidX.Compose.BoxConstraints.MinHeight.get -> AndroidX.Compose.Dp
+AndroidX.Compose.BoxConstraints.MinWidth.get -> AndroidX.Compose.Dp
 AndroidX.Compose.BoxWithConstraints
 AndroidX.Compose.BoxWithConstraints.BoxWithConstraints(System.Func<AndroidX.Compose.BoxConstraints, AndroidX.Compose.ComposableNode!>! content) -> void
 AndroidX.Compose.Brush
@@ -158,7 +158,7 @@ AndroidX.Compose.CircularProgressIndicator
 AndroidX.Compose.CircularProgressIndicator.CircularProgressIndicator() -> void
 AndroidX.Compose.CircularProgressIndicator.Color.get -> AndroidX.Compose.Color?
 AndroidX.Compose.CircularProgressIndicator.Color.set -> void
-AndroidX.Compose.CircularProgressIndicator.StrokeWidthDp.get -> float?
+AndroidX.Compose.CircularProgressIndicator.StrokeWidthDp.get -> AndroidX.Compose.Dp?
 AndroidX.Compose.CircularProgressIndicator.StrokeWidthDp.set -> void
 AndroidX.Compose.CircularProgressIndicator.TrackColor.get -> AndroidX.Compose.Color?
 AndroidX.Compose.CircularProgressIndicator.TrackColor.set -> void
@@ -549,7 +549,7 @@ AndroidX.Compose.HorizontalDivider
 AndroidX.Compose.HorizontalDivider.Color.get -> AndroidX.Compose.Color?
 AndroidX.Compose.HorizontalDivider.Color.set -> void
 AndroidX.Compose.HorizontalDivider.HorizontalDivider() -> void
-AndroidX.Compose.HorizontalDivider.ThicknessDp.get -> float?
+AndroidX.Compose.HorizontalDivider.ThicknessDp.get -> AndroidX.Compose.Dp?
 AndroidX.Compose.HorizontalDivider.ThicknessDp.set -> void
 AndroidX.Compose.HorizontalMultiBrowseCarousel<T>
 AndroidX.Compose.HorizontalMultiBrowseCarousel<T>.HorizontalMultiBrowseCarousel(System.Collections.Generic.IReadOnlyList<T>! items, float preferredItemWidth, System.Func<T, AndroidX.Compose.ComposableNode!>! itemContent) -> void
@@ -769,7 +769,7 @@ AndroidX.Compose.MeasureScope
 AndroidX.Compose.MeasureScope.Density.get -> float
 AndroidX.Compose.MeasureScope.FontScale.get -> float
 AndroidX.Compose.MeasureScope.Layout(int width, int height, System.Action<AndroidX.Compose.PlacementScope!>! placementBlock) -> AndroidX.Compose.MeasureResult!
-AndroidX.Compose.MeasureScope.RoundToPx(float dp) -> int
+AndroidX.Compose.MeasureScope.RoundToPx(AndroidX.Compose.Dp dp) -> int
 AndroidX.Compose.MediumFlexibleTopAppBar
 AndroidX.Compose.MediumFlexibleTopAppBar.Actions.get -> AndroidX.Compose.ComposableNode?
 AndroidX.Compose.MediumFlexibleTopAppBar.Actions.set -> void
@@ -1483,7 +1483,7 @@ AndroidX.Compose.TriStateCheckbox.TriStateCheckbox(AndroidX.Compose.UI.State.Tog
 AndroidX.Compose.VerticalDivider
 AndroidX.Compose.VerticalDivider.Color.get -> AndroidX.Compose.Color?
 AndroidX.Compose.VerticalDivider.Color.set -> void
-AndroidX.Compose.VerticalDivider.ThicknessDp.get -> float?
+AndroidX.Compose.VerticalDivider.ThicknessDp.get -> AndroidX.Compose.Dp?
 AndroidX.Compose.VerticalDivider.ThicknessDp.set -> void
 AndroidX.Compose.VerticalDivider.VerticalDivider() -> void
 AndroidX.Compose.VerticalPager<T>
@@ -2458,7 +2458,7 @@ static AndroidX.Compose.Modifier.FillMaxWidth(float fraction = 1) -> AndroidX.Co
 static AndroidX.Compose.Modifier.FocusGroup() -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.FocusRequester(AndroidX.Compose.FocusRequester! requester) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Focusable(bool enabled = true) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.Modifier.GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, AndroidX.Compose.TransformOrigin? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.Modifier.GraphicsLayer(float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, AndroidX.Compose.Dp? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, AndroidX.Compose.TransformOrigin? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.Height(AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.HeightIn(AndroidX.Compose.Dp? min = null, AndroidX.Compose.Dp? max = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.Modifier.HorizontalScroll(AndroidX.Compose.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> AndroidX.Compose.Modifier!
@@ -2554,7 +2554,7 @@ static AndroidX.Compose.ModifierExtensions.FillMaxWidth(this AndroidX.Compose.Mo
 static AndroidX.Compose.ModifierExtensions.FocusGroup(this AndroidX.Compose.Modifier! modifier) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.FocusRequester(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.FocusRequester! requester) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Focusable(this AndroidX.Compose.Modifier! modifier, bool enabled = true) -> AndroidX.Compose.Modifier!
-static AndroidX.Compose.ModifierExtensions.GraphicsLayer(this AndroidX.Compose.Modifier! modifier, float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, float? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, AndroidX.Compose.TransformOrigin? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
+static AndroidX.Compose.ModifierExtensions.GraphicsLayer(this AndroidX.Compose.Modifier! modifier, float? scaleX = null, float? scaleY = null, float? alpha = null, float? translationX = null, float? translationY = null, AndroidX.Compose.Dp? shadowElevation = null, float? rotationX = null, float? rotationY = null, float? rotationZ = null, float? cameraDistance = null, AndroidX.Compose.TransformOrigin? transformOrigin = null, AndroidX.Compose.Shape? shape = null, bool? clip = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.Height(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp height) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.HeightIn(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.Dp? min = null, AndroidX.Compose.Dp? max = null) -> AndroidX.Compose.Modifier!
 static AndroidX.Compose.ModifierExtensions.HorizontalScroll(this AndroidX.Compose.Modifier! modifier, AndroidX.Compose.ScrollState! state, bool enabled = true, bool reverseScrolling = false) -> AndroidX.Compose.Modifier!

--- a/src/Microsoft.AndroidX.Compose/VerticalDivider.cs
+++ b/src/Microsoft.AndroidX.Compose/VerticalDivider.cs
@@ -9,8 +9,8 @@ namespace AndroidX.Compose;
 /// </summary>
 public sealed class VerticalDivider : ComposableNode
 {
-    /// <summary>Optional explicit thickness in Dp. Leave null to use the Material default.</summary>
-    public float? ThicknessDp { get; set; }
+    /// <summary>Optional explicit thickness. Leave null to use the Material default.</summary>
+    public Dp? ThicknessDp { get; set; }
 
     /// <summary>Optional explicit color. Leave null to use the Material default.</summary>
     public Color? Color { get; set; }
@@ -26,7 +26,7 @@ public sealed class VerticalDivider : ComposableNode
 
         DividerKt.VerticalDivider(
             modifier:  modifier,
-            thickness: ThicknessDp ?? 0f,
+            thickness: Dp.Pack(ThicknessDp),
             color:     Color is { } c ? c.ToPacked() : 0L,
             _composer: composer,
             p4:        0,


### PR DESCRIPTION
Compose layout dimensions should be strongly typed at the public C# boundary instead of surfacing as ambiguous floats. This makes unit expectations explicit while preserving the existing Kotlin ABI and default behavior.

- Change progress stroke width, divider thickness, box constraints, `MeasureScope.RoundToPx`, and graphics-layer shadow elevation to `Dp`/`Dp?`.
- Keep raw-float lowering at binding and JNI boundaries; the generated graphics-layer bridge uses `Dp.Pack` and retains omission-aware Kotlin default-mask handling.
- Update XML docs, gallery examples, focused device tests, modifier structural-key coverage, and the public API baseline.

Validation:
- Focused `ValueType_Dp_LowersToPackHelper` generator test passed.
- Facade, DeviceTests, and Gallery builds passed.
- Both new focused tests passed on a Pixel 10. A full device suite run was interrupted by concurrent sibling sessions replacing the shared test package.