### PR TITLE
Enforce non-null public API contracts

### DIFF
--- a/src/Microsoft.AndroidX.Compose.DeviceTests/RichTextNullContractTests.cs
+++ b/src/Microsoft.AndroidX.Compose.DeviceTests/RichTextNullContractTests.cs
@@ -1,0 +1,79 @@
+using AndroidX.Compose;
+
+namespace Microsoft.AndroidX.Compose.DeviceTests;
+
+/// <summary>Verifies required rich-text inputs reject null consistently.</summary>
+[TestClass]
+public class RichTextNullContractTests
+{
+    [TestMethod]
+    public void AnnotatedString_RejectsNullText()
+    {
+#pragma warning disable CS8600, CS8625
+        var exception = Assert.ThrowsExactly<ArgumentNullException>(
+            () => new AnnotatedString((string)null));
+#pragma warning restore CS8600, CS8625
+
+        Assert.AreEqual("text", exception.ParamName);
+    }
+
+    [TestMethod]
+    public void AnnotatedStringBuilder_RejectsNullAppendText()
+    {
+        var builder = new AnnotatedStringBuilder();
+
+#pragma warning disable CS8625
+        var exception = Assert.ThrowsExactly<ArgumentNullException>(
+            () => builder.Append(null));
+#pragma warning restore CS8625
+
+        Assert.AreEqual("text", exception.ParamName);
+    }
+
+    [TestMethod]
+    public void AnnotatedStringBuilder_RejectsNullStringAnnotationValues()
+    {
+        var builder = new AnnotatedStringBuilder();
+
+#pragma warning disable CS8625
+        var tagException = Assert.ThrowsExactly<ArgumentNullException>(
+            () => builder.AddStringAnnotation(null, "value", 0, 0));
+        var annotationException = Assert.ThrowsExactly<ArgumentNullException>(
+            () => builder.AddStringAnnotation("tag", null, 0, 0));
+#pragma warning restore CS8625
+
+        Assert.AreEqual("tag", tagException.ParamName);
+        Assert.AreEqual("annotation", annotationException.ParamName);
+    }
+
+    [TestMethod]
+    public void LinkAnnotation_RejectsNullRequiredValues()
+    {
+#pragma warning disable CS8625
+        var urlException = Assert.ThrowsExactly<ArgumentNullException>(
+            () => LinkAnnotation.Url(null));
+        var tagException = Assert.ThrowsExactly<ArgumentNullException>(
+            () => LinkAnnotation.Clickable(null, static _ => { }));
+        var callbackException = Assert.ThrowsExactly<ArgumentNullException>(
+            () => LinkAnnotation.Clickable("tag", null));
+#pragma warning restore CS8625
+
+        Assert.AreEqual("url", urlException.ParamName);
+        Assert.AreEqual("tag", tagException.ParamName);
+        Assert.AreEqual("onClick", callbackException.ParamName);
+    }
+
+    [TestMethod]
+    public void LinkClickListener_RejectsNullRequiredValues()
+    {
+#pragma warning disable CS8625
+        var tagException = Assert.ThrowsExactly<ArgumentNullException>(
+            () => new LinkClickListener(null, static _ => { }));
+        var callbackException = Assert.ThrowsExactly<ArgumentNullException>(
+            () => new LinkClickListener("tag", null));
+#pragma warning restore CS8625
+
+        Assert.AreEqual("tag", tagException.ParamName);
+        Assert.AreEqual("onClick", callbackException.ParamName);
+    }
+}

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -619,6 +619,10 @@ public class FacadeGeneratorTests
         Assert.Contains("public sealed partial class Text : global::AndroidX.Compose.ComposableNode", emitted);
         Assert.Contains("readonly string _text;", emitted);
         Assert.Contains("public Text(string text)", emitted);
+        Assert.Contains(
+            "public Text(string text)\n        {\n            global::System.ArgumentNullException.ThrowIfNull(text);",
+            emitted.ReplaceLineEndings("\n"));
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(text);", emitted);
         Assert.Contains("global::AndroidX.Compose.ComposeBridges.Text(_text, BuildModifier(), composer);", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
@@ -665,6 +669,10 @@ public class FacadeGeneratorTests
         Assert.NotNull(emitted);
         // Ctor surfaces the user param with the propagated default.
         Assert.Contains($"public Widget({type} value = {emittedDefault})", emitted);
+        if (type == "string")
+            Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(value);", emitted);
+        else if (type == "string?")
+            Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(value);", emitted);
     }
 
     [Fact]
