### PR TITLE
Tighten public value and pager state contracts

### DIFF
--- a/src/Microsoft.AndroidX.Compose.DeviceTests/PublicValueContractTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/PublicValueContractTests.cs
@@ -1,0 +1,112 @@
+using AndroidX.Compose;
+
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+/// <summary>Verifies managed value semantics and pager argument contracts.</summary>
+[TestClass]
+public class PublicValueContractTests
+{
+    [TestMethod]
+    public void DatePickerYearRange_DefaultMatchesKotlinDefault()
+    {
+        DatePickerYearRange range = default;
+
+        Assert.AreEqual(1900, range.StartYear);
+        Assert.AreEqual(2100, range.EndYear);
+        Assert.AreEqual(new DatePickerYearRange(1900, 2100), range);
+        Assert.IsTrue(range == new DatePickerYearRange(1900, 2100));
+        Assert.AreEqual("DatePickerYearRange(1900..2100)", range.ToString());
+    }
+
+    [TestMethod]
+    public void FocusState_UsesValueSemantics()
+    {
+        var first = new FocusState(true, true, false);
+        var second = new FocusState(true, true, false);
+
+        Assert.AreEqual(first, second);
+        Assert.AreEqual(first.GetHashCode(), second.GetHashCode());
+        Assert.IsTrue(first == second);
+        Assert.IsTrue(first != new FocusState(false, true, false));
+        Assert.AreEqual(
+            "FocusState(IsFocused=True, HasFocus=True, IsCaptured=False)",
+            first.ToString());
+    }
+
+    [TestMethod]
+    public void Constraints_UsesValueSemanticsWithoutExposingPacking()
+    {
+        var first = Constraints.Create(1, 20, 3, 40);
+        var second = Constraints.Create(1, 20, 3, 40);
+
+        Assert.AreEqual(first, second);
+        Assert.AreEqual(first.GetHashCode(), second.GetHashCode());
+        Assert.IsTrue(first == second);
+        Assert.IsTrue(first != Constraints.Create(1, 21, 3, 40));
+        Assert.AreEqual(
+            "Constraints(MinWidth=1, MaxWidth=20, MinHeight=3, MaxHeight=40)",
+            first.ToString());
+    }
+
+    [TestMethod]
+    public void BoxConstraints_UsesValueSemantics()
+    {
+        var first = new BoxConstraints(1, 20, 3, 40);
+        var second = new BoxConstraints(1, 20, 3, 40);
+
+        Assert.AreEqual(first, second);
+        Assert.AreEqual(first.GetHashCode(), second.GetHashCode());
+        Assert.IsTrue(first == second);
+        Assert.IsTrue(first != new BoxConstraints(1, 21, 3, 40));
+        Assert.AreEqual(
+            "BoxConstraints(MinWidth=1, MaxWidth=20, MinHeight=3, MaxHeight=40)",
+            first.ToString());
+    }
+
+    [TestMethod]
+    public void PagerState_RejectsInvalidInitialPage()
+    {
+        var exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new PagerState(static () => 1, initialPage: -1));
+
+        Assert.AreEqual("initialPage", exception.ParamName);
+    }
+
+    [TestMethod]
+    [DataRow(-0.5001f)]
+    [DataRow(0.5f)]
+    [DataRow(float.NaN)]
+    public void PagerState_RejectsInvalidInitialPageOffsetFraction(float value)
+    {
+        var exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new PagerState(static () => 1, initialPageOffsetFraction: value));
+
+        Assert.AreEqual("initialPageOffsetFraction", exception.ParamName);
+    }
+
+    [TestMethod]
+    public void PagerState_AcceptsInitialPageOffsetFractionBoundaries()
+    {
+        _ = new PagerState(static () => 1, initialPageOffsetFraction: -0.5f);
+        _ = new PagerState(
+            static () => 1,
+            initialPageOffsetFraction: MathF.BitDecrement(0.5f));
+    }
+
+    [TestMethod]
+    public void PagerState_ValidatesPageCountOnlyWhenRequested()
+    {
+        int invocationCount = 0;
+        var state = new PagerState(() =>
+        {
+            invocationCount++;
+            return -1;
+        });
+
+        Assert.AreEqual(0, invocationCount);
+        var exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => _ = state.PageCount);
+        Assert.AreEqual("pageCount", exception.ParamName);
+        Assert.AreEqual(1, invocationCount);
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.DeviceTests/PublicValueContractTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/PublicValueContractTests.cs
@@ -74,7 +74,7 @@ public class PublicValueContractTests
 
     [TestMethod]
     [DataRow(-0.5001f)]
