### PR TITLE
Avoid duplicate graphics path native library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
         run: |
           dotnet build "$RUNNER_TEMP/template-smoke/TemplateSmoke.csproj" \
             -p:RestoreAdditionalProjectSources="$RUNNER_TEMP/template-packages" \
+            -p:TreatWarningsAsErrors=true \
+            -warnaserror:XA4301 \
             -bl:"$GITHUB_WORKSPACE/Microsoft.AndroidX.Compose.Template.binlog"
 
       - name: Publish packages to GitHub Packages

--- a/src/Microsoft.AndroidX.Compose/Microsoft.AndroidX.Compose.csproj
+++ b/src/Microsoft.AndroidX.Compose/Microsoft.AndroidX.Compose.csproj
@@ -87,4 +87,14 @@
       <Bind>false</Bind>
     </AndroidJavaSource>
   </ItemGroup>
+  <Target Name="_ExcludeTransitiveGraphicsPathNativeLibraryFromAar"
+          AfterTargets="_CategorizeAndroidLibraries"
+          BeforeTargets="_CreateAarCache">
+    <!-- The NuGet dependency supplies this native library to applications.
+         https://github.com/dotnet/android-libraries/issues/1503 -->
+    <ItemGroup>
+      <EmbeddedNativeLibrary Remove="@(EmbeddedNativeLibrary)"
+                             Condition="'%(Filename)%(Extension)' == 'libandroidx.graphics.path.so'" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
`Xamarin.AndroidX.Graphics.Path` supplies its native library transitively, but the Android class-library build also embeds the extracted `.so` files into `Microsoft.AndroidX.Compose.aar`. Template consumers then receive identical copies from both sources and report XA4301.

This removes `libandroidx.graphics.path.so` from `EmbeddedNativeLibrary` before the facade AAR is created, while preserving the NuGet dependency that supplies it to applications. The template smoke build now treats compiler warnings as errors and explicitly promotes XA4301 so this packaging regression cannot return unnoticed.

The packed facade AAR retains its Java helper JAR, the template restores `Xamarin.AndroidX.Graphics.Path 1.1.0.1`, and the final APK contains one native library copy for each selected ABI.

Upstream tracking: https://github.com/dotnet/android-libraries/issues/1503