@@ -908,6 +916,7 @@ public class FacadeGeneratorTests
         // Nullable IFunction2? slot surfaces as a named property, not a
         // ctor primitive.
         Assert.Contains("public global::AndroidX.Compose.ComposableNode? Header { get; set; }", emitted);
+        Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(header);", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
         Assert.Empty(errors);
@@ -951,6 +960,7 @@ public class FacadeGeneratorTests
         // Java enum surfaces as a ctor field + ctor param + bridge arg pass-through.
         Assert.Contains("readonly global::AndroidX.Compose.Demo.FakeToggleableState _state;", emitted);
         Assert.Contains("global::AndroidX.Compose.Demo.FakeToggleableState state", emitted);
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(state);", emitted);
         Assert.Contains("ComposeBridges.TriStateCheckbox(_state,", emitted);
 
         // Sanity-check: the synthetic compilation must actually compile —
@@ -1328,6 +1338,7 @@ public class FacadeGeneratorTests
         Assert.NotNull(emitted);
         Assert.Contains("readonly global::System.Action<bool> _onCheckedChange;", emitted);
         Assert.Contains("public IconToggleButton(bool @checked, global::System.Action<bool> onCheckedChange)", emitted);
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(onCheckedChange);", emitted);
         Assert.Contains("composer.RememberAction(v => _onCheckedChange(v is global::Java.Lang.Boolean __b && __b.BooleanValue()));", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
@@ -1644,7 +1655,8 @@ public class FacadeGeneratorTests
         Assert.Contains("readonly global::AndroidX.Compose.UI.Graphics.Painter.Painter? _painter;", emitted);
 
         // Painter ctor null-guards and stores into `_painter`.
-        Assert.Contains("_painter = painter ?? throw new global::System.ArgumentNullException(nameof(painter));", emitted);
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(painter);", emitted);
+        Assert.Contains("_painter = painter;", emitted);
 
         // Render preamble: caller-owned Painter is forwarded directly;
         // resource-id path wraps the local ref into a managed peer via
@@ -4244,6 +4256,7 @@ public class FacadeGeneratorTests
         Assert.Contains("public Icon(global::AndroidX.Compose.UI.Graphics.Vector.ImageVector imageVector,", emitted);
         Assert.Contains("public Icon(int drawableResourceId,", emitted);
         Assert.Contains("public Icon(global::AndroidX.Compose.UI.Graphics.Painter.Painter painter,", emitted);
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(imageVector);", emitted);
 
         // Render dispatch: secondary branch runs first, with renamed
         // locals (__secModifier / __secDefaults) to avoid CS0136

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators.Tests/FacadeGeneratorTests.cs
@@ -280,6 +280,17 @@ public class FacadeGeneratorTests
         return (output, diags, emitted);
     }
 