-    [DataRow(0.5f)]
+    [DataRow(0.5001f)]
     [DataRow(float.NaN)]
     public void PagerState_RejectsInvalidInitialPageOffsetFraction(float value)
     {
@@ -88,9 +88,7 @@ public class PublicValueContractTests
     public void PagerState_AcceptsInitialPageOffsetFractionBoundaries()
     {
         _ = new PagerState(static () => 1, initialPageOffsetFraction: -0.5f);
-        _ = new PagerState(
-            static () => 1,
-            initialPageOffsetFraction: MathF.BitDecrement(0.5f));
+        _ = new PagerState(static () => 1, initialPageOffsetFraction: 0.5f);
     }
 
     [TestMethod]

--- a/src/Microsoft.AndroidX.Compose/BoxConstraints.cs
+++ b/src/Microsoft.AndroidX.Compose/BoxConstraints.cs
@@ -22,7 +22,7 @@ namespace AndroidX.Compose;
 /// store the struct and read it after composition completes.
 /// </para>
 /// </remarks>
-public readonly struct BoxConstraints
+public readonly struct BoxConstraints : IEquatable<BoxConstraints>
 {
     /// <summary>Minimum width the content may take, in dp. Always finite.</summary>
     public float MinWidth { get; }
@@ -43,4 +43,31 @@ public readonly struct BoxConstraints
         MinHeight = minHeight;
         MaxHeight = maxHeight;
     }
+
+    /// <inheritdoc/>
+    public bool Equals(BoxConstraints other) =>
+        MinWidth.Equals(other.MinWidth) &&
+        MaxWidth.Equals(other.MaxWidth) &&
+        MinHeight.Equals(other.MinHeight) &&
+        MaxHeight.Equals(other.MaxHeight);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is BoxConstraints other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        HashCode.Combine(MinWidth, MaxWidth, MinHeight, MaxHeight);
+
+    /// <summary>Compares two constraint snapshots by their four dp bounds.</summary>
+    public static bool operator ==(BoxConstraints left, BoxConstraints right) =>
+        left.Equals(right);
+
+    /// <summary>Compares two constraint snapshots by their four dp bounds.</summary>
+    public static bool operator !=(BoxConstraints left, BoxConstraints right) =>
+        !left.Equals(right);
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"BoxConstraints(MinWidth={MinWidth}, MaxWidth={MaxWidth}, MinHeight={MinHeight}, MaxHeight={MaxHeight})";
 }

--- a/src/Microsoft.AndroidX.Compose/Constraints.cs
+++ b/src/Microsoft.AndroidX.Compose/Constraints.cs
@@ -25,7 +25,7 @@ namespace AndroidX.Compose;
 /// passing it by value through user code is fine.
 /// </para>
 /// </remarks>
-public readonly struct Constraints
+public readonly struct Constraints : IEquatable<Constraints>
 {
     /// <summary>The packed <c>long</c> bit pattern Compose uses internally.</summary>
     internal long Value { get; }
@@ -113,4 +113,26 @@ public readonly struct Constraints
     /// Mirrors Kotlin's <c>Constraints.constrainHeight(value)</c>.
     /// </summary>
     public int ConstrainHeight(int height) => Math.Clamp(height, MinHeight, MaxHeight);
+
+    /// <inheritdoc/>
+    public bool Equals(Constraints other) => Value == other.Value;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is Constraints other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Value.GetHashCode();
+
+    /// <summary>Compares two constraint envelopes by their four bounds.</summary>
+    public static bool operator ==(Constraints left, Constraints right) =>
+        left.Equals(right);
+
+    /// <summary>Compares two constraint envelopes by their four bounds.</summary>
+    public static bool operator !=(Constraints left, Constraints right) =>
+        !left.Equals(right);
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"Constraints(MinWidth={MinWidth}, MaxWidth={MaxWidth}, MinHeight={MinHeight}, MaxHeight={MaxHeight})";
 }