+    static string GeneratedMethodBody(string emitted, string methodName)
+    {
+        var method = CSharpSyntaxTree.ParseText(emitted)
+            .GetRoot()
+            .DescendantNodes()
+            .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>()
+            .Single(m => m.Identifier.ValueText == methodName);
+        return method.Body?.ToFullString()
+            ?? throw new System.InvalidOperationException($"Generated method '{methodName}' has no body.");
+    }
+
     const string ButtonAttrs = """
         [assembly: ComposeDefaults("ButtonDefault",
             "!onClick", "modifier", "enabled", "shape", "colors",
@@ -622,7 +633,8 @@ public class FacadeGeneratorTests
         Assert.Contains(
             "public Text(string text)\n        {\n            global::System.ArgumentNullException.ThrowIfNull(text);",
             emitted.ReplaceLineEndings("\n"));
-        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(text);", emitted);
+        var helperBody = GeneratedMethodBody(emitted, "Text_PrimaryResource_Implicit");
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(text);", helperBody);
         Assert.Contains("global::AndroidX.Compose.ComposeBridges.Text(_text, BuildModifier(), composer);", emitted);
 
         var errors = output.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToArray();
@@ -672,7 +684,10 @@ public class FacadeGeneratorTests
         if (type == "string")
             Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(value);", emitted);
         else if (type == "string?")
-            Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(value);", emitted);
+        {
+            var helperBody = GeneratedMethodBody(emitted, "Widget_PrimaryResource_Implicit");
+            Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(value);", helperBody);
+        }
     }
 
     [Fact]
@@ -1657,6 +1672,12 @@ public class FacadeGeneratorTests
         // Painter ctor null-guards and stores into `_painter`.
         Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(painter);", emitted);
         Assert.Contains("_painter = painter;", emitted);
+        var resourceHelperBody = GeneratedMethodBody(emitted, "Image_PrimaryResource_Implicit");
+        var painterHelperBody = GeneratedMethodBody(emitted, "Image_PrimaryPainter_Implicit");
+        Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(painter);", resourceHelperBody);
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(painter);", painterHelperBody);
+        Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(contentDescription);", resourceHelperBody);
+        Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(contentDescription);", painterHelperBody);
 
         // Render preamble: caller-owned Painter is forwarded directly;
         // resource-id path wraps the local ref into a managed peer via
@@ -4257,6 +4278,9 @@ public class FacadeGeneratorTests
         Assert.Contains("public Icon(int drawableResourceId,", emitted);
         Assert.Contains("public Icon(global::AndroidX.Compose.UI.Graphics.Painter.Painter painter,", emitted);
         Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(imageVector);", emitted);
+        var secondaryHelperBody = GeneratedMethodBody(emitted, "Icon_Secondary_Implicit");
+        Assert.Contains("global::System.ArgumentNullException.ThrowIfNull(imageVector);", secondaryHelperBody);
+        Assert.DoesNotContain("global::System.ArgumentNullException.ThrowIfNull(contentDescription);", secondaryHelperBody);
 
         // Render dispatch: secondary branch runs first, with renamed
         // locals (__secModifier / __secDefaults) to avoid CS0136

--- a/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
+++ b/src/Microsoft.AndroidX.Compose.SourceGenerators/ComposeFacadeGenerator.cs
@@ -1919,17 +1919,32 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             route, implicitComposer, ref hasParameter);
         sb.AppendLine(", ulong __omittedArguments = 0, int __directChanged = 0)");
         sb.AppendLine("        {");
+        if (route == ComposableMethodRoute.Secondary)
+        {
+            var discriminator = secondaryCtorInfo
+                ?? throw new InvalidOperationException("Secondary composable route requires secondary constructor metadata.");
+            EmitNullGuard(sb, "            ", discriminator.Discriminator.Name);
+        }
+        foreach (var slot in ctorSlotsAll)
+        {
+            if (slot.Kind == FacadeSlotKind.PainterResource)
+            {
+                if (route == ComposableMethodRoute.PrimaryPainter)
+                    EmitNullGuard(sb, "            ", "painter");
+            }
+            else if (RequiresCtorNullGuard(slot))
+            {
+                EmitNullGuard(sb, "            ", CtorIdentifier(slot));
+            }
+        }
         foreach (var slot in requiredNamedSlots.Concat(contentSlots))
         {
-            sb.Append("            global::System.ArgumentNullException.ThrowIfNull(")
-              .Append(EscapeIdent(slot.Kind is FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3
-                  ? ComposableMethodIdentifier(PropertyName(slot))
-                  : slot.Param.Name))
-              .AppendLine(");");
-        }
-        if (route == ComposableMethodRoute.PrimaryPainter)
-        {
-            sb.AppendLine("            global::System.ArgumentNullException.ThrowIfNull(painter);");
+            EmitNullGuard(
+                sb,
+                "            ",
+                slot.Kind is FacadeSlotKind.RequiredFunction2 or FacadeSlotKind.RequiredFunction3
+                    ? ComposableMethodIdentifier(PropertyName(slot))
+                    : slot.Param.Name);
         }
         var surfacedIndices = BuildComposableMethodSurfaceIndices(requiredCtorSlots,
             optionalCtorSlots, requiredNamedSlots, contentSlots, optionalNamedSlots,
@@ -3527,8 +3542,10 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         }
         sb.AppendLine(")");
         sb.AppendLine("        {");
-        sb.Append("            _").Append(discName).Append(" = ").Append(EscapeIdent(discName))
-          .Append(" ?? throw new global::System.ArgumentNullException(nameof(").Append(EscapeIdent(discName)).AppendLine("));");
+        EmitNullGuard(sb, "            ", discName);
+        foreach (var s in emittedSlots.Where(RequiresCtorNullGuard))
+            EmitNullGuard(sb, "            ", CtorIdentifier(s));
+        sb.Append("            _").Append(discName).Append(" = ").Append(EscapeIdent(discName)).AppendLine(";");
 
         // Store the emitted slots in their fields. Same logic as
         // EmitFacadeCtor's body for non-PainterResource non-stateholder
@@ -3766,6 +3783,18 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
         sb.AppendLine("        {");
         foreach (var s in ctorSlots)
         {
+            if (s.Kind == FacadeSlotKind.PainterResource)
+            {
+                if (painterShape == PainterCtorShape.Painter)
+                    EmitNullGuard(sb, "            ", "painter");
+            }
+            else if (RequiresCtorNullGuard(s))
+            {
+                EmitNullGuard(sb, "            ", CtorIdentifier(s));
+            }
+        }
+        foreach (var s in ctorSlots)
+        {
             // Phase 4b — auto-create wrapper instance when the
             // Remember bridge has user params. The Render body
             // reads init values off `_state` to pass into Remember,
@@ -3782,7 +3811,7 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
                 // Painter ctor: store the wrapper into _painter; leave
                 // _drawableResourceId at default (the sibling ctor sets
                 // it). Render branches on `_painter is not null`.
-                sb.AppendLine("            _painter = painter ?? throw new global::System.ArgumentNullException(nameof(painter));");
+                sb.AppendLine("            _painter = painter;");
             }
             else
             {
@@ -3790,6 +3819,19 @@ public sealed class ComposeFacadeGenerator : IIncrementalGenerator
             }
         }
         sb.AppendLine("        }");
+    }
+
+    static bool RequiresCtorNullGuard(FacadeSlot slot) =>
+        slot.Kind is FacadeSlotKind.OnClick or FacadeSlotKind.Callback ||
+        slot.Kind == FacadeSlotKind.Primitive &&
+        slot.Param.Type.IsReferenceType &&
+        slot.Param.NullableAnnotation != NullableAnnotation.Annotated;
+
+    static void EmitNullGuard(StringBuilder sb, string indent, string parameterName)
+    {
+        var escaped = EscapeIdent(parameterName);
+        sb.Append(indent).Append("global::System.ArgumentNullException.ThrowIfNull(")
+          .Append(escaped).AppendLine(");");
     }
 
     static string CtorFieldType(FacadeSlot slot) => CtorParamType(slot);

--- a/src/Microsoft.AndroidX.Compose/AnnotatedString.cs
+++ b/src/Microsoft.AndroidX.Compose/AnnotatedString.cs
@@ -33,9 +33,10 @@ public sealed class AnnotatedString : Java.Lang.Object
     /// plain string. Equivalent to <c>AnnotatedString(text)</c> in
     /// Kotlin.
     /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="text"/> is
+    /// <see langword="null"/>.</exception>
     public AnnotatedString(string text)
-        : this(new AndroidX.Compose.UI.Text.AnnotatedString(
-            text, new List<AndroidX.Compose.UI.Text.AnnotatedString.Range>()))
+        : this(CreateBinding(text))
     {
     }
 
@@ -47,4 +48,11 @@ public sealed class AnnotatedString : Java.Lang.Object
 
     AndroidX.Compose.UI.Text.AnnotatedString Binding() =>
         Java.Lang.Object.GetObject<AndroidX.Compose.UI.Text.AnnotatedString>(Handle, JniHandleOwnership.DoNotTransfer)!;
+
+    static AndroidX.Compose.UI.Text.AnnotatedString CreateBinding(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return new AndroidX.Compose.UI.Text.AnnotatedString(
+            text, new List<AndroidX.Compose.UI.Text.AnnotatedString.Range>());
+    }
 }

--- a/src/Microsoft.AndroidX.Compose/AnnotatedString.cs
+++ b/src/Microsoft.AndroidX.Compose/AnnotatedString.cs
@@ -53,6 +53,6 @@ public sealed class AnnotatedString : Java.Lang.Object
     {
         ArgumentNullException.ThrowIfNull(text);
         return new AndroidX.Compose.UI.Text.AnnotatedString(
-            text, new List<AndroidX.Compose.UI.Text.AnnotatedString.Range>());
+            text, []);
     }
 }

--- a/src/Microsoft.AndroidX.Compose/AnnotatedStringBuilder.cs
+++ b/src/Microsoft.AndroidX.Compose/AnnotatedStringBuilder.cs
@@ -25,8 +25,11 @@ public sealed class AnnotatedStringBuilder
     public int Length => _builder.Length;
 
     /// <summary>Append a plain run of text at the current cursor.</summary>
+    /// <exception cref="ArgumentNullException"><paramref name="text"/> is
+    /// <see langword="null"/>.</exception>
     public AnnotatedStringBuilder Append(string text)
     {
+        ArgumentNullException.ThrowIfNull(text);
         _builder.Append(text);
         return this;
     }
@@ -71,8 +74,14 @@ public sealed class AnnotatedStringBuilder
     /// appended range. Used by clients to look up metadata at tapped
     /// offsets without affecting the displayed text.
     /// </summary>
-    public void AddStringAnnotation(string tag, string annotation, int start, int end) =>
+    /// <exception cref="ArgumentNullException"><paramref name="tag"/> or
+    /// <paramref name="annotation"/> is <see langword="null"/>.</exception>
+    public void AddStringAnnotation(string tag, string annotation, int start, int end)
+    {
+        ArgumentNullException.ThrowIfNull(tag);
+        ArgumentNullException.ThrowIfNull(annotation);
         _builder.AddStringAnnotation(tag, annotation, start, end);
+    }
 
     /// <summary>Apply a <see cref="SpanStyle"/> to a specific range.</summary>
     public void AddStyle(SpanStyle style, int start, int end)

--- a/src/Microsoft.AndroidX.Compose/DropdownMenuItem.cs
+++ b/src/Microsoft.AndroidX.Compose/DropdownMenuItem.cs
@@ -22,8 +22,15 @@ public sealed class DropdownMenuItem : ComposableNode
     readonly ComposableNode _text;
     readonly Action _onClick;
 
+    /// <summary>Creates a menu item with required text content and click callback.</summary>
+    /// <param name="text">Composable content displayed by the item.</param>
+    /// <param name="onClick">Callback invoked when the item is selected.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="text"/> or
+    /// <paramref name="onClick"/> is <see langword="null"/>.</exception>
     public DropdownMenuItem(ComposableNode text, Action onClick)
     {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(onClick);
         _text    = text;
         _onClick = onClick;
     }

--- a/src/Microsoft.AndroidX.Compose/LinkAnnotation.cs
+++ b/src/Microsoft.AndroidX.Compose/LinkAnnotation.cs
@@ -31,8 +31,11 @@ public sealed class LinkAnnotation
     /// <param name="style">Optional default <see cref="SpanStyle"/> to
     /// apply to the linked range; pass <see langword="null"/> to
     /// inherit from the enclosing text styling.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="url"/> is
+    /// <see langword="null"/>.</exception>
     public static LinkAnnotation Url(string url, SpanStyle? style = null)
     {
+        ArgumentNullException.ThrowIfNull(url);
         var styles = style is null ? null : new BindingTextLinkStyles(style.Build(), null, null, null);
         return new LinkAnnotation(new BindingLink.Url(url, styles, null));
     }
@@ -48,8 +51,11 @@ public sealed class LinkAnnotation
     /// <param name="onClick">Callback fired on tap. Receives <paramref name="tag"/>.</param>
     /// <param name="style">Optional default <see cref="SpanStyle"/> for
     /// the linked range.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="tag"/> or
+    /// <paramref name="onClick"/> is <see langword="null"/>.</exception>
     public static LinkAnnotation Clickable(string tag, Action<string> onClick, SpanStyle? style = null)
     {
+        ArgumentNullException.ThrowIfNull(tag);
         ArgumentNullException.ThrowIfNull(onClick);
         var styles   = style is null ? null : new BindingTextLinkStyles(style.Build(), null, null, null);
         var listener = new LinkClickListener(tag, onClick);

--- a/src/Microsoft.AndroidX.Compose/LinkClickListener.cs
+++ b/src/Microsoft.AndroidX.Compose/LinkClickListener.cs
@@ -18,6 +18,8 @@ internal sealed class LinkClickListener : Java.Lang.Object, AndroidX.Compose.UI.
 
     public LinkClickListener(string tag, Action<string> onClick)
     {
+        ArgumentNullException.ThrowIfNull(tag);
+        ArgumentNullException.ThrowIfNull(onClick);
         _tag     = tag;
         _onClick = onClick;
     }

--- a/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
+++ b/src/Microsoft.AndroidX.Compose/ModifierExtensions.cs
@@ -1275,8 +1275,13 @@ public static class ModifierExtensions
     /// semantics; call the overload taking <c>mergeDescendants</c> for
     /// that.
     /// </summary>
-    public static Modifier Semantics(this Modifier modifier, string contentDescription) =>
-        modifier.Semantics(mergeDescendants: false, contentDescription, role: null);
+    /// <exception cref="ArgumentNullException"><paramref name="contentDescription"/>
+    /// is <see langword="null"/>.</exception>
+    public static Modifier Semantics(this Modifier modifier, string contentDescription)
+    {
+        ArgumentNullException.ThrowIfNull(contentDescription);
+        return modifier.Semantics(mergeDescendants: false, contentDescription, role: null);
+    }
 
     /// <summary>
     /// <c>Modifier.semantics(mergeDescendants) { contentDescription = ... }</c> —
@@ -1284,8 +1289,13 @@ public static class ModifierExtensions
     /// container that should announce itself instead of its children
     /// (e.g. a card with a label and a value).
     /// </summary>
-    public static Modifier Semantics(this Modifier modifier, bool mergeDescendants, string contentDescription) =>
-        modifier.Semantics(mergeDescendants, contentDescription, role: null);
+    /// <exception cref="ArgumentNullException"><paramref name="contentDescription"/>
+    /// is <see langword="null"/>.</exception>
+    public static Modifier Semantics(this Modifier modifier, bool mergeDescendants, string contentDescription)
+    {
+        ArgumentNullException.ThrowIfNull(contentDescription);
+        return modifier.Semantics(mergeDescendants, contentDescription, role: null);
+    }
 
     /// <summary>
     /// <c>Modifier.semantics { role = ... }</c> — tags the node with
@@ -1341,8 +1351,13 @@ public static class ModifierExtensions
     /// should appear as a single accessibility node with a curated
     /// description, hiding implementation details.
     /// </summary>
-    public static Modifier ClearAndSetSemantics(this Modifier modifier, string contentDescription) =>
-        modifier.ClearAndSetSemantics(contentDescription, role: null);
+    /// <exception cref="ArgumentNullException"><paramref name="contentDescription"/>
+    /// is <see langword="null"/>.</exception>
+    public static Modifier ClearAndSetSemantics(this Modifier modifier, string contentDescription)
+    {
+        ArgumentNullException.ThrowIfNull(contentDescription);
+        return modifier.ClearAndSetSemantics(contentDescription, role: null);
+    }
 
     /// <summary>
     /// <c>Modifier.clearAndSetSemantics { contentDescription = ...; role = ... }</c> —


### PR DESCRIPTION
Required reference parameters currently accept null inconsistently across handwritten APIs and generated facade surfaces, allowing failures to occur later inside Compose or JNI. This change makes those contracts fail fast and consistently with `ArgumentNullException`.

## Summary

- Guard confirmed handwritten gaps in rich-text APIs, `DropdownMenuItem`, and non-null semantics overloads.
- Extend `ComposeFacadeGenerator` so required strings, delegates, Java/object wrappers, painter inputs, secondary discriminators, and catalog content are guarded consistently.
- Preserve nullable and optional generated slots without changing public signatures or API baselines.
- Add focused generator coverage and Android device tests for rich-text contracts.

## Validation

- 314 source-generator tests passed.
- Compose facade, Gallery, MAUI library, and MAUI sample builds passed.
- 5 targeted rich-text device tests passed on a Pixel 10.