--- a/src/Microsoft.AndroidX.Compose/DatePickerYearRange.cs
+++ b/src/Microsoft.AndroidX.Compose/DatePickerYearRange.cs
@@ -4,8 +4,18 @@ namespace AndroidX.Compose;
 /// Inclusive range of years displayed by a <see cref="DatePicker"/> or
 /// <see cref="DateRangePicker"/>.
 /// </summary>
-public readonly struct DatePickerYearRange
+/// <remarks>
+/// The default value represents Kotlin's default picker range,
+/// <c>1900..2100</c>.
+/// </remarks>
+public readonly struct DatePickerYearRange : IEquatable<DatePickerYearRange>
 {
+    const int DefaultStartYear = 1900;
+    const int DefaultEndYear = 2100;
+
+    readonly int _encodedStartYear;
+    readonly int _encodedEndYear;
+
     /// <summary>Creates an inclusive year range.</summary>
     /// <param name="startYear">First selectable year.</param>
     /// <param name="endYear">Last selectable year.</param>
@@ -14,13 +24,37 @@ public readonly struct DatePickerYearRange
         if (endYear < startYear)
             throw new ArgumentOutOfRangeException(nameof(endYear), endYear, "End year must be greater than or equal to start year.");
 
-        StartYear = startYear;
-        EndYear = endYear;
+        _encodedStartYear = startYear ^ DefaultStartYear;
+        _encodedEndYear = endYear ^ DefaultEndYear;
     }
 
-    /// <summary>First selectable year.</summary>
-    public int StartYear { get; }
+    /// <summary>First selectable year. Defaults to <c>1900</c>.</summary>
+    public int StartYear => _encodedStartYear ^ DefaultStartYear;
 
-    /// <summary>Last selectable year.</summary>
-    public int EndYear { get; }
+    /// <summary>Last selectable year. Defaults to <c>2100</c>.</summary>
+    public int EndYear => _encodedEndYear ^ DefaultEndYear;
+
+    /// <inheritdoc/>
+    public bool Equals(DatePickerYearRange other) =>
+        _encodedStartYear == other._encodedStartYear &&
+        _encodedEndYear == other._encodedEndYear;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is DatePickerYearRange other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        HashCode.Combine(_encodedStartYear, _encodedEndYear);
+
+    /// <summary>Compares two year ranges by their inclusive endpoints.</summary>
+    public static bool operator ==(DatePickerYearRange left, DatePickerYearRange right) =>
+        left.Equals(right);
+
+    /// <summary>Compares two year ranges by their inclusive endpoints.</summary>
+    public static bool operator !=(DatePickerYearRange left, DatePickerYearRange right) =>
+        !left.Equals(right);
+
+    /// <inheritdoc/>
+    public override string ToString() => $"DatePickerYearRange({StartYear}..{EndYear})";
 }

--- a/src/Microsoft.AndroidX.Compose/FocusState.cs
+++ b/src/Microsoft.AndroidX.Compose/FocusState.cs
@@ -11,7 +11,7 @@ namespace AndroidX.Compose;
 /// once and hand back a value type the caller can keep without worrying
 /// about peer lifetime.
 /// </summary>
-public readonly struct FocusState
+public readonly struct FocusState : IEquatable<FocusState>
 {
     /// <summary>
     /// <c>true</c> if the node owning the modifier currently has focus.
@@ -44,4 +44,30 @@ public readonly struct FocusState
 
     internal static FocusState From(IFocusState state) =>
         new(state.IsFocused, state.HasFocus, state.IsCaptured);
+
+    /// <inheritdoc/>
+    public bool Equals(FocusState other) =>
+        IsFocused == other.IsFocused &&
+        HasFocus == other.HasFocus &&
+        IsCaptured == other.IsCaptured;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is FocusState other && Equals(other);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        HashCode.Combine(IsFocused, HasFocus, IsCaptured);
+
+    /// <summary>Compares two focus snapshots by their state flags.</summary>
+    public static bool operator ==(FocusState left, FocusState right) =>
+        left.Equals(right);
+
+    /// <summary>Compares two focus snapshots by their state flags.</summary>
+    public static bool operator !=(FocusState left, FocusState right) =>
+        !left.Equals(right);
+
+    /// <inheritdoc/>
+    public override string ToString() =>
+        $"FocusState(IsFocused={IsFocused}, HasFocus={HasFocus}, IsCaptured={IsCaptured})";
 }

--- a/src/Microsoft.AndroidX.Compose/PagerState.cs
+++ b/src/Microsoft.AndroidX.Compose/PagerState.cs
@@ -76,7 +76,7 @@ public sealed class PagerState
     /// Index of the page to start on (default <c>0</c>).
     /// </param>
     /// <param name="initialPageOffsetFraction">
-    /// Initial fractional offset in <c>[-0.5, 0.5)</c> (default
+    /// Initial fractional offset in <c>[-0.5, 0.5]</c> (default
     /// <c>0f</c>).
     /// </param>
     public PagerState(Func<int> pageCount, int initialPage = 0, float initialPageOffsetFraction = 0f)
@@ -84,11 +84,11 @@ public sealed class PagerState
         ArgumentNullException.ThrowIfNull(pageCount);
         if (initialPage < 0)
             throw new ArgumentOutOfRangeException(nameof(initialPage), initialPage, "Initial page must be greater than or equal to zero.");
-        if (!(initialPageOffsetFraction >= -0.5f && initialPageOffsetFraction < 0.5f))
+        if (!(initialPageOffsetFraction >= -0.5f && initialPageOffsetFraction <= 0.5f))
             throw new ArgumentOutOfRangeException(
                 nameof(initialPageOffsetFraction),
                 initialPageOffsetFraction,
-                "Initial page offset fraction must be in the range [-0.5, 0.5).");
+                "Initial page offset fraction must be in the range [-0.5, 0.5].");
 
         _pageCountFn = new ComposableLambda0Int(() => ValidatePageCount(pageCount()));
         Jvm = PagerStateKt.PagerState(
@@ -126,7 +126,7 @@ public sealed class PagerState
     public int TargetPage => Jvm.TargetPage;
 
     /// <summary>
-    /// Fractional offset of the current page in <c>[-0.5, 0.5)</c>,
+    /// Fractional offset of the current page in <c>[-0.5, 0.5]</c>,
     /// where <c>0</c> means the page is fully snapped. Mirrors Kotlin's
     /// <c>PagerState.currentPageOffsetFraction</c>.
     /// </summary>

--- a/src/Microsoft.AndroidX.Compose/PagerState.cs
+++ b/src/Microsoft.AndroidX.Compose/PagerState.cs
@@ -65,7 +65,9 @@ public sealed class PagerState
     /// </summary>
     /// <param name="pageCount">
     /// Lambda invoked by the pager on every measure pass to determine
-    /// the total page count. Must close over a stable source that
+    /// the non-negative total page count. The lambda is not invoked by
+    /// this constructor; its result is validated each time the pager
+    /// requests it. Must close over a stable source that
     /// matches the <see cref="HorizontalPager{T}"/> /
     /// <see cref="VerticalPager{T}"/> items list passed alongside this
     /// state — recomposition-local list rebuilds will be missed.
@@ -80,7 +82,15 @@ public sealed class PagerState
     public PagerState(Func<int> pageCount, int initialPage = 0, float initialPageOffsetFraction = 0f)
     {
         ArgumentNullException.ThrowIfNull(pageCount);
-        _pageCountFn = new ComposableLambda0Int(pageCount);
+        if (initialPage < 0)
+            throw new ArgumentOutOfRangeException(nameof(initialPage), initialPage, "Initial page must be greater than or equal to zero.");
+        if (!(initialPageOffsetFraction >= -0.5f && initialPageOffsetFraction < 0.5f))
+            throw new ArgumentOutOfRangeException(
+                nameof(initialPageOffsetFraction),
+                initialPageOffsetFraction,
+                "Initial page offset fraction must be in the range [-0.5, 0.5).");
+
+        _pageCountFn = new ComposableLambda0Int(() => ValidatePageCount(pageCount()));
         Jvm = PagerStateKt.PagerState(
             currentPage:               initialPage,
             currentPageOffsetFraction: initialPageOffsetFraction,
@@ -124,8 +134,17 @@ public sealed class PagerState
 
     /// <summary>
     /// Total number of pages reported by the <c>pageCount</c> lambda
-    /// supplied at construction. Mirrors Kotlin's
+    /// supplied at construction. A negative result throws
+    /// <see cref="ArgumentOutOfRangeException"/> when requested.
+    /// Mirrors Kotlin's
     /// <c>PagerState.pageCount</c>.
     /// </summary>
     public int PageCount => Jvm.PageCount;
+
+    static int ValidatePageCount(int pageCount)
+    {
+        if (pageCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(pageCount), pageCount, "Page count must be greater than or equal to zero.");
+        return pageCount;
+    }
 }

--- a/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.AndroidX.Compose/PublicAPI.Unshipped.txt
@@ -110,6 +110,7 @@ AndroidX.Compose.Box
 AndroidX.Compose.Box.Box(bool propagateMinConstraints = false) -> void
 AndroidX.Compose.BoxConstraints
 AndroidX.Compose.BoxConstraints.BoxConstraints() -> void
+AndroidX.Compose.BoxConstraints.Equals(AndroidX.Compose.BoxConstraints other) -> bool
 AndroidX.Compose.BoxConstraints.MaxHeight.get -> float
 AndroidX.Compose.BoxConstraints.MaxWidth.get -> float
 AndroidX.Compose.BoxConstraints.MinHeight.get -> float
@@ -224,6 +225,7 @@ AndroidX.Compose.Constraints
 AndroidX.Compose.Constraints.ConstrainHeight(int height) -> int
 AndroidX.Compose.Constraints.ConstrainWidth(int width) -> int
 AndroidX.Compose.Constraints.Constraints() -> void
+AndroidX.Compose.Constraints.Equals(AndroidX.Compose.Constraints other) -> bool
 AndroidX.Compose.Constraints.HasBoundedHeight.get -> bool
 AndroidX.Compose.Constraints.HasBoundedWidth.get -> bool
 AndroidX.Compose.Constraints.MaxHeight.get -> int
@@ -274,6 +276,7 @@ AndroidX.Compose.DatePickerYearRange
 AndroidX.Compose.DatePickerYearRange.DatePickerYearRange() -> void
 AndroidX.Compose.DatePickerYearRange.DatePickerYearRange(int startYear, int endYear) -> void
 AndroidX.Compose.DatePickerYearRange.EndYear.get -> int
+AndroidX.Compose.DatePickerYearRange.Equals(AndroidX.Compose.DatePickerYearRange other) -> bool
 AndroidX.Compose.DatePickerYearRange.StartYear.get -> int
 AndroidX.Compose.DateRangePicker
 AndroidX.Compose.DateRangePicker.DateRangePicker(AndroidX.Compose.DateRangePickerState? state = null, bool showModeToggle = true) -> void
@@ -526,6 +529,7 @@ AndroidX.Compose.FocusRequester.FocusRequester() -> void
 AndroidX.Compose.FocusRequester.FreeFocus() -> bool
 AndroidX.Compose.FocusRequester.RequestFocus() -> void
 AndroidX.Compose.FocusState
+AndroidX.Compose.FocusState.Equals(AndroidX.Compose.FocusState other) -> bool
 AndroidX.Compose.FocusState.FocusState() -> void
 AndroidX.Compose.FocusState.FocusState(bool isFocused, bool hasFocus, bool isCaptured) -> void
 AndroidX.Compose.FocusState.HasFocus.get -> bool
@@ -1541,6 +1545,9 @@ override AndroidX.Compose.BadgedBox.Render(AndroidX.Compose.Runtime.IComposer! c
 override AndroidX.Compose.BottomAppBar.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.BottomSheetScaffold.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.Box.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
+override AndroidX.Compose.BoxConstraints.Equals(object? obj) -> bool
+override AndroidX.Compose.BoxConstraints.GetHashCode() -> int
+override AndroidX.Compose.BoxConstraints.ToString() -> string!
 override AndroidX.Compose.BoxWithConstraints.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.Button.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.Canvas.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
@@ -1555,6 +1562,9 @@ override AndroidX.Compose.Color.ToString() -> string!
 override AndroidX.Compose.Column.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.Composed.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.CompositionLocalProvider.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
+override AndroidX.Compose.Constraints.Equals(object? obj) -> bool
+override AndroidX.Compose.Constraints.GetHashCode() -> int
+override AndroidX.Compose.Constraints.ToString() -> string!
 override AndroidX.Compose.CornerRadius.Equals(object? obj) -> bool
 override AndroidX.Compose.CornerRadius.GetHashCode() -> int
 override AndroidX.Compose.CornerRadius.ToString() -> string!
@@ -1562,6 +1572,9 @@ override AndroidX.Compose.Crossfade<T>.Render(AndroidX.Compose.Runtime.IComposer
 override AndroidX.Compose.CustomTab.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.DatePicker.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.DatePickerDialog.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
+override AndroidX.Compose.DatePickerYearRange.Equals(object? obj) -> bool
+override AndroidX.Compose.DatePickerYearRange.GetHashCode() -> int
+override AndroidX.Compose.DatePickerYearRange.ToString() -> string!
 override AndroidX.Compose.DateRangePicker.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.DateRangePickerDialog.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.DerivedState<T>.ToString() -> string!
@@ -1595,6 +1608,9 @@ override AndroidX.Compose.FlexibleBottomAppBar.Render(AndroidX.Compose.Runtime.I
 override AndroidX.Compose.FloatingActionButton.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.FlowColumn.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.FlowRow.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
+override AndroidX.Compose.FocusState.Equals(object? obj) -> bool
+override AndroidX.Compose.FocusState.GetHashCode() -> int
+override AndroidX.Compose.FocusState.ToString() -> string!
 override AndroidX.Compose.HorizontalCenteredHeroCarousel<T>.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.HorizontalDivider.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
 override AndroidX.Compose.HorizontalMultiBrowseCarousel<T>.Render(AndroidX.Compose.Runtime.IComposer! composer) -> void
@@ -1728,6 +1744,8 @@ static AndroidX.Compose.Arrangement.SpacedBy(AndroidX.Compose.Dp dp) -> AndroidX
 static AndroidX.Compose.Arrangement.SpacedBy(int dp) -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Start.get -> AndroidX.Compose.Arrangement!
 static AndroidX.Compose.Arrangement.Top.get -> AndroidX.Compose.Arrangement!
+static AndroidX.Compose.BoxConstraints.operator !=(AndroidX.Compose.BoxConstraints left, AndroidX.Compose.BoxConstraints right) -> bool
+static AndroidX.Compose.BoxConstraints.operator ==(AndroidX.Compose.BoxConstraints left, AndroidX.Compose.BoxConstraints right) -> bool
 static AndroidX.Compose.Brush.HorizontalGradient(AndroidX.Compose.Color[]! colors, float startX = 0, float endX = Infinity, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.UI.Graphics.Brush!
 static AndroidX.Compose.Brush.HorizontalGradient(params AndroidX.Compose.Color[]! colors) -> AndroidX.Compose.UI.Graphics.Brush!
 static AndroidX.Compose.Brush.LinearGradient(AndroidX.Compose.Color[]! colors, AndroidX.Compose.Offset start, AndroidX.Compose.Offset end, AndroidX.Compose.TileMode tileMode = AndroidX.Compose.TileMode.Clamp) -> AndroidX.Compose.UI.Graphics.Brush!
@@ -2031,6 +2049,8 @@ static AndroidX.Compose.CompositionLocal<T>.StaticOf(System.Func<T>! defaultFact
 static AndroidX.Compose.Constraints.Create(int minWidth, int maxWidth, int minHeight, int maxHeight) -> AndroidX.Compose.Constraints
 static AndroidX.Compose.Constraints.FixedHeight(int height) -> AndroidX.Compose.Constraints
 static AndroidX.Compose.Constraints.FixedWidth(int width) -> AndroidX.Compose.Constraints
+static AndroidX.Compose.Constraints.operator !=(AndroidX.Compose.Constraints left, AndroidX.Compose.Constraints right) -> bool
+static AndroidX.Compose.Constraints.operator ==(AndroidX.Compose.Constraints left, AndroidX.Compose.Constraints right) -> bool
 static AndroidX.Compose.ContentScale.Crop.get -> AndroidX.Compose.ContentScale!
 static AndroidX.Compose.ContentScale.FillBounds.get -> AndroidX.Compose.ContentScale!
 static AndroidX.Compose.ContentScale.FillHeight.get -> AndroidX.Compose.ContentScale!
@@ -2041,6 +2061,8 @@ static AndroidX.Compose.ContentScale.None.get -> AndroidX.Compose.ContentScale!
 static AndroidX.Compose.CornerRadius.Zero.get -> AndroidX.Compose.CornerRadius
 static AndroidX.Compose.CornerRadius.operator !=(AndroidX.Compose.CornerRadius left, AndroidX.Compose.CornerRadius right) -> bool
 static AndroidX.Compose.CornerRadius.operator ==(AndroidX.Compose.CornerRadius left, AndroidX.Compose.CornerRadius right) -> bool
+static AndroidX.Compose.DatePickerYearRange.operator !=(AndroidX.Compose.DatePickerYearRange left, AndroidX.Compose.DatePickerYearRange right) -> bool
+static AndroidX.Compose.DatePickerYearRange.operator ==(AndroidX.Compose.DatePickerYearRange left, AndroidX.Compose.DatePickerYearRange right) -> bool
 static AndroidX.Compose.Dp.Zero.get -> AndroidX.Compose.Dp
 static AndroidX.Compose.Dp.implicit operator AndroidX.Compose.Dp(float value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.Dp.implicit operator AndroidX.Compose.Dp(int value) -> AndroidX.Compose.Dp
@@ -2061,6 +2083,8 @@ static AndroidX.Compose.DpExtensions.Dp(this float value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.DpExtensions.Dp(this int value) -> AndroidX.Compose.Dp
 static AndroidX.Compose.DrawingStyle.Fill.get -> AndroidX.Compose.UI.Graphics.Drawscope.DrawStyle!
 static AndroidX.Compose.DrawingStyle.Stroke(float width, AndroidX.Compose.StrokeCap cap = AndroidX.Compose.StrokeCap.Butt, AndroidX.Compose.StrokeJoin join = AndroidX.Compose.StrokeJoin.Miter, float miter = 4) -> AndroidX.Compose.UI.Graphics.Drawscope.DrawStyle!
+static AndroidX.Compose.FocusState.operator !=(AndroidX.Compose.FocusState left, AndroidX.Compose.FocusState right) -> bool
+static AndroidX.Compose.FocusState.operator ==(AndroidX.Compose.FocusState left, AndroidX.Compose.FocusState right) -> bool
 static AndroidX.Compose.FontFamily.Cursive.get -> AndroidX.Compose.FontFamily!
 static AndroidX.Compose.FontFamily.Default.get -> AndroidX.Compose.FontFamily!
 static AndroidX.Compose.FontFamily.Monospace.get -> AndroidX.Compose.FontFamily!


### PR DESCRIPTION
`default(DatePickerYearRange)` previously produced `0..0`, even though Kotlin's picker default is `1900..2100`, and several public value wrappers lacked consistent managed value semantics. Pager state construction also relied on downstream validation instead of reporting invalid managed inputs directly.

This change:
- XOR-encodes `DatePickerYearRange` endpoints against `1900` and `2100`, so the CLR all-zero state has the correct semantics while preserving every possible `int` endpoint and the existing JNI conversion path.
- Adds `IEquatable<T>`, equality operators, hash codes, and readable `ToString()` output for `DatePickerYearRange`, `FocusState`, `Constraints`, and `BoxConstraints` without exposing packed storage.
- Validates `PagerState.initialPage` and `initialPageOffsetFraction` immediately with precise exceptions, while wrapping `pageCount` so it remains lazy and is validated only when Compose requests it.
- Adds focused on-device coverage for default semantics, equality, formatting, pager boundaries, exception parameter names, and lazy page-count evaluation.

## Validation

- `dotnet build src\Microsoft.AndroidX.Compose\Microsoft.AndroidX.Compose.csproj`
- `dotnet build src\Microsoft.AndroidX.Compose.Gallery\Microsoft.AndroidX.Compose.Gallery.csproj`
- 10 focused `PublicValueContractTests` passed on a connected Android device
- `PublicAPI.Unshipped.txt` verified with ordinal sorting